### PR TITLE
#343 wrongly placed candidates.clear() causes too many error messages

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
@@ -309,10 +309,9 @@ public class BeanMappingMethod extends MappingMethod {
                                     .dateFormat( mapping != null ? mapping.getDateFormat() : null )
                                     .build();
 
-                            // candidates are handled
-                            candidates.clear();
                         }
-
+                        // candidates are handled
+                        candidates.clear();
 
                         if ( propertyMapping != null && newPropertyMapping != null ) {
                             // TODO improve error message


### PR DESCRIPTION
Error made in merging #343  and #65. Candidates are not always cleared, causing wrong and too many error messages.

No reproducer is present (new functionality).
