### PR TITLE
#331 remove remaining runtime dependencies from processor to mapstruct core

### DIFF
--- a/build-config/src/main/resources/build-config/checkstyle.xml
+++ b/build-config/src/main/resources/build-config/checkstyle.xml
@@ -103,6 +103,9 @@
         <module name="UnusedImports">
             <property name="processJavadoc" value="true"/>
         </module>
+        <module name="ImportControl">
+            <property name="file" value="${basedir}/../build-config/src/main/resources/build-config/import-control.xml" />
+        </module>
 
 
         <!-- Checks for Size Violations.                    -->

--- a/build-config/src/main/resources/build-config/import-control.xml
+++ b/build-config/src/main/resources/build-config/import-control.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!DOCTYPE import-control PUBLIC 
+    "-//Puppy Crawl//DTD Import Control 1.1//EN" 
+    "http://www.puppycrawl.com/dtds/import_control_1_1.dtd">
+<import-control pkg="org.mapstruct">
+
+    <allow pkg=".*" regex="true" />
+
+    <subpackage name="ap">
+        <!-- the annotation processor may not use the annotations or enums specified in org.mapstruct directly... -->
+        <disallow pkg="org.mapstruct" exact-match="true" />
+
+        <subpackage name="prism">
+            <!-- ... with exception to the package org.mapstruct.ap.prism -->
+            <allow pkg=".*" regex="true" /> 
+        </subpackage>
+        <subpackage name="test">
+            <allow pkg=".*" regex="true" />
+        </subpackage>
+        <subpackage name="testutil">
+            <allow pkg=".*" regex="true" />
+        </subpackage>
+    </subpackage>
+</import-control>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -239,7 +239,7 @@
                         <failsOnError>true</failsOnError>
                         <violationSeverity>error</violationSeverity>
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
-
+                      <propertyExpansion>basedir=${basedir}</propertyExpansion>
                         <!--
                             Excluding generated sources; Not required for the Maven build, but the Eclipse CS plug-in
                             would check the generated files without these exclusions; Note that the exclusions must be
@@ -455,7 +455,8 @@
                     <strictCheck>true</strictCheck>
                     <excludes>
                         <exclude>.idea/**</exclude>
-                        <exclude>**/checkstyle.xml</exclude>
+                        <exclude>**/build-config/checkstyle.xml</exclude>
+                        <exclude>**/build-config/import-control.xml</exclude>
                         <exclude>copyright.txt</exclude>
                         <exclude>**/license.txt</exclude>
                         <exclude>**/mapstruct.xml</exclude>

--- a/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import javax.lang.model.element.ExecutableElement;
 import javax.tools.Diagnostic;
 
-import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.ap.model.PropertyMapping.ConstantMappingBuilder;
 import org.mapstruct.ap.model.PropertyMapping.JavaExpressionMappingBuilder;
 import org.mapstruct.ap.model.PropertyMapping.PropertyMappingBuilder;
@@ -41,6 +40,7 @@ import org.mapstruct.ap.model.source.Mapping;
 import org.mapstruct.ap.model.source.SourceMethod;
 import org.mapstruct.ap.model.source.SourceReference;
 import org.mapstruct.ap.option.ReportingPolicy;
+import org.mapstruct.ap.prism.CollectionMappingStrategyPrism;
 import org.mapstruct.ap.util.Executables;
 import org.mapstruct.ap.util.MapperConfig;
 import org.mapstruct.ap.util.Strings;
