### PR TITLE
#277 fixing faulty match check in built-in methods on return/target type...

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/model/source/builtin/BuiltInMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/builtin/BuiltInMethod.java
@@ -76,8 +76,18 @@ public abstract class BuiltInMethod implements Method {
         }
         Type sourceType = sourceTypes.iterator().next();
 
-        if ( targetType.erasure().isAssignableTo( getReturnType().erasure() )
-            && sourceType.erasure().isAssignableTo( getParameter().getType().erasure() ) ) {
+        if ( getReturnType().isAssignableTo( targetType.erasure() )
+            && sourceType.erasure().isAssignableTo( getParameter().getType() ) ) {
+            return doTypeVarsMatch( sourceType, targetType );
+        }
+        if ( getReturnType().getFullyQualifiedName().equals( "java.lang.Object" )
+            && sourceType.erasure().isAssignableTo( getParameter().getType() ) ) {
+            // return type could be a type parameter T
+            return doTypeVarsMatch( sourceType, targetType );
+        }
+        if ( getReturnType().isAssignableTo( targetType.erasure() )
+            &&  getParameter().getType().getFullyQualifiedName().equals( "java.lang.Object" ) ) {
+            // parameter type could be a type parameter T
             return doTypeVarsMatch( sourceType, targetType );
         }
         return false;
@@ -167,6 +177,8 @@ public abstract class BuiltInMethod implements Method {
     public boolean doTypeVarsMatch(Type parameter, Type returnType) {
         return true;
     }
+
+
 
     /**
      * There's currently only one parameter foreseen instead of a list of parameter

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/BuiltInTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/BuiltInTest.java
@@ -18,15 +18,8 @@
  */
 package org.mapstruct.ap.test.builtin;
 
-import org.mapstruct.ap.test.builtin.mapper.MapSourceTargetMapper;
-import org.mapstruct.ap.test.builtin.mapper.IterableSourceTargetMapper;
-import org.mapstruct.ap.test.builtin.mapper.SourceTargetWithDateMapper;
-import org.mapstruct.ap.test.builtin.target.TargetWithDate;
-import org.mapstruct.ap.test.builtin.target.IterableTarget;
-import org.mapstruct.ap.test.builtin.target.MapTarget;
-import org.mapstruct.ap.test.builtin.source.SourceWithDate;
-import org.mapstruct.ap.test.builtin.source.IterableSource;
-import org.mapstruct.ap.test.builtin.source.MapSource;
+import org.mapstruct.ap.test.builtin.target.TargetWithSqlDate;
+import org.mapstruct.ap.test.builtin.mapper.SourceTargetWithSqlDateMapper;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -44,7 +37,6 @@ import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 
-import static org.fest.assertions.Assertions.assertThat;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -61,16 +53,30 @@ import org.mapstruct.ap.test.builtin.mapper.CalendarToStringMapper;
 import org.mapstruct.ap.test.builtin.mapper.CalendarToXmlGregCalMapper;
 import org.mapstruct.ap.test.builtin.mapper.DateToCalendarMapper;
 import org.mapstruct.ap.test.builtin.mapper.DateToXmlGregCalMapper;
+import org.mapstruct.ap.test.builtin.mapper.IterableSourceTargetMapper;
 import org.mapstruct.ap.test.builtin.mapper.JaxbListMapper;
 import org.mapstruct.ap.test.builtin.mapper.JaxbMapper;
+import org.mapstruct.ap.test.builtin.mapper.MapSourceTargetMapper;
+import org.mapstruct.ap.test.builtin.mapper.SourceTargetWithDateMapper;
 import org.mapstruct.ap.test.builtin.mapper.StringToCalendarMapper;
 import org.mapstruct.ap.test.builtin.mapper.StringToXmlGregCalMapper;
 import org.mapstruct.ap.test.builtin.mapper.XmlGregCalToCalendarMapper;
 import org.mapstruct.ap.test.builtin.mapper.XmlGregCalToDateMapper;
 import org.mapstruct.ap.test.builtin.mapper.XmlGregCalToStringMapper;
+import org.mapstruct.ap.test.builtin.source.IterableSource;
+import org.mapstruct.ap.test.builtin.source.MapSource;
+import org.mapstruct.ap.test.builtin.source.SourceWithDate;
+import org.mapstruct.ap.test.builtin.target.IterableTarget;
+import org.mapstruct.ap.test.builtin.target.MapTarget;
+import org.mapstruct.ap.test.builtin.target.TargetWithDate;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.fest.assertions.Assertions.assertThat;
 
 /**
  * Test for the generation of built-in mapping methods.
@@ -301,6 +307,22 @@ public class BuiltInTest {
         TargetWithDate targetWithDate = SourceTargetWithDateMapper.INSTANCE.toTargetWithDate( new SourceWithDate() );
         assertThat( targetWithDate ).isNotNull();
         assertThat( targetWithDate.getDate() ).isNull();
+    }
+
+    @Test
+    @IssueKey( "277" )
+    @WithClasses( { SourceWithDate.class, TargetWithSqlDate.class, SourceTargetWithSqlDateMapper.class } )
+    @ExpectedCompilationOutcome(
+            value = CompilationResult.FAILED,
+            diagnostics = {
+                @Diagnostic( type = SourceTargetWithSqlDateMapper.class,
+                        kind = javax.tools.Diagnostic.Kind.ERROR,
+                        line = 35,
+                        messageRegExp = "Can't map property \"java\\.util\\.Date date\" to "
+                                + "\"java\\.sql\\.Date date\"" )
+            }
+    )
+    public void shouldNotMapJavaUtilDateToJavaSqlDate() {
     }
 
     private JAXBElement<String> createJaxb(String test) {

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/mapper/SourceTargetWithSqlDateMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/mapper/SourceTargetWithSqlDateMapper.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.builtin.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.builtin.source.SourceWithDate;
+import org.mapstruct.ap.test.builtin.target.TargetWithSqlDate;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Andreas Gudian
+ *
+ */
+@Mapper
+public interface SourceTargetWithSqlDateMapper {
+
+    SourceTargetWithSqlDateMapper INSTANCE = Mappers.getMapper( SourceTargetWithSqlDateMapper.class );
+
+    TargetWithSqlDate toTargetWithSqlDate(SourceWithDate source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/target/TargetWithSqlDate.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/target/TargetWithSqlDate.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.builtin.target;
+
+import java.sql.Date;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class TargetWithSqlDate {
+
+    private Date date;
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate( Date date ) {
+        this.date = date;
+    }
+
+
+}


### PR DESCRIPTION
....

The check was carried out in the wrong direction. Iso carrying out if a return type is assignable to a target type, MapStruct checked the other way around (target type assignable to return type). 

In fixing, this poses a problem for a typed variable, e.g. `<T> T jaxbElemToValue( JAXBElement<T> element )`. The erasure of the return type is an Object, which is never assignable to, lets say T being a String.

Therefore to additional checks have been added on the assumption that a a Typed variable erasure is an java.lang.Object. 

So the full check now is:

``` java
        if ( getReturnType().erasure().isAssignableTo( targetType.erasure() )
            && sourceType.erasure().isAssignableTo( getParameter().getType().erasure() ) ) {
            return doTypeVarsMatch( sourceType, targetType );
        }
        if ( getReturnType().erasure().getFullyQualifiedName().equals( "java.lang.Object" )
            && sourceType.erasure().isAssignableTo( getParameter().getType().erasure() ) ) {
            // return type could be a type parameter T
            return doTypeVarsMatch( sourceType, targetType );
        }
        if ( getReturnType().erasure().isAssignableTo( targetType.erasure() )
            &&  getParameter().getType().erasure().getFullyQualifiedName().equals( "java.lang.Object" ) ) {
            // parameter type could be a type parameter T
            return doTypeVarsMatch( sourceType, targetType );
        }
        return false;
```

Perhaps there are more elegant ways to achieve this than a String equals check on the FQN.
