### PR TITLE
#168 allow to globally configure mappings using @GlobalMapping

### DIFF
--- a/core-common/src/main/java/org/mapstruct/factory/Mappers.java
+++ b/core-common/src/main/java/org/mapstruct/factory/Mappers.java
@@ -18,11 +18,9 @@
  */
 package org.mapstruct.factory;
 
-import org.mapstruct.Mapper;
-
 /**
  * Factory for obtaining mapper instances if no explicit component model such as CDI is configured via
- * {@link Mapper#componentModel()}.
+ * {@link org.mapstruct.Mapper#componentModel()}.
  * <p>
  * Mapper implementation types are expected to have the same fully qualified name as their interface type, with the
  * suffix {@code Impl} appended. When using this factory, mapper types - and any mappers they use - are instantiated by

--- a/core-jdk8/src/main/java/org/mapstruct/GlobalMapping.java
+++ b/core-jdk8/src/main/java/org/mapstruct/GlobalMapping.java
@@ -1,0 +1,70 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The global mapping configuration is used to avoid repeating the same &#64;{@link Mapping} annotations on different
+ * mapping methods. Global mappings can be specified within &#64;{@link Mapper} and &#64;{@link MapperConfig}.
+ * <p>
+ * The {@link Mapping}s specified within a global mapping are applied to all mapping methods that fulfill the
+ * restrictions on source type and target type:
+ * <ul>
+ * <li> {@link #sourceType()} is omitted, or one of the source parameter types of the mapping method is assignable to
+ * the specified {@link #sourceType()}
+ * <li> {@link #targetType()} is omitted, or the result type of the mapping method is assignable to the specified
+ * {@link #targetType()}
+ * </ul>
+ * An &#64;{@link Mapping} annotation on a mapping method has precedence over the configuration for the same source or
+ * target property in a global mapping.
+ *
+ * @author Andreas Gudian
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ })
+@Documented
+public @interface GlobalMapping {
+
+    /**
+     * The type that at least one of the source parameter types of a mapping method must be assignable to. If omitted,
+     * no restriction on the source types is imposed.
+     *
+     * @return the source type restriction
+     */
+    Class<?> sourceType() default Object.class;
+
+    /**
+     * The type that the result type of a mapping method must be assignable to. If omitted, no restriction on the result
+     * type is imposed.
+     *
+     * @return the target type restriction
+     */
+    Class<?> targetType() default Object.class;
+
+    /**
+     * The mapping configuration to apply to all matching methods.
+     *
+     * @return the mapping configuration to be applied to all matching methods
+     */
+    Mapping[] mappings();
+}