@@ -99,7 +99,7 @@ public class BeanMappingMethod extends MappingMethod {
          */
         private Map<String, ExecutableElement> initTargetPropertyAccessors() {
             // fetch settings from element to implement
-            CollectionMappingStrategy cmStrategy = getEffectiveCollectionMappingStrategy();
+            CollectionMappingStrategyPrism cmStrategy = getEffectiveCollectionMappingStrategy();
 
             // collect all candidate target accessors
             List<ExecutableElement> candidates = new ArrayList<ExecutableElement>();
@@ -114,15 +114,15 @@ public class BeanMappingMethod extends MappingMethod {
                 // A target access is in general a setter method on the target object. However, in case of collections,
                 // the current target accessor can also be a getter method.
                 // The following if block, checks if the target accessor should be overruled by an add method.
-                if ( cmStrategy == CollectionMappingStrategy.SETTER_PREFERRED
-                    || cmStrategy == CollectionMappingStrategy.ADDER_PREFERRED ) {
+                if ( cmStrategy == CollectionMappingStrategyPrism.SETTER_PREFERRED
+                    || cmStrategy == CollectionMappingStrategyPrism.ADDER_PREFERRED ) {
 
                     // first check if there's a setter method.
                     ExecutableElement adderMethod = null;
                     if ( Executables.isSetterMethod( candidate ) ) {
                         Type targetType = ctx.getTypeFactory().getSingleParameter( candidate ).getType();
                         // ok, the current accessor is a setter. So now the strategy determines what to use
-                        if ( cmStrategy == CollectionMappingStrategy.ADDER_PREFERRED ) {
+                        if ( cmStrategy == CollectionMappingStrategyPrism.ADDER_PREFERRED ) {
                             adderMethod = method.getResultType().getAdderForType( targetType, targetPropertyName );
                         }
                     }
@@ -389,7 +389,7 @@ public class BeanMappingMethod extends MappingMethod {
             }
         }
 
-        private CollectionMappingStrategy getEffectiveCollectionMappingStrategy() {
+        private CollectionMappingStrategyPrism getEffectiveCollectionMappingStrategy() {
             MapperConfig mapperSettings = MapperConfig.getInstanceOn( ctx.getMapperTypeElement() );
             return mapperSettings.getCollectionMappingStrategy();
         }

--- a/processor/src/main/java/org/mapstruct/ap/prism/CollectionMappingStrategyPrism.java
+++ b/processor/src/main/java/org/mapstruct/ap/prism/CollectionMappingStrategyPrism.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.prism;
+
+/**
+ * Prism for the enum {@link org.mapstruct.CollectionMappingStrategy}
+ *
+ * @author Andreas Gudian
+ */
+public enum CollectionMappingStrategyPrism {
+
+    ACCESSOR_ONLY,
+    SETTER_PREFERRED,
+    ADDER_PREFERRED,
+    DEFAULT;
+}

--- a/processor/src/main/java/org/mapstruct/ap/util/MapperConfig.java
+++ b/processor/src/main/java/org/mapstruct/ap/util/MapperConfig.java
@@ -22,18 +22,19 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
-import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.ap.option.ReportingPolicy;
+import org.mapstruct.ap.prism.CollectionMappingStrategyPrism;
 import org.mapstruct.ap.prism.MapperConfigPrism;
 import org.mapstruct.ap.prism.MapperPrism;
 
-import static org.mapstruct.CollectionMappingStrategy.valueOf;
+import static org.mapstruct.ap.prism.CollectionMappingStrategyPrism.valueOf;
 
 /**
  * Class decorating the {@link MapperPrism} with the 'default' configuration.
@@ -97,23 +98,23 @@ public class MapperConfig {
         }
     }
 
-    public CollectionMappingStrategy getCollectionMappingStrategy() {
-        CollectionMappingStrategy mapperPolicy = valueOf( mapperPrism.collectionMappingStrategy() );
+    public CollectionMappingStrategyPrism getCollectionMappingStrategy() {
+        CollectionMappingStrategyPrism mapperPolicy = valueOf( mapperPrism.collectionMappingStrategy() );
 
-        if ( !mapperPolicy.equals( CollectionMappingStrategy.DEFAULT ) ) {
+        if ( mapperPolicy != CollectionMappingStrategyPrism.DEFAULT ) {
             // it is not the default mapper configuration, so return the mapper configured value
             return mapperPolicy;
         }
         else if ( mapperConfigPrism != null ) {
             // try the config mapper configuration
-            CollectionMappingStrategy configPolicy = valueOf( mapperConfigPrism.collectionMappingStrategy() );
-            if ( !configPolicy.equals( CollectionMappingStrategy.DEFAULT ) ) {
+            CollectionMappingStrategyPrism configPolicy = valueOf( mapperConfigPrism.collectionMappingStrategy() );
+            if ( configPolicy != CollectionMappingStrategyPrism.DEFAULT ) {
                 // its not the default configuration, so return the mapper config configured value
                 return configPolicy;
             }
         }
         // when nothing specified, return ACCESSOR_ONLY (default option)
-        return CollectionMappingStrategy.ACCESSOR_ONLY;
+        return CollectionMappingStrategyPrism.ACCESSOR_ONLY;
     }
 
     public String componentModel() {

--- a/processor/src/test/java/org/mapstruct/ap/test/prism/EnumPrismsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/prism/EnumPrismsTest.java
@@ -1,0 +1,51 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.prism;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Test;
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.ap.prism.CollectionMappingStrategyPrism;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Test for manually created prisms on enumeration types
+ *
+ * @author Andreas Gudian
+ */
+public class EnumPrismsTest {
+    @Test
+    public void collectionMappingStrategyPrismIsCorrect() {
+        assertThat( namesOf( CollectionMappingStrategy.values() ) ).isEqualTo(
+            namesOf( CollectionMappingStrategyPrism.values() ) );
+    }
+
+    private static List<String> namesOf(Enum<?>[] values) {
+        List<String> names = new ArrayList<String>( values.length );
+
+        for ( Enum<?> e : values ) {
+            names.add( e.name() );
+        }
+
+        return names;
+    }
+}


### PR DESCRIPTION
... and add checkstyle rule to verify that for the future.

As an alternative to using the checkstyle rule, we could also pull out the prism generation to its own module with a "provided" dependency to `mapstruct` and then use `mapstruct` only with scope test in `processor`. 
When shading away freemarker, we would create a fat jar anyway and thus we could merge the prism classes into that jar as well.
