### PR TITLE
#348 Mapping parameters based on name when other mappings fail

### DIFF
--- a/core-jdk8/src/main/java/org/mapstruct/Mapping.java
+++ b/core-jdk8/src/main/java/org/mapstruct/Mapping.java
@@ -63,6 +63,7 @@ public @interface Mapping {
      * This may either be a simple property name (e.g. "address") or a dot-separated property path (e.g. "address.city"
      * or "address.city.name"). In case the annotated method has several source parameters, the property name must
      * qualified with the parameter name, e.g. "addressParam.city".</li>
+     * <li>When no matching property is found, MapStruct looks for a matching parameter name instead.</li>
      * <li>When used to map an enum constant, the name of the constant member is to be given.</li>
      * </ol>
      * Either this attribute or {@link #constant()} or {@link #expression()} may be specified for a given mapping.

--- a/core/src/main/java/org/mapstruct/Mapping.java
+++ b/core/src/main/java/org/mapstruct/Mapping.java
@@ -61,6 +61,7 @@ public @interface Mapping {
      * This may either be a simple property name (e.g. "address") or a dot-separated property path (e.g. "address.city"
      * or "address.city.name"). In case the annotated method has several source parameters, the property name must
      * qualified with the parameter name, e.g. "addressParam.city".</li>
+     * <li>When no matching property is found, MapStruct looks for a matching parameter name instead.</li>
      * <li>When used to map an enum constant, the name of the constant member is to be given.</li>
      * </ol>
      * Either this attribute or {@link #constant()} or {@link #expression()} may be specified for a given mapping.

--- a/processor/src/main/java/org/mapstruct/ap/model/common/Parameter.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/common/Parameter.java
@@ -71,4 +71,27 @@ public class Parameter extends ModelElement {
     public boolean isTargetType() {
         return targetType;
     }
+
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 23 * hash + (this.name != null ? this.name.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        final Parameter other = (Parameter) obj;
+        if ( (this.name == null) ? (other.name != null) : !this.name.equals( other.name ) ) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/source/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/SourceReference.java
@@ -233,7 +233,10 @@ public class SourceReference {
         }
 
         public SourceReference build() {
-            List<PropertyEntry> sourcePropertyEntries = Arrays.asList( new PropertyEntry( name, accessor, type ) );
+            List<PropertyEntry> sourcePropertyEntries = new ArrayList<PropertyEntry>();
+            if ( accessor != null ) {
+                sourcePropertyEntries.add( new PropertyEntry( name, accessor, type ) );
+            }
             return new SourceReference( sourceParameter, sourcePropertyEntries, true );
         }
     }

--- a/processor/src/main/resources/org.mapstruct.ap.model.BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.BeanMappingMethod.ftl
@@ -20,19 +20,26 @@
 -->
 @Override
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>) <@throws/> {
-    if ( <#list sourceParameters as sourceParam>${sourceParam.name} == null<#if sourceParam_has_next> && </#if></#list> ) {
+    if ( <#list sourceParametersExcludingPrimitives as sourceParam>${sourceParam.name} == null<#if sourceParam_has_next> && </#if></#list> ) {
         return<#if returnType.name != "void"> null</#if>;
     }
 
     <#if !existingInstanceMapping><@includeModel object=resultType/> ${resultName} = <#if factoryMethod??><@includeModel object=factoryMethod targetType=resultType raw=true/><#else>new <@includeModel object=resultType/>()</#if>;</#if>
     <#if (sourceParameters?size > 1)>
-        <#list sourceParameters as sourceParam>
+        <#list sourceParametersExcludingPrimitives as sourceParam>
             <#if (propertyMappingsByParameter[sourceParam.name]?size > 0)>
                 if ( ${sourceParam.name} != null ) {
                     <#list propertyMappingsByParameter[sourceParam.name] as propertyMapping>
                         <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping/>
                     </#list>
                 }
+            </#if>
+        </#list>
+        <#list sourcePrimitiveParameters as sourceParam>
+            <#if (propertyMappingsByParameter[sourceParam.name]?size > 0)>
+                <#list propertyMappingsByParameter[sourceParam.name] as propertyMapping>
+                    <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping/>
+                </#list>
             </#if>
         </#list>
     <#else>

--- a/processor/src/test/java/org/mapstruct/ap/test/severalsources/SeveralSourceParametersTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/severalsources/SeveralSourceParametersTest.java
@@ -99,6 +99,21 @@ public class SeveralSourceParametersTest {
     }
 
     @Test
+    @WithClasses({ Person.class, Address.class, DeliveryAddress.class, SourceTargetMapper.class })
+    public void shouldMapSeveralSourceAttributesAndParameters() {
+        Person person = new Person( "Bob", "Garner", 181, "An actor" );
+
+        DeliveryAddress deliveryAddress =
+                SourceTargetMapper.INSTANCE.personAndAddressToDeliveryAddress( person, 42, 12345, "Main street" );
+
+        assertThat( deliveryAddress.getLastName() ).isEqualTo( "Garner" );
+        assertThat( deliveryAddress.getZipCode() ).isEqualTo( 12345 );
+        assertThat( deliveryAddress.getHouseNumber() ).isEqualTo( 42 );
+        assertThat( deliveryAddress.getDescription() ).isEqualTo( "An actor" );
+        assertThat( deliveryAddress.getStreet()).isEqualTo( "Main street" );
+    }
+
+    @Test
     @WithClasses({ ErroneousSourceTargetMapper.class, Address.class, DeliveryAddress.class })
     @ProcessorOption(name = "unmappedTargetPolicy", value = "IGNORE")
     @ExpectedCompilationOutcome(

--- a/processor/src/test/java/org/mapstruct/ap/test/severalsources/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/severalsources/SourceTargetMapper.java
@@ -41,4 +41,9 @@ public interface SourceTargetMapper {
     })
     void personAndAddressToDeliveryAddress(Person person, Address address,
                                            @MappingTarget DeliveryAddress deliveryAddress);
+
+    @Mapping( target = "description", source = "person.description")
+    DeliveryAddress personAndAddressToDeliveryAddress(Person person, Integer houseNumber, int zipCode,
+            String street);
+
 }


### PR DESCRIPTION
After introducing nested properties (#65) also the option was created to map from a parameter directly (a non bean mapping). This PR introduces mapping based on on name when all other options fail of parameters.

I initially added a check if there are unused source parameters (and raise a warning when this is the case). However this does not work very well with expressions. In expressions you can refer to parameters without these parameters being marked as 'used'. Expression tests start to fail when this error handling was introduced.

Some cleanup needs to be added to the next release, were superflous null checks are removed. I'll write a PR for that.