--- a/core-jdk8/src/main/java/org/mapstruct/Mapper.java
+++ b/core-jdk8/src/main/java/org/mapstruct/Mapper.java
@@ -1,0 +1,123 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Marks an interface as mapper interface and activates the generation of a
+ * mapper implementation for that interface.
+ *
+ * @author Gunnar Morling
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.CLASS)
+public @interface Mapper {
+
+    /**
+     * The mapper types used by this mapper.
+     *
+     * @return The mapper types used by this mapper.
+     */
+    Class<?>[] uses() default { };
+
+    /**
+     * Additional types for which an import statement is to be added to the generated mapper implementation class.
+     * This allows to refer to those types from within mapping expressions given via {@link Mapping#expression()} using
+     * their simple name rather than their fully-qualified name.
+     *
+     * @return classes to add in the imports of the generated implementation.
+     */
+    Class<?>[] imports() default { };
+
+    /**
+     * How unmapped properties of the target type of a mapping should be
+     * reported. The method overrides an unmappedTargetPolicy set in a central
+     * configuration set by {@link #config() }
+     *
+     * @return The reporting policy for unmapped target properties.
+     */
+    ReportingPolicy unmappedTargetPolicy() default ReportingPolicy.DEFAULT;
+
+    /**
+     * Specifies the component model to which the generated mapper should
+     * adhere. Supported values are
+     * <ul>
+     * <li> {@code default}: the mapper uses no component model, instances are
+     * typically retrieved via {@link Mappers#getMapper(Class)}</li>
+     * <li>
+     * {@code cdi}: the generated mapper is an application-scoped CDI bean and
+     * can be retrieved via {@code @Inject}</li>
+     * <li>
+     * {@code spring}: the generated mapper is a Spring bean and
+     * can be retrieved via {@code @Autowired}</li>
+     * <li>
+     * {@code jsr330}: the generated mapper is annotated with {@code @Named} and
+     * can be retrieved via {@code @Inject}</li>
+     * </ul>
+     * The method overrides an unmappedTargetPolicy set in a central configuration set
+     * by {@link #config() }
+     *
+     * @return The component model for the generated mapper.
+     */
+    String componentModel() default "default";
+
+    /**
+     * A class annotated with {@link MapperConfig} which should be used as configuration template. Any settings given
+     * via {@link Mapper} will take precedence over the settings from the referenced configuration source. The list of
+     * referenced mappers will contain all mappers given via {@link Mapper#uses()} and {@link MapperConfig#uses()}.
+     *
+     * @return A class which should be used as configuration template.
+     */
+    Class<?> config() default void.class;
+
+    /**
+     * The strategy to be applied when propagating the value of collection-typed properties. By default, only JavaBeans
+     * accessor methods (setters or getters) will be used, but it is also possible to invoke a corresponding adder
+     * method for each element of the source collection (e.g. {@code orderDto.addOrderLine()}).
+     * <p>
+     * Any setting given for this attribute will take precedence over {@link MapperConfig#collectionMappingStrategy()},
+     * if present.
+     *
+     * @return The strategy applied when propagating the value of collection-typed properties.
+     */
+    CollectionMappingStrategy collectionMappingStrategy() default CollectionMappingStrategy.DEFAULT;
+
+    /**
+     * The strategy to be applied when {@code null} is passed as source value to the methods of this mapper. If no
+     * strategy is configured, the strategy given via {@link MapperConfig#nullValueMappingStrategy()} will be applied,
+     * using {@link NullValueMappingStrategy#RETURN_NULL} by default.
+     *
+     * @return The strategy to be applied when {@code null} is passed as source value to the methods of this mapper.
+     */
+    NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.DEFAULT;
+
+    /**
+     * Global mappings can be used to define mapping configurations for mapping methods that fulfill certain source
+     * and/or target type criteria without having to repeat the same &#64;{@link Mapping} annotations for those methods.
+     *
+     * @return The global mapping configuration for mapping methods within the annotated mapper.
+     */
+    GlobalMapping[] globalMappings() default { };
+}

--- a/core-jdk8/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core-jdk8/src/main/java/org/mapstruct/MapperConfig.java
@@ -89,4 +89,13 @@ public @interface MapperConfig {
      * @return The strategy to be applied when {@code null} is passed as source value to mapping methods.
      */
     NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.DEFAULT;
+
+    /**
+     * Global mappings can be used to define mapping configurations for mapping methods that fulfill certain source
+     * and/or target type criteria without having to repeat the same &#64;{@link Mapping} annotations for those methods.
+     *
+     * @return The global mapping configuration for mapping methods within all mappers that are configured with this
+     *         mapper config.
+     */
+    GlobalMapping[] globalMappings() default { };
 }

--- a/core-jdk8/src/main/java/org/mapstruct/Mapping.java
+++ b/core-jdk8/src/main/java/org/mapstruct/Mapping.java
@@ -39,9 +39,9 @@ import java.util.Date;
  *
  * @author Gunnar Morling
  */
