### PR TITLE
#325 book-keeping issue in reverse mapping

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/MapperCreationProcessor.java
@@ -312,12 +312,6 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
 
                 EnumMappingMethod.Builder builder = new EnumMappingMethod.Builder();
                 mergeWithReverseMappings( reverseMappingMethod, method );
-                if ( method.getMappings().isEmpty() ) {
-                    if ( reverseMappingMethod != null && !reverseMappingMethod.getMappings().isEmpty() ) {
-                        method.setMappings( reverse( reverseMappingMethod.getMappings() ) );
-                    }
-                }
-
                 MappingMethod enumMappingMethod = builder
                     .mappingContext( mappingContext )
                     .souceMethod( method )
@@ -388,8 +382,19 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
     private void mergeWithReverseMappings(SourceMethod reverseMappingMethod, SourceMethod method) {
         Map<String, List<Mapping>> newMappings = new HashMap<String, List<Mapping>>();
         if ( reverseMappingMethod != null && !reverseMappingMethod.getMappings().isEmpty() ) {
-            // define all the base mappings based on its forward counterpart
-            newMappings.putAll( reverse( reverseMappingMethod.getMappings() ) );
+            // define all the base mappings based on its forward counterpart.
+            // however, remove the mappings that are designated as constant, expression or ignore.
+            // They are characterized by the key ""
+
+            Map<String, List<Mapping>> reverseMappings = new HashMap<String, List<Mapping>>();
+            reverseMappings.putAll( reverseMappingMethod.getMappings() );
+            List<Mapping> nonSourceMappings =  method.getMappings().get( "" );
+            if (nonSourceMappings != null ) {
+                for (Mapping nonSourceMapping : nonSourceMappings) {
+                    reverseMappings.remove( nonSourceMapping.getTargetName() );
+                }
+            }
+            newMappings.putAll( reverse( reverseMappings ) );
         }
 
         if ( method.getMappings().isEmpty() ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapper.java
@@ -49,7 +49,7 @@ public interface SourceTargetMapper {
     @InheritInverseConfiguration(name = "forward")
     @Mappings({
         @Mapping(target = "someConstantDownstream", constant = "test"),
-        @Mapping(source = "propertyToIgnoreDownstream", ignore = true)
+        @Mapping(target = "propertyToIgnoreDownstream", ignore = true)
     })
     Source reverse(Target target);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapperAmbiguous1.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapperAmbiguous1.java
@@ -49,7 +49,7 @@ public interface SourceTargetMapperAmbiguous1 {
     @InheritInverseConfiguration
     @Mappings({
         @Mapping(target = "someConstantDownstream", constant = "test"),
-        @Mapping(source = "propertyToIgnoreDownstream", ignore = true)
+        @Mapping(target = "propertyToIgnoreDownstream", ignore = true)
     })
     Source reverse(Target target);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapperAmbiguous2.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapperAmbiguous2.java
@@ -49,7 +49,7 @@ public interface SourceTargetMapperAmbiguous2 {
     @InheritInverseConfiguration(name = "blah")
     @Mappings({
         @Mapping(target = "someConstantDownstream", constant = "test"),
-        @Mapping(source = "propertyToIgnoreDownstream", ignore = true)
+        @Mapping(target = "propertyToIgnoreDownstream", ignore = true)
     })
     Source reverse(Target target);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapperAmbiguous3.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapperAmbiguous3.java
@@ -50,7 +50,7 @@ public interface SourceTargetMapperAmbiguous3 {
     @InheritInverseConfiguration(name = "forward")
     @Mappings({
         @Mapping(target = "someConstantDownstream", constant = "test"),
-        @Mapping(source = "propertyToIgnoreDownstream", ignore = true)
+        @Mapping(target = "propertyToIgnoreDownstream", ignore = true)
     })
     Source reverse(Target target);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapperErroneouslyAnnotated.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapperErroneouslyAnnotated.java
@@ -42,7 +42,7 @@ public interface SourceTargetMapperErroneouslyAnnotated {
     @InheritInverseConfiguration(name = "forward")
     @Mappings({
         @Mapping(target = "someConstantDownstream", constant = "test"),
-        @Mapping(source = "propertyToIgnoreDownstream", ignore = true)
+        @Mapping(target = "propertyToIgnoreDownstream", ignore = true)
     })
     Source reverse(Target target);
 

--- a/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapperNonMatchingName.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/reverse/SourceTargetMapperNonMatchingName.java
@@ -42,7 +42,7 @@ public interface SourceTargetMapperNonMatchingName {
     @InheritInverseConfiguration(name = "blah")
     @Mappings({
         @Mapping(target = "someConstantDownstream", constant = "test"),
-        @Mapping(source = "propertyToIgnoreDownstream", ignore = true)
+        @Mapping(target = "propertyToIgnoreDownstream", ignore = true)
     })
     Source reverse(Target target);
 }


### PR DESCRIPTION
This PR fixes the issue as described in #325. Before merging, the reverse mappings which are either constant, ignored or expression need to be removed from the forward mapping before the forward mapping can act as a base for the reverse mappings.

Next, there was an issue in the unit tests, in which a source mapping was marked as ignore (iso the target).

Finally the enum mapping did ignore the mergeWithReverseMappings.
