### PR TITLE
#113 Moving expression to constant in Mapping, making room for other expression languages

### DIFF
--- a/core-jdk8/src/main/java/org/mapstruct/Mapping.java
+++ b/core-jdk8/src/main/java/org/mapstruct/Mapping.java
@@ -42,7 +42,7 @@ public @interface Mapping {
      * <li>The source name of the configured property as defined by the JavaBeans specification.</li>
      * <li>When used to map an enum constant, the name of the constant member is to be given<./li>.
      * </ol>
-     * Either this attribute or {@link #expression()} may be specified for a given mapping, but not both at the same
+     * Either this attribute or {@link #constant()} may be specified for a given mapping, but not both at the same
      * time.
      *
      * @return The source name of the configured property or enum constant.
@@ -66,15 +66,15 @@ public @interface Mapping {
     String dateFormat() default "";
 
     /**
-     * A constant {@link String} expression based on which the specified target property is to be set. If the designated
+     * A constant {@link String} based on which the specified target property is to be set. If the designated
      * target property is not of type {@code String}, the value will be converted by applying a matching conversion
      * method or built-in conversion.
      * <p>
      * Either this attribute or {@link #source()} may be specified for a given mapping, but not both at the same time.
      * If this attribute is given, the target property must be specified via {@link #target()}.
      *
-     * @return A constant {@code String} expression specifying the value for the designated target prperty
+     * @return A constant {@code String} constant specifying the value for the designated target property
      */
-    String expression() default "";
+    String constant() default "";
 
 }

--- a/core/src/main/java/org/mapstruct/Mapping.java
+++ b/core/src/main/java/org/mapstruct/Mapping.java
@@ -40,7 +40,7 @@ public @interface Mapping {
      * <li>The source name of the configured property as defined by the JavaBeans specification.</li>
      * <li>When used to map an enum constant, the name of the constant member is to be given<./li>.
      * </ol>
-     * Either this attribute or {@link #expression()} may be specified for a given mapping, but not both at the same
+     * Either this attribute or {@link #constant()} may be specified for a given mapping, but not both at the same
      * time.
      *
      * @return The source name of the configured property or enum constant.
@@ -64,15 +64,15 @@ public @interface Mapping {
     String dateFormat() default "";
 
     /**
-     * A constant {@link String} expression based on which the specified target property is to be set. If the designated
+     * A constant {@link String} based on which the specified target property is to be set. If the designated
      * target property is not of type {@code String}, the value will be converted by applying a matching conversion
      * method or built-in conversion.
      * <p>
      * Either this attribute or {@link #source()} may be specified for a given mapping, but not both at the same time.
      * If this attribute is given, the target property must be specified via {@link #target()}.
      *
-     * @return A constant {@code String} expression specifying the value for the designated target prperty
+     * @return A constant {@code String} constant specifying the value for the designated target property
      */
-    String expression() default "";
+    String constant() default "";
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
@@ -42,7 +42,7 @@ public class Mapping {
     private final String sourceName;
     private final String sourceParameterName;
     private final String sourcePropertyName;
-    private final String expression;
+    private final String constant;
     private final String targetName;
     private final String dateFormat;
     private final AnnotationMirror mirror;
@@ -74,18 +74,18 @@ public class Mapping {
             mappingPrism.values.source()
         );
 
-        if ( mappingPrism.source().isEmpty() && mappingPrism.expression().isEmpty() ) {
+        if ( mappingPrism.source().isEmpty() && mappingPrism.constant().isEmpty() ) {
             messager.printMessage(
                 Diagnostic.Kind.ERROR,
-                "Either define a source or an expression in a Mapping",
+                "Either define a source or a constant in a Mapping",
                 element
             );
             return null;
         }
-        else if ( !mappingPrism.source().isEmpty() && !mappingPrism.expression().isEmpty() ) {
+        else if ( !mappingPrism.source().isEmpty() && !mappingPrism.constant().isEmpty() ) {
             messager.printMessage(
                 Diagnostic.Kind.ERROR,
-                "Source and expression are both defined in Mapping, either define a source or an expression",
+                "Source and constant are both defined in Mapping, either define a source or an expression",
                 element
             );
             return null;
@@ -95,7 +95,7 @@ public class Mapping {
             mappingPrism.source(),
             sourceNameParts != null ? sourceNameParts[0] : null,
             sourceNameParts != null ? sourceNameParts[1] : mappingPrism.source(),
-            mappingPrism.expression(),
+            mappingPrism.constant(),
             mappingPrism.target(),
             mappingPrism.dateFormat(),
             mappingPrism.mirror,
@@ -123,13 +123,13 @@ public class Mapping {
         return parts;
     }
 
-    private Mapping(String sourceName, String sourceParameterName, String sourcePropertyName, String expression,
+    private Mapping(String sourceName, String sourceParameterName, String sourcePropertyName, String constant,
                     String targetName, String dateFormat, AnnotationMirror mirror,
                     AnnotationValue sourceAnnotationValue, AnnotationValue targetAnnotationValue) {
         this.sourceName = sourceName;
         this.sourceParameterName = sourceParameterName;
         this.sourcePropertyName = sourcePropertyName;
-        this.expression = expression;
+        this.constant = constant;
         this.targetName = targetName.equals( "" ) ? sourceName : targetName;
         this.dateFormat = dateFormat;
         this.mirror = mirror;
@@ -165,8 +165,8 @@ public class Mapping {
         return sourceParameterName;
     }
 
-    public String getExpression() {
-        return expression;
+    public String getConstant() {
+        return constant;
     }
 
 
@@ -193,13 +193,13 @@ public class Mapping {
 
     public Mapping reverse() {
         Mapping reverse = null;
-        if ( expression != null ) {
+        if ( constant != null ) {
             /* mapping can only be reversed if the source was not a constant */
             reverse = new Mapping(
                 targetName,
                 null,
                 targetName,
-                expression,
+                constant,
                 sourceName,
                 dateFormat,
                 mirror,

--- a/processor/src/main/java/org/mapstruct/ap/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/MapperCreationProcessor.java
@@ -410,8 +410,8 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
         String sourcePropertyName;
         if ( mapping != null ) {
             dateFormat = mapping.getDateFormat();
-            isSourceConstant = !mapping.getExpression().isEmpty();
-            sourceConstant = "\"" + mapping.getExpression() + "\"";
+            isSourceConstant = !mapping.getConstant().isEmpty();
+            sourceConstant = "\"" + mapping.getConstant() + "\"";
             sourcePropertyName = mapping.getSourcePropertyName();
         }
         else {
@@ -674,7 +674,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
                     }
 
                 }
-                else if ( mappedProperty.getExpression().isEmpty() &&
+                else if ( mappedProperty.getConstant().isEmpty() &&
                     !hasSourceProperty( method, mappedProperty.getSourcePropertyName() ) ) {
                     messager.printMessage(
                         Kind.ERROR,

--- a/processor/src/test/java/org/mapstruct/ap/test/sourceconstants/ErroneousMapper1.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/sourceconstants/ErroneousMapper1.java
@@ -33,11 +33,11 @@ public interface ErroneousMapper1 {
     ErroneousMapper1 INSTANCE = Mappers.getMapper( ErroneousMapper1.class );
 
     @Mappings( {
-        @Mapping( target = "stringConstant", expression = "stringConstant"),
-        @Mapping( source = "test" , target = "integerConstant", expression = "14"),
-        @Mapping( target = "longWrapperConstant", expression = "3001"),
-        @Mapping( target = "dateConstant", dateFormat = "dd-MM-yyyy", expression = "09-01-2014"),
-        @Mapping( target = "nameConstants", expression = "jack-jill-tom" )
+        @Mapping( target = "stringConstant", constant = "stringConstant"),
+        @Mapping( source = "test" , target = "integerConstant", constant = "14"),
+        @Mapping( target = "longWrapperConstant", constant = "3001"),
+        @Mapping( target = "dateConstant", dateFormat = "dd-MM-yyyy", constant = "09-01-2014"),
+        @Mapping( target = "nameConstants", constant = "jack-jill-tom" )
     } )
     Target sourceToTarget(Source s);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/sourceconstants/ErroneousMapper2.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/sourceconstants/ErroneousMapper2.java
@@ -33,11 +33,11 @@ public interface ErroneousMapper2 {
     ErroneousMapper2 INSTANCE = Mappers.getMapper( ErroneousMapper2.class );
 
     @Mappings( {
-        @Mapping( target = "stringConstant", expression = "stringConstant"),
+        @Mapping( target = "stringConstant", constant = "stringConstant"),
         @Mapping( target = "integerConstant" ),
-        @Mapping( target = "longWrapperConstant", expression = "3001"),
-        @Mapping( target = "dateConstant", dateFormat = "dd-MM-yyyy", expression = "09-01-2014"),
-        @Mapping( target = "nameConstants", expression = "jack-jill-tom" )
+        @Mapping( target = "longWrapperConstant", constant = "3001"),
+        @Mapping( target = "dateConstant", dateFormat = "dd-MM-yyyy", constant = "09-01-2014"),
+        @Mapping( target = "nameConstants", constant = "jack-jill-tom" )
     } )
     Target sourceToTarget(Source s);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/sourceconstants/SourceConstantsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/sourceconstants/SourceConstantsTest.java
@@ -96,7 +96,7 @@ public class SourceConstantsTest {
             @Diagnostic(type = ErroneousMapper1.class,
                 kind = Kind.ERROR,
                 line = 42,
-                messageRegExp = "Source and expression are both defined in Mapping, either define a source or an "
+                messageRegExp = "Source and constant are both defined in Mapping, either define a source or an "
                         + "expression"),
             @Diagnostic(type = ErroneousMapper1.class,
                 kind = Kind.WARNING,
@@ -121,7 +121,7 @@ public class SourceConstantsTest {
             @Diagnostic(type = ErroneousMapper2.class,
                 kind = Kind.ERROR,
                 line = 42,
-                messageRegExp = "Either define a source or an expression in a Mapping"),
+                messageRegExp = "Either define a source or a constant in a Mapping"),
             @Diagnostic(type = ErroneousMapper2.class,
                 kind = Kind.WARNING,
                 line = 42,

--- a/processor/src/test/java/org/mapstruct/ap/test/sourceconstants/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/sourceconstants/SourceTargetMapper.java
@@ -33,11 +33,11 @@ public interface SourceTargetMapper {
     SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
 
     @Mappings( {
-        @Mapping( target = "stringConstant", expression = "stringConstant"),
-        @Mapping( target = "integerConstant", expression = "14"),
-        @Mapping( target = "longWrapperConstant", expression = "3001"),
-        @Mapping( target = "dateConstant", dateFormat = "dd-MM-yyyy", expression = "09-01-2014"),
-        @Mapping( target = "nameConstants", expression = "jack-jill-tom" )
+        @Mapping( target = "stringConstant", constant = "stringConstant"),
+        @Mapping( target = "integerConstant", constant = "14"),
+        @Mapping( target = "longWrapperConstant", constant = "3001"),
+        @Mapping( target = "dateConstant", dateFormat = "dd-MM-yyyy", constant = "09-01-2014"),
+        @Mapping( target = "nameConstants", constant = "jack-jill-tom" )
     } )
     Target sourceToTarget(Source s);
     Source targetToSource(Target t);


### PR DESCRIPTION
For quick understanding :) please look at tests:
1. `org.mapstruct.ap.test.multiple.manytoone.SourceTargetMapper`
2. `org.mapstruct.ap.test.multiple.onetomany.SourceTargetMapper`

This is a first attempt. This solves a considerable part of the current issues I have. 

About the solution, I need to add unit test for the error situations that are introduced. But have a look and see if this makes sense. If I need other tests as well ,let me know.

I'm thinking of deprecating (or removing, suggestions?) the current multiple sources mechanism (so, where a `@mapping` to the same target is allowed more than one time in the `@Mappings`) in favor for the newly introduced comma separated mechanism (in order to align with many-sources-to-one-target). 