-@Repeatable(Mappings.class)
-@Retention(RetentionPolicy.SOURCE)
-@Target(ElementType.METHOD)
+@Retention( RetentionPolicy.CLASS )
+@Target( ElementType.METHOD )
+@Repeatable( Mappings.class )
 public @interface Mapping {
 
     /**

--- a/core/src/main/java/org/mapstruct/GlobalMapping.java
+++ b/core/src/main/java/org/mapstruct/GlobalMapping.java
@@ -1,0 +1,70 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * The global mapping configuration is used to avoid repeating the same &#64;{@link Mapping} annotations on different
+ * mapping methods. Global mappings can be specified within &#64;{@link Mapper} and &#64;{@link MapperConfig}.
+ * <p>
+ * The {@link Mapping}s specified within a global mapping are applied to all mapping methods that fulfill the
+ * restrictions on source type and target type:
+ * <ul>
+ * <li> {@link #sourceType()} is omitted, or one of the source parameter types of the mapping method is assignable to
+ * the specified {@link #sourceType()}
+ * <li> {@link #targetType()} is omitted, or the result type of the mapping method is assignable to the specified
+ * {@link #targetType()}
+ * </ul>
+ * An &#64;{@link Mapping} annotation on a mapping method has precedence over the configuration for the same source or
+ * target property in a global mapping.
+ *
+ * @author Andreas Gudian
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ })
+@Documented
+public @interface GlobalMapping {
+
+    /**
+     * The type that at least one of the source parameter types of a mapping method must be assignable to. If omitted,
+     * no restriction on the source types is imposed.
+     *
+     * @return the source type restriction
+     */
+    Class<?> sourceType() default Object.class;
+
+    /**
+     * The type that the result type of a mapping method must be assignable to. If omitted, no restriction on the result
+     * type is imposed.
+     *
+     * @return the target type restriction
+     */
+    Class<?> targetType() default Object.class;
+
+    /**
+     * The mapping configuration to apply to all matching methods.
+     *
+     * @return the mapping configuration to be applied to all matching methods
+     */
+    Mapping[] mappings();
+}

--- a/core/src/main/java/org/mapstruct/Mapper.java
+++ b/core/src/main/java/org/mapstruct/Mapper.java
@@ -1,0 +1,123 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Marks an interface as mapper interface and activates the generation of a
+ * mapper implementation for that interface.
+ *
+ * @author Gunnar Morling
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.CLASS)
+public @interface Mapper {
+
+    /**
+     * The mapper types used by this mapper.
+     *
+     * @return The mapper types used by this mapper.
+     */
+    Class<?>[] uses() default { };
+
+    /**
+     * Additional types for which an import statement is to be added to the generated mapper implementation class.
+     * This allows to refer to those types from within mapping expressions given via {@link Mapping#expression()} using
+     * their simple name rather than their fully-qualified name.
+     *
+     * @return classes to add in the imports of the generated implementation.
+     */
+    Class<?>[] imports() default { };
+
+    /**
+     * How unmapped properties of the target type of a mapping should be
+     * reported. The method overrides an unmappedTargetPolicy set in a central
+     * configuration set by {@link #config() }
+     *
+     * @return The reporting policy for unmapped target properties.
+     */
+    ReportingPolicy unmappedTargetPolicy() default ReportingPolicy.DEFAULT;
+
+    /**
+     * Specifies the component model to which the generated mapper should
+     * adhere. Supported values are
+     * <ul>
+     * <li> {@code default}: the mapper uses no component model, instances are
+     * typically retrieved via {@link Mappers#getMapper(Class)}</li>
+     * <li>
+     * {@code cdi}: the generated mapper is an application-scoped CDI bean and
+     * can be retrieved via {@code @Inject}</li>
+     * <li>
+     * {@code spring}: the generated mapper is a Spring bean and
+     * can be retrieved via {@code @Autowired}</li>
+     * <li>
+     * {@code jsr330}: the generated mapper is annotated with {@code @Named} and
+     * can be retrieved via {@code @Inject}</li>
+     * </ul>
+     * The method overrides an unmappedTargetPolicy set in a central configuration set
+     * by {@link #config() }
+     *
+     * @return The component model for the generated mapper.
+     */
+    String componentModel() default "default";
+
+    /**
+     * A class annotated with {@link MapperConfig} which should be used as configuration template. Any settings given
+     * via {@link Mapper} will take precedence over the settings from the referenced configuration source. The list of
+     * referenced mappers will contain all mappers given via {@link Mapper#uses()} and {@link MapperConfig#uses()}.
+     *
+     * @return A class which should be used as configuration template.
+     */
+    Class<?> config() default void.class;
+
+    /**
+     * The strategy to be applied when propagating the value of collection-typed properties. By default, only JavaBeans
+     * accessor methods (setters or getters) will be used, but it is also possible to invoke a corresponding adder
+     * method for each element of the source collection (e.g. {@code orderDto.addOrderLine()}).
+     * <p>
+     * Any setting given for this attribute will take precedence over {@link MapperConfig#collectionMappingStrategy()},
+     * if present.
+     *
+     * @return The strategy applied when propagating the value of collection-typed properties.
+     */
+    CollectionMappingStrategy collectionMappingStrategy() default CollectionMappingStrategy.DEFAULT;
+
+    /**
+     * The strategy to be applied when {@code null} is passed as source value to the methods of this mapper. If no
+     * strategy is configured, the strategy given via {@link MapperConfig#nullValueMappingStrategy()} will be applied,
+     * using {@link NullValueMappingStrategy#RETURN_NULL} by default.
+     *
+     * @return The strategy to be applied when {@code null} is passed as source value to the methods of this mapper.
+     */
+    NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.DEFAULT;
+
+    /**
+     * Global mappings can be used to define mapping configurations for mapping methods that fulfill certain source
+     * and/or target type criteria without having to repeat the same &#64;{@link Mapping} annotations for those methods.
+     *
+     * @return The global mapping configuration for mapping methods within the annotated mapper.
+     */
+    GlobalMapping[] globalMappings() default { };
+}

