### PR TITLE
#385 Inheritance selection on best fit source- and target type 

### DIFF
--- a/core-common/src/main/java/org/mapstruct/BeanMapping.java
+++ b/core-common/src/main/java/org/mapstruct/BeanMapping.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Configures the mapping between two bean types
+ *
+ * @author Sjaak Derksen
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.SOURCE)
+public @interface BeanMapping {
+
+
+    /**
+     * Specifies the result type of the method to select in case ambiguous mappings / factory methods.
+     *
+     *
+     * @return the resultType to select
+     */
+    Class resultType() default void.class;
+}

--- a/processor/src/main/java/org/mapstruct/ap/model/AssignmentFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/AssignmentFactory.java
@@ -21,15 +21,12 @@ package org.mapstruct.ap.model;
 import java.util.List;
 import java.util.Set;
 
-import javax.tools.Diagnostic;
 
 import org.mapstruct.ap.model.assignment.Assignment;
 import org.mapstruct.ap.model.common.ConversionContext;
 import org.mapstruct.ap.model.common.Type;
 import org.mapstruct.ap.model.source.Method;
-import org.mapstruct.ap.model.source.SourceMethod;
 import org.mapstruct.ap.model.source.builtin.BuiltInMethod;
-import org.mapstruct.ap.model.source.selector.MethodSelectors;
 
 /**
  * Factory class for creating all types of assignments
@@ -56,51 +53,6 @@ public class AssignmentFactory {
 
     public static Direct createDirect(String sourceRef) {
         return new Direct( sourceRef );
-    }
-
-    public static MethodReference createFactoryMethod( Type returnType, MappingBuilderContext ctx ) {
-        MethodReference result = null;
-        for ( SourceMethod method : ctx.getSourceModel() ) {
-            if ( !method.overridesMethod() && !method.isIterableMapping() && !method.isMapMapping()
-                    && method.getSourceParameters().isEmpty() ) {
-
-                List<Type> parameterTypes = MethodSelectors.getParameterTypes(
-                        ctx.getTypeFactory(),
-                        method.getParameters(),
-                        null,
-                        returnType
-                );
-
-                if ( method.matches( parameterTypes, returnType ) ) {
-                    if ( result == null ) {
-                        MapperReference mapperReference = findMapperReference( ctx.getMapperReferences(), method );
-                        result = new MethodReference( method, mapperReference, null );
-                    }
-                    else {
-                        ctx.getMessager().printMessage(
-                                Diagnostic.Kind.ERROR,
-                                String.format(
-                                        "Ambiguous factory methods: \"%s\" conflicts with \"%s\".",
-                                        result,
-                                        method
-                                ),
-                                method.getExecutable()
-                        );
-                    }
-                }
-            }
-        }
-        return result;
-    }
-
-    private static MapperReference findMapperReference( List<MapperReference> mapperReferences, SourceMethod method ) {
-        for ( MapperReference ref : mapperReferences ) {
-            if ( ref.getType().equals( method.getDeclaringMapper() ) ) {
-                ref.setUsed( !method.isStatic() );
-                return ref;
-            }
-        }
-        return null;
     }
 }
 

--- a/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
@@ -103,7 +103,7 @@ public class BeanMappingMethod extends MappingMethod {
             boolean mapNullToDefault =
                 MapperConfig.getInstanceOn( ctx.getMapperTypeElement() ).isMapToDefault( prism );
 
-            MethodReference factoryMethod = AssignmentFactory.createFactoryMethod( method.getReturnType(), ctx );
+            MethodReference factoryMethod = ctx.getMappingResolver().getFactoryMethod( method, method.getResultType() );
             return new BeanMappingMethod( method, propertyMappings, factoryMethod, mapNullToDefault );
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
@@ -124,8 +124,7 @@ public class IterableMappingMethod extends MappingMethod {
             boolean mapNullToDefault
                 = MapperConfig.getInstanceOn( ctx.getMapperTypeElement() ).isMapToDefault( prism );
 
-            MethodReference factoryMethod = AssignmentFactory.createFactoryMethod( method.getReturnType(), ctx );
-
+            MethodReference factoryMethod = ctx.getMappingResolver().getFactoryMethod( method, method.getResultType() );
             return new IterableMappingMethod(
                     method,
                     assignment,

--- a/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
@@ -141,7 +141,7 @@ public class MapMappingMethod extends MappingMethod {
             boolean mapNullToDefault =
                 MapperConfig.getInstanceOn( ctx.getMapperTypeElement() ).isMapToDefault( prism );
 
-            MethodReference factoryMethod = AssignmentFactory.createFactoryMethod( method.getReturnType(), ctx );
+            MethodReference factoryMethod = ctx.getMappingResolver().getFactoryMethod( method, method.getResultType() );
 
             keyAssignment = new LocalVarWrapper( keyAssignment, method.getThrownTypes() );
             valueAssignment = new LocalVarWrapper( valueAssignment, method.getThrownTypes() );

--- a/processor/src/main/java/org/mapstruct/ap/model/MappingBuilderContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MappingBuilderContext.java
@@ -94,6 +94,17 @@ public class MappingBuilderContext {
                                        String targetPropertyName, String dateFormat, List<TypeMirror> qualifiers,
                                        String sourceReference);
 
+        /**
+         * returns a no arg factory method
+         *
+         * @param mappingMethod target mapping method
+         * @param targetType return type to match
+         *
+         * @return a method reference to the factory method, or null if no suitable, or ambiguous method found
+         *
+         */
+        MethodReference getFactoryMethod(Method mappingMethod, Type targetType);
+
         Set<VirtualMappingMethod> getUsedVirtualMappings();
     }
 
