### PR TITLE
#262 prefix processor options with 'mapstruct.'

### DIFF
--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -90,7 +90,7 @@
                     </processors>
                     <options>
                         <!-- suppressGeneratorTimestamp=false is the default -->
-                        <suppressGeneratorTimestamp>false</suppressGeneratorTimestamp>
+                        <mapstruct.suppressGeneratorTimestamp>false</mapstruct.suppressGeneratorTimestamp>
                     </options>
                 </configuration>
                 <executions>

--- a/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
@@ -93,9 +93,9 @@ public class MappingProcessor extends AbstractProcessor {
      */
     private static final boolean ANNOTATIONS_CLAIMED_EXCLUSIVELY = false;
 
-    protected static final String SUPPRESS_GENERATOR_TIMESTAMP = "suppressGeneratorTimestamp";
-    protected static final String UNMAPPED_TARGET_POLICY = "unmappedTargetPolicy";
-    protected static final String DEFAULT_COMPONENT_MODEL = "defaultComponentModel";
+    protected static final String SUPPRESS_GENERATOR_TIMESTAMP = "mapstruct.suppressGeneratorTimestamp";
+    protected static final String UNMAPPED_TARGET_POLICY = "mapstruct.unmappedTargetPolicy";
+    protected static final String DEFAULT_COMPONENT_MODEL = "mapstruct.defaultComponentModel";
 
     private Options options;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/severalsources/SeveralSourceParametersTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/severalsources/SeveralSourceParametersTest.java
@@ -100,7 +100,7 @@ public class SeveralSourceParametersTest {
 
     @Test
     @WithClasses({ ErroneousSourceTargetMapper.class, Address.class, DeliveryAddress.class })
-    @ProcessorOption(name = "unmappedTargetPolicy", value = "IGNORE")
+    @ProcessorOption(name = "mapstruct.unmappedTargetPolicy", value = "IGNORE")
     @ExpectedCompilationOutcome(
         value = CompilationResult.FAILED,
         diagnostics = {

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/UnmappedTargetTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/UnmappedTargetTest.java
@@ -87,7 +87,7 @@ public class UnmappedTargetTest {
 
     @Test
     @WithClasses({ Source.class, Target.class, SourceTargetMapper.class })
-    @ProcessorOption(name = "unmappedTargetPolicy", value = "ERROR")
+    @ProcessorOption(name = "mapstruct.unmappedTargetPolicy", value = "ERROR")
     @ExpectedCompilationOutcome(
         value = CompilationResult.FAILED,
         diagnostics = {


### PR DESCRIPTION
Whoops, had this lying around for quite a while now. Here's the pull request.