--- a/core/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core/src/main/java/org/mapstruct/MapperConfig.java
@@ -26,14 +26,16 @@ import java.lang.annotation.Target;
 import org.mapstruct.factory.Mappers;
 
 /**
- * Marks an interface as mapper interface and activates the generation of a
- * mapper implementation for that interface.
+ * Marks a class-, interface-, enum declaration as (common) configuration.
  *
- * @author Gunnar Morling
+ * The {@link #unmappedTargetPolicy() } and {@link #componentModel() } can be overruled by a specific {@link Mapper}
+ * annotation. {@link #uses() } will be used in addition to what is specified in the {@link Mapper} annotation.
+ *
+ * @author Sjaak Derksen
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.CLASS)
-public @interface Mapper {
+public @interface MapperConfig {
 
     /**
      * The mapper types used by this mapper.
@@ -43,22 +45,12 @@ public @interface Mapper {
     Class<?>[] uses() default { };
 
     /**
-     * Additional types for which an import statement is to be added to the generated mapper implementation class.
-     * This allows to refer to those types from within mapping expressions given via {@link Mapping#expression()} using
-     * their simple name rather than their fully-qualified name.
-     *
-     * @return classes to add in the imports of the generated implementation.
-     */
-    Class<?>[] imports() default { };
-
-    /**
      * How unmapped properties of the target type of a mapping should be
-     * reported. The method overrides an unmappedTargetPolicy set in a central
-     * configuration set by {@link #config() }
+     * reported.
      *
      * @return The reporting policy for unmapped target properties.
      */
