### PR TITLE
#169 Copying sources from core-common to core/core-jdk8 using maven-resources-plugin

### DIFF
--- a/core-common/pom.xml
+++ b/core-common/pom.xml
@@ -68,19 +68,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/core-jdk8/pom.xml
+++ b/core-jdk8/pom.xml
@@ -111,20 +111,22 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>add-copied-common-sources</id>
+                        <id>copy-resources</id>
                         <phase>process-resources</phase>
                         <goals>
-                            <goal>unpack-dependencies</goal>
+                            <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <includeArtifactIds>mapstruct-common</includeArtifactIds>
-                            <includes>**/*.java</includes>
-                            <classifier>sources</classifier>
                             <outputDirectory>${project.build.directory}/${common.sources.dir}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/../core-common/src/main/java</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
                         </configuration>
                     </execution>
                 </executions>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -102,20 +102,22 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
+                <artifactId>maven-resources-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>add-copied-common-sources</id>
+                        <id>copy-resources</id>
                         <phase>process-resources</phase>
                         <goals>
-                            <goal>unpack-dependencies</goal>
+                            <goal>copy-resources</goal>
                         </goals>
                         <configuration>
-                            <includeArtifactIds>mapstruct-common</includeArtifactIds>
-                            <includes>**/*.java</includes>
-                            <classifier>sources</classifier>
                             <outputDirectory>${project.build.directory}/${common.sources.dir}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/../core-common/src/main/java</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
... to allow faster builds and nicer roundtrips in IDEs.

I noticed that `mvn clean test` doesn't work as expected, as core and core-jdk8 require a generated source-jar in core-common. Plus, when I changed someting in core-common in the IDE, I always had to perfrom a build on the console for the changes to show up in the IDE.

This PR fixes that: m2e understands nicely what the resources plugin wants to do (at least during a clean :wink:) and on the console I can do `mvn clean compile` :)
