### PR TITLE
#202 allow remote debugging an intetegration test 

### DIFF
--- a/integrationtest/src/test/resources/pom.xml
+++ b/integrationtest/src/test/resources/pom.xml
@@ -115,6 +115,34 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>debug-forked-javac</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-compile</id>
+                                <configuration>
+                                    <fork>true</fork>
+                                    <compilerArgs>
+                                        <arg>-J-Xdebug</arg>
+                                        <arg>-J-Xnoagent</arg>
+                                        <arg>-J-Djava.compiler=NONE</arg>
+                                        <arg>-J-Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000</arg>
+                                    </compilerArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 
     <dependencies>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -43,6 +43,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <com.jolira.hickory.version>1.0.0</com.jolira.hickory.version>
         <org.apache.maven.plugins.enforcer.version>1.2</org.apache.maven.plugins.enforcer.version>
+        <org.apache.maven.plugins.surefire.version>2.17</org.apache.maven.plugins.surefire.version>
         <org.springframework.version>4.0.3.RELEASE</org.springframework.version>
 
         <forkCount>1</forkCount>
@@ -200,11 +201,11 @@
                 <artifactId>mapstruct-processor</artifactId>
                 <version>${project.version}</version>
             </dependency>
-			<dependency>
-				<groupId>org.apache.maven.shared</groupId>
-				<artifactId>maven-verifier</artifactId>
-				<version>1.5</version>
-			</dependency>
+            <dependency>
+                <groupId>org.apache.maven.shared</groupId>
+                <artifactId>maven-verifier</artifactId>
+                <version>1.5</version>
+            </dependency>
 
             <!-- Not directly used but required for dependency convergence -->
             <dependency>
@@ -337,10 +338,17 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>2.17</version>
+                    <version>${org.apache.maven.plugins.surefire.version}</version>
                     <configuration>
                         <forkCount>${forkCount}</forkCount>
                     </configuration>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.apache.maven.surefire</groupId>
+                            <artifactId>surefire-junit47</artifactId>
+                            <version>${org.apache.maven.plugins.surefire.version}</version>
+                        </dependency>
+                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>com.mycila.maven-license-plugin</groupId>
@@ -425,16 +433,16 @@
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>0.7.1.201405082137</version>
                 </plugin>
-	            <plugin>
-	                <groupId>org.jvnet.jaxb2.maven2</groupId>
-	                <artifactId>maven-jaxb2-plugin</artifactId>
-	                <version>0.9.0</version>
-	            </plugin>
-	            <plugin>
-	                <groupId>org.codehaus.mojo</groupId>
-	                <artifactId>properties-maven-plugin</artifactId>
-	                <version>1.0-alpha-2</version>
-	            </plugin>
+                <plugin>
+                    <groupId>org.jvnet.jaxb2.maven2</groupId>
+                    <artifactId>maven-jaxb2-plugin</artifactId>
+                    <version>0.9.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>properties-maven-plugin</artifactId>
+                    <version>1.0-alpha-2</version>
+                </plugin>
             </plugins>
         </pluginManagement>
 


### PR DESCRIPTION
using a command like the following:

`mvn test -Dtest=SimpleTest#oracle_java_6 -DprocessorIntegrationTest.debug=true`

The `-Dtest=<classPattern>#<methodPattern>` is plain vanilla Surefire (although I had to pin down the usage of the junit47-provider in the surefire config, see parent/pom.xml), as [documented on the surefire page](http://maven.apache.org/surefire/maven-surefire-plugin/examples/single-test.html).

The new option `-DprocessorIntegrationTest.debug=true` causes one of these two things:
- if the test case uses Toolchains (i.e. lets the compiler use a different javac than the one running the current process), then a profile is activated that tells the compiler plugin to fork that javac execution with these remote-debug arguments: `-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=8000`
- if the test case does not use Toolchains, the Maven Verifer is forced to be executed in a forked process, whereas the implementation there would call `mvnDebug` instead of `mvn` - typically, that should result in the same remote debug settings as above.

I'll create another PR for the mapstruct-org changes to document that there as well.
