### PR TITLE
#417 Making dateFormat in @IterableMapping optional, adding checks for @...

### DIFF
--- a/core-common/src/main/java/org/mapstruct/IterableMapping.java
+++ b/core-common/src/main/java/org/mapstruct/IterableMapping.java
@@ -41,7 +41,7 @@ public @interface IterableMapping {
      *
      * @return A date format string as processable by {@link SimpleDateFormat}.
      */
-    String dateFormat();
+    String dateFormat() default "";
 
     /**
      * A qualifier can be specified to aid the selection process of a suitable mapper. This is useful in case multiple

--- a/processor/src/main/java/org/mapstruct/ap/model/source/IterableMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/IterableMapping.java
@@ -19,9 +19,12 @@
 package org.mapstruct.ap.model.source;
 
 import java.util.List;
+import javax.annotation.processing.Messager;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
 
 import org.mapstruct.ap.prism.IterableMappingPrism;
 
@@ -37,9 +40,19 @@ public class IterableMapping {
     private final AnnotationMirror mirror;
     private final AnnotationValue dateFormatAnnotationValue;
 
-    public static IterableMapping fromPrism(IterableMappingPrism iterableMapping) {
+    public static IterableMapping fromPrism(IterableMappingPrism iterableMapping, ExecutableElement method,
+                                            Messager messager) {
         if ( iterableMapping == null ) {
             return null;
+        }
+
+        if ( iterableMapping.dateFormat().isEmpty() && iterableMapping.qualifiedBy().isEmpty() ) {
+            messager.printMessage(
+                Diagnostic.Kind.ERROR,
+                "'dateformat' and 'qualifiedBy' are both undefined in @IterableMapping, either define a "
+                    + "'dateformat', 'qualfiedBy' or both.",
+                method
+            );
         }
 
         return new IterableMapping(

--- a/processor/src/main/java/org/mapstruct/ap/model/source/MapMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/MapMapping.java
@@ -19,8 +19,11 @@
 package org.mapstruct.ap.model.source;
 
 import java.util.List;
+import javax.annotation.processing.Messager;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
 
 import org.mapstruct.ap.prism.MapMappingPrism;
 
@@ -37,10 +40,23 @@ public class MapMapping {
     private final List<TypeMirror> valueQualifiers;
     private final AnnotationMirror mirror;
 
-    public static MapMapping fromPrism(MapMappingPrism mapMapping) {
+    public static MapMapping fromPrism(MapMappingPrism mapMapping, ExecutableElement method, Messager messager) {
         if ( mapMapping == null ) {
             return null;
         }
+
+        if ( mapMapping.keyDateFormat().isEmpty()
+            && mapMapping.keyQualifiedBy().isEmpty()
+            && mapMapping.valueDateFormat().isEmpty()
+            && mapMapping.valueQualifiedBy().isEmpty() ) {
+            messager.printMessage(
+                Diagnostic.Kind.ERROR,
+                "'keyDateFormat', 'keyQualifiedBy', 'valueDateFormat' and 'valueQualfiedBy' are all undefined in "
+                    + "@MapMapping, define at least one of them.",
+                method
+            );
+        }
+
 
         return new MapMapping(
             mapMapping.keyDateFormat(),

--- a/processor/src/main/java/org/mapstruct/ap/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/MethodRetrievalProcessor.java
@@ -169,8 +169,8 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
             returnType,
             exceptionTypes,
             getMappings( method ),
-            IterableMapping.fromPrism( IterableMappingPrism.getInstanceOn( method ) ),
-            MapMapping.fromPrism( MapMappingPrism.getInstanceOn( method ) ),
+            IterableMapping.fromPrism( IterableMappingPrism.getInstanceOn( method ), method, messager ),
+            MapMapping.fromPrism( MapMappingPrism.getInstanceOn( method ), method, messager ),
             typeUtils,
             messager,
             typeFactory

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/EmptyItererableMappingMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/EmptyItererableMappingMapper.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.erroneous;
+
+import java.util.Date;
+import java.util.List;
+import org.mapstruct.IterableMapping;
+import org.mapstruct.Mapper;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper
+public interface EmptyItererableMappingMapper {
+
+
+    @IterableMapping
+    List<String> stringListToDateList(List<Date> dates);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/EmptyMapMappingMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/EmptyMapMappingMapper.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.erroneous;
+
+import java.util.Date;
+import java.util.Map;
+import org.mapstruct.MapMapping;
+import org.mapstruct.Mapper;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper
+public interface EmptyMapMappingMapper {
+
+    @MapMapping
+    Map<String, String> longDateMapToStringStringMap(Map<Long, Date> source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionMappingTest.java
@@ -56,4 +56,35 @@ public class ErroneousCollectionMappingTest {
     public void shouldFailToGenerateImplementationBetweenCollectionAndNonCollection() {
     }
 
+    @Test
+    @IssueKey("417")
+    @WithClasses({ EmptyItererableMappingMapper.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = EmptyItererableMappingMapper.class,
+                kind = Kind.ERROR,
+                line = 35,
+                messageRegExp = "'dateformat' and 'qualifiedBy' are both undefined in @IterableMapping, "
+                    + "either define a 'dateformat', 'qualfiedBy' or both.")
+        }
+    )
+    public void shouldFailOnEmptyIterableAnnotation() {
+    }
+
+    @Test
+    @IssueKey("417")
+    @WithClasses({ EmptyMapMappingMapper.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = EmptyMapMappingMapper.class,
+                kind = Kind.ERROR,
+                line = 34,
+                messageRegExp = "'keyDateFormat', 'keyQualifiedBy', 'valueDateFormat' and 'valueQualfiedBy' are all "
+                    + "undefined in @MapMapping, define at least one of them.")
+        }
+    )
+    public void shouldFailOnEmptyMapAnnotation() {
+    }
 }


### PR DESCRIPTION
...IterableMapping and @MapMapping

* `@IterableMapping#dateFormat` is not mandatory anymore in `@IterableMapping`due to the introduction of `@IterableMapping#qualifiedBy`
* one of the parameters  `@IterableMapping#dateFormat` or  `@IterableMapping#qualifiedBy `needs to be specified. 
* the same is valid for `@MapMapping`