### PR TITLE
#405 Fixing factory methods, not using raw type for @TargetType and supe...

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/GeneratedType.java
@@ -164,8 +164,6 @@ public abstract class GeneratedType extends ModelElement {
             }
         }
 
-        addWithDependents( collection, typeToAdd.getImplementationType() );
-
         for ( Type type : typeToAdd.getTypeParameters() ) {
             addWithDependents( collection, type );
         }

--- a/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
@@ -166,7 +166,9 @@ public class IterableMappingMethod extends MappingMethod {
         if ( elementAssignment != null ) {
             types.addAll( elementAssignment.getImportTypes() );
         }
-
+        if ( factoryMethod == null ) {
+            types.addAll( getReturnType().getImportTypes() );
+        }
         return types;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
@@ -195,6 +195,9 @@ public class MapMappingMethod extends MappingMethod {
         if ( valueAssignment != null ) {
             types.addAll( valueAssignment.getImportTypes() );
         }
+        if ( factoryMethod == null ) {
+            types.addAll( getReturnType().getImportTypes() );
+        }
 
         return types;
     }

--- a/processor/src/main/java/org/mapstruct/ap/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MappingMethod.java
@@ -111,7 +111,6 @@ public abstract class MappingMethod extends ModelElement {
         }
 
         types.add( getReturnType() );
-        types.addAll( getReturnType().getImportTypes() );
         types.addAll( thrownTypes );
         return types;
     }

--- a/processor/src/main/resources/org.mapstruct.ap.model.IterableMappingMethod.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.IterableMappingMethod.ftl
@@ -107,7 +107,7 @@
 <#macro iterableCreation>
     <@compress single_line=true>
         <#if factoryMethod??>
-            <@includeModel object=factoryMethod/>
+            <@includeModel object=factoryMethod targetType=resultType raw=true/>
         <#else>
             new
             <#if resultType.implementationType??>

--- a/processor/src/main/resources/org.mapstruct.ap.model.MapMappingMethod.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.MapMappingMethod.ftl
@@ -68,7 +68,7 @@
 <#macro returnObjectCreation>
     <@compress single_line=true>
         <#if factoryMethod??>
-             <@includeModel object=factoryMethod/>
+             <@includeModel object=factoryMethod targetType=resultType raw=true/>
         <#else>
              new
              <#if resultType.implementationType??>

--- a/processor/src/main/resources/org.mapstruct.ap.model.MethodReference.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.MethodReference.ftl
@@ -25,7 +25,7 @@
         <#list parameters as param>
             <#if param.targetType>
                 <#-- a class is passed on for casting, see @TargetType -->
-                <@includeModel object=ext.targetType/>.class
+                <@includeModel object=ext.targetType raw=true/>.class
             <#else>
                 <@includeModel object=assignment targetType=singleSourceParameterType raw=ext.raw/>
             </#if>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_405/EntityFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_405/EntityFactory.java
@@ -1,0 +1,29 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._405;
+
+
+import org.mapstruct.TargetType;
+
+public class EntityFactory {
+
+    public <T> T createEntity(@TargetType Class<T> entityClass) {
+        return null;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_405/Issue405Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_405/Issue405Test.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._405;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Reproducer for https://github.com/mapstruct/mapstruct/issues/405.
+ *
+ * @author Sjaak Derksen
+ */
+@IssueKey( "405" )
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue405Test {
+
+    @Test
+    @WithClasses( { EntityFactory.class, Person.class, People.class, PersonMapper.class } )
+    public void shouldGenerateFactoryCorrectMethodForIterables() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_405/People.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_405/People.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._405;
+
+
+import java.util.List;
+
+public class People {
+    private String name;
+    private List<People> children;
+
+    public List<People> getChildren() {
+        return children;
+    }
+
+    public void setChildren(List<People> children) {
+        this.children = children;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_405/Person.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_405/Person.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._405;
+
+
+import java.util.List;
+
+public class Person {
+    private String id;
+    private List<Person> children;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public List<Person> getChildren() {
+        return children;
+    }
+
+    public void setChildren(List<Person> children) {
+        this.children = children;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_405/PersonMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_405/PersonMapper.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2012-2014 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._405;
+
+import java.util.List;
+import java.util.Map;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = {EntityFactory.class } )
+public abstract class PersonMapper {
+
+    public static final PersonMapper INSTANCE = Mappers.getMapper( PersonMapper.class );
+
+    @Mappings( {
+        @Mapping( source = "id", target = "name" ) }
+    )
+    abstract People personToPeople(Person person);
+
+    abstract List<People> personListToPeopleList(List<Person> children);
+
+    abstract Map<Integer, People> personListToPeopleMap(Map<Integer, Person> children);
+
+}


### PR DESCRIPTION
...rfluous implementation classes imports

1. The model for methods was not always applied correctly to factory methods. Hence, the result type was not passed along.
2. Non Raw types were passed as @TargetType, compilation error.
3. Superflous imports for implementation types when using factory methods in iterable and map mappings. Responsibility of importing impllementation type has been made dependent on whether or not a 'new' is required (no factory method)