### PR TITLE
#14 Add basic support for @AfterMapping / @BeforeMapping methods

### DIFF
--- a/core-common/src/main/java/org/mapstruct/AfterMapping.java
+++ b/core-common/src/main/java/org/mapstruct/AfterMapping.java
@@ -26,12 +26,77 @@ import java.lang.annotation.Target;
 import org.mapstruct.util.Experimental;
 
 /**
- * Marks a method to be invoked at the end of a generated the mapping method.
+ * Marks a method to be invoked at the end of a generated mapping method, right before the last {@code return} statement
+ * of the mapping method. The method can be implemented in an abstract mapper class or be declared in a type (class or
+ * interface) referenced in {@link Mapper#uses()} in order to be used in a mapping method.
  * <p>
- * If the method has parameters, the method invocation is only generated if all parameters can be assigned by the source
- * or target parameters of the mapping method.
+ * Only methods with return type {@code void} may be annotated with this annotation.
+ * <p>
+ * If the method has parameters, the method invocation is only generated if all parameters can be <em>assigned</em> by
+ * the source or target parameters of the mapping method:
+ * <ul>
+ * <li>A parameter annotated with {@code @}{@link MappingTarget} is populated with the target instance of the mapping.
+ * </li>
+ * <li>A parameter annotated with {@code @}{@link TargetType} is populated with the target type of the mapping.</li>
+ * <li>Any other parameter is populated with a source parameter of the mapping, whereas each source parameter is used
+ * once at most.</li>
+ * </ul>
+ * <p>
+ * All <em>after-mapping</em> methods that can be applied to a mapping method will be used. Their order is determined by
+ * their location of definition:
+ * <ul>
+ * <li>The order of methods within one type can not be guaranteed, as it depends on the compiler and the processing
+ * environment implementation.</li>
+ * <li>Methods declared in one type are used after methods declared in their super-type.</li>
+ * <li>Methods implemented in the mapper itself are used before methods from types referenced in {@link Mapper#uses()}.
+ * </li>
+ * <li>Types referenced in {@link Mapper#uses()} are searched for <em>after-mapping</em> methods in the order specified
+ * in the annotation.</li>
+ * </ul>
+ * <p>
+ * Example:
+ *
+ * <pre>
+ * <code>
+ * &#64;AfterMapping
+ * public void calledWithoutArgs() {
+ *     // ...
+ * }
+ *
+ * &#64;AfterMapping
+ * public void calledWithSourceAndTargetType(SourceEntity anySource, &#64;TargetType Class&lt;?&gt; targetType) {
+ *     // ...
+ * }
+ *
+ * &#64;AfterMapping
+ * public void calledWithSourceAndTarget(Object anySource, &#64;MappingTarget TargetDto target) {
+ *     // ...
+ * }
+ *
+ * public abstract TargetDto toTargetDto(SourceEntity source);
+ *
+ * // generates:
+ *
+ * public TargetDto toTargetDto(SourceEntity source) {
+ *     if ( source == null ) {
+ *         return null;
+ *     }
+ *
+ *     TargetDto targetDto = new TargetDto();
+ *
+ *     // actual mapping code
+ *
+ *     calledWithoutArgs();
+ *     calledWithSourceAndTargetType( source, TargetDto.class );
+ *     calledWithSourceAndTarget( source, targetDto );
+ *
+ *     return targetDto;
+ * }
+ * </code>
+ * </pre>
  *
  * @author Andreas Gudian
+ * @see BeforeMapping
  */
 @Experimental
 @Target(ElementType.METHOD)

--- a/core-common/src/main/java/org/mapstruct/AfterMapping.java
+++ b/core-common/src/main/java/org/mapstruct/AfterMapping.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.mapstruct.util.Experimental;
+
+/**
+ * Marks a method to be invoked at the end of a generated the mapping method.
+ * <p>
+ * If the method has parameters, the method invocation is only generated if all parameters can be assigned by the source
+ * or target parameters of the mapping method.
+ *
+ * @author Andreas Gudian
+ */
+@Experimental
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface AfterMapping {
+
+}

--- a/core-common/src/main/java/org/mapstruct/BeforeMapping.java
+++ b/core-common/src/main/java/org/mapstruct/BeforeMapping.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.mapstruct.util.Experimental;
+
+/**
+ * Marks a method to be invoked at the beginning of a generated mapping method.
+ * <p>
+ * If the method has parameters, the method invocation is only generated if all parameters can be assigned by the source
+ * or target parameters of the mapping method.
+ *
+ * @author Andreas Gudian
+ */
+@Experimental
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface BeforeMapping {
+
+}

--- a/core-common/src/main/java/org/mapstruct/BeforeMapping.java
+++ b/core-common/src/main/java/org/mapstruct/BeforeMapping.java
@@ -26,12 +26,81 @@ import java.lang.annotation.Target;
 import org.mapstruct.util.Experimental;
 
 /**
- * Marks a method to be invoked at the beginning of a generated mapping method.
+ * Marks a method to be invoked at the beginning of a generated mapping method. The method can be implemented in an
+ * abstract mapper class or be declared in a type (class or interface) referenced in {@link Mapper#uses()} in order to
+ * be used in a mapping method.
  * <p>
- * If the method has parameters, the method invocation is only generated if all parameters can be assigned by the source
- * or target parameters of the mapping method.
+ * Only methods with return type {@code void} may be annotated with this annotation.
+ * <p>
+ * If the method has parameters, the method invocation is only generated if all parameters can be <em>assigned</em> by
+ * the source or target parameters of the mapping method:
+ * <ul>
+ * <li>A parameter annotated with {@code @}{@link MappingTarget} is populated with the target instance of the mapping.
+ * </li>
+ * <li>A parameter annotated with {@code @}{@link TargetType} is populated with the target type of the mapping.</li>
+ * <li>Any other parameter is populated with a source parameter of the mapping, whereas each source parameter is used
+ * once at most.</li>
+ * </ul>
+ * If a <em>before-mapping</em> method does not contain a {@code @}{@link MappingTarget} parameter, it is invoked
+ * directly at the beginning of the applicable mapping method. If it contains a {@code @}{@link MappingTarget}
+ * parameter, the method is invoked after the target parameter has been initialized in the mapping method.
+ * <p>
+ * All <em>before-mapping</em> methods that can be applied to a mapping method will be used. Their order is determined
+ * by their location of definition:
+ * <ul>
+ * <li>The order of methods within one type can not be guaranteed, as it depends on the compiler and the processing
+ * environment implementation.</li>
+ * <li>Methods declared in one type are used after methods declared in their super-type.</li>
+ * <li>Methods implemented in the mapper itself are used before methods from types referenced in {@link Mapper#uses()}.
+ * </li>
+ * <li>Types referenced in {@link Mapper#uses()} are searched for <em>after-mapping</em> methods in the order specified
+ * in the annotation.</li>
+ * </ul>
+ * <p>
+ * Example:
+ *
+ * <pre>
+ * <code>
+ * &#64;BeforeMapping
+ * public void calledWithoutArgs() {
+ *     // ...
+ * }
+ *
+ * &#64;BeforeMapping
+ * public void calledWithSourceAndTargetType(SourceEntity anySource, &#64;TargetType Class&lt;?&gt; targetType) {
+ *     // ...
+ * }
+ *
+ * &#64;BeforeMapping
+ * public void calledWithSourceAndTarget(Object anySource, &#64;MappingTarget TargetDto target) {
+ *     // ...
+ * }
+ *
+ * public abstract TargetDto toTargetDto(SourceEntity source);
+ *
+ * // generates:
+ *
+ * public TargetDto toTargetDto(SourceEntity source) {
+ *     calledWithoutArgs();
+ *     calledWithSourceAndTargetType( source, TargetDto.class );
+ *
+ *     if ( source == null ) {
+ *         return null;
+ *     }
+ *
+ *     TargetDto targetDto = new TargetDto();
+ *
+ *     calledWithSourceAndTarget( source, targetDto );
+ *
+ *     // actual mapping code
+ *
+ *     return targetDto;
+ * }
+ * </code>
+ * </pre>
  *
  * @author Andreas Gudian
+ * @see AfterMapping
  */
 @Experimental
 @Target(ElementType.METHOD)

--- a/core-common/src/main/java/org/mapstruct/MapMapping.java
+++ b/core-common/src/main/java/org/mapstruct/MapMapping.java
@@ -67,9 +67,10 @@ public @interface MapMapping {
 
 
     /**
-     * A value qualifier can be specified to aid the selection process of a suitable mapper. This is useful in case
-     * multiple mappers (hand written of internal) qualify and result in an 'Ambiguous mapping methods found' error.
-     *
+     * A value qualifier can be specified to aid the selection process of a suitable mapper for the values in the map.
+     * This is useful in case multiple mappers (hand written of internal) qualify and result in an 'Ambiguous mapping
+     * methods found' error.
+     * <p>
      * A qualifier is a custom annotation and can be placed on either a hand written mapper class or a method.
      *
      * @return the qualifiers

--- a/core-common/src/main/java/org/mapstruct/util/Experimental.java
+++ b/core-common/src/main/java/org/mapstruct/util/Experimental.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.util;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Features that are marked with this annotation are considered <em>experimental</em>.
+ *
+ * @author Andreas Gudian
+ */
+@Documented
+@Retention(RetentionPolicy.SOURCE)
+public @interface Experimental {
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
@@ -162,13 +162,20 @@ public class BeanMappingMethod extends MappingMethod {
 
             sortPropertyMappingsByDependencies();
 
+            List<LifecycleCallbackMethodReference> beforeMappingMethods =
+                LifecycleCallbackFactory.beforeMappingMethods( method, ctx );
+            List<LifecycleCallbackMethodReference> afterMappingMethods =
+                LifecycleCallbackFactory.afterMappingMethods( method, ctx );
+
             return new BeanMappingMethod(
                 method,
                 propertyMappings,
                 factoryMethod,
                 mapNullToDefault,
                 resultType,
-                existingVariableNames
+                existingVariableNames,
+                beforeMappingMethods,
+                afterMappingMethods
             );
         }
 
@@ -572,8 +579,10 @@ public class BeanMappingMethod extends MappingMethod {
                               MethodReference factoryMethod,
                               boolean mapNullToDefault,
                               Type resultType,
-                              Collection<String> existingVariableNames ) {
-        super( method, existingVariableNames );
+                              Collection<String> existingVariableNames,
+                              List<LifecycleCallbackMethodReference> beforeMappingReferences,
+                              List<LifecycleCallbackMethodReference> afterMappingReferences) {
+        super( method, existingVariableNames, beforeMappingReferences, afterMappingReferences );
         this.propertyMappings = propertyMappings;
 
         // intialize constant mappings as all mappings, but take out the ones that can be contributed to a

--- a/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
@@ -163,9 +163,9 @@ public class BeanMappingMethod extends MappingMethod {
             sortPropertyMappingsByDependencies();
 
             List<LifecycleCallbackMethodReference> beforeMappingMethods =
-                LifecycleCallbackFactory.beforeMappingMethods( method, ctx );
+                LifecycleCallbackFactory.beforeMappingMethods( method, qualifiers, ctx );
             List<LifecycleCallbackMethodReference> afterMappingMethods =
-                LifecycleCallbackFactory.afterMappingMethods( method, ctx );
+                LifecycleCallbackFactory.afterMappingMethods( method, qualifiers, ctx );
 
             return new BeanMappingMethod(
                 method,

--- a/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
@@ -150,9 +150,9 @@ public class IterableMappingMethod extends MappingMethod {
                 = ctx.getMappingResolver().getFactoryMethod( method, method.getResultType(), null, null );
 
             List<LifecycleCallbackMethodReference> beforeMappingMethods =
-                LifecycleCallbackFactory.beforeMappingMethods( method, ctx );
+                LifecycleCallbackFactory.beforeMappingMethods( method, qualifiers, ctx );
             List<LifecycleCallbackMethodReference> afterMappingMethods =
-                LifecycleCallbackFactory.afterMappingMethods( method, ctx );
+                LifecycleCallbackFactory.afterMappingMethods( method, qualifiers, ctx );
 
             return new IterableMappingMethod(
                     method,

--- a/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
@@ -149,19 +149,28 @@ public class IterableMappingMethod extends MappingMethod {
             MethodReference factoryMethod
                 = ctx.getMappingResolver().getFactoryMethod( method, method.getResultType(), null, null );
 
+            List<LifecycleCallbackMethodReference> beforeMappingMethods =
+                LifecycleCallbackFactory.beforeMappingMethods( method, ctx );
+            List<LifecycleCallbackMethodReference> afterMappingMethods =
+                LifecycleCallbackFactory.afterMappingMethods( method, ctx );
+
             return new IterableMappingMethod(
                     method,
                     assignment,
                     factoryMethod,
                     mapNullToDefault,
-                    loopVariableName );
+                    loopVariableName,
+                    beforeMappingMethods,
+                    afterMappingMethods );
         }
     }
 
 
     private IterableMappingMethod(Method method, Assignment parameterAssignment, MethodReference factoryMethod,
-                                  boolean mapNullToDefault, String loopVariableName ) {
-        super( method );
+                                  boolean mapNullToDefault, String loopVariableName,
+                                 List<LifecycleCallbackMethodReference> beforeMappingReferences,
+                                 List<LifecycleCallbackMethodReference> afterMappingReferences) {
+        super( method, beforeMappingReferences, afterMappingReferences );
         this.elementAssignment = parameterAssignment;
         this.factoryMethod = factoryMethod;
         this.overridden = method.overridesMethod();

--- a/processor/src/main/java/org/mapstruct/ap/model/LifecycleCallbackFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/LifecycleCallbackFactory.java
@@ -1,0 +1,197 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.lang.model.type.TypeKind;
+
+import org.mapstruct.ap.model.common.Parameter;
+import org.mapstruct.ap.model.common.Type;
+import org.mapstruct.ap.model.source.Method;
+import org.mapstruct.ap.model.source.SourceMethod;
+
+/**
+ * Factory for creating lists of appropriate {@link LifecycleCallbackMethodReference}s
+ *
+ * @author Andreas Gudian
+ */
+public final class LifecycleCallbackFactory {
+
+    private LifecycleCallbackFactory() {
+    }
+
+    /**
+     * @param method the method to obtain the beforeMapping methods for
+     * @param ctx the builder context
+     * @return all applicable {@code @BeforeMapping} methods for the given method
+     */
+    public static List<LifecycleCallbackMethodReference> beforeMappingMethods(
+            Method method, MappingBuilderContext ctx) {
+        return collectLifecycleCallbackMethods( method, filterBeforeMappingMethods( ctx.getSourceModel() ), ctx );
+    }
+
+    /**
+     * @param method the method to obtain the afterMapping methods for
+     * @param ctx the builder context
+     * @return all applicable {@code @AfterMapping} methods for the given method
+     */
+    public static List<LifecycleCallbackMethodReference> afterMappingMethods(
+            Method method, MappingBuilderContext ctx) {
+        return collectLifecycleCallbackMethods( method, filterAfterMappingMethods( ctx.getSourceModel() ), ctx );
+    }
+
+    private static List<LifecycleCallbackMethodReference> collectLifecycleCallbackMethods(
+            Method method, List<SourceMethod> callbackMethods, MappingBuilderContext ctx) {
+
+        List<Parameter> availableParams = new ArrayList<Parameter>( method.getParameters() );
+        if ( method.getMappingTargetParameter() == null ) {
+            availableParams.add( new Parameter( null, method.getResultType(), true, false ) );
+        }
+
+        Parameter targetTypeParameter = new Parameter(
+            null,
+            ctx.getTypeFactory().classTypeOf( method.getResultType() ),
+            false,
+            true );
+
+        availableParams.add( targetTypeParameter );
+
+        List<LifecycleCallbackMethodReference> result = new ArrayList<LifecycleCallbackMethodReference>();
+
+        for ( SourceMethod callback : callbackMethods ) {
+            List<Parameter> parameterAssignments = getParameterAssignments( availableParams, callback.getParameters() );
+
+            if ( parameterAssignments != null
+                && callback.matches( extractSourceTypes( parameterAssignments ), method.getResultType() ) ) {
+
+                markMapperReferenceAsUsed( ctx.getMapperReferences(), callback );
+                result.add( new LifecycleCallbackMethodReference( callback, parameterAssignments ) );
+            }
+        }
+        return result;
+    }
+
+    private static void markMapperReferenceAsUsed(List<MapperReference> references, SourceMethod method) {
+        for ( MapperReference ref : references ) {
+            if ( ref.getType().equals( method.getDeclaringMapper() ) ) {
+                ref.setUsed( !method.isStatic() );
+                ref.setTypeRequiresImport( true );
+
+                return;
+            }
+        }
+    }
+
+    private static List<Type> extractSourceTypes(List<Parameter> parameters) {
+        List<Type> result = new ArrayList<Type>( parameters.size() );
+
+        for ( Parameter param : parameters ) {
+            if ( !param.isMappingTarget() && !param.isTargetType() ) {
+                result.add( param.getType() );
+            }
+        }
+
+        return result;
+    }
+
+    private static List<Parameter> getParameterAssignments(
+            List<Parameter> availableParams, List<Parameter> methodParameters) {
+        List<Parameter> result = new ArrayList<Parameter>( methodParameters.size() );
+
+        for ( Parameter methodParam : methodParameters ) {
+            List<Parameter> assignableParams = findCandidateParameters( availableParams, methodParam );
+
+            if ( assignableParams.isEmpty() ) {
+                return null;
+            }
+
+            if ( assignableParams.size() == 1 ) {
+                result.add( assignableParams.get( 0 ) );
+            }
+            else if ( assignableParams.size() > 1 ) {
+                Parameter paramWithMatchingName = findParameterWithName( assignableParams, methodParam.getName() );
+
+                if ( paramWithMatchingName != null ) {
+                    result.add( paramWithMatchingName );
+                }
+                else {
+                    return null;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static Parameter findParameterWithName(List<Parameter> parameters, String name) {
+        for ( Parameter param : parameters ) {
+            if ( name.equals( param.getName() ) ) {
+                return param;
+            }
+        }
+
+        return null;
+    }
+
+    private static List<Parameter> findCandidateParameters(List<Parameter> candiateParameters, Parameter parameter) {
+        List<Parameter> result = new ArrayList<Parameter>( candiateParameters.size() );
+
+        for ( Parameter candidate : candiateParameters ) {
+            if ( ( isTypeVarOrWildcard( parameter ) || candidate.getType().isAssignableTo( parameter.getType() ) )
+                && parameter.isMappingTarget() == candidate.isMappingTarget()
+                && !parameter.isTargetType() && !candidate.isTargetType() ) {
+                result.add( candidate );
+            }
+            else if ( parameter.isTargetType() && candidate.isTargetType() ) {
+                result.add( candidate );
+            }
+        }
+
+        return result;
+    }
+
+    private static boolean isTypeVarOrWildcard(Parameter parameter) {
+        TypeKind kind = parameter.getType().getTypeMirror().getKind();
+        return kind == TypeKind.TYPEVAR || kind == TypeKind.WILDCARD;
+    }
+
+    private static List<SourceMethod> filterBeforeMappingMethods(List<SourceMethod> methods) {
+        List<SourceMethod> result = new ArrayList<SourceMethod>();
+        for ( SourceMethod method : methods ) {
+            if ( method.isBeforeMappingMethod() ) {
+                result.add( method );
+            }
+        }
+
+        return result;
+    }
+
+    private static List<SourceMethod> filterAfterMappingMethods(List<SourceMethod> methods) {
+        List<SourceMethod> result = new ArrayList<SourceMethod>();
+        for ( SourceMethod method : methods ) {
+            if ( method.isAfterMappingMethod() ) {
+                result.add( method );
+            }
+        }
+
+        return result;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/model/LifecycleCallbackMethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/LifecycleCallbackMethodReference.java
@@ -1,0 +1,73 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.model;
+
+import java.beans.Introspector;
+import java.util.List;
+import java.util.Set;
+
+import org.mapstruct.ap.model.common.Parameter;
+import org.mapstruct.ap.model.common.Type;
+import org.mapstruct.ap.model.source.SourceMethod;
+import org.mapstruct.ap.util.Collections;
+import org.mapstruct.ap.util.Strings;
+
+/**
+ * Represents a reference to a method that is annotated with {@code @BeforeMapping} or {@code @AfterMapping}.
+ *
+ * @author Andreas Gudian
+ */
+public class LifecycleCallbackMethodReference extends MappingMethod {
+
+    private final Type declaringType;
+    private final List<Parameter> parameterAssignments;
+
+    public LifecycleCallbackMethodReference(SourceMethod method, List<Parameter> parameterAssignments) {
+        super( method );
+        this.declaringType = method.getDeclaringMapper();
+        this.parameterAssignments = parameterAssignments;
+    }
+
+    public Type getDeclaringType() {
+        return declaringType;
+    }
+
+    public String getInstanceVariableName() {
+        return Strings.getSaveVariableName( Introspector.decapitalize( declaringType.getName() ) );
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return declaringType != null ? Collections.asSet( declaringType ) : java.util.Collections.<Type> emptySet();
+    }
+
+    public List<Parameter> getParameterAssignments() {
+        return parameterAssignments;
+    }
+
+    public boolean hasMappingTargetParameter() {
+        for ( Parameter param : parameterAssignments ) {
+            if ( param.isMappingTarget() ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
@@ -191,19 +191,28 @@ public class MapMappingMethod extends MappingMethod {
             keyAssignment = new LocalVarWrapper( keyAssignment, method.getThrownTypes() );
             valueAssignment = new LocalVarWrapper( valueAssignment, method.getThrownTypes() );
 
+            List<LifecycleCallbackMethodReference> beforeMappingMethods =
+                LifecycleCallbackFactory.beforeMappingMethods( method, ctx );
+            List<LifecycleCallbackMethodReference> afterMappingMethods =
+                LifecycleCallbackFactory.afterMappingMethods( method, ctx );
+
             return new MapMappingMethod(
                 method,
                 keyAssignment,
                 valueAssignment,
                 factoryMethod,
-                mapNullToDefault
+                mapNullToDefault,
+                beforeMappingMethods,
+                afterMappingMethods
             );
         }
     }
 
     private MapMappingMethod(Method method, Assignment keyAssignment, Assignment valueAssignment,
-                             MethodReference factoryMethod, boolean mapNullToDefault) {
-        super( method );
+                             MethodReference factoryMethod, boolean mapNullToDefault,
+                             List<LifecycleCallbackMethodReference> beforeMappingReferences,
+                             List<LifecycleCallbackMethodReference> afterMappingReferences) {
+        super( method, beforeMappingReferences, afterMappingReferences );
 
         this.keyAssignment = keyAssignment;
         this.valueAssignment = valueAssignment;

--- a/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
@@ -192,9 +192,9 @@ public class MapMappingMethod extends MappingMethod {
             valueAssignment = new LocalVarWrapper( valueAssignment, method.getThrownTypes() );
 
             List<LifecycleCallbackMethodReference> beforeMappingMethods =
-                LifecycleCallbackFactory.beforeMappingMethods( method, ctx );
+                LifecycleCallbackFactory.beforeMappingMethods( method, null, ctx );
             List<LifecycleCallbackMethodReference> afterMappingMethods =
-                LifecycleCallbackFactory.afterMappingMethods( method, ctx );
+                LifecycleCallbackFactory.afterMappingMethods( method, null, ctx );
 
             return new MapMappingMethod(
                 method,

--- a/processor/src/main/java/org/mapstruct/ap/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/ForgedMethod.java
@@ -21,6 +21,7 @@ package org.mapstruct.ap.model.source;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
 import javax.lang.model.element.ExecutableElement;
 
 import org.mapstruct.ap.model.common.Accessibility;
@@ -28,6 +29,8 @@ import org.mapstruct.ap.model.common.Parameter;
 import org.mapstruct.ap.model.common.Type;
 import org.mapstruct.ap.util.MapperConfiguration;
 import org.mapstruct.ap.util.Strings;
+
+import static org.mapstruct.ap.util.Collections.first;
 
 /**
  * This method will be generated in absence of a suitable abstract method to implement.
@@ -74,17 +77,17 @@ public class ForgedMethod implements Method {
     }
 
     @Override
-    public boolean matches(Type sourceTypes, Type targetType) {
+    public boolean matches(List<Type> sourceTypes, Type targetType) {
 
         if ( !targetType.equals( returnType ) ) {
             return false;
         }
 
-        if ( parameters.size() != 1 ) {
+        if ( parameters.size() != 1 || sourceTypes.size() != 1 ) {
             return false;
         }
 
-        if ( !sourceTypes.equals( parameters.get( 0 ).getType() ) ) {
+        if ( !first( sourceTypes ).equals( parameters.get( 0 ).getType() ) ) {
             return false;
         }
 
@@ -167,6 +170,11 @@ public class ForgedMethod implements Method {
     @Override
     public ExecutableElement getExecutable() {
         return positionHintElement;
+    }
+
+    @Override
+    public boolean isLifecycleCallbackMethod() {
+        return false;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/model/source/Method.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/Method.java
@@ -29,9 +29,8 @@ import org.mapstruct.ap.model.source.builtin.BuiltInMethod;
 import org.mapstruct.ap.util.MapperConfiguration;
 
 /**
- * This interface makes available common method properties and a matching method
- *
- * There are 2 known implementors: {@link BuiltInMethod} and {@link Method}
+ * This interface makes available common method properties and a matching method There are 2 known implementors:
+ * {@link BuiltInMethod} and {@link SourceMethod}
  *
  * @author Sjaak Derksen
  */
@@ -41,12 +40,12 @@ public interface Method {
      * Checks whether the provided sourceType and provided targetType match with the parameter respectively return type
      * of the method. The check also should incorporate wild card and generic type variables
      *
-     * @param sourceType the sourceType to match to the parameter
+     * @param sourceTypes the sourceTypes to match to the parameter
      * @param targetType the targetType to match to the returnType
      *
      * @return true when match
      */
-    boolean matches(Type sourceType, Type targetType );
+    boolean matches(List<Type> sourceTypes, Type targetType );
 
     /**
      * Returns the mapper type declaring this method if it is not declared by the mapper interface currently processed
@@ -150,4 +149,9 @@ public interface Method {
      * @return the mapper config when this method needs to be implemented
      */
     MapperConfiguration getMapperConfiguration();
+
+    /*
+     * @return {@code true}, if the method represents a mapping lifecycle callback (Before/After mapping method)
+     */
+    boolean isLifecycleCallbackMethod();
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/source/MethodMatcher.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/MethodMatcher.java
@@ -38,6 +38,7 @@ import org.mapstruct.ap.model.common.Parameter;
 import org.mapstruct.ap.model.common.Type;
 import org.mapstruct.ap.model.common.TypeFactory;
 
+import static org.mapstruct.ap.util.Collections.hasNonNullElements;
 import static org.mapstruct.ap.util.SpecificCompilerWorkarounds.isSubType;
 
 /**
@@ -146,7 +147,7 @@ public class MethodMatcher {
                                     Type candidateSourceType,
                                     Map<TypeVariable, TypeMirror> genericTypesMap) {
 
-        if ( isNotObjectClass( candidateSourceType.getTypeMirror() ) ) {
+        if ( !isJavaLangObject( candidateSourceType.getTypeMirror() ) ) {
             TypeMatcher parameterMatcher = new TypeMatcher( Assignability.VISITED_ASSIGNABLE_FROM, genericTypesMap );
             if ( !parameterMatcher.visit( candidateSourceType.getTypeMirror(), sourceType.getTypeMirror() ) ) {
                 if ( sourceType.isPrimitive() ) {
@@ -171,7 +172,7 @@ public class MethodMatcher {
                                     Map<TypeVariable, TypeMirror> genericTypesMap) {
 
 
-        if ( isNotObjectClass( candidateResultType.getTypeMirror() ) && !candidateResultType.isVoid() ) {
+        if ( !isJavaLangObject( candidateResultType.getTypeMirror() ) && !candidateResultType.isVoid() ) {
 
             TypeMatcher returnTypeMatcher = new TypeMatcher( Assignability.VISITED_ASSIGNABLE_TO, genericTypesMap );
             if ( !returnTypeMatcher.visit( candidateResultType.getTypeMirror(), resultType.getTypeMirror() ) ) {
@@ -205,23 +206,12 @@ public class MethodMatcher {
 
     /**
      * @param type the type
-     * @return {@code true}, if the type does NOT represent java.lang.Object
+     * @return {@code true}, if the type represents java.lang.Object
      */
-    private boolean isNotObjectClass(TypeMirror type) {
-        return !( type.getKind() == TypeKind.DECLARED
-                        && ( (TypeElement) ( (DeclaredType) type ).asElement() ).getQualifiedName().contentEquals(
-                            Object.class.getName() ) );
-    }
-
-    private static <E> boolean hasNonNullElements(List<E> elements) {
-        if ( elements != null ) {
-            for ( E e : elements ) {
-                if ( e != null ) {
-                    return true;
-                }
-            }
-        }
-        return false;
+    private boolean isJavaLangObject(TypeMirror type) {
+        return type.getKind() == TypeKind.DECLARED
+            && ( (TypeElement) ( (DeclaredType) type ).asElement() ).getQualifiedName().contentEquals(
+                Object.class.getName() );
     }
 
     private enum Assignability {

--- a/processor/src/main/java/org/mapstruct/ap/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/SourceMethod.java
@@ -34,8 +34,7 @@ import org.mapstruct.ap.model.common.Parameter;
 import org.mapstruct.ap.model.common.Type;
 import org.mapstruct.ap.model.common.TypeFactory;
 import org.mapstruct.ap.model.source.SourceReference.PropertyEntry;
-import org.mapstruct.ap.prism.AfterMappingPrism;
-import org.mapstruct.ap.prism.BeforeMappingPrism;
+import org.mapstruct.ap.util.Executables;
 import org.mapstruct.ap.util.FormattingMessager;
 import org.mapstruct.ap.util.MapperConfiguration;
 import org.mapstruct.ap.util.Strings;
@@ -520,26 +519,14 @@ public class SourceMethod implements Method {
 
     @Override
     public boolean isLifecycleCallbackMethod() {
-        return isBeforeMappingMethod() || isAfterMappingMethod();
+        return Executables.isLifecycleCallbackMethod( getExecutable() );
     }
 
     public boolean isAfterMappingMethod() {
-        return isAfterMappingMethod( getExecutable() );
+        return Executables.isAfterMappingMethod( getExecutable() );
     }
 
     public boolean isBeforeMappingMethod() {
-        return isBeforeMappingMethod( getExecutable() );
-    }
-
-    public static boolean isLifecycleCallbackMethod(ExecutableElement executableElement) {
-        return isBeforeMappingMethod( executableElement ) || isAfterMappingMethod( executableElement );
-    }
-
-    private static boolean isAfterMappingMethod(ExecutableElement executableElement) {
-        return AfterMappingPrism.getInstanceOn( executableElement ) != null;
-    }
-
-    private static boolean isBeforeMappingMethod(ExecutableElement executableElement) {
-        return BeforeMappingPrism.getInstanceOn( executableElement ) != null;
+        return Executables.isBeforeMappingMethod( getExecutable() );
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/SourceMethod.java
@@ -34,6 +34,8 @@ import org.mapstruct.ap.model.common.Parameter;
 import org.mapstruct.ap.model.common.Type;
 import org.mapstruct.ap.model.common.TypeFactory;
 import org.mapstruct.ap.model.source.SourceReference.PropertyEntry;
+import org.mapstruct.ap.prism.AfterMappingPrism;
+import org.mapstruct.ap.prism.BeforeMappingPrism;
 import org.mapstruct.ap.util.FormattingMessager;
 import org.mapstruct.ap.util.MapperConfiguration;
 import org.mapstruct.ap.util.Strings;
@@ -476,9 +478,9 @@ public class SourceMethod implements Method {
      * {@inheritDoc} {@link Method}
      */
     @Override
-    public boolean matches(Type sourceType, Type targetType) {
+    public boolean matches(List<Type> sourceTypes, Type targetType) {
         MethodMatcher matcher = new MethodMatcher( typeUtils, typeFactory, this );
-        return matcher.matches( sourceType, targetType );
+        return matcher.matches( sourceTypes, targetType );
     }
 
     /**
@@ -516,4 +518,28 @@ public class SourceMethod implements Method {
         return config;
     }
 
+    @Override
+    public boolean isLifecycleCallbackMethod() {
+        return isBeforeMappingMethod() || isAfterMappingMethod();
+    }
+
+    public boolean isAfterMappingMethod() {
+        return isAfterMappingMethod( getExecutable() );
+    }
+
+    public boolean isBeforeMappingMethod() {
+        return isBeforeMappingMethod( getExecutable() );
+    }
+
+    public static boolean isLifecycleCallbackMethod(ExecutableElement executableElement) {
+        return isBeforeMappingMethod( executableElement ) || isAfterMappingMethod( executableElement );
+    }
+
+    private static boolean isAfterMappingMethod(ExecutableElement executableElement) {
+        return AfterMappingPrism.getInstanceOn( executableElement ) != null;
+    }
+
+    private static boolean isBeforeMappingMethod(ExecutableElement executableElement) {
+        return BeforeMappingPrism.getInstanceOn( executableElement ) != null;
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/source/builtin/BuiltInMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/builtin/BuiltInMethod.java
@@ -35,6 +35,8 @@ import org.mapstruct.ap.model.source.Method;
 import org.mapstruct.ap.util.MapperConfiguration;
 import org.mapstruct.ap.util.Strings;
 
+import static org.mapstruct.ap.util.Collections.first;
+
 /**
  * Represents a "built-in" mapping method which will be added as private method to the generated mapper. Built-in
  * methods are used in cases where a {@link SimpleConversion} doesn't suffice, e.g. as several lines of source code or a
@@ -72,7 +74,12 @@ public abstract class BuiltInMethod implements Method {
      * excluding generic type variables. When the implementor sees a need for this, this method can be overridden.
      */
     @Override
-    public boolean matches(Type sourceType, Type targetType) {
+    public boolean matches(List<Type> sourceTypes, Type targetType) {
+        if ( sourceTypes.size() != 1 ) {
+            return false;
+        }
+
+        Type sourceType = first( sourceTypes );
 
         if ( getReturnType().isAssignableTo( targetType.erasure() )
             && sourceType.erasure().isAssignableTo( getParameter().getType() ) ) {
@@ -235,5 +242,10 @@ public abstract class BuiltInMethod implements Method {
     @Override
     public MapperConfiguration getMapperConfiguration() {
         return null;
+    }
+
+    @Override
+    public boolean isLifecycleCallbackMethod() {
+        return false;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/QualifierSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/QualifierSelector.java
@@ -34,16 +34,18 @@ import org.mapstruct.ap.model.source.SourceMethod;
 import org.mapstruct.ap.prism.QualifierPrism;
 
 /**
- * This selector selects a best match based on qualifiers name.
+ * This selector selects a best match based on qualifier annotations.
  * <p>
  * A method is said to be marked with a qualifier annotation if the class in which it resides is annotated with a
  * qualifier annotation or if the method itself is annotated with a qualifier annotation or both.
  * <p>
  * Rules:
  * <ol>
- * <li>If a method is marked with a qualifier annotation, it does not contribute to a match otherwise and is hence
- * removed from the list of potential mapping methods</li>
- * <li>If multiple qualifiers (qualifedBy) are specified, all should match to make a match.</li>
+ * <li>If no qualifiers are requested in the selection criteria, then only candidate methods without any qualifier
+ * annotations remain in the list of potential candidates</li>
+ * <li>If multiple qualifiers (qualifedBy) are specified, then all of them need to be present at a candidate for it to
+ * match.</li>
+ * <li>If no candidate matches the required qualifiers, then all candidates are returned.</li>
  * </ol>
  *
  * @author Sjaak Derksen

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/TypeSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/TypeSelector.java
@@ -19,6 +19,7 @@
 package org.mapstruct.ap.model.source.selector;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.mapstruct.ap.model.common.Type;
@@ -40,7 +41,7 @@ public class TypeSelector implements MethodSelector {
 
         List<T> result = new ArrayList<T>();
         for ( T method : methods ) {
-            if ( method.matches( sourceType, targetType ) ) {
+            if ( !method.isLifecycleCallbackMethod() && method.matches( Arrays.asList( sourceType ), targetType ) ) {
                 result.add( method );
             }
         }

--- a/processor/src/main/java/org/mapstruct/ap/prism/PrismGenerator.java
+++ b/processor/src/main/java/org/mapstruct/ap/prism/PrismGenerator.java
@@ -22,7 +22,10 @@ import javax.xml.bind.annotation.XmlElementDecl;
 
 import net.java.dev.hickory.prism.GeneratePrism;
 import net.java.dev.hickory.prism.GeneratePrisms;
+
+import org.mapstruct.AfterMapping;
 import org.mapstruct.BeanMapping;
+import org.mapstruct.BeforeMapping;
 import org.mapstruct.DecoratedWith;
 import org.mapstruct.InheritConfiguration;
 import org.mapstruct.InheritInverseConfiguration;
@@ -55,6 +58,8 @@ import org.mapstruct.TargetType;
     @GeneratePrism(value = InheritConfiguration.class, publicAccess = true),
     @GeneratePrism(value = InheritInverseConfiguration.class, publicAccess = true),
     @GeneratePrism(value = Qualifier.class, publicAccess = true),
+    @GeneratePrism(value = AfterMapping.class, publicAccess = true),
+    @GeneratePrism(value = BeforeMapping.class, publicAccess = true),
 
     // external types
     @GeneratePrism(value = XmlElementDecl.class, publicAccess = true)

--- a/processor/src/main/java/org/mapstruct/ap/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/MethodRetrievalProcessor.java
@@ -48,6 +48,7 @@ import org.mapstruct.ap.prism.MapMappingPrism;
 import org.mapstruct.ap.prism.MappingPrism;
 import org.mapstruct.ap.prism.MappingsPrism;
 import org.mapstruct.ap.util.AnnotationProcessingException;
+import org.mapstruct.ap.util.Executables;
 import org.mapstruct.ap.util.FormattingMessager;
 import org.mapstruct.ap.util.MapperConfiguration;
 import org.mapstruct.ap.util.Message;
@@ -272,7 +273,7 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
     }
 
     private boolean isValidLifecycleCallbackMethod(ExecutableElement method, Type returnType) {
-        return isVoid( returnType ) && SourceMethod.isLifecycleCallbackMethod( method );
+        return isVoid( returnType ) && Executables.isLifecycleCallbackMethod( method );
     }
 
     private boolean isValidReferencedMethod(List<Parameter> parameters) {

--- a/processor/src/main/java/org/mapstruct/ap/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/creation/MappingResolverImpl.java
@@ -419,14 +419,17 @@ public class MappingResolverImpl implements MappingResolver {
 
         private boolean isCreateMethodForMapping(Method methodCandidate) {
             // a create method may not return void and has no target parameter
-            return methodCandidate.getSourceParameters().size() == 1 && !methodCandidate.getReturnType().isVoid()
-                && methodCandidate.getMappingTargetParameter() == null;
+            return methodCandidate.getSourceParameters().size() == 1
+                && !methodCandidate.getReturnType().isVoid()
+                && methodCandidate.getMappingTargetParameter() == null
+                && !methodCandidate.isLifecycleCallbackMethod();
         }
 
         private boolean isUpdateMethodForMapping(Method methodCandidate) {
             // an update method may, or may not return void and has a target parameter
             return methodCandidate.getSourceParameters().size() == 1
-                && methodCandidate.getMappingTargetParameter() != null;
+                && methodCandidate.getMappingTargetParameter() != null
+                && !methodCandidate.isLifecycleCallbackMethod();
         }
 
         private <T extends Method> T getBestMatch(List<T> methods, Type sourceType, Type returnType) {

--- a/processor/src/main/java/org/mapstruct/ap/util/Collections.java
+++ b/processor/src/main/java/org/mapstruct/ap/util/Collections.java
@@ -85,4 +85,15 @@ public class Collections {
 
         return result;
     }
+
+    public static <E> boolean hasNonNullElements(Iterable<E> elements) {
+        if ( elements != null ) {
+            for ( E e : elements ) {
+                if ( e != null ) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/util/Executables.java
+++ b/processor/src/main/java/org/mapstruct/ap/util/Executables.java
@@ -34,6 +34,9 @@ import org.mapstruct.ap.services.Services;
 import org.mapstruct.ap.spi.AccessorNamingStrategy;
 import org.mapstruct.ap.spi.MethodType;
 
+import org.mapstruct.ap.prism.AfterMappingPrism;
+import org.mapstruct.ap.prism.BeforeMappingPrism;
+
 import static javax.lang.model.util.ElementFilter.methodsIn;
 import static org.mapstruct.ap.util.SpecificCompilerWorkarounds.replaceTypeElementIfNecessary;
 
@@ -163,7 +166,7 @@ public class Executables {
             }
         }
 
-        alreadyCollected.addAll( safeToAdd );
+        alreadyCollected.addAll( 0, safeToAdd );
     }
 
     /**
@@ -208,5 +211,30 @@ public class Executables {
     private static boolean hasNonObjectSuperclass(TypeElement element) {
         return element.getSuperclass().getKind() == TypeKind.DECLARED
             && asTypeElement( element.getSuperclass() ).getSuperclass().getKind() == TypeKind.DECLARED;
+    }
+
+    /**
+     * @param executableElement the element to check
+     * @return {@code true}, if the executable element is a method annotated with {@code @BeforeMapping} or
+     *         {@code @AfterMapping}
+     */
+    public static boolean isLifecycleCallbackMethod(ExecutableElement executableElement) {
+        return isBeforeMappingMethod( executableElement ) || isAfterMappingMethod( executableElement );
+    }
+
+    /**
+     * @param executableElement the element to check
+     * @return {@code true}, if the executable element is a method annotated with {@code @AfterMapping}
+     */
+    public static boolean isAfterMappingMethod(ExecutableElement executableElement) {
+        return AfterMappingPrism.getInstanceOn( executableElement ) != null;
+    }
+
+    /**
+     * @param executableElement the element to check
+     * @return {@code true}, if the executable element is a method annotated with {@code @BeforeMapping}
+     */
+    public static boolean isBeforeMappingMethod(ExecutableElement executableElement) {
+        return BeforeMappingPrism.getInstanceOn( executableElement ) != null;
     }
 }

--- a/processor/src/main/resources/org.mapstruct.ap.model.BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.BeanMappingMethod.ftl
@@ -20,13 +20,28 @@
 -->
 @Override
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
+    <#list beforeMappingReferencesWithoutMappingTarget as callback>
+    	<@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+    	<#if !callback_has_next>
+
+    	</#if>
+    </#list>
     <#if !mapNullToDefault>
     if ( <#list sourceParametersExcludingPrimitives as sourceParam>${sourceParam.name} == null<#if sourceParam_has_next> && </#if></#list> ) {
         return<#if returnType.name != "void"> null</#if>;
     }
     </#if>
 
-    <#if !existingInstanceMapping><@includeModel object=resultType/> ${resultName} = <#if factoryMethod??><@includeModel object=factoryMethod targetType=resultType/><#else>new <@includeModel object=resultType/>()</#if>;</#if>
+    <#if !existingInstanceMapping>
+        <@includeModel object=resultType/> ${resultName} = <#if factoryMethod??><@includeModel object=factoryMethod targetType=resultType/><#else>new <@includeModel object=resultType/>()</#if>;
+
+    </#if>
+    <#list beforeMappingReferencesWithMappingTarget as callback>
+    	<@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+    	<#if !callback_has_next>
+
+    	</#if>
+    </#list>
     <#if (sourceParameters?size > 1)>
         <#list sourceParametersExcludingPrimitives as sourceParam>
             <#if (propertyMappingsByParameter[sourceParam.name]?size > 0)>
@@ -53,6 +68,12 @@
     </#if>
     <#list constantMappings as constantMapping>
          <@includeModel object=constantMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping/>
+    </#list>
+    <#list afterMappingReferences as callback>
+    	<#if callback_index = 0>
+
+    	</#if>
+    	<@includeModel object=callback targetBeanName=resultName targetType=resultType/>
     </#list>
     <#if returnType.name != "void">
 

--- a/processor/src/main/resources/org.mapstruct.ap.model.EnumMappingMethod.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.EnumMappingMethod.ftl
@@ -20,6 +20,12 @@
 -->
 @Override
 public <@includeModel object=returnType/> ${name}(<@includeModel object=sourceParameter/>) {
+    <#list beforeMappingReferencesWithoutMappingTarget as callback>
+        <@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+        <#if !callback_has_next>
+
+        </#if>
+    </#list>
     if ( ${sourceParameter.name} == null ) {
         return  null;
     }
@@ -33,6 +39,18 @@ public <@includeModel object=returnType/> ${name}(<@includeModel object=sourcePa
     </#list>
     default: throw new IllegalArgumentException( "Unexpected enum constant: " + ${sourceParameter.name} );
     }
+    <#list beforeMappingReferencesWithMappingTarget as callback>
+        <#if callback_index = 0>
+
+        </#if>
+        <@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+    </#list>
+    <#list afterMappingReferences as callback>
+        <#if callback_index = 0>
+
+        </#if>
+        <@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+    </#list>
 
     return ${resultName};
 }

--- a/processor/src/main/resources/org.mapstruct.ap.model.IterableMappingMethod.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.IterableMappingMethod.ftl
@@ -20,6 +20,12 @@
 -->
 <#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
+    <#list beforeMappingReferencesWithoutMappingTarget as callback>
+    	<@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+    	<#if !callback_has_next>
+
+    	</#if>
+    </#list>
     if ( ${sourceParameter.name} == null ) {
         <#if !mapNullToDefault>
             <#-- returned target type starts to miss-align here with target handed via param, TODO is this right? -->
@@ -50,6 +56,21 @@
         <#if !existingInstanceMapping>
             <@includeModel object=resultElementType/>[] ${resultName} = new <@includeModel object=resultElementType/>[<@iterableSize/>];
         </#if>
+    <#else>
+        <#if existingInstanceMapping>
+            ${resultName}.clear();
+        <#else>
+            <#-- Use the interface type on the left side, except it is java.lang.Iterable; use the implementation type - if present - on the right side -->
+            <@iterableLocalVarDef/> ${resultName} = <@iterableCreation/>;
+        </#if>
+    </#if>
+    <#list beforeMappingReferencesWithMappingTarget as callback>
+    	<@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+    	<#if !callback_has_next>
+
+    	</#if>
+    </#list>
+    <#if resultType.arrayType>
         int ${index1Name} = 0;
         for ( <@includeModel object=sourceElementType/> ${loopVariableName} : ${sourceParameter.name} ) {
             <#if existingInstanceMapping>
@@ -61,17 +82,16 @@
             ${index1Name}++;
         }
     <#else>
-        <#if existingInstanceMapping>
-            ${resultName}.clear();
-        <#else>
-            <#-- Use the interface type on the left side, except it is java.lang.Iterable; use the implementation type - if present - on the right side -->
-            <@iterableLocalVarDef/> ${resultName} = <@iterableCreation/>;
-        </#if>
-
         for ( <@includeModel object=sourceElementType/> ${loopVariableName} : ${sourceParameter.name} ) {
             <@includeModel object=elementAssignment targetBeanName=resultName targetWriteAccessorName="add" targetType=resultElementType/>
         }
     </#if>
+    <#list afterMappingReferences as callback>
+    	<#if callback_index = 0>
+
+    	</#if>
+    	<@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+    </#list>
 
     <#if returnType.name != "void">
         return ${resultName};

--- a/processor/src/main/resources/org.mapstruct.ap.model.LifecycleCallbackMethodReference.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.LifecycleCallbackMethodReference.ftl
@@ -1,0 +1,21 @@
+<#--
+
+     Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+     and/or other contributors as indicated by the @authors tag. See the
+     copyright.txt file in the distribution for a full listing of all
+     contributors.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<#if declaringType??>${instanceVariableName}.</#if>${name}(<#list parameterAssignments as param> <#if param.targetType><@includeModel object=ext.targetType raw=true/>.class<#elseif param.mappingTarget>${ext.targetBeanName}<#else>${param.name}</#if><#if param_has_next>,<#else> </#if></#list>);

--- a/processor/src/main/resources/org.mapstruct.ap.model.MapMappingMethod.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.MapMappingMethod.ftl
@@ -20,6 +20,12 @@
 -->
 <#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType /> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
+    <#list beforeMappingReferencesWithoutMappingTarget as callback>
+    	<@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+    	<#if !callback_has_next>
+
+    	</#if>
+    </#list>
     if ( ${sourceParameter.name} == null ) {
         <#if !mapNullToDefault>
             return<#if returnType.name != "void"> null</#if>;
@@ -39,6 +45,12 @@
         <@includeModel object=resultType /> ${resultName} = <@returnObjectCreation/>;
     </#if>
 
+    <#list beforeMappingReferencesWithMappingTarget as callback>
+        <@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+        <#if !callback_has_next>
+
+        </#if>
+    </#list>
     <#-- Once #148 has been addressed, the simple name of Map.Entry can be used -->
     for ( java.util.Map.Entry<<#list sourceParameter.type.typeParameters as typeParameter><@includeModel object=typeParameter /><#if typeParameter_has_next>, </#if></#list>> ${entryVariableName} : ${sourceParameter.name}.entrySet() ) {
     <#-- key -->
@@ -51,6 +63,12 @@
                    targetType=resultType.typeParameters[1].typeBound/>
         ${resultName}.put( ${keyVariableName}, ${valueVariableName} );
     }
+    <#list afterMappingReferences as callback>
+    	<#if callback_index = 0>
+
+    	</#if>
+    	<@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+    </#list>
     <#if returnType.name != "void">
 
         return ${resultName};

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/BaseMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/BaseMapper.java
@@ -53,6 +53,11 @@ public abstract class BaseMapper {
     }
 
     @BeforeMapping
+    public void withSourceBeforeMapping(SourceEnum source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
     public void withSourceBeforeMapping(List<Source> source) {
         INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
     }
@@ -85,6 +90,11 @@ public abstract class BaseMapper {
     }
 
     @BeforeMapping
+    public <T> void withSourceAndTargetTypeBeforeMapping(SourceEnum source, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
+    }
+
+    @BeforeMapping
     public <T> void withSourceAndTargetTypeBeforeMapping(List<Source> source, @TargetType Class<T> targetClass) {
         INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
     }
@@ -96,6 +106,11 @@ public abstract class BaseMapper {
 
     @BeforeMapping
     public void withSourceAndTargetBeforeMapping(Source source, @MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetBeforeMapping", source, target ) );
+    }
+
+    @BeforeMapping
+    public void withSourceAndTargetBeforeMapping(SourceEnum source, @MappingTarget TargetEnum target) {
         INVOCATIONS.add( new Invocation( "withSourceAndTargetBeforeMapping", source, target ) );
     }
 
@@ -112,6 +127,11 @@ public abstract class BaseMapper {
 
     @BeforeMapping
     public void withTargetBeforeMapping(@MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withTargetBeforeMapping", target ) );
+    }
+
+    @BeforeMapping
+    public void withTargetBeforeMapping(@MappingTarget TargetEnum target) {
         INVOCATIONS.add( new Invocation( "withTargetBeforeMapping", target ) );
     }
 
@@ -141,6 +161,11 @@ public abstract class BaseMapper {
     }
 
     @AfterMapping
+    public void withSourceAfterMapping(SourceEnum source) {
+        INVOCATIONS.add( new Invocation( "withSourceAfterMapping", source ) );
+    }
+
+    @AfterMapping
     public void withSourceAfterMapping(List<Source> source) {
         INVOCATIONS.add( new Invocation( "withSourceAfterMapping", source ) );
     }
@@ -161,6 +186,11 @@ public abstract class BaseMapper {
     }
 
     @AfterMapping
+    public void withSourceAndTargetAfterMapping(SourceEnum source, @MappingTarget TargetEnum target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetAfterMapping", source, target ) );
+    }
+
+    @AfterMapping
     public void withSourceAndTargetAfterMapping(List<Source> source, @MappingTarget List<Target> target) {
         INVOCATIONS.add( new Invocation( "withSourceAndTargetAfterMapping", source, target ) );
     }
@@ -172,6 +202,11 @@ public abstract class BaseMapper {
 
     @AfterMapping
     public void withTargetAfterMapping(@MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    public void withTargetAfterMapping(@MappingTarget TargetEnum target) {
         INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/BaseMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/BaseMapper.java
@@ -47,13 +47,31 @@ public abstract class BaseMapper {
     }
 
     @BeforeMapping
+    @Qualified
+    public void withSourceBeforeMappingQualified(Source source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMappingQualified", source ) );
+    }
+
+    @BeforeMapping
     public void withSourceBeforeMapping(List<Source> source) {
         INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
     }
 
     @BeforeMapping
+    @Qualified
+    public void withSourceBeforeMappingQualified(List<Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMappingQualified", source ) );
+    }
+
+    @BeforeMapping
     public void withSourceBeforeMapping(Map<String, Source> source) {
         INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
+    @Qualified
+    public void withSourceBeforeMappingQualified(Map<String, Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMappingQualified", source ) );
     }
 
     @BeforeMapping
@@ -158,13 +176,31 @@ public abstract class BaseMapper {
     }
 
     @AfterMapping
+    @Qualified
+    public void withTargetAfterMappingQualified(@MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMappingQualified", target ) );
+    }
+
+    @AfterMapping
     public void withTargetAfterMapping(@MappingTarget List<Target> target) {
         INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
     }
 
     @AfterMapping
+    @Qualified
+    public void withTargetAfterMappingQualified(@MappingTarget List<Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMappingQualified", target ) );
+    }
+
+    @AfterMapping
     public void withTargetAfterMapping(@MappingTarget Map<String, Target> target) {
         INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    @Qualified
+    public void withTargetAfterMappingQualified(@MappingTarget Map<String, Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMappingQualified", target ) );
     }
 
     @AfterMapping
@@ -184,5 +220,4 @@ public abstract class BaseMapper {
     public static void reset() {
         INVOCATIONS.clear();
     }
-
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/BaseMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/BaseMapper.java
@@ -1,0 +1,188 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.BeforeMapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.TargetType;
+
+/**
+ * @author Andreas Gudian
+ */
+public abstract class BaseMapper {
+
+    public abstract Target sourceToTarget(Source source);
+
+    private static final List<Invocation> INVOCATIONS = new ArrayList<Invocation>();
+
+    @BeforeMapping
+    public void noArgsBeforeMapping() {
+        INVOCATIONS.add( new Invocation( "noArgsBeforeMapping" ) );
+    }
+
+    @BeforeMapping
+    public void withSourceBeforeMapping(Source source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
+    public void withSourceBeforeMapping(List<Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
+    public void withSourceBeforeMapping(Map<String, Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
+    public void withSourceAsObjectBeforeMapping(Object source) {
+        INVOCATIONS.add( new Invocation( "withSourceAsObjectBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
+    public <T> void withSourceAndTargetTypeBeforeMapping(Source source, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
+    }
+
+    @BeforeMapping
+    public <T> void withSourceAndTargetTypeBeforeMapping(List<Source> source, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
+    }
+
+    @BeforeMapping
+    public <T> void withSourceAndTargetTypeBeforeMapping(Map<String, Source> source, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
+    }
+
+    @BeforeMapping
+    public void withSourceAndTargetBeforeMapping(Source source, @MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetBeforeMapping", source, target ) );
+    }
+
+    @BeforeMapping
+    public void withSourceAndTargetBeforeMapping(List<Source> source, @MappingTarget List<Target> target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetBeforeMapping", source, target ) );
+    }
+
+    @BeforeMapping
+    public void withSourceAndTargetBeforeMapping(Map<String, Source> source,
+                                                 @MappingTarget Map<String, Target> target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetBeforeMapping", source, target ) );
+    }
+
+    @BeforeMapping
+    public void withTargetBeforeMapping(@MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withTargetBeforeMapping", target ) );
+    }
+
+    @BeforeMapping
+    public void withTargetBeforeMapping(@MappingTarget List<Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetBeforeMapping", target ) );
+    }
+
+    @BeforeMapping
+    public void withTargetBeforeMapping(@MappingTarget Map<String, Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetBeforeMapping", target ) );
+    }
+
+    @BeforeMapping
+    public void withTargetAsObjectBeforeMapping(@MappingTarget Object target) {
+        INVOCATIONS.add( new Invocation( "withTargetAsObjectBeforeMapping", target ) );
+    }
+
+    @AfterMapping
+    public void noArgsAfterMapping() {
+        INVOCATIONS.add( new Invocation( "noArgsAfterMapping" ) );
+    }
+
+    @AfterMapping
+    public void withSourceAfterMapping(Source source) {
+        INVOCATIONS.add( new Invocation( "withSourceAfterMapping", source ) );
+    }
+
+    @AfterMapping
+    public void withSourceAfterMapping(List<Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceAfterMapping", source ) );
+    }
+
+    @AfterMapping
+    public void withSourceAfterMapping(Map<String, Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceAfterMapping", source ) );
+    }
+
+    @AfterMapping
+    public void withSourceAsObjectAfterMapping(Object source) {
+        INVOCATIONS.add( new Invocation( "withSourceAsObjectAfterMapping", source ) );
+    }
+
+    @AfterMapping
+    public void withSourceAndTargetAfterMapping(Source source, @MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetAfterMapping", source, target ) );
+    }
+
+    @AfterMapping
+    public void withSourceAndTargetAfterMapping(List<Source> source, @MappingTarget List<Target> target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetAfterMapping", source, target ) );
+    }
+
+    @AfterMapping
+    public void withSourceAndTargetAfterMapping(Map<String, Source> source, @MappingTarget Map<String, Target> target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetAfterMapping", source, target ) );
+    }
+
+    @AfterMapping
+    public void withTargetAfterMapping(@MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    public void withTargetAfterMapping(@MappingTarget List<Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    public void withTargetAfterMapping(@MappingTarget Map<String, Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    public void withTargetAsObjectAfterMapping(@MappingTarget Object target) {
+        INVOCATIONS.add( new Invocation( "withTargetAsObjectAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    public <T> void withTargetAndTargetTypeAfterMapping(@MappingTarget T target, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withTargetAndTargetTypeAfterMapping", target, targetClass ) );
+    }
+
+    public static List<Invocation> getInvocations() {
+        return INVOCATIONS;
+    }
+
+    public static void reset() {
+        INVOCATIONS.clear();
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/CallbackMethodTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/CallbackMethodTest.java
@@ -1,0 +1,220 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.fest.assertions.Assertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.AfterMapping;
+import org.mapstruct.BeforeMapping;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Test for callback methods that are defined using {@link BeforeMapping} / {@link AfterMapping}
+ *
+ * @author Andreas Gudian
+ */
+@RunWith( AnnotationProcessorTestRunner.class )
+@WithClasses( { ClassContainingCallbacks.class, Invocation.class, Source.class, Target.class, SourceTargetMapper.class,
+    SourceTargetCollectionMapper.class, BaseMapper.class } )
+@IssueKey("14")
+public class CallbackMethodTest {
+
+    @Before
+    public void reset() {
+        ClassContainingCallbacks.reset();
+        BaseMapper.reset();
+    }
+
+    @Test
+    public void callbackMethodsForBeanMappingCalled() {
+        SourceTargetMapper.INSTANCE.sourceToTarget( createSource() );
+
+        assertBeanMappingInvocations( ClassContainingCallbacks.getInvocations() );
+        assertBeanMappingInvocations( BaseMapper.getInvocations() );
+    }
+
+    @Test
+    public void callbackMethodsForBeanMappingWithResultParamCalled() {
+        SourceTargetMapper.INSTANCE.sourceToTarget( createSource(), createEmptyTarget() );
+
+        assertBeanMappingInvocations( ClassContainingCallbacks.getInvocations() );
+        assertBeanMappingInvocations( BaseMapper.getInvocations() );
+    }
+
+    @Test
+    public void callbackMethodsForIterableMappingCalled() {
+        SourceTargetCollectionMapper.INSTANCE.sourceToTarget( Arrays.asList( createSource() ) );
+
+        assertIterableMappingInvocations( ClassContainingCallbacks.getInvocations() );
+        assertIterableMappingInvocations( BaseMapper.getInvocations() );
+    }
+
+    @Test
+    public void callbackMethodsForIterableMappingWithResultParamCalled() {
+        SourceTargetCollectionMapper.INSTANCE.sourceToTarget(
+            Arrays.asList( createSource() ), new ArrayList<Target>() );
+
+        assertIterableMappingInvocations( ClassContainingCallbacks.getInvocations() );
+        assertIterableMappingInvocations( BaseMapper.getInvocations() );
+    }
+
+    @Test
+    public void callbackMethodsForMapMappingCalled() {
+        SourceTargetCollectionMapper.INSTANCE.sourceToTarget( toMap( "foo", createSource() ) );
+
+        assertMapMappingInvocations( ClassContainingCallbacks.getInvocations() );
+        assertMapMappingInvocations( BaseMapper.getInvocations() );
+    }
+
+    @Test
+    public void callbackMethodsForMapMappingWithResultParamCalled() {
+        SourceTargetCollectionMapper.INSTANCE.sourceToTarget(
+            toMap( "foo", createSource() ),
+            new HashMap<String, Target>() );
+
+        assertMapMappingInvocations( ClassContainingCallbacks.getInvocations() );
+        assertMapMappingInvocations( BaseMapper.getInvocations() );
+    }
+
+    private void assertBeanMappingInvocations(List<Invocation> invocations) {
+        Source source = createSource();
+        Target target = createResultTarget();
+        Target emptyTarget = createEmptyTarget();
+
+        Assertions.assertThat( invocations ).isEqualTo( beanMappingInvocationList( source, target, emptyTarget ) );
+    }
+
+    private void assertIterableMappingInvocations(List<Invocation> invocations) {
+        Source source = createSource();
+        List<Source> sourceList = Arrays.asList( source );
+
+        Target target = createResultTarget();
+        Target emptyTarget = createEmptyTarget();
+
+        List<Target> emptyTargetList = Collections.emptyList();
+        List<Target> targetList = Arrays.asList( target );
+
+        assertCollectionMappingInvocations(
+            invocations,
+            source,
+            sourceList,
+            target,
+            emptyTarget,
+            emptyTargetList,
+            targetList,
+            List.class );
+    }
+
+    private void assertMapMappingInvocations(List<Invocation> invocations) {
+        Source source = createSource();
+        Map<String, Source> sourceMap = toMap( "foo", source );
+
+        Target target = createResultTarget();
+        Target emptyTarget = createEmptyTarget();
+
+        Map<String, Target> emptyTargetMap = Collections.emptyMap();
+        Map<String, Target> targetMap = toMap( "foo", target );
+
+        assertCollectionMappingInvocations(
+            invocations,
+            source,
+            sourceMap,
+            target,
+            emptyTarget,
+            emptyTargetMap,
+            targetMap,
+            Map.class );
+    }
+
+    private <T> Map<String, T> toMap(String string, T value) {
+        Map<String, T> result = new HashMap<String, T>();
+        result.put( string, value );
+        return result;
+    }
+
+    private void assertCollectionMappingInvocations(List<Invocation> invocations, Object source,
+                                                    Object sourceCollection, Object target, Object emptyTarget,
+                                                    Object emptyTargetCollection, Object targetCollection,
+                                                    Class<?> targetCollectionClass) {
+        List<Invocation> expected =
+            allBeforeMappingMethods( sourceCollection, emptyTargetCollection, targetCollectionClass );
+        expected.addAll( beanMappingInvocationList( source, target, emptyTarget ) );
+        expected.addAll( allAfterMappingMethods( sourceCollection, targetCollection, targetCollectionClass ) );
+
+        Assertions.assertThat( invocations ).isEqualTo( expected );
+    }
+
+    private List<Invocation> beanMappingInvocationList(Object source, Object target, Object emptyTarget) {
+        List<Invocation> invocations = new ArrayList<Invocation>();
+
+        invocations.addAll( allBeforeMappingMethods( source, emptyTarget, Target.class ) );
+        invocations.addAll( allAfterMappingMethods( source, target, Target.class ) );
+
+        return invocations;
+    }
+
+    private List<Invocation> allAfterMappingMethods(Object source, Object target, Class<?> targetClass) {
+        return new ArrayList<Invocation>( Arrays.asList(
+            new Invocation( "noArgsAfterMapping" ),
+            new Invocation( "withSourceAfterMapping", source ),
+            new Invocation( "withSourceAsObjectAfterMapping", source ),
+            new Invocation( "withSourceAndTargetAfterMapping", source, target ),
+            new Invocation( "withTargetAfterMapping", target ),
+            new Invocation( "withTargetAsObjectAfterMapping", target ),
+            new Invocation( "withTargetAndTargetTypeAfterMapping", target, targetClass ) ) );
+    }
+
+    private List<Invocation> allBeforeMappingMethods(Object source, Object emptyTarget, Class<?> targetClass) {
+        return new ArrayList<Invocation>( Arrays.asList(
+            new Invocation( "noArgsBeforeMapping" ),
+            new Invocation( "withSourceBeforeMapping", source ),
+            new Invocation( "withSourceAsObjectBeforeMapping", source ),
+            new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ),
+            new Invocation( "withSourceAndTargetBeforeMapping", source, emptyTarget ),
+            new Invocation( "withTargetBeforeMapping", emptyTarget ),
+            new Invocation( "withTargetAsObjectBeforeMapping", emptyTarget ) ) );
+    }
+
+    private Source createSource() {
+        Source source = new Source();
+        source.setFoo( "foo" );
+        return source;
+    }
+
+    private Target createEmptyTarget() {
+        return new Target();
+    }
+
+    private Target createResultTarget() {
+        Target target = createEmptyTarget();
+        target.setFoo( "foo" );
+        return target;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/CallbackMethodTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/CallbackMethodTest.java
@@ -43,7 +43,8 @@ import static org.fest.assertions.Assertions.assertThat;
  */
 @RunWith( AnnotationProcessorTestRunner.class )
 @WithClasses( { ClassContainingCallbacks.class, Invocation.class, Source.class, Target.class, SourceTargetMapper.class,
-    SourceTargetCollectionMapper.class, BaseMapper.class, Qualified.class })
+    SourceTargetCollectionMapper.class, BaseMapper.class, Qualified.class,
+    SourceEnum.class, TargetEnum.class })
 @IssueKey("14")
 public class CallbackMethodTest {
 
@@ -119,6 +120,19 @@ public class CallbackMethodTest {
 
         assertQualifiedInvocations( ClassContainingCallbacks.getInvocations(), sourceList, targetList );
         assertQualifiedInvocations( BaseMapper.getInvocations(), sourceList, targetList );
+    }
+
+    @Test
+    public void callbackMethodsForEnumMappingCalled() {
+        SourceEnum source = SourceEnum.B;
+        TargetEnum target = SourceTargetMapper.INSTANCE.toTargetEnum( source );
+
+        List<Invocation> invocations = new ArrayList<Invocation>();
+        invocations.addAll( allBeforeMappingMethods( source, target, TargetEnum.class ) );
+        invocations.addAll( allAfterMappingMethods( source, target, TargetEnum.class ) );
+
+        assertThat( invocations ).isEqualTo( ClassContainingCallbacks.getInvocations() );
+        assertThat( invocations ).isEqualTo( BaseMapper.getInvocations() );
     }
 
     private void assertBeanMappingInvocations(List<Invocation> invocations) {

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ClassContainingCallbacks.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ClassContainingCallbacks.java
@@ -1,0 +1,184 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.BeforeMapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.TargetType;
+
+/**
+ * @author Andreas Gudian
+ */
+public class ClassContainingCallbacks {
+    private static final List<Invocation> INVOCATIONS = new ArrayList<Invocation>();
+
+    @BeforeMapping
+    public void noArgsBeforeMapping() {
+        INVOCATIONS.add( new Invocation( "noArgsBeforeMapping" ) );
+    }
+
+    @BeforeMapping
+    public void withSourceBeforeMapping(Source source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
+    public void withSourceBeforeMapping(List<Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
+    public void withSourceBeforeMapping(Map<String, Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
+    public void withSourceAsObjectBeforeMapping(Object source) {
+        INVOCATIONS.add( new Invocation( "withSourceAsObjectBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
+    public void withSourceAndTargetBeforeMapping(Source source, @MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetBeforeMapping", source, target ) );
+    }
+
+    @BeforeMapping
+    public void withSourceAndTargetBeforeMapping(List<Source> source, @MappingTarget List<Target> target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetBeforeMapping", source, target ) );
+    }
+
+    @BeforeMapping
+    public void withSourceAndTargetBeforeMapping(Map<String, Source> source,
+                                                 @MappingTarget Map<String, Target> target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetBeforeMapping", source, target ) );
+    }
+
+    @BeforeMapping
+    public void withTargetBeforeMapping(@MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withTargetBeforeMapping", target ) );
+    }
+
+    @BeforeMapping
+    public void withTargetBeforeMapping(@MappingTarget List<Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetBeforeMapping", target ) );
+    }
+
+    @BeforeMapping
+    public void withTargetBeforeMapping(@MappingTarget Map<String, Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetBeforeMapping", target ) );
+    }
+
+    @BeforeMapping
+    public void withTargetAsObjectBeforeMapping(@MappingTarget Object target) {
+        INVOCATIONS.add( new Invocation( "withTargetAsObjectBeforeMapping", target ) );
+    }
+
+    @BeforeMapping
+    public <T> void withSourceAndTargetTypeBeforeMapping(Source source, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
+    }
+
+    @BeforeMapping
+    public <T> void withSourceAndTargetTypeBeforeMapping(List<Source> source, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
+    }
+
+    @BeforeMapping
+    public <T> void withSourceAndTargetTypeBeforeMapping(Map<String, Source> source, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
+    }
+
+    @AfterMapping
+    public void noArgsAfterMapping() {
+        INVOCATIONS.add( new Invocation( "noArgsAfterMapping" ) );
+    }
+
+    @AfterMapping
+    public void withSourceAfterMapping(Source source) {
+        INVOCATIONS.add( new Invocation( "withSourceAfterMapping", source ) );
+    }
+
+    @AfterMapping
+    public void withSourceAfterMapping(List<Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceAfterMapping", source ) );
+    }
+
+    @AfterMapping
+    public void withSourceAfterMapping(Map<String, Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceAfterMapping", source ) );
+    }
+
+    @AfterMapping
+    public void withSourceAsObjectAfterMapping(Object source) {
+        INVOCATIONS.add( new Invocation( "withSourceAsObjectAfterMapping", source ) );
+    }
+
+    @AfterMapping
+    public void withSourceAndTargetAfterMapping(Source source, @MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetAfterMapping", source, target ) );
+    }
+
+    @AfterMapping
+    public void withSourceAndTargetAfterMapping(List<Source> source, @MappingTarget List<Target> target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetAfterMapping", source, target ) );
+    }
+
+    @AfterMapping
+    public void withSourceAndTargetAfterMapping(Map<String, Source> source, @MappingTarget Map<String, Target> target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetAfterMapping", source, target ) );
+    }
+
+    @AfterMapping
+    public void withTargetAfterMapping(@MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    public void withTargetAfterMapping(@MappingTarget List<Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    public void withTargetAfterMapping(@MappingTarget Map<String, Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    public void withTargetAsObjectAfterMapping(@MappingTarget Object target) {
+        INVOCATIONS.add( new Invocation( "withTargetAsObjectAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    public <T> void withTargetAndTargetTypeAfterMapping(@MappingTarget T target, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withTargetAndTargetTypeAfterMapping", target, targetClass ) );
+    }
+
+    public static List<Invocation> getInvocations() {
+        return INVOCATIONS;
+    }
+
+    public static void reset() {
+        INVOCATIONS.clear();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ClassContainingCallbacks.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ClassContainingCallbacks.java
@@ -50,6 +50,11 @@ public class ClassContainingCallbacks {
     }
 
     @BeforeMapping
+    public void withSourceBeforeMapping(SourceEnum source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
     public void withSourceBeforeMapping(List<Source> source) {
         INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
     }
@@ -82,6 +87,11 @@ public class ClassContainingCallbacks {
     }
 
     @BeforeMapping
+    public <T> void withSourceAndTargetTypeBeforeMapping(SourceEnum source, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
+    }
+
+    @BeforeMapping
     public <T> void withSourceAndTargetTypeBeforeMapping(List<Source> source, @TargetType Class<T> targetClass) {
         INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
     }
@@ -93,6 +103,11 @@ public class ClassContainingCallbacks {
 
     @BeforeMapping
     public void withSourceAndTargetBeforeMapping(Source source, @MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetBeforeMapping", source, target ) );
+    }
+
+    @BeforeMapping
+    public void withSourceAndTargetBeforeMapping(SourceEnum source, @MappingTarget TargetEnum target) {
         INVOCATIONS.add( new Invocation( "withSourceAndTargetBeforeMapping", source, target ) );
     }
 
@@ -109,6 +124,11 @@ public class ClassContainingCallbacks {
 
     @BeforeMapping
     public void withTargetBeforeMapping(@MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withTargetBeforeMapping", target ) );
+    }
+
+    @BeforeMapping
+    public void withTargetBeforeMapping(@MappingTarget TargetEnum target) {
         INVOCATIONS.add( new Invocation( "withTargetBeforeMapping", target ) );
     }
 
@@ -138,6 +158,11 @@ public class ClassContainingCallbacks {
     }
 
     @AfterMapping
+    public void withSourceAfterMapping(SourceEnum source) {
+        INVOCATIONS.add( new Invocation( "withSourceAfterMapping", source ) );
+    }
+
+    @AfterMapping
     public void withSourceAfterMapping(List<Source> source) {
         INVOCATIONS.add( new Invocation( "withSourceAfterMapping", source ) );
     }
@@ -158,6 +183,11 @@ public class ClassContainingCallbacks {
     }
 
     @AfterMapping
+    public void withSourceAndTargetAfterMapping(SourceEnum source, @MappingTarget TargetEnum target) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetAfterMapping", source, target ) );
+    }
+
+    @AfterMapping
     public void withSourceAndTargetAfterMapping(List<Source> source, @MappingTarget List<Target> target) {
         INVOCATIONS.add( new Invocation( "withSourceAndTargetAfterMapping", source, target ) );
     }
@@ -169,6 +199,11 @@ public class ClassContainingCallbacks {
 
     @AfterMapping
     public void withTargetAfterMapping(@MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    public void withTargetAfterMapping(@MappingTarget TargetEnum target) {
         INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ClassContainingCallbacks.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ClassContainingCallbacks.java
@@ -44,8 +44,20 @@ public class ClassContainingCallbacks {
     }
 
     @BeforeMapping
+    @Qualified
+    public void withSourceBeforeMappingQualified(Source source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMappingQualified", source ) );
+    }
+
+    @BeforeMapping
     public void withSourceBeforeMapping(List<Source> source) {
         INVOCATIONS.add( new Invocation( "withSourceBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
+    @Qualified
+    public void withSourceBeforeMappingQualified(List<Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMappingQualified", source ) );
     }
 
     @BeforeMapping
@@ -54,8 +66,29 @@ public class ClassContainingCallbacks {
     }
 
     @BeforeMapping
+    @Qualified
+    public void withSourceBeforeMappingQualified(Map<String, Source> source) {
+        INVOCATIONS.add( new Invocation( "withSourceBeforeMappingQualified", source ) );
+    }
+
+    @BeforeMapping
     public void withSourceAsObjectBeforeMapping(Object source) {
         INVOCATIONS.add( new Invocation( "withSourceAsObjectBeforeMapping", source ) );
+    }
+
+    @BeforeMapping
+    public <T> void withSourceAndTargetTypeBeforeMapping(Source source, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
+    }
+
+    @BeforeMapping
+    public <T> void withSourceAndTargetTypeBeforeMapping(List<Source> source, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
+    }
+
+    @BeforeMapping
+    public <T> void withSourceAndTargetTypeBeforeMapping(Map<String, Source> source, @TargetType Class<T> targetClass) {
+        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
     }
 
     @BeforeMapping
@@ -92,21 +125,6 @@ public class ClassContainingCallbacks {
     @BeforeMapping
     public void withTargetAsObjectBeforeMapping(@MappingTarget Object target) {
         INVOCATIONS.add( new Invocation( "withTargetAsObjectBeforeMapping", target ) );
-    }
-
-    @BeforeMapping
-    public <T> void withSourceAndTargetTypeBeforeMapping(Source source, @TargetType Class<T> targetClass) {
-        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
-    }
-
-    @BeforeMapping
-    public <T> void withSourceAndTargetTypeBeforeMapping(List<Source> source, @TargetType Class<T> targetClass) {
-        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
-    }
-
-    @BeforeMapping
-    public <T> void withSourceAndTargetTypeBeforeMapping(Map<String, Source> source, @TargetType Class<T> targetClass) {
-        INVOCATIONS.add( new Invocation( "withSourceAndTargetTypeBeforeMapping", source, targetClass ) );
     }
 
     @AfterMapping
@@ -155,13 +173,31 @@ public class ClassContainingCallbacks {
     }
 
     @AfterMapping
+    @Qualified
+    public void withTargetAfterMappingQualified(@MappingTarget Target target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMappingQualified", target ) );
+    }
+
+    @AfterMapping
     public void withTargetAfterMapping(@MappingTarget List<Target> target) {
         INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
     }
 
     @AfterMapping
+    @Qualified
+    public void withTargetAfterMappingQualified(@MappingTarget List<Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMappingQualified", target ) );
+    }
+
+    @AfterMapping
     public void withTargetAfterMapping(@MappingTarget Map<String, Target> target) {
         INVOCATIONS.add( new Invocation( "withTargetAfterMapping", target ) );
+    }
+
+    @AfterMapping
+    @Qualified
+    public void withTargetAfterMappingQualified(@MappingTarget Map<String, Target> target) {
+        INVOCATIONS.add( new Invocation( "withTargetAfterMappingQualified", target ) );
     }
 
     @AfterMapping

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/Invocation.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/Invocation.java
@@ -1,0 +1,87 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks;
+
+import java.util.Arrays;
+
+/**
+ * @author Andreas Gudian
+ */
+public class Invocation {
+    private final String methodName;
+    private final String arguments;
+
+    public Invocation(String methodName, Object... arguments) {
+        this.methodName = methodName;
+        this.arguments = Arrays.toString( arguments );
+    }
+
+    public String getMethodName() {
+        return methodName;
+    }
+
+    public String getArguments() {
+        return arguments;
+    }
+
+    @Override
+    public String toString() {
+        return "Invocation [methodName=" + methodName + ", arguments=" + arguments + "]";
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( arguments == null ) ? 0 : arguments.hashCode() );
+        result = prime * result + ( ( methodName == null ) ? 0 : methodName.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        Invocation other = (Invocation) obj;
+        if ( arguments == null ) {
+            if ( other.arguments != null ) {
+                return false;
+            }
+        }
+        else if ( !arguments.equals( other.arguments ) ) {
+            return false;
+        }
+        if ( methodName == null ) {
+            if ( other.methodName != null ) {
+                return false;
+            }
+        }
+        else if ( !methodName.equals( other.methodName ) ) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/Qualified.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/Qualified.java
@@ -18,20 +18,13 @@
  */
 package org.mapstruct.ap.test.callbacks;
 
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.MappingTarget;
-import org.mapstruct.factory.Mappers;
+import org.mapstruct.Qualifier;
 
 /**
  * @author Andreas Gudian
+ *
  */
-@Mapper( uses = ClassContainingCallbacks.class )
-public abstract class SourceTargetMapper extends BaseMapper {
-    public static final SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+@Qualifier
+public @interface Qualified {
 
-    public abstract void sourceToTarget(Source source, @MappingTarget Target target);
-
-    @BeanMapping(qualifiedBy = Qualified.class)
-    public abstract Target qualifiedSourceToTarget(Source source);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/Source.java
@@ -1,0 +1,70 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks;
+
+/**
+ * @author Andreas Gudian
+ */
+public class Source {
+    private String foo;
+
+    public String getFoo() {
+        return foo;
+    }
+
+    public void setFoo(String foo) {
+        this.foo = foo;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( foo == null ) ? 0 : foo.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        Source other = (Source) obj;
+        if ( foo == null ) {
+            if ( other.foo != null ) {
+                return false;
+            }
+        }
+        else if ( !foo.equals( other.foo ) ) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "Source [foo=" + foo + "]";
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/SourceEnum.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/SourceEnum.java
@@ -18,22 +18,10 @@
  */
 package org.mapstruct.ap.test.callbacks;
 
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.MappingTarget;
-import org.mapstruct.factory.Mappers;
-
 /**
  * @author Andreas Gudian
+ *
  */
-@Mapper( uses = ClassContainingCallbacks.class )
-public abstract class SourceTargetMapper extends BaseMapper {
-    public static final SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
-
-    public abstract void sourceToTarget(Source source, @MappingTarget Target target);
-
-    @BeanMapping(qualifiedBy = Qualified.class)
-    public abstract Target qualifiedSourceToTarget(Source source);
-
-    public abstract TargetEnum toTargetEnum(SourceEnum sourceEnum);
+public enum SourceEnum {
+    A, B, C;
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/SourceTargetCollectionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/SourceTargetCollectionMapper.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks;
+
+import java.util.List;
+import java.util.Map;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Andreas Gudian
+ */
+@Mapper( uses = ClassContainingCallbacks.class )
+public abstract class SourceTargetCollectionMapper extends BaseMapper {
+    public static final SourceTargetCollectionMapper INSTANCE = Mappers.getMapper( SourceTargetCollectionMapper.class );
+
+    public abstract List<Target> sourceToTarget(List<Source> source);
+
+    public abstract void sourceToTarget(List<Source> source, @MappingTarget List<Target> target);
+
+    public abstract Map<String, Target> sourceToTarget(Map<String, Source> source);
+
+    public abstract void sourceToTarget(Map<String, Source> source, @MappingTarget Map<String, Target> target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/SourceTargetCollectionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/SourceTargetCollectionMapper.java
@@ -21,6 +21,7 @@ package org.mapstruct.ap.test.callbacks;
 import java.util.List;
 import java.util.Map;
 
+import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
@@ -35,6 +36,9 @@ public abstract class SourceTargetCollectionMapper extends BaseMapper {
     public abstract List<Target> sourceToTarget(List<Source> source);
 
     public abstract void sourceToTarget(List<Source> source, @MappingTarget List<Target> target);
+
+    @IterableMapping(qualifiedBy = Qualified.class)
+    public abstract List<Target> qualifiedSourceToTarget(List<Source> source);
 
     public abstract Map<String, Target> sourceToTarget(Map<String, Source> source);
 

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/SourceTargetMapper.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Andreas Gudian
+ */
+@Mapper( uses = ClassContainingCallbacks.class )
+public abstract class SourceTargetMapper extends BaseMapper {
+    public static final SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    public abstract void sourceToTarget(Source source, @MappingTarget Target target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/Target.java
@@ -1,0 +1,70 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks;
+
+/**
+ * @author Andreas Gudian
+ */
+public class Target {
+    private String foo;
+
+    public String getFoo() {
+        return foo;
+    }
+
+    public void setFoo(String foo) {
+        this.foo = foo;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( foo == null ) ? 0 : foo.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        Target other = (Target) obj;
+        if ( foo == null ) {
+            if ( other.foo != null ) {
+                return false;
+            }
+        }
+        else if ( !foo.equals( other.foo ) ) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "Target [foo=" + foo + "]";
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/TargetEnum.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/TargetEnum.java
@@ -18,22 +18,10 @@
  */
 package org.mapstruct.ap.test.callbacks;
 
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.MappingTarget;
-import org.mapstruct.factory.Mappers;
-
 /**
  * @author Andreas Gudian
+ *
  */
-@Mapper( uses = ClassContainingCallbacks.class )
-public abstract class SourceTargetMapper extends BaseMapper {
-    public static final SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
-
-    public abstract void sourceToTarget(Source source, @MappingTarget Target target);
-
-    @BeanMapping(qualifiedBy = Qualified.class)
-    public abstract Target qualifiedSourceToTarget(Source source);
-
-    public abstract TargetEnum toTargetEnum(SourceEnum sourceEnum);
+public enum TargetEnum {
+    A, B, C;
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/Address.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/Address.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks.ongeneratedmethods;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Address {
+
+    private String addressLine;
+    private String town;
+
+    public String getAddressLine() {
+        return addressLine;
+    }
+
+    public void setAddressLine( String addressLine ) {
+        this.addressLine = addressLine;
+    }
+
+    public String getTown() {
+        return town;
+    }
+
+    public void setTown( String town ) {
+        this.town = town;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/AddressDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/AddressDto.java
@@ -1,0 +1,54 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks.ongeneratedmethods;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class AddressDto {
+
+    private int houseNumber;
+    private String street;
+    private String town;
+
+    public int getHouseNumber() {
+        return houseNumber;
+    }
+
+    public void setHouseNumber( int houseNumber ) {
+        this.houseNumber = houseNumber;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet( String street ) {
+        this.street = street;
+    }
+
+    public String getTown() {
+        return town;
+    }
+
+    public void setTown( String town ) {
+        this.town = town;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/Company.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/Company.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks.ongeneratedmethods;
+
+import java.util.List;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Company {
+
+    private List<Employee> employees;
+
+    public List<Employee> getEmployees() {
+        return employees;
+    }
+
+    public void setEmployees( List<Employee> employees ) {
+        this.employees = employees;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/CompanyDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/CompanyDto.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks.ongeneratedmethods;
+
+import java.util.List;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class CompanyDto {
+
+    private List<EmployeeDto> employees;
+
+    public List<EmployeeDto> getEmployees() {
+        return employees;
+    }
+
+    public void setEmployees( List<EmployeeDto> employees ) {
+        this.employees = employees;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/CompanyMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/CompanyMapper.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks.ongeneratedmethods;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper( unmappedTargetPolicy = ReportingPolicy.IGNORE, uses = CompanyMapperPostProcessing.class )
+public interface CompanyMapper {
+
+   CompanyMapper INSTANCE = Mappers.getMapper( CompanyMapper.class );
+
+   AddressDto toAddressDto(Address address);
+
+   CompanyDto toCompanyDto(Company company);
+
+   List<EmployeeDto> toEmployeeDtoList(List<Employee> employee);
+
+   EmployeeDto toEmployeeDto(Employee employee);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/CompanyMapperPostProcessing.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/CompanyMapperPostProcessing.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks.ongeneratedmethods;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.MappingTarget;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public  class CompanyMapperPostProcessing  {
+
+    @AfterMapping
+    public void toAddressDto(Address address, @MappingTarget AddressDto addressDto) {
+        String addressLine = address.getAddressLine();
+        int seperatorIndex = addressLine.indexOf( ";" );
+        addressDto.setStreet( addressLine.substring( 0, seperatorIndex ) );
+        String houseNumber = addressLine.substring( seperatorIndex + 1, addressLine.length() );
+        addressDto.setHouseNumber( Integer.parseInt( houseNumber ) );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/Employee.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/Employee.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks.ongeneratedmethods;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Employee {
+
+    private Address address;
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress( Address address ) {
+        this.address = address;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/EmployeeDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/EmployeeDto.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks.ongeneratedmethods;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class EmployeeDto {
+
+    private AddressDto address;
+
+    public AddressDto getAddress() {
+        return address;
+    }
+
+    public void setAddress( AddressDto address ) {
+        this.address = address;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/MappingResultPostprocessorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/MappingResultPostprocessorTest.java
@@ -1,0 +1,74 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.callbacks.ongeneratedmethods;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+
+@WithClasses({
+    Company.class,
+    CompanyDto.class,
+    Employee.class,
+    EmployeeDto.class,
+    Address.class,
+    AddressDto.class,
+    CompanyMapper.class,
+    CompanyMapperPostProcessing.class
+})
+@IssueKey("183")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class MappingResultPostprocessorTest {
+
+    @Test
+    public void test() {
+
+        // setup
+        Address address = new Address();
+        address.setAddressLine( "RoadToNowhere;5");
+        address.setTown( "SmallTown" );
+        Employee employee = new Employee();
+        employee.setAddress( address );
+        Company company = new Company();
+        company.setEmployees( Arrays.asList( new Employee[] { employee } ) );
+
+        // test
+        CompanyDto companyDto = CompanyMapper.INSTANCE.toCompanyDto( company );
+
+        // verify
+        assertThat( companyDto.getEmployees() ).isNotEmpty();
+        assertThat( companyDto.getEmployees().size() ).isEqualTo( 1 );
+        assertThat( companyDto.getEmployees().get( 0 ).getAddress() ).isNotNull();
+        assertThat( companyDto.getEmployees().get( 0 ).getAddress().getHouseNumber() ).isEqualTo( 5 );
+        assertThat( companyDto.getEmployees().get( 0 ).getAddress().getStreet() ).isEqualTo( "RoadToNowhere" );
+        assertThat( companyDto.getEmployees().get( 0 ).getAddress().getTown() ).isEqualTo( "SmallTown" );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/severalsources/ReferencedMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/severalsources/ReferencedMapper.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.severalsources;
+
+import org.mapstruct.BeforeMapping;
+
+/**
+ * @author Andreas Gudian
+ *
+ */
+public class ReferencedMapper {
+    private static boolean beforeMappingCalled = false;
+
+    @BeforeMapping
+    public void beforeMappingCallback(Person person, Address address) {
+        beforeMappingCalled = ( person != null && address != null );
+    }
+
+    public static boolean isBeforeMappingCalled() {
+        return beforeMappingCalled;
+    }
+
+    public static void setBeforeMappingCalled(boolean beforeMappingCalled) {
+        ReferencedMapper.beforeMappingCalled = beforeMappingCalled;
+    };
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/severalsources/SeveralSourceParametersTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/severalsources/SeveralSourceParametersTest.java
@@ -21,6 +21,7 @@ package org.mapstruct.ap.test.severalsources;
 import javax.lang.model.SourceVersion;
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
@@ -43,8 +44,18 @@ import static org.fest.assertions.Assertions.assertThat;
 @RunWith(AnnotationProcessorTestRunner.class)
 public class SeveralSourceParametersTest {
 
+    @Before
+    public void reset() {
+        ReferencedMapper.setBeforeMappingCalled( false );
+    }
+
     @Test
-    @WithClasses({ Person.class, Address.class, DeliveryAddress.class, SourceTargetMapper.class })
+    @WithClasses( {
+        Person.class,
+        Address.class,
+        DeliveryAddress.class,
+        SourceTargetMapper.class,
+        ReferencedMapper.class } )
     public void shouldMapSeveralSourceAttributesToCombinedTarget() {
         Person person = new Person( "Bob", "Garner", 181, "An actor" );
         Address address = new Address( "Main street", 12345, 42, "His address" );
@@ -57,10 +68,17 @@ public class SeveralSourceParametersTest {
         assertThat( deliveryAddress.getZipCode() ).isEqualTo( 12345 );
         assertThat( deliveryAddress.getHouseNumber() ).isEqualTo( 42 );
         assertThat( deliveryAddress.getDescription() ).isEqualTo( "An actor" );
+
+        assertThat( ReferencedMapper.isBeforeMappingCalled() ).isTrue();
     }
 
     @Test
-    @WithClasses({ Person.class, Address.class, DeliveryAddress.class, SourceTargetMapper.class })
+    @WithClasses( {
+        Person.class,
+        Address.class,
+        DeliveryAddress.class,
+        SourceTargetMapper.class,
+        ReferencedMapper.class } )
     public void shouldMapSeveralSourceAttributesToCombinedTargetWithTargetParameter() {
         Person person = new Person( "Bob", "Garner", 181, "An actor" );
         Address address = new Address( "Main street", 12345, 42, "His address" );
@@ -72,10 +90,17 @@ public class SeveralSourceParametersTest {
         assertThat( deliveryAddress.getZipCode() ).isEqualTo( 12345 );
         assertThat( deliveryAddress.getHouseNumber() ).isEqualTo( 42 );
         assertThat( deliveryAddress.getDescription() ).isEqualTo( "An actor" );
+
+        assertThat( ReferencedMapper.isBeforeMappingCalled() ).isTrue();
     }
 
     @Test
-    @WithClasses({ Person.class, Address.class, DeliveryAddress.class, SourceTargetMapper.class })
+    @WithClasses( {
+        Person.class,
+        Address.class,
+        DeliveryAddress.class,
+        SourceTargetMapper.class,
+        ReferencedMapper.class } )
     public void shouldSetAttributesFromNonNullParameters() {
         Person person = new Person( "Bob", "Garner", 181, "An actor" );
 
@@ -90,7 +115,12 @@ public class SeveralSourceParametersTest {
     }
 
     @Test
-    @WithClasses({ Person.class, Address.class, DeliveryAddress.class, SourceTargetMapper.class })
+    @WithClasses( {
+        Person.class,
+        Address.class,
+        DeliveryAddress.class,
+        SourceTargetMapper.class,
+        ReferencedMapper.class } )
     public void shouldReturnNullIfAllParametersAreNull() {
         DeliveryAddress deliveryAddress = SourceTargetMapper.INSTANCE
             .personAndAddressToDeliveryAddress( null, null );
@@ -99,7 +129,12 @@ public class SeveralSourceParametersTest {
     }
 
     @Test
-    @WithClasses({ Person.class, Address.class, DeliveryAddress.class, SourceTargetMapper.class })
+    @WithClasses( {
+        Person.class,
+        Address.class,
+        DeliveryAddress.class,
+        SourceTargetMapper.class,
+        ReferencedMapper.class } )
     public void shouldMapSeveralSourceAttributesAndParameters() {
         Person person = new Person( "Bob", "Garner", 181, "An actor" );
 
@@ -135,7 +170,6 @@ public class SeveralSourceParametersTest {
                 messageRegExp = "Several possible source properties for target property \"street\"."),
 
     })
-
     public void shouldFailToGenerateMappingsForAmbigiousSourceProperty() {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/severalsources/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/severalsources/SourceTargetMapper.java
@@ -24,7 +24,7 @@ import org.mapstruct.MappingTarget;
 import org.mapstruct.Mappings;
 import org.mapstruct.factory.Mappers;
 
-@Mapper
+@Mapper( uses = ReferencedMapper.class )
 public interface SourceTargetMapper {
 
     SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );


### PR DESCRIPTION
As outlined in issue #14.

Based on PR #67, as I reused some methods I created there... ;)

Oh, one thing that is not yet working is assigning potential return values from the callback method to any other objects. I'd like to deal with that in an extra issue.

Something that I implemented along the way (to get my test running), was making the MethodRetrievalProcessor also pick up methods declared in implemented interfaces and super-types of the type in question.