### PR TITLE
#341 method annotated with qualifier should not qualify for mappings wit...

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/MapperWithoutQualifiedBy.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/MapperWithoutQualifiedBy.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.qualifier;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.ap.test.selection.qualifier.bean.GermanRelease;
+import org.mapstruct.ap.test.selection.qualifier.bean.OriginalRelease;
+import org.mapstruct.ap.test.selection.qualifier.handwritten.Facts;
+import org.mapstruct.ap.test.selection.qualifier.handwritten.Reverse;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper( uses = { Facts.class, Reverse.class } )
+public interface MapperWithoutQualifiedBy {
+
+    MapperWithoutQualifiedBy INSTANCE = Mappers.getMapper( MapperWithoutQualifiedBy.class );
+
+    @Mappings( {
+        @Mapping( target = "title", source = "title" ),
+        @Mapping( target = "keyWords", ignore = true ),
+        @Mapping( target = "facts", ignore = true )
+    } )
+    GermanRelease map( OriginalRelease movies );
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/QualifierTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/QualifierTest.java
@@ -36,6 +36,7 @@ import org.mapstruct.ap.test.selection.qualifier.annotation.NonQualifierAnnotate
 import org.mapstruct.ap.test.selection.qualifier.annotation.TitleTranslator;
 import org.mapstruct.ap.test.selection.qualifier.handwritten.Facts;
 import org.mapstruct.ap.test.selection.qualifier.handwritten.PlotWords;
+import org.mapstruct.ap.test.selection.qualifier.handwritten.Reverse;
 import org.mapstruct.ap.test.selection.qualifier.handwritten.SomeOtherMapper;
 import org.mapstruct.ap.test.selection.qualifier.handwritten.YetAnotherMapper;
 import org.mapstruct.ap.testutil.IssueKey;
@@ -116,4 +117,24 @@ public class QualifierTest {
     public void shouldNotProduceMatchingMethod() {
     }
 
+
+    @Test
+    @WithClasses( {
+        MapperWithoutQualifiedBy.class,
+        Facts.class,
+        EnglishToGerman.class,
+        Reverse.class
+    } )
+    @IssueKey( "341" )
+    public void shouldNotUseQualifierAnnotatedMethod() {
+
+
+        OriginalRelease foreignMovies = new OriginalRelease();
+        foreignMovies.setTitle( "Sixth Sense, The" );
+
+        GermanRelease result = MapperWithoutQualifiedBy.INSTANCE.map( foreignMovies );
+        assertThat( result ).isNotNull();
+        assertThat( result.getTitle() ).isEqualTo( "ehT ,esneS htxiS");
+
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/handwritten/Reverse.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/handwritten/Reverse.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.qualifier.handwritten;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Reverse {
+
+    public String reverse( String in ) {
+        StringBuilder b = new StringBuilder(in);
+        return b.reverse().toString();
+    }
+
+}


### PR DESCRIPTION
...hout qualifiedBy

Mappings annotated with an `@Qualifier` annotated annotation, will not apply for `@Mapping`/`@IterableMapping`/`@MapMapping` that do not specify the `qualifiedBy`.
