### PR TITLE
shade away freemarker in mapstruct-processor

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -351,6 +351,11 @@
                     </dependencies>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <version>2.3</version>
+                </plugin>
+                <plugin>
                     <groupId>com.mycila.maven-license-plugin</groupId>
                     <artifactId>maven-license-plugin</artifactId>
                     <version>1.10.b1</version>

--- a/processor/.gitignore
+++ b/processor/.gitignore
@@ -1,0 +1,1 @@
+/dependency-reduced-pom.xml

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -101,6 +101,33 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>processor-deps-shading</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <minimizeJar>true</minimizeJar>
+                            <artifactSet>
+                                <includes>
+                                    <include>org.freemarker:freemarker</include>
+                                </includes>
+                            </artifactSet>
+                            <relocations>
+                                <relocation>
+                                    <pattern>freemarker</pattern>
+                                    <shadedPattern>org.mapstruct.ap.shaded.freemarker</shadedPattern>
+                                </relocation>
+                            </relocations>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
                     <execution>


### PR DESCRIPTION
- shade package freemarker to org.mapstruct.ap.shaded.freemarker
- build an uber-jar containing the processor and the required freemarker classes
- publish a dependency-reduced pom

I've tested the resulting processor jar within Eclipse JDT as single entry on the processor classpath... worked like a charm... :smile:
