### PR TITLE
#132 speed up tests by avoiding unneccessary compilations, allow parallel executions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -35,8 +35,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/core/src/test/java/org/mapstruct/MappersTest.java
+++ b/core/src/test/java/org/mapstruct/MappersTest.java
@@ -18,11 +18,11 @@
  */
 package org.mapstruct;
 
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
 import org.mapstruct.factory.Mappers;
 import org.mapstruct.test.model.Foo;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * Unit test for {@link Mappers}.

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -41,8 +41,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -61,8 +61,8 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.testng</groupId>
-            <artifactId>arquillian-testng-container</artifactId>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -76,8 +76,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.testng</groupId>
-            <artifactId>arquillian-testng-core</artifactId>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrationtest/src/test/java/org/mapstruct/itest/ConversionTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/ConversionTest.java
@@ -18,9 +18,9 @@
  */
 package org.mapstruct.itest;
 
-import org.testng.annotations.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
 
 public class ConversionTest {
 

--- a/integrationtest/src/test/java/org/mapstruct/itest/cdi/CdiBasedMapperTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/cdi/CdiBasedMapperTest.java
@@ -18,24 +18,26 @@
  */
 package org.mapstruct.itest.cdi;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
+import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.itest.cdi.other.DateMapper;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * Test for generation of CDI-based mapper implementations.
  *
  * @author Gunnar Morling
  */
-public class CdiBasedMapperTest extends Arquillian {
+@RunWith( Arquillian.class )
+public class CdiBasedMapperTest {
 
     @Inject
     private SourceTargetMapper mapper;

--- a/integrationtest/src/test/java/org/mapstruct/itest/jaxb/JaxbBasedMapperTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/jaxb/JaxbBasedMapperTest.java
@@ -18,41 +18,29 @@
  */
 package org.mapstruct.itest.jaxb;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.io.ByteArrayOutputStream;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Date;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 
-import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.testng.Arquillian;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.Test;
 import org.mapstruct.itest.jaxb.xsd.test1.ObjectFactory;
 import org.mapstruct.itest.jaxb.xsd.test1.OrderType;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * Test for generation of JAXB based mapper implementations.
  *
  * @author Sjaak Derksen
  */
-public class JaxbBasedMapperTest extends Arquillian {
-
-    @Deployment
-    public static JavaArchive createDeployment() {
-        return ShrinkWrap.create( JavaArchive.class )
-            .addPackage( SourceTargetMapper.class.getPackage() )
-            .addPackage( org.mapstruct.itest.jaxb.xsd.test1.ObjectFactory.class.getPackage() )
-            .addPackage( org.mapstruct.itest.jaxb.xsd.test2.ObjectFactory.class.getPackage() );
-    }
-
+public class JaxbBasedMapperTest {
     @Test
     public void shouldMapJaxb() throws ParseException, JAXBException {
 

--- a/integrationtest/src/test/java/org/mapstruct/itest/jsr330/Jsr330BasedMapperTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/jsr330/Jsr330BasedMapperTest.java
@@ -22,12 +22,13 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import javax.inject.Inject;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.itest.jsr330.Jsr330BasedMapperTest.SpringTestConfig;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.annotations.Test;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Test for generation of JSR-330-based Mapper implementations
@@ -35,7 +36,8 @@ import org.testng.annotations.Test;
  * @author Andreas Gudian
  */
 @ContextConfiguration(classes = SpringTestConfig.class )
-public class Jsr330BasedMapperTest extends AbstractTestNGSpringContextTests {
+@RunWith( SpringJUnit4ClassRunner.class )
+public class Jsr330BasedMapperTest {
     @Configuration
     @ComponentScan(basePackageClasses = Jsr330BasedMapperTest.class)
     public static class SpringTestConfig {

--- a/integrationtest/src/test/java/org/mapstruct/itest/spring/SpringBasedMapperTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/spring/SpringBasedMapperTest.java
@@ -18,15 +18,16 @@
  */
 package org.mapstruct.itest.spring;
 
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.itest.spring.SpringBasedMapperTest.SpringTestConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.testng.AbstractTestNGSpringContextTests;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * Test for generation of Spring-based Mapper implementations
@@ -34,7 +35,8 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Andreas Gudian
  */
 @ContextConfiguration(classes = SpringTestConfig.class )
-public class SpringBasedMapperTest extends AbstractTestNGSpringContextTests {
+@RunWith( SpringJUnit4ClassRunner.class )
+public class SpringBasedMapperTest {
     @Configuration
     @ComponentScan(basePackageClasses = SpringBasedMapperTest.class)
     public static class SpringTestConfig {

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -101,11 +101,6 @@
                 <version>2.3.19</version>
             </dependency>
             <dependency>
-                <groupId>org.testng</groupId>
-                <artifactId>testng</artifactId>
-                <version>6.3.1</version>
-            </dependency>
-            <dependency>
                 <groupId>org.easytesting</groupId>
                 <artifactId>fest-assert</artifactId>
                 <version>1.4</version>
@@ -120,7 +115,11 @@
                 <artifactId>hickory</artifactId>
                 <version>${com.jolira.hickory.version}</version>
             </dependency>
-
+            <dependency>
+				<groupId>junit</groupId>
+				<artifactId>junit</artifactId>
+				<version>4.11</version>
+			</dependency>
             <!-- CDI, Weld, Arquillian -->
             <dependency>
                 <groupId>javax.enterprise</groupId>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -60,8 +60,8 @@
 
         <!-- Test -->
         <dependency>
-            <groupId>org.testng</groupId>
-            <artifactId>testng</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/processor/src/test/java/org/mapstruct/ap/test/abstractclass/AbstractClassTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/abstractclass/AbstractClassTest.java
@@ -20,10 +20,11 @@ package org.mapstruct.ap.test.abstractclass;
 
 import static org.fest.assertions.Assertions.assertThat;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for the generation of implementation of abstract base classes.
@@ -32,7 +33,8 @@ import org.testng.annotations.Test;
  */
 @WithClasses( { Source.class, Target.class, SourceTargetMapper.class, AbstractBaseMapper.class,
     BaseMapperInterface.class } )
-public class AbstractClassTest extends MapperTestBase {
+@RunWith( AnnotationProcessorTestRunner.class )
+public class AbstractClassTest {
 
     @Test
     @IssueKey( "64" )

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/AccessibilityTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/AccessibilityTest.java
@@ -21,12 +21,13 @@ package org.mapstruct.ap.test.accessibility;
 import static java.lang.reflect.Modifier.isPrivate;
 import static java.lang.reflect.Modifier.isProtected;
 import static java.lang.reflect.Modifier.isPublic;
-import static org.testng.Assert.assertTrue;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for different accessibility modifiers
@@ -34,7 +35,8 @@ import org.testng.annotations.Test;
  * @author Andreas Gudian
  */
 @WithClasses({ Source.class, Target.class, DefaultSourceTargetMapperAbstr.class, DefaultSourceTargetMapperIfc.class })
-public class AccessibilityTest extends MapperTestBase {
+@RunWith( AnnotationProcessorTestRunner.class )
+public class AccessibilityTest {
 
     @Test
     @IssueKey("103")

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/BuiltInTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/BuiltInTest.java
@@ -38,29 +38,31 @@ import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 
-import org.mapstruct.ap.testutil.MapperTestBase;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for the generation of built-in mapping methods.
  *
  * @author Sjaak Derksen
  */
-public class BuiltInTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class BuiltInTest {
 
-    private TimeZone originalTimeZone;
+    private static TimeZone originalTimeZone;
 
     @BeforeClass
-    public void setDefaultTimeZoneToCet() {
+    public static void setDefaultTimeZoneToCet() {
         originalTimeZone = TimeZone.getDefault();
         TimeZone.setDefault( TimeZone.getTimeZone( "Europe/Berlin" ) );
     }
 
     @AfterClass
-    public void restoreOriginalTimeZone() {
+    public static void restoreOriginalTimeZone() {
         TimeZone.setDefault( originalTimeZone );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/IterableSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/IterableSource.java
@@ -19,6 +19,7 @@
 package org.mapstruct.ap.test.builtin;
 
 import java.util.List;
+
 import javax.xml.datatype.XMLGregorianCalendar;
 
 /**

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/IterableSourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/IterableSourceTargetMapper.java
@@ -19,6 +19,7 @@
 package org.mapstruct.ap.test.builtin;
 
 import java.util.List;
+
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.IterableMapping;

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/MapSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/MapSource.java
@@ -19,6 +19,7 @@
 package org.mapstruct.ap.test.builtin;
 
 import java.util.Map;
+
 import javax.xml.bind.JAXBElement;
 import javax.xml.datatype.XMLGregorianCalendar;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/MapSourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/MapSourceTargetMapper.java
@@ -19,6 +19,7 @@
 package org.mapstruct.ap.test.builtin;
 
 import java.util.Map;
+
 import javax.xml.bind.JAXBElement;
 import javax.xml.datatype.XMLGregorianCalendar;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/Source.java
@@ -21,6 +21,7 @@ package org.mapstruct.ap.test.builtin;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+
 import javax.xml.bind.JAXBElement;
 import javax.xml.datatype.XMLGregorianCalendar;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/Target.java
@@ -21,6 +21,7 @@ package org.mapstruct.ap.test.builtin;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
+
 import javax.xml.datatype.XMLGregorianCalendar;
 
 public class Target {

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/CollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/CollectionMappingTest.java
@@ -29,13 +29,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 @WithClasses({ Source.class, Target.class, Colour.class, SourceTargetMapper.class })
-public class CollectionMappingTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class CollectionMappingTest {
 
     @Test
     @IssueKey("6")

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/defaultimplementation/DefaultCollectionImplementationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/defaultimplementation/DefaultCollectionImplementationTest.java
@@ -18,6 +18,9 @@
  */
 package org.mapstruct.ap.test.collection.defaultimplementation;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.MapAssert.entry;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,13 +36,11 @@ import java.util.SortedSet;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 @WithClasses({
     Source.class,
@@ -48,7 +49,8 @@ import static org.fest.assertions.MapAssert.entry;
     TargetFoo.class,
     SourceTargetMapper.class
 })
-public class DefaultCollectionImplementationTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class DefaultCollectionImplementationTest {
 
     @Test
     @IssueKey("6")

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionMappingTest.java
@@ -20,20 +20,22 @@ package org.mapstruct.ap.test.collection.erroneous;
 
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for illegal mappings between collection types, iterable and non-iterable types etc.
  *
  * @author Gunnar Morling
  */
-public class ErroneousCollectionMappingTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class ErroneousCollectionMappingTest {
 
     @Test
     @IssueKey("6")

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/iterabletononiterable/IterableToNonIterableMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/iterabletononiterable/IterableToNonIterableMappingTest.java
@@ -18,17 +18,19 @@
  */
 package org.mapstruct.ap.test.collection.iterabletononiterable;
 
-import java.util.Arrays;
-
-import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
-import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
 
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
 @WithClasses({ Source.class, Target.class, SourceTargetMapper.class, StringListMapper.class })
-public class IterableToNonIterableMappingTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class IterableToNonIterableMappingTest {
 
     @Test
     @IssueKey("6")

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/map/MapMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/map/MapMappingTest.java
@@ -26,10 +26,11 @@ import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for implementation of {@code Map} mapping methods.
@@ -38,7 +39,8 @@ import org.testng.annotations.Test;
  */
 @WithClasses({ SourceTargetMapper.class, CustomNumberMapper.class, Source.class, Target.class })
 @IssueKey("44")
-public class MapMappingTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class MapMappingTest {
 
     @Test
     public void shouldCreateMapMethodImplementation() {

--- a/processor/src/test/java/org/mapstruct/ap/test/complex/CarMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/complex/CarMapperTest.java
@@ -18,22 +18,23 @@
  */
 package org.mapstruct.ap.test.complex;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.GregorianCalendar;
 import java.util.List;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.test.complex.other.DateMapper;
 import org.mapstruct.ap.test.complex.source.Car;
 import org.mapstruct.ap.test.complex.source.Category;
 import org.mapstruct.ap.test.complex.source.Person;
 import org.mapstruct.ap.test.complex.target.CarDto;
 import org.mapstruct.ap.test.complex.target.PersonDto;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 @WithClasses({
     Car.class,
@@ -44,7 +45,8 @@ import static org.fest.assertions.Assertions.assertThat;
     Category.class,
     DateMapper.class
 })
-public class CarMapperTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class CarMapperTest {
 
     @Test
     public void shouldProvideMapperInstance() throws Exception {

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/ConversionTest.java
@@ -18,14 +18,16 @@
  */
 package org.mapstruct.ap.test.conversion;
 
-import org.mapstruct.ap.testutil.MapperTestBase;
-import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
 @WithClasses({ Source.class, Target.class, SourceTargetMapper.class })
-public class ConversionTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class ConversionTest {
 
     @Test
     public void shouldApplyConversions() {

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/bignumbers/BigNumbersConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/bignumbers/BigNumbersConversionTest.java
@@ -18,22 +18,24 @@
  */
 package org.mapstruct.ap.test.conversion.bignumbers;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Tests conversions between {@link BigInteger} and numbers as well as String.
  *
  * @author Gunnar Morling
  */
-public class BigNumbersConversionTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class BigNumbersConversionTest {
 
     @Test
     @IssueKey("21")

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/date/DateConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/date/DateConversionTest.java
@@ -18,19 +18,20 @@
  */
 package org.mapstruct.ap.test.conversion.date;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.util.Arrays;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
 
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Tests application of format strings for conversions between strings and dates.
@@ -43,9 +44,10 @@ import static org.fest.assertions.Assertions.assertThat;
     SourceTargetMapper.class
 })
 @IssueKey("43")
-public class DateConversionTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class DateConversionTest {
 
-    @BeforeMethod
+    @Before
     public void setDefaultLocale() {
         Locale.setDefault( Locale.GERMAN );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/generics/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/generics/ConversionTest.java
@@ -22,13 +22,14 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import java.math.BigDecimal;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Tests for the invocation of generic methods for mapping bean properties.
@@ -41,7 +42,8 @@ import org.testng.annotations.Test;
     TypeA.class, TypeB.class, TypeC.class
 })
 @IssueKey(value = "79")
-public class ConversionTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class ConversionTest {
 
     @Test
     @WithClasses({ Source.class, Target.class, SourceTargetMapper.class })

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/BooleanConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/BooleanConversionTest.java
@@ -18,18 +18,20 @@
  */
 package org.mapstruct.ap.test.conversion.nativetypes;
 
-import org.mapstruct.ap.testutil.MapperTestBase;
-import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 @WithClasses({
     BooleanSource.class,
     BooleanTarget.class,
     BooleanMapper.class
 })
-public class BooleanConversionTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class BooleanConversionTest {
 
     @Test
     public void shouldApplyBooleanConversion() {

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/CharConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/CharConversionTest.java
@@ -18,18 +18,20 @@
  */
 package org.mapstruct.ap.test.conversion.nativetypes;
 
-import org.mapstruct.ap.testutil.MapperTestBase;
-import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 @WithClasses({
     CharSource.class,
     CharTarget.class,
     CharMapper.class
 })
-public class CharConversionTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class CharConversionTest {
 
     @Test
     public void shouldApplyCharConversion() {

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/NumberConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/NumberConversionTest.java
@@ -18,11 +18,12 @@
  */
 package org.mapstruct.ap.test.conversion.nativetypes;
 
-import org.mapstruct.ap.testutil.MapperTestBase;
-import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 @WithClasses({
     ByteSource.class,
@@ -51,7 +52,8 @@ import static org.fest.assertions.Assertions.assertThat;
     DoubleWrapperTarget.class,
     SourceTargetMapper.class
 })
-public class NumberConversionTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class NumberConversionTest {
 
     @Test
     public void shouldApplyByteConversions() {

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/precedence/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/precedence/ConversionTest.java
@@ -18,14 +18,16 @@
  */
 package org.mapstruct.ap.test.conversion.precedence;
 
-import org.mapstruct.ap.testutil.MapperTestBase;
-import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
 @WithClasses({ Source.class, Target.class, SourceTargetMapper.class, IntegerStringMapper.class })
-public class ConversionTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class ConversionTest {
 
     @Test
     public void shouldInvokeMappingMethodInsteadOfConversion() {

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/string/StringConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/string/StringConversionTest.java
@@ -18,18 +18,20 @@
  */
 package org.mapstruct.ap.test.conversion.string;
 
-import org.mapstruct.ap.testutil.MapperTestBase;
-import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 @WithClasses({
     Source.class,
     Target.class,
     SourceTargetMapper.class
 })
-public class StringConversionTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class StringConversionTest {
 
     @Test
     public void shouldApplyStringConversions() {

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/DecoratorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/DecoratorTest.java
@@ -18,18 +18,20 @@
  */
 package org.mapstruct.ap.test.decorator;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.util.Calendar;
+
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for the application of decorators.
@@ -43,7 +45,8 @@ import static org.fest.assertions.Assertions.assertThat;
     AddressDto.class
 })
 @IssueKey("163")
-public class DecoratorTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class DecoratorTest {
 
     @Test
     @WithClasses({

--- a/processor/src/test/java/org/mapstruct/ap/test/enums/EnumMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/enums/EnumMappingTest.java
@@ -18,17 +18,18 @@
  */
 package org.mapstruct.ap.test.enums;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for the generation and invocation of enum mapping methods.
@@ -37,7 +38,8 @@ import static org.fest.assertions.Assertions.assertThat;
  */
 @IssueKey("128")
 @WithClasses({ OrderMapper.class, OrderEntity.class, OrderType.class, OrderDto.class, ExternalOrderType.class })
-public class EnumMappingTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class EnumMappingTest {
 
     @Test
     public void shouldGenerateEnumMappingMethod() {

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousfactorymethod/FactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousfactorymethod/FactoryTest.java
@@ -18,14 +18,15 @@
  */
 package org.mapstruct.ap.test.erroneous.ambiguousfactorymethod;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.test.erroneous.ambiguousfactorymethod.a.BarFactory;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * @author Sjaak Derksen
@@ -35,7 +36,8 @@ import org.testng.annotations.Test;
     Bar.class, Foo.class, BarFactory.class, Source.class, SourceTargetMapperAndBarFactory.class,
     Target.class
 })
-public class FactoryTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class FactoryTest {
 
     @Test
     @IssueKey("81")

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/attributereference/ErroneousMappingsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/attributereference/ErroneousMappingsTest.java
@@ -20,13 +20,14 @@ package org.mapstruct.ap.test.erroneous.attributereference;
 
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for using unknown attributes in {@code @Mapping}.
@@ -34,7 +35,8 @@ import org.testng.annotations.Test;
  * @author Gunnar Morling
  */
 @WithClasses({ ErroneousMapper.class, Source.class, Target.class, AnotherTarget.class })
-public class ErroneousMappingsTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class ErroneousMappingsTest {
 
     @Test
     @IssueKey("11")

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/typemismatch/ErroneousMappingsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/typemismatch/ErroneousMappingsTest.java
@@ -20,13 +20,14 @@ package org.mapstruct.ap.test.erroneous.typemismatch;
 
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Tests failures expected for unmappable attributes.
@@ -34,7 +35,8 @@ import org.testng.annotations.Test;
  * @author Gunnar Morling
  */
 @WithClasses({ ErroneousMapper.class, Source.class, Target.class })
-public class ErroneousMappingsTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class ErroneousMappingsTest {
 
     @Test
     @IssueKey("6")

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/FactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/FactoryTest.java
@@ -25,11 +25,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.test.factories.a.BarFactory;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * @author Sjaak Derksen
@@ -40,7 +41,8 @@ import org.testng.annotations.Test;
     org.mapstruct.ap.test.factories.b.BarFactory.class, Source.class, SourceTargetMapperAndBar2Factory.class,
     Target.class, CustomList.class, CustomListImpl.class, CustomMap.class, CustomMapImpl.class, FactoryCreatable.class
 })
-public class FactoryTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class FactoryTest {
     @Test
     public void shouldUseTwoFactoryMethods() {
         Target target = SourceTargetMapperAndBar2Factory.INSTANCE.sourceToTarget( createSource() );

--- a/processor/src/test/java/org/mapstruct/ap/test/imports/ConflictingTypesNamesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/imports/ConflictingTypesNamesTest.java
@@ -18,13 +18,14 @@
  */
 package org.mapstruct.ap.test.imports;
 
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.test.imports.from.Foo;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for generating a mapper which references types whose names clash with names of used annotations and exceptions.
@@ -41,7 +42,8 @@ import static org.fest.assertions.Assertions.assertThat;
     Foo.class,
     org.mapstruct.ap.test.imports.to.Foo.class
 })
-public class ConflictingTypesNamesTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class ConflictingTypesNamesTest {
 
     @Test
     public void mapperImportingTypesWithConflictingNamesCanBeGenerated() {

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritance/InheritanceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritance/InheritanceTest.java
@@ -18,12 +18,13 @@
  */
 package org.mapstruct.ap.test.inheritance;
 
-import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
-import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for propagation of attributes inherited from super types.
@@ -31,7 +32,8 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Gunnar Morling
  */
 @WithClasses({ SourceBase.class, SourceExt.class, TargetBase.class, TargetExt.class, SourceTargetMapper.class })
-public class InheritanceTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class InheritanceTest {
 
     @Test
     @IssueKey("17")

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritance/attribute/AttributeInheritanceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritance/attribute/AttributeInheritanceTest.java
@@ -22,19 +22,21 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import javax.tools.Diagnostic.Kind;
 
-import org.mapstruct.ap.testutil.MapperTestBase;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for setting an attribute where the target attribute of a super-type.
  *
  * @author Gunnar Morling
  */
-public class AttributeInheritanceTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class AttributeInheritanceTest {
 
     @Test
     @WithClasses({ Source.class, Target.class, SourceTargetMapper.class })

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritance/complex/ComplexInheritanceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritance/complex/ComplexInheritanceTest.java
@@ -18,18 +18,20 @@
  */
 package org.mapstruct.ap.test.inheritance.complex;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.util.Arrays;
+
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for propagation of attributes inherited from super types.
@@ -41,7 +43,8 @@ import static org.fest.assertions.Assertions.assertThat;
     SourceExt.class, SourceExt2.class,
     TargetComposite.class, AdditionalFooSource.class
 })
-public class ComplexInheritanceTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class ComplexInheritanceTest {
 
     @Test
     @IssueKey("34")

--- a/processor/src/test/java/org/mapstruct/ap/test/jaxb/selection/JaxbFactoryMethodSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/jaxb/selection/JaxbFactoryMethodSelectionTest.java
@@ -22,13 +22,14 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import javax.xml.bind.annotation.XmlElementDecl;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.test.jaxb.selection.test1.OrderType;
 import org.mapstruct.ap.test.jaxb.selection.test2.ObjectFactory;
 import org.mapstruct.ap.test.jaxb.selection.test2.OrderShippingDetailsType;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for the selection of JAXB mapping and factory methods based on the "name" and "scope" attributes
@@ -42,7 +43,8 @@ import org.testng.annotations.Test;
     OrderDto.class, OrderShippingDetailsDto.class, OrderType.class, OrderShippingDetailsType.class,
     OrderMapper.class
 })
-public class JaxbFactoryMethodSelectionTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class JaxbFactoryMethodSelectionTest {
 
     @Test
     public void shouldMatchOnNameAndOrScope() {

--- a/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/ConfigTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/ConfigTest.java
@@ -19,13 +19,15 @@
 package org.mapstruct.ap.test.mapperconfig;
 
 import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  *
@@ -42,7 +44,8 @@ import org.testng.annotations.Test;
     CustomMapperViaMapperConfig.class,
     SourceTargetMapper.class
 } )
-public class ConfigTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class ConfigTest {
 
     @Test
     @WithClasses( { Target.class, SourceTargetMapper.class } )

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/VariableNamingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/VariableNamingTest.java
@@ -18,19 +18,20 @@
  */
 package org.mapstruct.ap.test.naming;
 
+import static org.fest.assertions.Assertions.assertThat;
+import static org.fest.assertions.MapAssert.entry;
+
 import java.util.Arrays;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for aming of variables/members which conflict with keywords or parameter names.
@@ -39,7 +40,8 @@ import static org.fest.assertions.MapAssert.entry;
  */
 @WithClasses({ SourceTargetMapper.class, While.class, Break.class, Source.class })
 @IssueKey("53")
-public class VariableNamingTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class VariableNamingTest {
 
     @Test
     public void shouldGenerateImplementationsOfMethodsWithProblematicVariableNmes() {

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/NestedMappingMethodInvocationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/NestedMappingMethodInvocationTest.java
@@ -18,8 +18,11 @@
  */
 package org.mapstruct.ap.test.nestedmethodcall;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import java.util.ArrayList;
 import java.util.List;
+
 import javax.xml.bind.JAXBElement;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
@@ -27,12 +30,11 @@ import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for the nested invocation of mapping methods.
@@ -47,7 +49,8 @@ import static org.fest.assertions.Assertions.assertThat;
     OrderDetailsType.class,
     OrderType.class
 })
-public class NestedMappingMethodInvocationTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class NestedMappingMethodInvocationTest {
 
     private static final QName QNAME = new QName( "dont-care" );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/OrderDetailsType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/OrderDetailsType.java
@@ -20,6 +20,7 @@
 package org.mapstruct.ap.test.nestedmethodcall;
 
 import java.util.List;
+
 import javax.xml.bind.JAXBElement;
 
 /**

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/OrderType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/OrderType.java
@@ -20,6 +20,7 @@
 package org.mapstruct.ap.test.nestedmethodcall;
 
 import java.util.List;
+
 import javax.xml.bind.JAXBElement;
 import javax.xml.datatype.XMLGregorianCalendar;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/SourceTargetMapper.java
@@ -20,6 +20,7 @@
 package org.mapstruct.ap.test.nestedmethodcall;
 
 import java.util.List;
+
 import javax.xml.bind.JAXBElement;
 import javax.xml.datatype.XMLGregorianCalendar;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/oneway/OnewayTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/oneway/OnewayTest.java
@@ -18,12 +18,13 @@
  */
 package org.mapstruct.ap.test.oneway;
 
-import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
-import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
 import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for propagation of attribute without setter in source and getter in
@@ -32,7 +33,8 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Gunnar Morling
  */
 @WithClasses({ Source.class, Target.class, SourceTargetMapper.class })
-public class OnewayTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class OnewayTest {
 
     @Test
     @IssueKey("17")

--- a/processor/src/test/java/org/mapstruct/ap/test/references/ReferencedMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/references/ReferencedMapperTest.java
@@ -26,10 +26,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * @author Andreas Gudian
@@ -38,7 +39,8 @@ import org.testng.annotations.Test;
 @IssueKey( "82" )
 @WithClasses( { Bar.class, Foo.class, FooMapper.class, ReferencedCustomMapper.class, Source.class,
     SourceTargetMapper.class, Target.class, BaseType.class, SomeType.class, SomeOtherType.class } )
-public class ReferencedMapperTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class ReferencedMapperTest {
     @Test
     public void referencedMappersAreInstatiatedCorrectly() {
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( createSource() );

--- a/processor/src/test/java/org/mapstruct/ap/test/references/samename/SeveralReferencedMappersWithSameSimpleNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/references/samename/SeveralReferencedMappersWithSameSimpleNameTest.java
@@ -18,16 +18,17 @@
  */
 package org.mapstruct.ap.test.references.samename;
 
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.test.references.samename.a.AnotherSourceTargetMapper;
 import org.mapstruct.ap.test.references.samename.a.CustomMapper;
 import org.mapstruct.ap.test.references.samename.model.Source;
 import org.mapstruct.ap.test.references.samename.model.Target;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for referring several mappers with the same simple name.
@@ -44,7 +45,8 @@ import static org.fest.assertions.Assertions.assertThat;
     Jsr330SourceTargetMapper.class,
     AnotherSourceTargetMapper.class
 })
-public class SeveralReferencedMappersWithSameSimpleNameTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class SeveralReferencedMappersWithSameSimpleNameTest {
 
     @Test
     public void severalMappersWithSameSimpleNameCanBeReferenced() {

--- a/processor/src/test/java/org/mapstruct/ap/test/severalsources/SeveralSourceParametersTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/severalsources/SeveralSourceParametersTest.java
@@ -18,19 +18,20 @@
  */
 package org.mapstruct.ap.test.severalsources;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import javax.lang.model.SourceVersion;
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for propagation of attribute without setter in source and getter in
@@ -39,7 +40,8 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Gunnar Morling
  */
 @IssueKey("31")
-public class SeveralSourceParametersTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class SeveralSourceParametersTest {
 
     @Test
     @WithClasses({ Person.class, Address.class, DeliveryAddress.class, SourceTargetMapper.class })

--- a/processor/src/test/java/org/mapstruct/ap/test/severaltargets/SourcePropertyMapSeveralTimesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/severaltargets/SourcePropertyMapSeveralTimesTest.java
@@ -24,10 +24,11 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.testng.annotations.Test;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Test for the generation of implementation of abstract base classes.
@@ -38,7 +39,8 @@ import org.testng.annotations.Test;
     Source.class, Target.class, SourceTargetMapper.class, TimeAndFormat.class,
     TimeAndFormatMapper.class
 })
-public class SourcePropertyMapSeveralTimesTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class SourcePropertyMapSeveralTimesTest {
 
     @Test
     @IssueKey("94")

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/UnmappedTargetTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/UnmappedTargetTest.java
@@ -18,18 +18,19 @@
  */
 package org.mapstruct.ap.test.unmappedtarget;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
-import org.mapstruct.ap.testutil.MapperTestBase;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
-import org.testng.annotations.Test;
-
-import static org.fest.assertions.Assertions.assertThat;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
  * Tests expected diagnostics for unmapped target properties.
@@ -37,7 +38,8 @@ import static org.fest.assertions.Assertions.assertThat;
  * @author Gunnar Morling
  */
 @IssueKey("35")
-public class UnmappedTargetTest extends MapperTestBase {
+@RunWith(AnnotationProcessorTestRunner.class)
+public class UnmappedTargetTest {
 
     @Test
     @WithClasses({ Source.class, Target.class, SourceTargetMapper.class })

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/AnnotationProcessorTestRunner.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/AnnotationProcessorTestRunner.java
@@ -1,0 +1,78 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.testutil.runner;
+
+import java.net.URL;
+
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+
+/**
+ * A JUnit4 runner for Annotation Processor tests.
+ * <p>
+ * Test classes and test methods are safe to be executed in parallel.
+ *
+ * @author Andreas Gudian
+ */
+public class AnnotationProcessorTestRunner extends BlockJUnit4ClassRunner {
+    static final ModifiableURLClassLoader TEST_CLASS_LOADER = new ModifiableURLClassLoader();
+
+    /**
+     * @param klass the test class
+     * @throws Exception see {@link BlockJUnit4ClassRunner#BlockJUnit4ClassRunner(Class)}
+     */
+    public AnnotationProcessorTestRunner(Class<?> klass) throws Exception {
+        super( replaceClassLoaderAndClass( klass ) );
+    }
+
+    /**
+     * newly loads the class with the test class loader and sets that loader as context class loader of the thread
+     *
+     * @param klass the class to replace
+     * @return the class loaded with the test class loader
+     */
+    private static Class<?> replaceClassLoaderAndClass(Class<?> klass) {
+        String classFileName = klass.getName().replace( ".", "/" ) + ".class";
+        URL classResource = klass.getClassLoader().getResource( classFileName );
+        String fullyQualifiedUrl = classResource.toExternalForm();
+        String basePath = fullyQualifiedUrl.substring( 0, fullyQualifiedUrl.length() - classFileName.length() );
+
+        TEST_CLASS_LOADER.addURL( basePath );
+
+        Thread.currentThread().setContextClassLoader( TEST_CLASS_LOADER );
+
+        try {
+            return TEST_CLASS_LOADER.loadClass( klass.getName() );
+        }
+        catch ( ClassNotFoundException e ) {
+            throw new RuntimeException( e );
+        }
+
+    }
+
+    @Override
+    protected Statement methodBlock(FrameworkMethod method) {
+        Statement statement = super.methodBlock( method );
+        statement = new CompilingStatement( statement, method, TEST_CLASS_LOADER );
+
+        return statement;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingStatement.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingStatement.java
@@ -16,15 +16,12 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.testutil;
+package org.mapstruct.ap.testutil.runner;
 
 import static org.fest.assertions.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -33,9 +30,7 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.tools.DiagnosticCollector;
@@ -46,42 +41,32 @@ import javax.tools.StandardJavaFileManager;
 import javax.tools.StandardLocation;
 import javax.tools.ToolProvider;
 
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
 import org.mapstruct.ap.MappingProcessor;
+import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
 import org.mapstruct.ap.testutil.compilation.model.CompilationOutcomeDescriptor;
 import org.mapstruct.ap.testutil.compilation.model.DiagnosticDescriptor;
-import org.testng.annotations.BeforeMethod;
 
 /**
- * Base class for all mapper tests.
- * </p>
- * The classes to be compiled for a given test method must be specified via
- * {@link WithClasses}. In addition the following things can be configured
- * optionally :
- * <ul>
- * <li>Processor options to be considered during compilation via
- * {@link ProcessorOption}.</li>
- * <li>The expected compilation outcome and expected diagnostics can be
- * specified via {@link ExpectedCompilationOutcome}. If no outcome is specified,
- * a successful compilation is assumed.</li>
- * </ul>
+ * A JUnit4 statement that performs source generation using the annotation processor and compiles those sources.
  *
- * @author Gunnar Morling
+ * @author Andreas Gudian
  */
-public abstract class MapperTestBase {
+class CompilingStatement extends Statement {
+    /**
+     * Property to specify the sub-directory below /target/ where the generated files are placed
+     */
+    public static final String MAPPER_TEST_OUTPUT_DIR_PROPERTY = "mapper.test.output.dir";
+    private static final String TARGET_COMPILATION_TESTS = "/target/"
+        + System.getProperty( MAPPER_TEST_OUTPUT_DIR_PROPERTY, "compilation-tests" ) + "_";
 
     private static final String LINE_SEPARATOR = System.getProperty( "line.separator" );
     private static final DiagnosticDescriptorComparator COMPARATOR = new DiagnosticDescriptorComparator();
-    private static final String TARGET_COMPILATION_TESTS = "/target/" + System.getProperty(
-        "mapper.test.output.dir",
-        "compilation-tests"
-    ) + "_";
-
-    private static Map<Integer, Integer> threadsWithEnhancedClassloader = new ConcurrentHashMap<Integer, Integer>();
-
-    private static ThreadLocal<Integer> threadNumber = new ThreadLocal<Integer>() {
+    private static final ThreadLocal<Integer> THREAD_NUMBER = new ThreadLocal<Integer>() {
         private AtomicInteger highWaterMark = new AtomicInteger( 0 );
 
         @Override
@@ -90,22 +75,36 @@ public abstract class MapperTestBase {
         }
     };
 
-    private static ThreadLocal<CompilationCache> compilationCache = new ThreadLocal<CompilationCache>() {
+    private static final ThreadLocal<CompilationCache> COMPILATION_CACHE = new ThreadLocal<CompilationCache>() {
         @Override
         protected CompilationCache initialValue() {
             return new CompilationCache();
         }
     };
 
+    private static final List<String> LIBRARIES = Arrays.asList( "mapstruct.jar", "guava.jar", "javax.inject.jar" );
+
+    private final Statement next;
+    private final FrameworkMethod method;
+    private final ModifiableURLClassLoader classloader;
+
     private JavaCompiler compiler;
     private String sourceDir;
     private String classOutputDir;
     private String sourceOutputDir;
     private List<File> classPath;
-    private final List<String> libraries;
 
-    public MapperTestBase() {
-        this.libraries = Arrays.asList( "mapstruct.jar", "guava.jar", "javax.inject.jar" );
+    public CompilingStatement(Statement next, FrameworkMethod method, ModifiableURLClassLoader classloader) {
+        this.next = next;
+        this.method = method;
+        this.classloader = classloader;
+    }
+
+    @Override
+    public void evaluate() throws Throwable {
+        generateMapperImplementation();
+
+        next.evaluate();
     }
 
     protected void setupCompiler() throws Exception {
@@ -113,7 +112,7 @@ public abstract class MapperTestBase {
 
         String basePath = getBasePath();
 
-        Integer i = threadNumber.get();
+        Integer i = THREAD_NUMBER.get();
 
         sourceDir = basePath + "/src/test/java";
         classOutputDir = basePath + TARGET_COMPILATION_TESTS + i + "/classes";
@@ -122,51 +121,35 @@ public abstract class MapperTestBase {
         String testDependenciesDir = basePath + "/target/test-dependencies/";
 
         classPath = new ArrayList<File>();
-        for ( String library : libraries ) {
+        for ( String library : LIBRARIES ) {
             classPath.add( new File( testDependenciesDir, library ) );
         }
 
         createOutputDirs();
 
-        // TODO #140 Is there a better way to do this?
-        if ( !threadsWithEnhancedClassloader.containsKey( i ) ) {
-            // we need to make sure that the the generated classes are loaded by the same classloader as the test has
-            // been loaded already. Otherwise some tests won't work.
-            URLClassLoader classLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
-            Class<?> clazz = URLClassLoader.class;
-            Method method = clazz.getDeclaredMethod( "addURL", new Class[] { URL.class } );
-            method.setAccessible( true );
-            method.invoke( classLoader, new File( classOutputDir ).toURI().toURL() );
-
-            threadsWithEnhancedClassloader.put( i, i );
-        }
+        classloader.addOutputDir( classOutputDir );
     }
 
-    @BeforeMethod
-    public void generateMapperImplementation(Method testMethod) throws Exception {
-        CompilationResultHolder compilationResult =
-            compile( getTestClasses( testMethod ), getProcessorOptions( testMethod ) );
+    protected void generateMapperImplementation() throws Exception {
+        CompilationResultHolder compilationResult = compile( getTestClasses(), getProcessorOptions() );
 
-        CompilationOutcomeDescriptor actualResult = CompilationOutcomeDescriptor.forResult(
-            sourceDir,
-            compilationResult.compilationSuccessful,
-            compilationResult.diagnostics.getDiagnostics()
-        );
-        CompilationOutcomeDescriptor expectedResult = CompilationOutcomeDescriptor.forExpectedCompilationResult(
-                testMethod.getAnnotation( ExpectedCompilationOutcome.class )
-        );
+        CompilationOutcomeDescriptor actualResult =
+            CompilationOutcomeDescriptor.forResult(
+                sourceDir,
+                compilationResult.compilationSuccessful,
+                compilationResult.diagnostics.getDiagnostics() );
+        CompilationOutcomeDescriptor expectedResult =
+            CompilationOutcomeDescriptor.forExpectedCompilationResult(
+                method.getAnnotation( ExpectedCompilationOutcome.class ) );
 
         if ( expectedResult.getCompilationResult() == CompilationResult.SUCCEEDED ) {
-            assertThat( actualResult.getCompilationResult() )
-                .describedAs(
-                    "Compilation failed. Diagnostics: " + compilationResult.diagnostics.getDiagnostics()
-                )
-                .isEqualTo( CompilationResult.SUCCEEDED );
+            assertThat( actualResult.getCompilationResult() ).describedAs(
+                "Compilation failed. Diagnostics: " + compilationResult.diagnostics.getDiagnostics() ).isEqualTo(
+                CompilationResult.SUCCEEDED );
         }
         else {
-            assertThat( actualResult.getCompilationResult() )
-                .describedAs( "Compilation succeeded but should have failed." )
-                .isEqualTo( CompilationResult.FAILED );
+            assertThat( actualResult.getCompilationResult() ).describedAs(
+                "Compilation succeeded but should have failed." ).isEqualTo( CompilationResult.FAILED );
         }
 
         assertDiagnostics( actualResult.getDiagnostics(), expectedResult.getDiagnostics() );
@@ -188,9 +171,8 @@ public abstract class MapperTestBase {
                 actualDiagnostics.toString().replace( ", ", LINE_SEPARATOR ),
                 LINE_SEPARATOR,
                 LINE_SEPARATOR,
-                expectedDiagnostics.toString().replace( ", ", LINE_SEPARATOR )
-            )
-        ).hasSize( expectedDiagnostics.size() );
+                expectedDiagnostics.toString().replace( ", ", LINE_SEPARATOR ) ) ).hasSize(
+            expectedDiagnostics.size() );
 
         while ( actualIterator.hasNext() ) {
 
@@ -209,9 +191,7 @@ public abstract class MapperTestBase {
                     "Unexpected message for diagnostic %s:%s %s",
                     actual.getSourceFileName(),
                     actual.getLine(),
-                    actual.getKind()
-                )
-            ).matches( ".*" + expected.getMessage() + ".*" );
+                    actual.getKind() ) ).matches( ".*" + expected.getMessage() + ".*" );
         }
     }
 
@@ -219,26 +199,24 @@ public abstract class MapperTestBase {
      * Returns the classes to be compiled for this test.
      *
      * @param testMethod The test method of interest
-     *
      * @return A set containing the classes to be compiled for this test
      */
-    private Set<Class<?>> getTestClasses(Method testMethod) {
+    private Set<Class<?>> getTestClasses() {
         Set<Class<?>> testClasses = new HashSet<Class<?>>();
 
-        WithClasses withClasses = testMethod.getAnnotation( WithClasses.class );
+        WithClasses withClasses = method.getAnnotation( WithClasses.class );
         if ( withClasses != null ) {
             testClasses.addAll( Arrays.asList( withClasses.value() ) );
         }
 
-        withClasses = this.getClass().getAnnotation( WithClasses.class );
+        withClasses = method.getMethod().getDeclaringClass().getAnnotation( WithClasses.class );
         if ( withClasses != null ) {
             testClasses.addAll( Arrays.asList( withClasses.value() ) );
         }
 
         if ( testClasses.isEmpty() ) {
             throw new IllegalStateException(
-                "The classes to be compiled during the test must be specified via @WithClasses."
-            );
+                "The classes to be compiled during the test must be specified via @WithClasses." );
         }
 
         return testClasses;
@@ -248,18 +226,17 @@ public abstract class MapperTestBase {
      * Returns the processor options to be used this test.
      *
      * @param testMethod The test method of interest
-     *
      * @return A list containing the processor options to be used for this test
      */
-    private List<String> getProcessorOptions(Method testMethod) {
-        ProcessorOption processorOption = testMethod.getAnnotation( ProcessorOption.class );
+    private List<String> getProcessorOptions() {
+        ProcessorOption processorOption = method.getAnnotation( ProcessorOption.class );
 
         if ( processorOption == null ) {
-            processorOption = this.getClass().getAnnotation( ProcessorOption.class );
+            processorOption = method.getMethod().getDeclaringClass().getAnnotation( ProcessorOption.class );
         }
 
-        return processorOption != null ? Arrays.asList( asOptionString( processorOption ) ) :
-            Collections.<String>emptyList();
+        return processorOption != null ? Arrays.asList( asOptionString( processorOption ) )
+                        : Collections.<String> emptyList();
     }
 
     private String asOptionString(ProcessorOption processorOption) {
@@ -270,14 +247,8 @@ public abstract class MapperTestBase {
         Set<File> sourceFiles = new HashSet<File>( classes.size() );
 
         for ( Class<?> clazz : classes ) {
-            sourceFiles.add(
-                new File(
-                    sourceDir +
-                        File.separator +
-                        clazz.getName().replace( ".", File.separator ) +
-                        ".java"
-                )
-            );
+            sourceFiles.add( new File( sourceDir + File.separator + clazz.getName().replace( ".", File.separator )
+                + ".java" ) );
         }
 
         return sourceFiles;
@@ -287,7 +258,7 @@ public abstract class MapperTestBase {
         throws Exception {
         CompilationRequest request = new CompilationRequest( sourceClasses, processorOptions );
 
-        CompilationCache cache = compilationCache.get();
+        CompilationCache cache = COMPILATION_CACHE.get();
         if ( request.equals( cache.lastRequest ) ) {
             return cache.lastResult;
         }
@@ -308,14 +279,8 @@ public abstract class MapperTestBase {
             throw new RuntimeException( e );
         }
 
-        CompilationTask task = compiler.getTask(
-            null,
-            fileManager,
-            diagnostics,
-            processorOptions,
-            null,
-            compilationUnits
-        );
+        CompilationTask task =
+            compiler.getTask( null, fileManager, diagnostics, processorOptions, null, compilationUnits );
         task.setProcessors( Arrays.asList( new MappingProcessor() ) );
 
         CompilationResultHolder resultHolder = new CompilationResultHolder( diagnostics, task.call() );

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/ModifiableURLClassLoader.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/ModifiableURLClassLoader.java
@@ -1,0 +1,85 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.testutil.runner;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * A parallel capable class loader for which additional URLs can be added after construction, and that will force
+ * classes from org.mapstruct.at.test.** packages to be loaded with this instance
+ *
+ * @author Andreas Gudian
+ */
+public class ModifiableURLClassLoader extends URLClassLoader {
+    private static final String ORG_MAPSTRUCT_AP_TEST = "org.mapstruct.ap.test.";
+    static {
+
+        ClassLoader.registerAsParallelCapable();
+    }
+
+    private ConcurrentMap<URL, URL> addedURLs = new ConcurrentHashMap<URL, URL>();
+
+    public ModifiableURLClassLoader() {
+        super( new URL[] {}, new FilteringParentClassLoader() );
+    }
+
+    @Override
+    protected void addURL(URL url) {
+        if ( addedURLs.putIfAbsent( url, url ) == null ) {
+            super.addURL( url );
+        }
+    }
+
+    /**
+     * @param basePath
+     */
+    public void addURL(String basePath) {
+        try {
+            addURL( new URL( basePath ) );
+        }
+        catch ( MalformedURLException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+    public void addOutputDir(String outputDir) {
+        try {
+            addURL( new File( outputDir ).toURI().toURL() );
+        }
+        catch ( MalformedURLException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+    private static final class FilteringParentClassLoader extends ClassLoader {
+        @Override
+        protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+            if ( name.startsWith( ORG_MAPSTRUCT_AP_TEST ) ) {
+                return null;
+            }
+
+            return super.loadClass( name, resolve );
+        }
+    }
+}


### PR DESCRIPTION
Avoiding unneccessary compilations made the tests run in half the time on my machine.

Parallel executions can be started with `mvn test` and:
-  `-DforkCount` > 1
- or: `-Dparallel=classes` and `-DthreadCount` > 1.

However... :wink: I did not see any speed improvements when running in parallel (quad-core, SSD). 

Using the MemFileManager was not that easily possible, as it's package-private. 

Any suggestions?