-    ReportingPolicy unmappedTargetPolicy() default ReportingPolicy.DEFAULT;
+    ReportingPolicy unmappedTargetPolicy() default ReportingPolicy.WARN;
 
     /**
      * Specifies the component model to which the generated mapper should
@@ -76,40 +68,34 @@ public @interface Mapper {
      * {@code jsr330}: the generated mapper is annotated with {@code @Named} and
      * can be retrieved via {@code @Inject}</li>
      * </ul>
-     * The method overrides an unmappedTargetPolicy set in a central configuration set
-     * by {@link #config() }
      *
      * @return The component model for the generated mapper.
      */
     String componentModel() default "default";
 
     /**
-     * A class annotated with {@link MapperConfig} which should be used as configuration template. Any settings given
-     * via {@link Mapper} will take precedence over the settings from the referenced configuration source. The list of
-     * referenced mappers will contain all mappers given via {@link Mapper#uses()} and {@link MapperConfig#uses()}.
-     *
-     * @return A class which should be used as configuration template.
-     */
-    Class<?> config() default void.class;
-
-    /**
      * The strategy to be applied when propagating the value of collection-typed properties. By default, only JavaBeans
      * accessor methods (setters or getters) will be used, but it is also possible to invoke a corresponding adder
      * method for each element of the source collection (e.g. {@code orderDto.addOrderLine()}).
-     * <p>
-     * Any setting given for this attribute will take precedence over {@link MapperConfig#collectionMappingStrategy()},
-     * if present.
      *
      * @return The strategy applied when propagating the value of collection-typed properties.
      */
     CollectionMappingStrategy collectionMappingStrategy() default CollectionMappingStrategy.DEFAULT;
 
     /**
-     * The strategy to be applied when {@code null} is passed as source value to the methods of this mapper. If no
-     * strategy is configured, the strategy given via {@link MapperConfig#nullValueMappingStrategy()} will be applied,
-     * using {@link NullValueMappingStrategy#RETURN_NULL} by default.
+     * The strategy to be applied when {@code null} is passed as source value to mapping methods. If no strategy is
+     * configured, {@link NullValueMappingStrategy#RETURN_NULL} will be used by default.
      *
-     * @return The strategy to be applied when {@code null} is passed as source value to the methods of this mapper.
+     * @return The strategy to be applied when {@code null} is passed as source value to mapping methods.
      */
     NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.DEFAULT;
+
+    /**
+     * Global mappings can be used to define mapping configurations for mapping methods that fulfill certain source
+     * and/or target type criteria without having to repeat the same &#64;{@link Mapping} annotations for those methods.
+     *
+     * @return The global mapping configuration for mapping methods within all mappers that are configured with this
+     *         mapper config.
+     */
+    GlobalMapping[] globalMappings() default { };
 }

