### PR TITLE
183 Calling generated methods in a Mapper via the Decorator

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/model/Decorator.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/Decorator.java
@@ -25,7 +25,6 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 
 import org.mapstruct.ap.model.common.Accessibility;
-import org.mapstruct.ap.model.common.ModelElement;
 import org.mapstruct.ap.model.common.Type;
 import org.mapstruct.ap.model.common.TypeFactory;
 import org.mapstruct.ap.prism.DecoratedWithPrism;
@@ -40,7 +39,7 @@ public class Decorator extends GeneratedType {
     private static final String IMPLEMENTATION_SUFFIX = "Impl";
 
     private Decorator(TypeFactory typeFactory, String packageName, String name, String superClassName,
-                      String interfaceName, List<MappingMethod> methods, List<? extends ModelElement> fields,
+                      String interfaceName, List<MappingMethod> methods, List<Field> fields, Initializers constructors,
                       boolean suppressGeneratorTimestamp, Accessibility accessibility) {
         super(
             typeFactory,
@@ -50,6 +49,7 @@ public class Decorator extends GeneratedType {
             interfaceName,
             methods,
             fields,
+            constructors,
             suppressGeneratorTimestamp,
             accessibility
         );
@@ -62,22 +62,20 @@ public class Decorator extends GeneratedType {
         Type decoratorType = typeFactory.getType( decoratorPrism.value() );
 
         return new Decorator(
-            typeFactory,
-            elementUtils.getPackageOf( mapperElement ).getQualifiedName().toString(),
-            mapperElement.getSimpleName().toString() + IMPLEMENTATION_SUFFIX,
-            decoratorType.getName(),
-            mapperElement.getKind() == ElementKind.INTERFACE ? mapperElement.getSimpleName().toString() : null,
-            methods,
-            Arrays.asList(
-                new Field( typeFactory.getType( mapperElement ), "delegate" ),
-                new DecoratorConstructor(
-                    mapperElement.getSimpleName().toString() + IMPLEMENTATION_SUFFIX,
-                    mapperElement.getSimpleName().toString() + "Impl_",
-                    hasDelegateConstructor
-                )
-            ),
-            suppressGeneratorTimestamp,
-            Accessibility.fromModifiers( mapperElement.getModifiers() )
+                typeFactory,
+                elementUtils.getPackageOf( mapperElement ).getQualifiedName().toString(),
+                mapperElement.getSimpleName().toString() + IMPLEMENTATION_SUFFIX,
+                decoratorType.getName(),
+                mapperElement.getKind() == ElementKind.INTERFACE ? mapperElement.getSimpleName().toString() : null,
+                methods,
+                Arrays.asList( new Field( typeFactory.getType( mapperElement ), "delegate" ) ),
+                new DecoratorConstructors(
+                        mapperElement.getSimpleName().toString() + IMPLEMENTATION_SUFFIX,
+                        mapperElement.getSimpleName().toString() + "Impl_",
+                        hasDelegateConstructor
+                ),
+                suppressGeneratorTimestamp,
+                Accessibility.fromModifiers( mapperElement.getModifiers() )
         );
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/model/DecoratorConstructors.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/DecoratorConstructors.java
@@ -1,0 +1,61 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.model;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.mapstruct.ap.model.common.ModelElement;
+import org.mapstruct.ap.model.common.Type;
+
+/**
+ * Represents the constructor of a decorator.
+ *
+ * @author Gunnar Morling
+ */
+public class DecoratorConstructors extends ModelElement implements Initializers {
+
+    private final String name;
+    private final String delegateName;
+    private final boolean invokeSuperConstructor;
+
+    public DecoratorConstructors(String name, String delegateName, boolean invokeSuperConstructor) {
+        this.name = name;
+        this.delegateName = delegateName;
+        this.invokeSuperConstructor = invokeSuperConstructor;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public String getDelegateName() {
+        return delegateName;
+    }
+
+    public boolean isInvokeSuperConstructor() {
+        return invokeSuperConstructor;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/model/DecoratorReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/DecoratorReference.java
@@ -16,29 +16,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.decorator.nested;
+package org.mapstruct.ap.model;
+
+import org.mapstruct.ap.model.common.Type;
 
 /**
- *
  * @author Sjaak Derksen
  */
-public abstract class CompanyMapperDecorator implements CompanyMapper {
+public class DecoratorReference extends MapperReference {
 
-    private final CompanyMapper delegate;
-
-    public CompanyMapperDecorator( CompanyMapper delegate ) {
-        this.delegate = delegate;
+    public DecoratorReference(Type type) {
+        super( type, "delegator" );
     }
-
-    @Override
-    public AddressDto toAddressDto(Address address) {
-        AddressDto addressDto = delegate.toAddressDto( address );
-        String addressLine = address.getAddressLine();
-        int seperatorIndex = addressLine.indexOf( ";" );
-        addressDto.setStreet( addressLine.substring( 0, seperatorIndex ) );
-        String houseNumber = addressLine.substring( seperatorIndex + 1, addressLine.length() );
-        addressDto.setHouseNumber( Integer.parseInt( houseNumber ) );
-        return addressDto;
-    }
-
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/GeneratedType.java
@@ -45,6 +45,7 @@ public abstract class GeneratedType extends ModelElement {
     private final List<Annotation> annotations;
     private final List<MappingMethod> methods;
     private final List<? extends ModelElement> fields;
+    private final Initializers constructors;
 
     private final boolean suppressGeneratorTimestamp;
     private final Accessibility accessibility;
@@ -57,7 +58,8 @@ public abstract class GeneratedType extends ModelElement {
     protected GeneratedType(TypeFactory typeFactory, String packageName, String name, String superClassName,
                             String interfaceName,
                             List<MappingMethod> methods,
-                            List<? extends ModelElement> fields,
+                            List<? extends Field> fields,
+                            Initializers constructors,
                             boolean suppressGeneratorTimestamp, Accessibility accessibility) {
         this.packageName = packageName;
         this.name = name;
@@ -67,6 +69,7 @@ public abstract class GeneratedType extends ModelElement {
         this.annotations = new ArrayList<Annotation>();
         this.methods = methods;
         this.fields = fields;
+        this.constructors = constructors;
 
         this.suppressGeneratorTimestamp = suppressGeneratorTimestamp;
         this.accessibility = accessibility;
@@ -104,6 +107,10 @@ public abstract class GeneratedType extends ModelElement {
 
     public List<? extends ModelElement> getFields() {
         return fields;
+    }
+
+    public Initializers getConstructors() {
+        return constructors;
     }
 
     public boolean isSuppressGeneratorTimestamp() {

--- a/processor/src/main/java/org/mapstruct/ap/model/Initializers.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/Initializers.java
@@ -18,43 +18,18 @@
  */
 package org.mapstruct.ap.model;
 
-import java.util.Collections;
 import java.util.Set;
-
-import org.mapstruct.ap.model.common.ModelElement;
 import org.mapstruct.ap.model.common.Type;
 
 /**
- * Represents the constructor of a decorator.
+ * This class is a holder for both constructors and initialization methods
  *
- * @author Gunnar Morling
+ * @author Sjaak Derksen
  */
-public class DecoratorConstructor extends ModelElement {
+public interface Initializers {
 
-    private final String name;
-    private final String delegateName;
-    private final boolean invokeSuperConstructor;
+    Set<Type> getImportTypes();
 
-    public DecoratorConstructor(String name, String delegateName, boolean invokeSuperConstructor) {
-        this.name = name;
-        this.delegateName = delegateName;
-        this.invokeSuperConstructor = invokeSuperConstructor;
-    }
+    String getName();
 
-    @Override
-    public Set<Type> getImportTypes() {
-        return Collections.emptySet();
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getDelegateName() {
-        return delegateName;
-    }
-
-    public boolean isInvokeSuperConstructor() {
-        return invokeSuperConstructor;
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/Mapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/Mapper.java
@@ -40,11 +40,18 @@ public class Mapper extends GeneratedType {
     private final List<MapperReference> referencedMappers;
     private final Decorator decorator;
 
-    private Mapper(TypeFactory typeFactory, String packageName, String name, String superClassName,
-                   String interfaceName,
-                   List<MappingMethod> methods, boolean suppressGeneratorTimestamp, Accessibility accessibility,
-                   List<MapperReference> referencedMappers, Decorator decorator) {
-
+    //CHECKSTYLE:OFF
+    private Mapper( TypeFactory typeFactory,
+            String packageName,
+            String name,
+            String superClassName,
+            String interfaceName,
+            List<MappingMethod> methods,
+            boolean suppressGeneratorTimestamp,
+            Accessibility accessibility,
+            List<MapperReference> referencedMappers,
+            Initializers constructors,
+            Decorator decorator ) {
         super(
             typeFactory,
             packageName,
@@ -53,6 +60,7 @@ public class Mapper extends GeneratedType {
             interfaceName,
             methods,
             referencedMappers,
+            constructors,
             suppressGeneratorTimestamp,
             accessibility
         );
@@ -111,6 +119,11 @@ public class Mapper extends GeneratedType {
             String implementationName = element.getSimpleName()
                 + ( decorator == null ? IMPLEMENTATION_SUFFIX : DECORATED_IMPLEMENTATION_SUFFIX );
 
+            Initializers constructors = null;
+            if ( decorator != null ) {
+                constructors = new MapperInitializer( implementationName, decorator.getName() );
+            }
+
             return new Mapper(
                 typeFactory,
                 elementUtils.getPackageOf( element ).getQualifiedName().toString(),
@@ -121,6 +134,7 @@ public class Mapper extends GeneratedType {
                 suppressGeneratorTimestamp,
                 Accessibility.fromModifiers( element.getModifiers() ),
                 mapperReferences,
+                constructors,
                 decorator
             );
         }

--- a/processor/src/main/java/org/mapstruct/ap/model/MapperInitializer.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MapperInitializer.java
@@ -16,29 +16,41 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.decorator.nested;
+package org.mapstruct.ap.model;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.mapstruct.ap.model.common.ModelElement;
+import org.mapstruct.ap.model.common.Type;
 
 /**
+ * Represents the constructor of a decorator.
  *
  * @author Sjaak Derksen
  */
-public abstract class CompanyMapperDecorator implements CompanyMapper {
+public class MapperInitializer extends ModelElement implements Initializers {
 
-    private final CompanyMapper delegate;
+    private final String name;
+    private final String delegatorName;
 
-    public CompanyMapperDecorator( CompanyMapper delegate ) {
-        this.delegate = delegate;
+    public MapperInitializer(String name, String delegatorName) {
+        this.name = name;
+        this.delegatorName = delegatorName;
     }
 
     @Override
-    public AddressDto toAddressDto(Address address) {
-        AddressDto addressDto = delegate.toAddressDto( address );
-        String addressLine = address.getAddressLine();
-        int seperatorIndex = addressLine.indexOf( ";" );
-        addressDto.setStreet( addressLine.substring( 0, seperatorIndex ) );
-        String houseNumber = addressLine.substring( seperatorIndex + 1, addressLine.length() );
-        addressDto.setHouseNumber( Integer.parseInt( houseNumber ) );
-        return addressDto;
+    public Set<Type> getImportTypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public String getDelegatorName() {
+        return delegatorName;
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/assignment/AssignmentFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/assignment/AssignmentFactory.java
@@ -44,12 +44,14 @@ public class AssignmentFactory {
     }
 
     public static FactoryMethod createFactory(SourceMethod method, MapperReference declaringMapper) {
-        return new MethodReference( method, declaringMapper, null );
+        String variableName = declaringMapper != null ? declaringMapper.getVariableName() : null;
+        return new MethodReference( method, variableName, null );
     }
 
     public static Assignment createMethodReference(SourceMethod method, MapperReference declaringMapper,
                                                    Type targetType) {
-        return new MethodReference( method, declaringMapper, targetType );
+        String variableName = declaringMapper != null ? declaringMapper.getVariableName() : null;
+        return new MethodReference( method, variableName, targetType );
     }
 
     public static Assignment createMethodReference(BuiltInMethod method, ConversionContext contextParam) {

--- a/processor/src/main/java/org/mapstruct/ap/model/assignment/MethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/assignment/MethodReference.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Set;
 import org.mapstruct.ap.model.Assignment;
 import org.mapstruct.ap.model.FactoryMethod;
-import org.mapstruct.ap.model.MapperReference;
 import org.mapstruct.ap.model.MappingMethod;
 
 import org.mapstruct.ap.model.common.ConversionContext;
@@ -41,7 +40,7 @@ import org.mapstruct.ap.model.source.builtin.BuiltInMethod;
  */
 public class MethodReference extends MappingMethod implements Assignment, FactoryMethod {
 
-    private final MapperReference declaringMapper;
+    private final String variableName;
     private final Set<Type> importTypes;
     private final List<Type> exceptionTypes;
 
@@ -66,13 +65,13 @@ public class MethodReference extends MappingMethod implements Assignment, Factor
      * Creates a new reference to the given method.
      *
      * @param method the target method of the reference
-     * @param declaringMapper the method declaring the mapper; {@code null} if the current mapper itself
+     * @param variableName instance variable in mapper to call this method upon
      * @param targetType in case the referenced method has a parameter for passing the target type, the given
      * target type, otherwise {@code null}
      */
-    public MethodReference(SourceMethod method, MapperReference declaringMapper, Type targetType) {
+    public MethodReference(SourceMethod method, String variableName, Type targetType) {
         super( method );
-        this.declaringMapper = declaringMapper;
+        this.variableName = variableName;
         this.contextParam = null;
         Set<Type> imported = new HashSet( method.getThrownTypes() );
         if ( targetType != null ) {
@@ -84,18 +83,14 @@ public class MethodReference extends MappingMethod implements Assignment, Factor
 
     public MethodReference(BuiltInMethod method, ConversionContext contextParam) {
         super( method );
-        this.declaringMapper = null;
+        this.variableName = null;
         this.contextParam = method.getContextParameter( contextParam );
         this.importTypes = Collections.emptySet();
         this.exceptionTypes = Collections.emptyList();
     }
 
-    public MapperReference getDeclaringMapper() {
-        return declaringMapper;
-    }
-
     public String getMapperVariableName() {
-        return declaringMapper.getVariableName();
+        return variableName;
     }
 
     public String getContextParam() {

--- a/processor/src/main/java/org/mapstruct/ap/processor/creation/MappingResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/creation/MappingResolver.java
@@ -32,6 +32,7 @@ import javax.tools.Diagnostic.Kind;
 import org.mapstruct.ap.conversion.ConversionProvider;
 import org.mapstruct.ap.conversion.Conversions;
 import org.mapstruct.ap.model.Assignment;
+import org.mapstruct.ap.model.DecoratorReference;
 import org.mapstruct.ap.model.MapperReference;
 import org.mapstruct.ap.model.VirtualMappingMethod;
 import org.mapstruct.ap.model.assignment.AssignmentFactory;
@@ -443,7 +444,8 @@ public class MappingResolver {
 
         private MapperReference findMapperReference( List<MapperReference> mapperReferences, SourceMethod method ) {
             for ( MapperReference ref : mapperReferences ) {
-                if ( ref.getType().equals( method.getDeclaringMapper() ) ) {
+                if ( ref.getType().equals( method.getDeclaringMapper() )
+                        || ( method.getDeclaringMapper() == null && ref instanceof DecoratorReference ) ) {
                     return ref;
                 }
             }

--- a/processor/src/main/resources/org.mapstruct.ap.model.DecoratorConstructors.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.DecoratorConstructors.ftl
@@ -18,31 +18,14 @@
      limitations under the License.
 
 -->
-package ${packageName};
+public ${name}() {
+    this( new ${delegateName}() );
+}
 
-<#list importTypes as importedType>
-import ${importedType.fullyQualifiedName};
-</#list>
-
-@Generated(
-    value = "org.mapstruct.ap.MappingProcessor"<#if suppressGeneratorTimestamp == false>,
-    date = "${.now?string("yyyy-MM-dd'T'HH:mm:ssZ")}"</#if>
-)
-<#list annotations as annotation>
-<#nt><@includeModel object=annotation/>
-</#list>
-<#lt>${accessibility.keyword} class ${name}<#if superClassName??> extends ${superClassName}</#if><#if interfaceName??> implements ${interfaceName}</#if> {
-<#list fields as field>
-
-<#nt>    <@includeModel object=field/>
-</#list>
-<#if constructors??>
-
-         <@includeModel object=constructors/>
-
-</#if>
-<#list methods as method>
-
-<#nt>    <@includeModel object=method/>
-</#list>
+private ${name}(${delegateName} delegate) {
+    <#if invokeSuperConstructor>
+    super( delegate );
+    </#if>
+    delegate.init( this );
+    this.delegate = delegate;
 }

--- a/processor/src/main/resources/org.mapstruct.ap.model.DecoratorReference.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.DecoratorReference.ftl
@@ -18,13 +18,4 @@
      limitations under the License.
 
 -->
-public ${name}() {
-    this( new ${delegateName}() );
-}
-
-private ${name}(${delegateName} delegate) {
-    <#if invokeSuperConstructor>
-    super( delegate );
-    </#if>
-    this.delegate = delegate;
-}
+private <@includeModel object=type/> ${variableName};

--- a/processor/src/main/resources/org.mapstruct.ap.model.MapperInitializer.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.MapperInitializer.ftl
@@ -18,31 +18,6 @@
      limitations under the License.
 
 -->
-package ${packageName};
-
-<#list importTypes as importedType>
-import ${importedType.fullyQualifiedName};
-</#list>
-
-@Generated(
-    value = "org.mapstruct.ap.MappingProcessor"<#if suppressGeneratorTimestamp == false>,
-    date = "${.now?string("yyyy-MM-dd'T'HH:mm:ssZ")}"</#if>
-)
-<#list annotations as annotation>
-<#nt><@includeModel object=annotation/>
-</#list>
-<#lt>${accessibility.keyword} class ${name}<#if superClassName??> extends ${superClassName}</#if><#if interfaceName??> implements ${interfaceName}</#if> {
-<#list fields as field>
-
-<#nt>    <@includeModel object=field/>
-</#list>
-<#if constructors??>
-
-         <@includeModel object=constructors/>
-
-</#if>
-<#list methods as method>
-
-<#nt>    <@includeModel object=method/>
-</#list>
+public void init(${delegatorName} delegator) {
+    this.delegator = delegator;
 }

--- a/processor/src/main/resources/org.mapstruct.ap.model.assignment.MethodReference.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.assignment.MethodReference.ftl
@@ -19,8 +19,8 @@
 
 -->
 <@compress single_line=true>
-    <#-- method is either internal to the mapper class, or external (via uses) declaringMapper!=null -->
-    <#if declaringMapper??>${mapperVariableName}.</#if>${name}<#if (parameters?size > 0)>( <@arguments/> )<#else>()</#if>
+    <#-- method is either internal to the mapper class, or external via a mapper instance Variable -->
+    <#if mapperVariableName??>${mapperVariableName}.</#if>${name}<#if (parameters?size > 0)>( <@arguments/> )<#else>()</#if>
     <#macro arguments>
         <#list parameters as param>
             <#if param.targetType>

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/Address.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/Address.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.decorator.nested;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Address {
+
+    private String addressLine;
+    private String town;
+
+    public String getAddressLine() {
+        return addressLine;
+    }
+
+    public void setAddressLine( String addressLine ) {
+        this.addressLine = addressLine;
+    }
+
+    public String getTown() {
+        return town;
+    }
+
+    public void setTown( String town ) {
+        this.town = town;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/AddressDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/AddressDto.java
@@ -1,0 +1,54 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.decorator.nested;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class AddressDto {
+
+    private int houseNumber;
+    private String street;
+    private String town;
+
+    public int getHouseNumber() {
+        return houseNumber;
+    }
+
+    public void setHouseNumber( int houseNumber ) {
+        this.houseNumber = houseNumber;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet( String street ) {
+        this.street = street;
+    }
+
+    public String getTown() {
+        return town;
+    }
+
+    public void setTown( String town ) {
+        this.town = town;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/Company.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/Company.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.decorator.nested;
+
+import java.util.List;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Company {
+
+    private List<Employee> employees;
+
+    public List<Employee> getEmployees() {
+        return employees;
+    }
+
+    public void setEmployees( List<Employee> employees ) {
+        this.employees = employees;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/CompanyDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/CompanyDto.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.decorator.nested;
+
+import java.util.List;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class CompanyDto {
+
+    private List<EmployeeDto> employees;
+
+    public List<EmployeeDto> getEmployees() {
+        return employees;
+    }
+
+    public void setEmployees( List<EmployeeDto> employees ) {
+        this.employees = employees;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/CompanyMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/CompanyMapper.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.decorator.nested;
+
+import java.util.List;
+import org.mapstruct.DecoratedWith;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+@DecoratedWith(CompanyMapperDecorator.class)
+public interface CompanyMapper {
+
+   CompanyMapper INSTANCE = Mappers.getMapper( CompanyMapper.class );
+
+   AddressDto toAddressDto(Address address);
+
+   CompanyDto toCompanyDto(Company company);
+
+   List<EmployeeDto> toEmployeeDtoList(List<Employee> employee);
+
+   EmployeeDto toEmployeeDto(Employee employee);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/CompanyMapperDecorator.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/CompanyMapperDecorator.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.decorator.nested;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public abstract class CompanyMapperDecorator implements CompanyMapper {
+
+    private final CompanyMapper delegate;
+
+    public CompanyMapperDecorator( CompanyMapper delegate ) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public AddressDto toAddressDto(Address address) {
+        AddressDto addressDto = delegate.toAddressDto( address );
+        String addressLine = address.getAddressLine();
+        int seperatorIndex = addressLine.indexOf( ";" );
+        addressDto.setStreet( addressLine.substring( 0, seperatorIndex - 1 ) );
+        String houseNumber = addressLine.substring( seperatorIndex + 1, addressLine.length() );
+        addressDto.setHouseNumber( Integer.getInteger( houseNumber ) );
+        return addressDto;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/Employee.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/Employee.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.decorator.nested;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Employee {
+
+    private Address address;
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress( Address address ) {
+        this.address = address;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/EmployeeDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/EmployeeDto.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.decorator.nested;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class EmployeeDto {
+
+    private AddressDto address;
+
+    public AddressDto getAddress() {
+        return address;
+    }
+
+    public void setAddress( AddressDto address ) {
+        this.address = address;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/NestedDecoratorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/NestedDecoratorTest.java
@@ -1,0 +1,74 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.decorator.nested;
+
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+
+@WithClasses({
+    Company.class,
+    CompanyDto.class,
+    Employee.class,
+    EmployeeDto.class,
+    Address.class,
+    AddressDto.class,
+    CompanyMapper.class,
+    CompanyMapperDecorator.class
+})
+@IssueKey("183")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class NestedDecoratorTest {
+
+    @Test
+    public void test() {
+
+        // setup
+        Address address = new Address();
+        address.setAddressLine( "RoadToNowhere;5");
+        address.setTown( "SmallTown" );
+        Employee employee = new Employee();
+        employee.setAddress( address );
+        Company company = new Company();
+        company.setEmployees( Arrays.asList( new Employee[] { employee } ) );
+
+        // test
+        CompanyDto companyDto = CompanyMapper.INSTANCE.toCompanyDto( company );
+
+//        // verify
+        assertThat( companyDto.getEmployees() ).isNotEmpty();
+        assertThat( companyDto.getEmployees().size() ).isEqualTo( 1 );
+        assertThat( companyDto.getEmployees().get( 0 ).getAddress() ).isNotNull();
+//        assertThat( companyDto.getEmployees().get( 0 ).getAddress().getHouseNumber() ).isEqualTo( 5 );
+//        assertThat( companyDto.getEmployees().get( 0 ).getAddress().getStreet() ).isEqualTo( "RoadToNowhere" );
+        assertThat( companyDto.getEmployees().get( 0 ).getAddress().getTown() ).isEqualTo( "SmallTown" );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/NestedDecoratorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/nested/NestedDecoratorTest.java
@@ -62,12 +62,12 @@ public class NestedDecoratorTest {
         // test
         CompanyDto companyDto = CompanyMapper.INSTANCE.toCompanyDto( company );
 
-//        // verify
+        // verify
         assertThat( companyDto.getEmployees() ).isNotEmpty();
         assertThat( companyDto.getEmployees().size() ).isEqualTo( 1 );
         assertThat( companyDto.getEmployees().get( 0 ).getAddress() ).isNotNull();
-//        assertThat( companyDto.getEmployees().get( 0 ).getAddress().getHouseNumber() ).isEqualTo( 5 );
-//        assertThat( companyDto.getEmployees().get( 0 ).getAddress().getStreet() ).isEqualTo( "RoadToNowhere" );
+        assertThat( companyDto.getEmployees().get( 0 ).getAddress().getHouseNumber() ).isEqualTo( 5 );
+        assertThat( companyDto.getEmployees().get( 0 ).getAddress().getStreet() ).isEqualTo( "RoadToNowhere" );
         assertThat( companyDto.getEmployees().get( 0 ).getAddress().getTown() ).isEqualTo( "SmallTown" );
     }
 


### PR DESCRIPTION
1. Suppose you have a tree structure of objects which are mapped by one mapper (you can of course break-up, but that should not be needed de-facto).

2. Suppose that you need to decorate a leaf deep down in this tree structure.

Currently you need to decorate each branch leading towards the leaf to be able to 'reach' it. A simple test has been added to demonstrate. This conflicts very much with the idea of making things simple. You should only decorate the methods that are strictly needed to be decorated.

I needed to create a call back in the constructor of the `DecoratorImpl`.  That should be scrutinized for better solutions.
