### PR TITLE
#359 Upgrading to FreeMarker 2.3.21; Updating license.txt

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -17,10 +17,25 @@
 
 ------------------------------------------------------------------------
 
- MAPSTRUCT SUBCOMPONENTS WITH DIFFERENT LICENCES
+ MAPSTRUCT SUBCOMPONENTS WITH DIFFERENT COPYRIGHT OWNERS
 
- The MapStruct distribution includes FreeMarker, a software developed by
- the Visigoth Software Society (http://www.visigoths.org/) which is
- distributed under a BSD-style license. Your use of FreeMarker is subject
- to the terms and conditions of this license (see
- http://freemarker.sourceforge.net/docs/app_license.html).
+ The MapStruct distribution (ZIP, TAR.GZ) as well as the MapStruct
+ library (JAR) include FreeMarker, a software developed by Attila
+ Szegedi, Daniel Dekany and Jonathan Revusky. FreeMarker is licensed
+ under the same license as MapStruct itself - Apache License, Version
+ 2.0 - but the copyright owners are the aforementioned individuals.
+
+ The MapStruct distribution (ZIP, TAR.GZ) as well as the MapStruct
+ library (JAR) include a number of files that are licensed by the
+ Apache Software Foundation under the same license as MapStruct itself -
+ Apache License, Version 2.0 - but the copyright owner is the Apache
+ Software Foundation. These files are:
+
+     freemarker/ext/jsp/web-app_2_2.dtd
+     freemarker/ext/jsp/web-app_2_3.dtd
+     freemarker/ext/jsp/web-app_2_4.xsd
+     freemarker/ext/jsp/web-app_2_5.xsd
+     freemarker/ext/jsp/web-jsptaglibrary_1_1.dtd
+     freemarker/ext/jsp/web-jsptaglibrary_1_2.dtd
+     freemarker/ext/jsp/web-jsptaglibrary_2_0.xsd
+     freemarker/ext/jsp/web-jsptaglibrary_2_1.xsd

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -99,7 +99,7 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.19</version>
+                <version>2.3.21</version>
             </dependency>
             <dependency>
                 <groupId>org.easytesting</groupId>


### PR DESCRIPTION
@agudian, can you check out this one, some of your Maven-foo is needed :)

Turns out the latest FreeMarker also uses the Apache license which is nice as everything uses the same license now. I've updated the license.txt file. Here comes the issue though: The shading pulls in LICENSE.txt and NOTICE.txt from FreeMarker into META-INF of the JAR. The latter is fine, but the former should be replaced by our own license.txt (which mentions the FreeMarker copyright holders).

Could you give this a try, I didn't manage to do so :/ Ideally, our license.txt should be in all our JARs, and optionally we could put the FreeMarker one to META-INF/FreeMarker for reference. Thx!