--- a/core/src/main/java/org/mapstruct/Mapping.java
+++ b/core/src/main/java/org/mapstruct/Mapping.java
@@ -38,7 +38,7 @@ import java.util.Date;
  *
  * @author Gunnar Morling
  */
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 @Target(ElementType.METHOD)
 public @interface Mapping {
 

--- a/core/src/main/java/org/mapstruct/Mappings.java
+++ b/core/src/main/java/org/mapstruct/Mappings.java
@@ -28,7 +28,7 @@ import java.lang.annotation.Target;
  *
  * @author Gunnar Morling
  */
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 @Target(ElementType.METHOD)
 public @interface Mappings {
 

--- a/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.annotation.processing.Messager;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -37,7 +38,6 @@ import javax.tools.Diagnostic.Kind;
 
 import org.mapstruct.ap.model.common.TypeFactory;
 import org.mapstruct.ap.prism.MappingPrism;
-import org.mapstruct.ap.prism.MappingsPrism;
 import org.mapstruct.ap.util.Executables;
 
 /**
@@ -62,12 +62,15 @@ public class Mapping {
     private final AnnotationValue targetAnnotationValue;
     private SourceReference sourceReference;
 
-    public static Map<String, List<Mapping>> fromMappingsPrism(MappingsPrism mappingsAnnotation,
+    public static Map<String, List<Mapping>> fromMappingPrisms(List<MappingPrism> mappingPrisms,
                                                                ExecutableElement method,
                                                                Messager messager) {
         Map<String, List<Mapping>> mappings = new HashMap<String, List<Mapping>>();
 
-        for ( MappingPrism mappingPrism : mappingsAnnotation.value() ) {
+        for ( MappingPrism mappingPrism : mappingPrisms ) {
+            if ( !mappings.containsKey( mappingPrism.target() ) ) {
+                mappings.put( mappingPrism.target(), new ArrayList<Mapping>() );
+            }
             Mapping mapping = fromMappingPrism( mappingPrism, method, messager );
             if ( mapping != null ) {
                 List<Mapping> mappingsOfProperty = mappings.get( mappingPrism.target() );

--- a/processor/src/main/java/org/mapstruct/ap/prism/PrismGenerator.java
+++ b/processor/src/main/java/org/mapstruct/ap/prism/PrismGenerator.java
@@ -23,6 +23,7 @@ import javax.xml.bind.annotation.XmlElementDecl;
 import net.java.dev.hickory.prism.GeneratePrism;
 import net.java.dev.hickory.prism.GeneratePrisms;
 import org.mapstruct.DecoratedWith;
+import org.mapstruct.GlobalMapping;
 import org.mapstruct.InheritConfiguration;
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.IterableMapping;
@@ -51,6 +52,7 @@ import org.mapstruct.TargetType;
     @GeneratePrism(value = MappingTarget.class, publicAccess = true),
     @GeneratePrism(value = DecoratedWith.class, publicAccess = true),
     @GeneratePrism(value = MapperConfig.class, publicAccess = true),
+    @GeneratePrism(value = GlobalMapping.class, publicAccess = true),
     @GeneratePrism(value = InheritConfiguration.class, publicAccess = true),
     @GeneratePrism(value = InheritInverseConfiguration.class, publicAccess = true),
     @GeneratePrism(value = Qualifier.class, publicAccess = true),

--- a/processor/src/main/java/org/mapstruct/ap/util/MapperConfig.java
+++ b/processor/src/main/java/org/mapstruct/ap/util/MapperConfig.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.DeclaredType;
@@ -30,6 +31,7 @@ import javax.lang.model.type.TypeMirror;
 
 import org.mapstruct.ap.option.ReportingPolicy;
 import org.mapstruct.ap.prism.CollectionMappingStrategyPrism;
+import org.mapstruct.ap.prism.GlobalMappingPrism;
 import org.mapstruct.ap.prism.MapperConfigPrism;
 import org.mapstruct.ap.prism.MapperPrism;
 import org.mapstruct.ap.prism.NullValueMappingPrism;
@@ -73,11 +75,25 @@ public class MapperConfig {
     }
 
     public List<TypeMirror> uses() {
-        Set<TypeMirror> uses = new HashSet<TypeMirror>( mapperPrism.uses() );
+        List<TypeMirror> result = new ArrayList<TypeMirror>();
+        Set<TypeMirror> alreadyAdded = new HashSet<TypeMirror>();
+
+        addAllOnce( result, alreadyAdded, mapperPrism.uses() );
+
         if ( mapperConfigPrism != null ) {
-            uses.addAll( mapperConfigPrism.uses() );
+            addAllOnce( result, alreadyAdded, mapperConfigPrism.uses() );
         }
-        return new ArrayList<TypeMirror>( uses );
+
+        return result;
+    }
+
+    private void addAllOnce(List<TypeMirror> result, Set<TypeMirror> alreadyAdded, List<TypeMirror> toAdd) {
+        for ( TypeMirror item : toAdd ) {
+            if ( !alreadyAdded.contains( item ) ) {
+                result.add( item );
+                alreadyAdded.add( item );
+            }
+        }
     }
 
     public List<TypeMirror> imports() {
@@ -162,6 +178,16 @@ public class MapperConfig {
         else {
             return "default";
         }
+    }
+
+    public List<GlobalMappingPrism> globalMappings() {
+        List<GlobalMappingPrism> globalMappings = new ArrayList<GlobalMappingPrism>( mapperPrism.globalMappings() );
+
+        if ( mapperConfigPrism != null ) {
+            globalMappings.addAll( mapperConfigPrism.globalMappings() );
+        }
+
+        return globalMappings;
     }
 
     public boolean isValid() {

--- a/processor/src/test/java/org/mapstruct/ap/test/globalmapping/BaseVehicleDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/globalmapping/BaseVehicleDto.java
@@ -16,26 +16,20 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+package org.mapstruct.ap.test.globalmapping;
 
 /**
- * Configures the mappings of several bean attributes.
+ * @author Andreas Gudian
  *
- * @author Gunnar Morling
  */
-@Retention(RetentionPolicy.CLASS)
-@Target(ElementType.METHOD)
-public @interface Mappings {
+public abstract class BaseVehicleDto {
+    private long id;
 
-    /**
-     * The configuration of the bean attributes.
-     *
-     * @return The configuration of the bean attributes.
-     */
-    Mapping[] value();
+    public long getId() {
+        return id;
+    }
+
+    public void setId(long id) {
+        this.id = id;
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/globalmapping/BaseVehicleEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/globalmapping/BaseVehicleEntity.java
@@ -16,26 +16,29 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+package org.mapstruct.ap.test.globalmapping;
 
 /**
- * Configures the mappings of several bean attributes.
+ * @author Andreas Gudian
  *
- * @author Gunnar Morling
  */
-@Retention(RetentionPolicy.CLASS)
-@Target(ElementType.METHOD)
-public @interface Mappings {
+public abstract class BaseVehicleEntity {
+    private long primaryKey;
+    private String auditTrail;
 
-    /**
-     * The configuration of the bean attributes.
-     *
-     * @return The configuration of the bean attributes.
-     */
-    Mapping[] value();
+    public long getPrimaryKey() {
+        return primaryKey;
+    }
+
+    public void setPrimaryKey(long primaryKey) {
+        this.primaryKey = primaryKey;
+    }
+
+    public String getAuditTrail() {
+        return auditTrail;
+    }
+
+    public void setAuditTrail(String auditTrail) {
+        this.auditTrail = auditTrail;
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/globalmapping/CarDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/globalmapping/CarDto.java
@@ -16,26 +16,20 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+package org.mapstruct.ap.test.globalmapping;
 
 /**
- * Configures the mappings of several bean attributes.
+ * @author Andreas Gudian
  *
- * @author Gunnar Morling
  */
-@Retention(RetentionPolicy.CLASS)
-@Target(ElementType.METHOD)
-public @interface Mappings {
+public class CarDto extends BaseVehicleDto {
+    private String colour;
 
-    /**
-     * The configuration of the bean attributes.
-     *
-     * @return The configuration of the bean attributes.
-     */
-    Mapping[] value();
+    public String getColour() {
+        return colour;
+    }
+
+    public void setColour(String colour) {
+        this.colour = colour;
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/globalmapping/CarEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/globalmapping/CarEntity.java
@@ -16,26 +16,20 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct;
-
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+package org.mapstruct.ap.test.globalmapping;
 
 /**
- * Configures the mappings of several bean attributes.
+ * @author Andreas Gudian
  *
- * @author Gunnar Morling
  */
-@Retention(RetentionPolicy.CLASS)
-@Target(ElementType.METHOD)
-public @interface Mappings {
+public class CarEntity extends BaseVehicleEntity {
+    private String color;
 
-    /**
-     * The configuration of the bean attributes.
-     *
-     * @return The configuration of the bean attributes.
-     */
-    Mapping[] value();
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/globalmapping/CarMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/globalmapping/CarMapper.java
@@ -1,0 +1,57 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.globalmapping;
+
+import org.mapstruct.GlobalMapping;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Andreas Gudian
+ *
+ */
+@Mapper(
+    unmappedTargetPolicy = ReportingPolicy.ERROR,
+    config = DictionaryConfigHolder.class,
+    globalMappings = {
+        @GlobalMapping(
+            sourceType = BaseVehicleDto.class,
+            targetType = BaseVehicleEntity.class,
+            mappings = @Mapping(source = "id", target = "primaryKey")
+        ),
+        @GlobalMapping(
+            targetType = BaseVehicleEntity.class,
+            mappings = @Mapping(target = "auditTrail", ignore = true)
+        )
+    }
+)
+public interface CarMapper {
+    CarMapper INSTANCE = Mappers.getMapper( CarMapper.class );
+
+    CarEntity toCarEntity(CarDto carDto);
+
+    @InheritInverseConfiguration( name = "toCarEntity" )
+    CarDto toCarDto(CarEntity entity);
+
+    @Mapping( target = "auditTrail", constant = "fixed" )
+    CarEntity toCarEntityWithFixedAuditTrail(CarDto carDto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/globalmapping/DictionaryConfigHolder.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/globalmapping/DictionaryConfigHolder.java
@@ -16,26 +16,25 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct;
+package org.mapstruct.ap.test.globalmapping;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
+import org.mapstruct.GlobalMapping;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.Mapping;
 
 /**
- * Configures the mappings of several bean attributes.
+ * Provides a global dictionary for British English to American English
  *
- * @author Gunnar Morling
+ * @author Andreas Gudian
  */
-@Retention(RetentionPolicy.CLASS)
-@Target(ElementType.METHOD)
-public @interface Mappings {
+@MapperConfig(
+    globalMappings = {
+        @GlobalMapping(
+            targetType = BaseVehicleEntity.class,
+            mappings = { @Mapping( source = "colour", target = "color" ) }
+        )
+    }
+)
+public class DictionaryConfigHolder {
 
-    /**
-     * The configuration of the bean attributes.
-     *
-     * @return The configuration of the bean attributes.
-     */
-    Mapping[] value();
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/globalmapping/GlobalMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/globalmapping/GlobalMappingTest.java
@@ -1,0 +1,83 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.globalmapping;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Andreas Gudian
+ *
+ */
+@RunWith( AnnotationProcessorTestRunner.class )
+@WithClasses( {
+    BaseVehicleDto.class,
+    BaseVehicleEntity.class,
+    CarDto.class,
+    CarEntity.class,
+    CarMapper.class,
+    DictionaryConfigHolder.class } )
+public class GlobalMappingTest {
+
+    @Test
+    @IssueKey( "168" )
+    public void globalMappingIsApplied() {
+        CarDto carDto = new CarDto();
+        carDto.setColour( "red" );
+        carDto.setId( 42L );
+
+        CarEntity carEntity = CarMapper.INSTANCE.toCarEntity( carDto );
+
+        assertThat( carEntity.getColor() ).isEqualTo( "red" );
+        assertThat( carEntity.getPrimaryKey() ).isEqualTo( 42L );
+        assertThat( carEntity.getAuditTrail() ).isNull();
+    }
+
+    @Test
+    @IssueKey( "168" )
+    public void globalMappingIsOverriddenAtMethodLevel() {
+        CarDto carDto = new CarDto();
+        carDto.setColour( "red" );
+        carDto.setId( 42L );
+
+        CarEntity carEntity = CarMapper.INSTANCE.toCarEntityWithFixedAuditTrail( carDto );
+
+        assertThat( carEntity.getColor() ).isEqualTo( "red" );
+        assertThat( carEntity.getPrimaryKey() ).isEqualTo( 42L );
+        assertThat( carEntity.getAuditTrail() ).isEqualTo( "fixed" );
+    }
+
+    @Test
+    @IssueKey( "168" )
+    public void globalMappingIsAppliedInReverse() {
+        CarEntity carEntity = new CarEntity();
+        carEntity.setColor( "red" );
+        carEntity.setPrimaryKey( 42L );
+
+        CarDto carDto = CarMapper.INSTANCE.toCarDto( carEntity );
+
+        assertThat( carDto.getColour() ).isEqualTo( "red" );
+        assertThat( carDto.getId() ).isEqualTo( 42L );
+    }
+}


### PR DESCRIPTION
I had to move ```@Mapper``` and ```@MapperConfig``` to ```core``` and ```core-jdk8```, as they now require ```@GlobalMapping```, which in turn requires ```@Mapping```... 