@@ -190,4 +201,5 @@ public class MappingBuilderContext {
     public Set<VirtualMappingMethod> getUsedVirtualMappings() {
         return mappingResolver.getUsedVirtualMappings();
     }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/InheritanceSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/InheritanceSelector.java
@@ -20,7 +20,6 @@ package org.mapstruct.ap.model.source.selector;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.lang.model.type.TypeMirror;
 
 import org.mapstruct.ap.model.common.Parameter;
 import org.mapstruct.ap.model.common.Type;
@@ -37,11 +36,14 @@ public class InheritanceSelector implements MethodSelector {
     public <T extends Method> List<T> getMatchingMethods(
         Method mappingMethod,
         List<T> methods,
-        Type parameterType,
-        Type returnType,
-        List<TypeMirror> qualifiers,
-        String targetPropertyName
+        Type sourceType,
+        Type targetType,
+        SelectionCriteria criteria
     ) {
+
+        if ( sourceType == null ) {
+            return methods;
+        }
 
         List<T> candidatesWithBestMatchingSourceType = new ArrayList<T>();
         int bestMatchingSourceTypeDistance = Integer.MAX_VALUE;
@@ -50,7 +52,7 @@ public class InheritanceSelector implements MethodSelector {
         for ( T method : methods ) {
             Parameter singleSourceParam = method.getSourceParameters().iterator().next();
 
-            int sourceTypeDistance = parameterType.distanceTo( singleSourceParam.getType() );
+            int sourceTypeDistance = sourceType.distanceTo( singleSourceParam.getType() );
             bestMatchingSourceTypeDistance =
                 addToCandidateListIfMinimal(
                     candidatesWithBestMatchingSourceType,

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/MethodSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/MethodSelector.java
@@ -19,7 +19,6 @@
 package org.mapstruct.ap.model.source.selector;
 
 import java.util.List;
-import javax.lang.model.type.TypeMirror;
 
 import org.mapstruct.ap.model.common.Type;
 import org.mapstruct.ap.model.source.Method;
@@ -39,14 +38,12 @@ public interface MethodSelector {
      * @param <T> either SourceMethod or BuiltInMethod
      * @param mappingMethod mapping method, defined in Mapper for which this selection is carried out
      * @param methods list of available methods
-     * @param parameterType parameter type that should be matched
-     * @param returnType return type that should be matched
-     * @param qualifiers list of custom annotations, used in the qualifying process
-     * @param targetPropertyName some information can be derived from the target property
+     * @param sourceType parameter type that should be matched
+     * @param targetType return type that should be matched
+     * @param criteria criteria used in the selection process
      *
      * @return list of methods that passes the matching process
      */
-    <T extends Method> List<T> getMatchingMethods(Method mappingMethod, List<T> methods, Type parameterType,
-                                                  Type returnType, List<TypeMirror> qualifiers,
-                                                  String targetPropertyName);
+    <T extends Method> List<T> getMatchingMethods(Method mappingMethod, List<T> methods, Type sourceType,
+                                                  Type targetType, SelectionCriteria criteria);
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/MethodSelectors.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/MethodSelectors.java
@@ -21,7 +21,6 @@ package org.mapstruct.ap.model.source.selector;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
@@ -51,9 +50,8 @@ public class MethodSelectors implements MethodSelector {
 
     @Override
     public <T extends Method> List<T> getMatchingMethods(Method mappingMethod, List<T> methods,
-                                                         Type parameterType, Type returnType,
-                                                         List<TypeMirror> qualifiers,
-                                                         String targetPropertyName) {
+                                                         Type sourceType, Type targetType,
+                                                         SelectionCriteria criteria) {
 
         List<T> candidates = new ArrayList<T>( methods );
 
@@ -61,10 +59,9 @@ public class MethodSelectors implements MethodSelector {
             candidates = selector.getMatchingMethods(
                 mappingMethod,
                 candidates,
-                parameterType,
-                returnType,
-                qualifiers,
-                targetPropertyName
+                sourceType,
+                targetType,
+                criteria
             );
         }
         return candidates;
@@ -80,13 +77,16 @@ public class MethodSelectors implements MethodSelector {
      */
     public static List<Type> getParameterTypes(TypeFactory typeFactory, List<Parameter> parameters, Type sourceType,
                                                Type returnType) {
-        List<Type> result = new ArrayList<Type>( parameters.size() );
+        List<Type> result = new ArrayList<Type>();
         for ( Parameter param : parameters ) {
             if ( param.isTargetType() ) {
                 result.add( typeFactory.classTypeOf( returnType ) );
             }
             else {
-                result.add( sourceType );
+                if ( sourceType != null ) {
+                    /* for factory methods (sourceType==null), no parameter must be added */
+                    result.add( sourceType );
+                }
             }
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/MethodSelectors.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/MethodSelectors.java
@@ -42,9 +42,10 @@ public class MethodSelectors implements MethodSelector {
         selectors =
             Arrays.<MethodSelector>asList(
                 new TypeSelector( typeFactory ),
-                new InheritanceSelector(),
+                new QualifierSelector( typeUtils, elementUtils ),
+                new TargetTypeSelector( typeUtils, elementUtils ),
                 new XmlElementDeclSelector( typeUtils ),
-                new QualifierSelector( typeUtils, elementUtils )
+                new InheritanceSelector()
             );
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/QualifierSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/QualifierSelector.java
@@ -59,10 +59,10 @@ public class QualifierSelector implements MethodSelector {
 
     @Override
     public <T extends Method> List<T> getMatchingMethods(Method mappingMethod, List<T> methods,
-                                                         Type parameterType, Type returnType,
-                                                         List<TypeMirror> qualifiers,
-                                                         String targetPropertyName) {
+                                                         Type sourceType, Type targetType,
+                                                         SelectionCriteria criteria) {
 
+        List<TypeMirror> qualifiers = criteria.getQualifiers();
         if ( qualifiers == null || qualifiers.isEmpty() ) {
             // remove the method marked as qualifier from the list
             List<T> nonQualiferAnnotatedMethods = new ArrayList<T>();

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/SelectionCriteria.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/SelectionCriteria.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.model.source.selector;
+
+import java.util.List;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * This class groups the selection criteria in one class
+ *
+ * @author Sjaak Derksen
+ */
+public class SelectionCriteria {
+
+    private final List<TypeMirror> qualifiers;
+    private final String targetPropertyName;
+
+    public SelectionCriteria(List<TypeMirror> qualifiers, String targetPropertyName) {
+        this.qualifiers = qualifiers;
+        this.targetPropertyName = targetPropertyName;
+    }
+
+    public List<TypeMirror> getQualifiers() {
+        return qualifiers;
+    }
+
+    public String getTargetPropertyName() {
+        return targetPropertyName;
+    }
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/TargetTypeSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/TargetTypeSelector.java
@@ -1,0 +1,69 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.model.source.selector;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+import org.mapstruct.ap.model.common.Type;
+import org.mapstruct.ap.model.source.Method;
+
+/**
+ * This selector selects a best match based on the result type.
+ * <p>
+ *  Suppose: Sedan -> Car -> Vehicle, MotorCycle -> Vehicle
+ *  By means of this selector one can pinpoint the exact desired return type (Sedan, Car, MotorCycle, Vehicle)
+ *
+ * @author Sjaak Derksen
+ */
+public class TargetTypeSelector implements MethodSelector {
+
+    private final Types typeUtils;
+
+    public TargetTypeSelector( Types typeUtils, Elements elementUtils ) {
+        this.typeUtils = typeUtils;
+    }
+
+    @Override
+    public <T extends Method> List<T> getMatchingMethods(Method mappingMethod, List<T> methods,
+                                                         Type sourceType, Type targetType,
+                                                         SelectionCriteria criteria) {
+
+        TypeMirror qualifyingTypeMirror = criteria.getQualifyingResultType();
+        if ( qualifyingTypeMirror != null ) {
+
+            List<T> candidatesWithQualifyingTargetType = new ArrayList<T>();
+            for ( T method : methods ) {
+                TypeMirror resultTypeMirror = method.getResultType().getTypeElement().asType();
+                if ( typeUtils.isSameType( qualifyingTypeMirror, resultTypeMirror ) ) {
+                    candidatesWithQualifyingTargetType.add( method );
+                }
+            }
+
+            return candidatesWithQualifyingTargetType;
+        }
+        else {
+            return methods;
+        }
+    }
+}
+

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/TypeSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/TypeSelector.java
@@ -20,7 +20,6 @@ package org.mapstruct.ap.model.source.selector;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.lang.model.type.TypeMirror;
 
 import org.mapstruct.ap.model.common.Type;
 import org.mapstruct.ap.model.common.TypeFactory;
@@ -43,19 +42,18 @@ public class TypeSelector implements MethodSelector {
 
     @Override
     public <T extends Method> List<T> getMatchingMethods(Method mappingMethod, List<T> methods,
-                                                         Type parameterType, Type returnType,
-                                                         List<TypeMirror> qualifiers,
-                                                         String targetPropertyName) {
+                                                         Type sourceType, Type targetType,
+                                                         SelectionCriteria criteria) {
 
         List<T> result = new ArrayList<T>();
         for ( T method : methods ) {
-            if ( method.getSourceParameters().size() != 1 ) {
+            if ( method.getSourceParameters().size() > 1 ) {
                 continue;
             }
 
             List<Type> parameterTypes =
-                MethodSelectors.getParameterTypes( typeFactory, method.getParameters(), parameterType, returnType );
-            if ( method.matches( parameterTypes, returnType ) ) {
+                MethodSelectors.getParameterTypes( typeFactory, method.getParameters(), sourceType, targetType );
+            if ( method.matches( parameterTypes, targetType ) ) {
                 result.add( method );
             }
         }

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/XmlElementDeclSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/XmlElementDeclSelector.java
@@ -52,9 +52,8 @@ public class XmlElementDeclSelector implements MethodSelector {
 
     @Override
     public <T extends Method> List<T> getMatchingMethods(Method mappingMethod, List<T> methods,
-                                                         Type parameterType, Type returnType,
-                                                         List<TypeMirror> qualifiers,
-                                                         String targetPropertyName) {
+                                                         Type sourceType, Type targetType,
+                                                         SelectionCriteria criteria) {
 
         // only true source methods are qualifying
         if ( !(mappingMethod instanceof SourceMethod) ) {
@@ -83,7 +82,7 @@ public class XmlElementDeclSelector implements MethodSelector {
             TypeMirror scope = xmlElememtDecl.scope();
             TypeMirror target = sourceMappingMethod.getExecutable().getReturnType();
 
-            boolean nameIsSetAndMatches = name != null && name.equals( targetPropertyName );
+            boolean nameIsSetAndMatches = name != null && name.equals( criteria.getTargetPropertyName() );
             boolean scopeIsSetAndMatches = scope != null && typeUtils.isSameType( scope, target );
 
             if ( nameIsSetAndMatches ) {

--- a/processor/src/main/java/org/mapstruct/ap/prism/PrismGenerator.java
+++ b/processor/src/main/java/org/mapstruct/ap/prism/PrismGenerator.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlElementDecl;
 
 import net.java.dev.hickory.prism.GeneratePrism;
 import net.java.dev.hickory.prism.GeneratePrisms;
+import org.mapstruct.BeanMapping;
 import org.mapstruct.DecoratedWith;
 import org.mapstruct.InheritConfiguration;
 import org.mapstruct.InheritInverseConfiguration;
@@ -46,6 +47,7 @@ import org.mapstruct.TargetType;
     @GeneratePrism(value = Mapping.class, publicAccess = true),
     @GeneratePrism(value = Mappings.class, publicAccess = true),
     @GeneratePrism(value = IterableMapping.class, publicAccess = true),
+    @GeneratePrism(value = BeanMapping.class, publicAccess = true),
     @GeneratePrism(value = MapMapping.class, publicAccess = true),
     @GeneratePrism(value = TargetType.class, publicAccess = true),
     @GeneratePrism(value = MappingTarget.class, publicAccess = true),

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousfactorymethod/FactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousfactorymethod/FactoryTest.java
@@ -44,14 +44,13 @@ public class FactoryTest {
     @ExpectedCompilationOutcome(
         value = CompilationResult.FAILED,
         diagnostics = {
-            @Diagnostic(type = BarFactory.class,
+            @Diagnostic(type = SourceTargetMapperAndBarFactory.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
-                line = 29,
-                messageRegExp = "Ambiguous factory methods: \"org\\.mapstruct\\.ap\\.test\\.erroneous\\."
-                    + "ambiguousfactorymethod\\.Bar createBar\\(\\)\" conflicts with "
-                    + "\"org\\.mapstruct\\.ap\\.test\\.erroneous\\.ambiguousfactorymethod\\.Bar "
-                    + "org\\.mapstruct\\.ap\\.test\\.erroneous\\.ambiguousfactorymethod"
-                    + "\\.a\\.BarFactory\\.createBar\\(\\)\"\\")
+                line = 35,
+                messageRegExp = "Ambiguous mapping methods found for factorizing "
+                        + "org.mapstruct.ap.test.erroneous.ambiguousfactorymethod.Bar: "
+                        + "org.mapstruct.ap.test.erroneous.ambiguousfactorymethod.Bar createBar\\(\\), "
+                        + "org.mapstruct.ap.test.erroneous.ambiguousfactorymethod.Bar .*BarFactory.createBar\\(\\)." )
         }
     )
     public void shouldUseTwoFactoryMethods() {

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/Apple.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/Apple.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.inheritance;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Apple extends Fruit {
+
+    public Apple(String type) {
+        super( type );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/AppleDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/AppleDto.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.inheritance;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class AppleDto extends FruitDto {
+
+    public AppleDto(String type) {
+        super( type );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/Banana.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/Banana.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.inheritance;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Banana extends Fruit {
+
+    public Banana(String type) {
+        super( type );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/BananaDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/BananaDto.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.inheritance;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class BananaDto extends FruitDto {
+
+    public BananaDto(String type) {
+        super( type );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/ConflictingFruitFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/ConflictingFruitFactory.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.inheritance;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class ConflictingFruitFactory {
+
+    public Apple createApple() {
+        return new Apple( "apple" );
+    }
+
+    public Banana createBanana() {
+        return new Banana( "banana" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/ErroneousFruitMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/ErroneousFruitMapper.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.inheritance;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper(uses = ConflictingFruitFactory.class)
+
+public interface ErroneousFruitMapper {
+
+    ErroneousFruitMapper INSTANCE = Mappers.getMapper( ErroneousFruitMapper.class );
+
+    @Mapping(target = "type", ignore = true)
+    Fruit map(FruitDto source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/Fruit.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/Fruit.java
@@ -16,37 +16,27 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.model.source.selector;
-
-import java.util.List;
-import javax.lang.model.type.TypeMirror;
+package org.mapstruct.ap.test.selection.inheritance;
 
 /**
- * This class groups the selection criteria in one class
  *
  * @author Sjaak Derksen
  */
-public class SelectionCriteria {
+public class Fruit {
 
-    private final List<TypeMirror> qualifiers;
-    private final String targetPropertyName;
-    private final TypeMirror qualifyingResultType;
+    private String type;
 
-    public SelectionCriteria(List<TypeMirror> qualifiers, String targetPropertyName, TypeMirror qualifyingResultType) {
-        this.qualifiers = qualifiers;
-        this.targetPropertyName = targetPropertyName;
-        this.qualifyingResultType = qualifyingResultType;
+    public Fruit(String type) {
+        this.type = type;
     }
 
-    public List<TypeMirror> getQualifiers() {
-        return qualifiers;
+    public String getType() {
+        return type;
     }
 
-    public String getTargetPropertyName() {
-        return targetPropertyName;
+    public void setType(String type) {
+        this.type = type;
     }
 
-    public TypeMirror getQualifyingResultType() {
-        return qualifyingResultType;
-    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/FruitDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/FruitDto.java
@@ -16,37 +16,27 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.model.source.selector;
-
-import java.util.List;
-import javax.lang.model.type.TypeMirror;
+package org.mapstruct.ap.test.selection.inheritance;
 
 /**
- * This class groups the selection criteria in one class
  *
  * @author Sjaak Derksen
  */
-public class SelectionCriteria {
+public class FruitDto {
 
-    private final List<TypeMirror> qualifiers;
-    private final String targetPropertyName;
-    private final TypeMirror qualifyingResultType;
+    private String type;
 
-    public SelectionCriteria(List<TypeMirror> qualifiers, String targetPropertyName, TypeMirror qualifyingResultType) {
-        this.qualifiers = qualifiers;
-        this.targetPropertyName = targetPropertyName;
-        this.qualifyingResultType = qualifyingResultType;
+    public FruitDto(String type) {
+        this.type = type;
     }
 
-    public List<TypeMirror> getQualifiers() {
-        return qualifiers;
+    public String getType() {
+        return type;
     }
 
-    public String getTargetPropertyName() {
-        return targetPropertyName;
+    public void setType(String type) {
+        this.type = type;
     }
 
-    public TypeMirror getQualifyingResultType() {
-        return qualifyingResultType;
-    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/InheritanceSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/InheritanceSelectionTest.java
@@ -1,0 +1,74 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.inheritance;
+
+import javax.tools.Diagnostic.Kind;
+import static org.fest.assertions.Assertions.assertThat;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@IssueKey("385")
+@WithClasses({
+    Fruit.class,
+    FruitDto.class,
+    Apple.class,
+    AppleDto.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class InheritanceSelectionTest {
+
+
+    @Test
+    @WithClasses( { ConflictingFruitFactory.class, ErroneousFruitMapper.class, Banana.class } )
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousFruitMapper.class,
+                kind = Kind.ERROR,
+                line = 36,
+                messageRegExp = "Ambiguous mapping methods found for factorizing .*Fruit: "
+                    + ".*Apple .*ConflictingFruitFactory\\.createApple\\(\\), "
+                    + ".*Banana .*ConflictingFruitFactory\\.createBanana\\(\\)\\.")
+        }
+    )
+    public void testForkedInheritanceHierarchyShouldResultInAmbigousMappingMethod() {
+    }
+
+    @Test
+    @WithClasses( { ConflictingFruitFactory.class, TargetTypeSelectingFruitMapper.class, Banana.class } )
+    public void testForkedInheritanceHierarchyButDefinedTargetType() {
+
+        FruitDto fruitDto = new FruitDto( null );
+        Fruit fruit = TargetTypeSelectingFruitMapper.INSTANCE.map( fruitDto );
+        assertThat( fruit ).isNotNull();
+        assertThat( fruit.getType() ).isEqualTo( "apple" );
+
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/TargetTypeSelectingFruitMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/inheritance/TargetTypeSelectingFruitMapper.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.inheritance;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper(uses = ConflictingFruitFactory.class)
+
+public interface TargetTypeSelectingFruitMapper {
+
+    TargetTypeSelectingFruitMapper INSTANCE = Mappers.getMapper( TargetTypeSelectingFruitMapper.class );
+
+    @BeanMapping(resultType = Apple.class)
+    @Mapping(target = "type", ignore = true)
+    Fruit map(FruitDto source);
+
+}


### PR DESCRIPTION

* General improvement, factories and mapping method selection make use of the same (selector) mechanism.

* For the source-type, the fit was not applied in two directions. For that purpose the absolute (type) distance is used iso distance.

* There was no target-type inheritance implemented.