### PR TITLE
#390 included maven coordinates as comments in generated code

### DIFF
--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -45,8 +45,8 @@
         </dependency>
 
         <!-- Compile-only; Using "provided" scope as there is no such scope in Maven;
-             these dependencies are not required at runtime, only for prism generation
-             and tests -->
+        these dependencies are not required at runtime, only for prism generation
+        and tests -->
         <dependency>
             <groupId>com.jolira</groupId>
             <artifactId>hickory</artifactId>
@@ -90,6 +90,17 @@
 
     <build>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                        </manifest>
+                    </archive>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/processor/src/main/java/org/mapstruct/ap/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/GeneratedType.java
@@ -18,11 +18,15 @@
  */
 package org.mapstruct.ap.model;
 
+import java.io.IOException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.jar.Manifest;
 import javax.annotation.Generated;
 
 import org.mapstruct.ap.model.common.Accessibility;
@@ -36,6 +40,9 @@ import org.mapstruct.ap.model.common.TypeFactory;
  * @author Gunnar Morling
  */
 public abstract class GeneratedType extends ModelElement {
+
+    private static final String COMMENT_TAG = "Implementation-Version";
+    private static final String COMMENTS = initComment();
 
     private final String packageName;
     private final String name;
@@ -118,6 +125,10 @@ public abstract class GeneratedType extends ModelElement {
         return accessibility;
     }
 
+    public String getComments() {
+        return COMMENTS;
+    }
+
     @Override
     public SortedSet<Type> getImportTypes() {
         SortedSet<Type> importedTypes = new TreeSet<Type>();
@@ -167,5 +178,24 @@ public abstract class GeneratedType extends ModelElement {
         for ( Type type : typeToAdd.getTypeParameters() ) {
             addWithDependents( collection, type );
         }
+    }
+
+    private static String initComment() {
+        String result = null;
+        try {
+            Enumeration<URL> resources = GeneratedType.class.getClassLoader().getResources( "META-INF/MANIFEST.MF" );
+            while ( resources.hasMoreElements() ) {
+                Manifest manifest = new Manifest( resources.nextElement().openStream() );
+                String resultValue = manifest.getMainAttributes().getValue( COMMENT_TAG );
+                if (resultValue != null ) {
+                    result = COMMENT_TAG + ": " + resultValue;
+                    break;
+                }
+            }
+        }
+        catch ( IOException ex ) {
+            return result;
+        }
+        return result;
     }
 }

--- a/processor/src/main/resources/org.mapstruct.ap.model.GeneratedType.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.GeneratedType.ftl
@@ -26,7 +26,8 @@ import ${importedType.importName};
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor"<#if suppressGeneratorTimestamp == false>,
-    date = "${.now?string("yyyy-MM-dd'T'HH:mm:ssZ")}"</#if>
+    date = "${.now?string("yyyy-MM-dd'T'HH:mm:ssZ")}"</#if><#if comments??>,
+    comments = "${comments}"</#if>
 )
 <#list annotations as annotation>
 <#nt><@includeModel object=annotation/>


### PR DESCRIPTION
I've realized this feature by adding a manifest entry in the MANIFEST.MF file by means of the maven-jar-plugin. This is read by the annotation processor and included in the generated code.

Simple and effective :smile:

The full maven coordinates are added (groupId:artifactId:version).

One more remark: the `@Generated#comments` does not show up in the unit test (because the maven-jar-plugin is active at the end of the build).