### PR TITLE
#278 fix for applying expressions in the reverse, test for Boolean isPro...

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
@@ -235,7 +235,7 @@ public class Mapping {
     public Mapping reverse() {
         Mapping reverse = null;
         // mapping can only be reversed if the source was not a constant nor an expression
-        if ( constant != null && expression != null ) {
+        if ( constant.isEmpty() && expression.isEmpty() ) {
             reverse = new Mapping(
                 targetName,
                 null,

--- a/processor/src/main/java/org/mapstruct/ap/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/MapperCreationProcessor.java
@@ -415,11 +415,12 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
 
         for ( List<Mapping> mappingList : mappings.values() ) {
             for ( Mapping mapping : mappingList ) {
-                if ( !reversed.containsKey( mapping.getTargetName() ) ) {
-                    reversed.put( mapping.getTargetName(), new ArrayList<Mapping>() );
-                }
+
                 Mapping reverseMapping = mapping.reverse();
                 if ( reverseMapping != null ) {
+                    if ( !reversed.containsKey( mapping.getTargetName() ) ) {
+                        reversed.put( mapping.getTargetName(), new ArrayList<Mapping>() );
+                    }
                     reversed.get( mapping.getTargetName() ).add( reverseMapping );
                 }
             }

--- a/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/BooleanWorkAroundMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/BooleanWorkAroundMapper.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.source.expressions.java;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper
+public interface BooleanWorkAroundMapper {
+
+    BooleanWorkAroundMapper INSTANCE = Mappers.getMapper( BooleanWorkAroundMapper.class );
+
+    @Mapping( expression = "java(source.isVal())", target = "val" )
+    TargetBooleanWorkAround mapST( SourceBooleanWorkAround source );
+    SourceBooleanWorkAround mapTS( TargetBooleanWorkAround target );
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/JavaExpressionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/JavaExpressionTest.java
@@ -34,12 +34,11 @@ import org.mapstruct.ap.testutil.IssueKey;
 /**
  * @author Sjaak Derksen
  */
-@WithClasses({ Source.class, Target.class, TimeAndFormat.class })
 @RunWith(AnnotationProcessorTestRunner.class)
 public class JavaExpressionTest {
 
    @Test
-   @WithClasses({ SourceTargetMapper.class })
+   @WithClasses({ Source.class, Target.class, TimeAndFormat.class, SourceTargetMapper.class })
     public void testJavaExpressionInsertion() throws ParseException {
         Source source = new Source();
         String format = "dd-MM-yyyy,hh:mm:ss";
@@ -58,7 +57,13 @@ public class JavaExpressionTest {
 
     @IssueKey( "255" )
     @Test
-    @WithClasses({ SourceTargetMapperSeveralSources.class, Source2.class })
+    @WithClasses({
+        Source.class,
+        Source2.class ,
+        Target.class,
+        TimeAndFormat.class,
+        SourceTargetMapperSeveralSources.class
+      })
     public void testJavaExpressionInsertionWithSeveralSources() throws ParseException {
         Source source1 = new Source();
         String format = "dd-MM-yyyy,hh:mm:ss";
@@ -87,7 +92,7 @@ public class JavaExpressionTest {
     }
 
    @Test
-   @WithClasses({ SourceTargetMapper.class })
+   @WithClasses({ Source.class, Target.class, TimeAndFormat.class, SourceTargetMapper.class })
     public void testJavaExpressionInsertionWithExistingTarget() throws ParseException {
         Source source = new Source();
         String format = "dd-MM-yyyy,hh:mm:ss";
@@ -106,4 +111,27 @@ public class JavaExpressionTest {
         assertThat( target.getAnotherProp() ).isNull();
         assertThat( target ).isEqualTo( target2 );
     }
+
+    @IssueKey( "278" )
+    @Test
+    @WithClasses({
+        SourceBooleanWorkAround.class,
+        TargetBooleanWorkAround.class,
+        BooleanWorkAroundMapper.class
+      })
+    public void testBooleanGetterWorkAround() throws ParseException {
+
+        SourceBooleanWorkAround source = new SourceBooleanWorkAround();
+        source.setVal( Boolean.TRUE );
+
+        TargetBooleanWorkAround target = BooleanWorkAroundMapper.INSTANCE.mapST( source );
+        assertThat( target ).isNotNull();
+        assertThat( target.isVal() ).isTrue();
+
+        SourceBooleanWorkAround source2 = BooleanWorkAroundMapper.INSTANCE.mapTS( target );
+        assertThat( source2 ).isNotNull();
+        assertThat( source2.isVal() ).isTrue();
+
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/SourceBooleanWorkAround.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/SourceBooleanWorkAround.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.source.expressions.java;
+
+public class SourceBooleanWorkAround {
+    private Boolean val;
+
+    public Boolean isVal() {
+        return val;
+    }
+
+    public void setVal(Boolean val) {
+        this.val = val;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/TargetBooleanWorkAround.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/TargetBooleanWorkAround.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.source.expressions.java;
+
+public class TargetBooleanWorkAround {
+    private boolean val;
+
+    public boolean isVal() {
+        return val;
+    }
+
+    public void setVal(boolean val) {
+        this.val = val;
+    }
+}


### PR DESCRIPTION
...perty method workaround

Fixing problem in 'org.mapstruct.ap.model.source.Mapping'. 

Adding a unit test for demonstrating how to get around the target accessor isProperty for Boolean target accessors by means of expressions, which we can use to refer to when the  -enableIntrospection switch to XJC (JAXB) is not an option.

The unit test also demonstrates the fix (of course).  
