### PR TITLE
#433 introduce resultType in @Mapping

### DIFF
--- a/core-common/src/main/java/org/mapstruct/IterableMapping.java
+++ b/core-common/src/main/java/org/mapstruct/IterableMapping.java
@@ -29,6 +29,9 @@ import java.util.Date;
 /**
  * Configures the mapping between two iterable types, e.g. {@code List<String>} and {@code List<Date>}.
  *
+ * <p>Note: either  @IterableMapping#dateFormat, @IterableMapping#resultType or @IterableMapping#qualifiedBy
+ * must be specified</p>
+ *
  * @author Gunnar Morling
  */
 @Target(ElementType.METHOD)
@@ -52,4 +55,12 @@ public @interface IterableMapping {
      * @return the qualifiers
      */
     Class<? extends Annotation>[] qualifiedBy() default { };
+
+    /**
+     * Specifies the type of the element to be used in the result of the mapping method in case multiple mapping
+     * methods qualify.
+     *
+     * @return the elementTargetType to select
+     */
+    Class<?> elementTargetType() default void.class;
 }

--- a/core-common/src/main/java/org/mapstruct/MapMapping.java
+++ b/core-common/src/main/java/org/mapstruct/MapMapping.java
@@ -29,6 +29,8 @@ import java.util.Date;
 /**
  * Configures the mapping between two map types, e.g. {@code Map<String, String>} and {@code Map<Long, Date>}.
  *
+ * <p>Note: at least one element needs to be specified</p>
+ *
  * @author Gunnar Morling
  */
 @Target(ElementType.METHOD)
@@ -73,4 +75,20 @@ public @interface MapMapping {
      * @return the qualifiers
      */
     Class<? extends Annotation>[] valueQualifiedBy() default { };
+
+    /**
+     * Specifies the type of the key to be used in the result of the mapping method in case multiple mapping
+     * methods qualify.
+     *     *
+     * @return the resultType to select
+     */
+    Class<?> keyTargetType() default void.class;
+
+    /**
+     * Specifies the type of the value to be used in the result of the mapping method in case multiple mapping
+     * methods qualify.
+     *     *
+     * @return the resultType to select
+     */
+    Class<?> valueTargetType() default void.class;
 }

--- a/core-jdk8/src/main/java/org/mapstruct/Mapping.java
+++ b/core-jdk8/src/main/java/org/mapstruct/Mapping.java
@@ -136,4 +136,11 @@ public @interface Mapping {
      * @return the qualifiers
      */
     Class<? extends Annotation>[] qualifiedBy() default { };
+
+   /**
+     * Specifies the result type of the mapping method to be used in case multiple mapping methods qualify.
+     *
+     * @return the resultType to select
+     */
+    Class<?> resultType() default void.class;
 }

--- a/core/src/main/java/org/mapstruct/Mapping.java
+++ b/core/src/main/java/org/mapstruct/Mapping.java
@@ -134,4 +134,11 @@ public @interface Mapping {
      * @return the qualifiers
      */
     Class<? extends Annotation>[] qualifiedBy() default { };
+
+    /**
+     * Specifies the result type of the mapping method to be used in case multiple mapping methods qualify.
+     *
+     * @return the resultType to select
+     */
+    Class<?> resultType() default void.class;
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
@@ -170,6 +170,7 @@ public class BeanMappingMethod extends MappingMethod {
                                     .targetPropertyName( mapping.getTargetName() )
                                     .sourceReference( sourceRef )
                                     .qualifiers( mapping.getQualifiers() )
+                                    .resultType( mapping.getResultType() )
                                     .dateFormat( mapping.getDateFormat() )
                                     .build();
                                 handledTargets.add( mapping.getTargetName() );
@@ -191,6 +192,7 @@ public class BeanMappingMethod extends MappingMethod {
                             .targetAccessor( targetProperty )
                             .dateFormat( mapping.getDateFormat() )
                             .qualifiers( mapping.getQualifiers() )
+                            .resultType( mapping.getResultType() )
                             .build();
                         handledTargets.add( mapping.getTargetName() );
                     }
@@ -277,6 +279,7 @@ public class BeanMappingMethod extends MappingMethod {
                                 .targetPropertyName( targetProperty.getKey() )
                                 .sourceReference( sourceRef )
                                 .qualifiers( mapping != null ? mapping.getQualifiers() : null )
+                                .resultType( mapping != null ? mapping.getResultType() : null )
                                 .dateFormat( mapping != null ? mapping.getDateFormat() : null )
                                 .build();
 
@@ -339,6 +342,7 @@ public class BeanMappingMethod extends MappingMethod {
                             .targetPropertyName( targetProperty.getKey() )
                             .sourceReference( sourceRef )
                             .qualifiers( mapping != null ? mapping.getQualifiers() : null )
+                            .resultType( mapping != null ? mapping.getResultType() : null )
                             .dateFormat( mapping != null ? mapping.getDateFormat() : null )
                             .build();
 

--- a/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
@@ -100,6 +100,7 @@ public class IterableMappingMethod extends MappingMethod {
                 null, // there is no targetPropertyName
                 dateFormat,
                 qualifiers,
+                null, // resulttype does not seem to make sense
                 loopVariableName
             );
 

--- a/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
@@ -54,6 +54,7 @@ public class IterableMappingMethod extends MappingMethod {
         private MappingBuilderContext ctx;
         private String dateFormat;
         private List<TypeMirror> qualifiers;
+        private TypeMirror qualifyingElementTargetType;
 
         public Builder mappingContext(MappingBuilderContext mappingContext) {
             this.ctx = mappingContext;
@@ -72,6 +73,11 @@ public class IterableMappingMethod extends MappingMethod {
 
         public Builder qualifiers(List<TypeMirror> qualifiers) {
             this.qualifiers = qualifiers;
+            return this;
+        }
+
+        public Builder qualifyingElementTargetType(TypeMirror qualifyingElementTargetType) {
+            this.qualifyingElementTargetType = qualifyingElementTargetType;
             return this;
         }
 
@@ -100,7 +106,7 @@ public class IterableMappingMethod extends MappingMethod {
                 null, // there is no targetPropertyName
                 dateFormat,
                 qualifiers,
-                null, // resulttype does not seem to make sense
+                qualifyingElementTargetType,
                 loopVariableName
             );
 

--- a/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
@@ -52,6 +52,8 @@ public class MapMappingMethod extends MappingMethod {
         private String valueDateFormat;
         private List<TypeMirror> keyQualifiers;
         private List<TypeMirror> valueQualifiers;
+        private TypeMirror keyQualifyingTargetType;
+        private TypeMirror valueQualifyingTargetType;
         private Method method;
         private MappingBuilderContext ctx;
 
@@ -85,6 +87,16 @@ public class MapMappingMethod extends MappingMethod {
             return this;
         }
 
+        public Builder keyQualifyingTargetType(TypeMirror keyQualifyingTargetType) {
+            this.keyQualifyingTargetType = keyQualifyingTargetType;
+            return this;
+        }
+
+        public Builder valueQualifyingTargetType(TypeMirror valueQualifyingTargetType) {
+            this.valueQualifyingTargetType = valueQualifyingTargetType;
+            return this;
+        }
+
         public MapMappingMethod build() {
 
             List<Type> sourceTypeParams = method.getSourceParameters().iterator().next().getType().getTypeParameters();
@@ -102,7 +114,7 @@ public class MapMappingMethod extends MappingMethod {
                 null, // there is no targetPropertyName
                 keyDateFormat,
                 keyQualifiers,
-                null, // resulttype does not seem to make sense
+                keyQualifyingTargetType,
                 "entry.getKey()"
             );
 
@@ -126,7 +138,7 @@ public class MapMappingMethod extends MappingMethod {
                 null, // there is no targetPropertyName
                 valueDateFormat,
                 valueQualifiers,
-                null, // resulttype does not seem to make sense
+                valueQualifyingTargetType,
                 "entry.getValue()"
             );
 

--- a/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
@@ -102,6 +102,7 @@ public class MapMappingMethod extends MappingMethod {
                 null, // there is no targetPropertyName
                 keyDateFormat,
                 keyQualifiers,
+                null, // resulttype does not seem to make sense
                 "entry.getKey()"
             );
 
@@ -125,6 +126,7 @@ public class MapMappingMethod extends MappingMethod {
                 null, // there is no targetPropertyName
                 valueDateFormat,
                 valueQualifiers,
+                null, // resulttype does not seem to make sense
                 "entry.getValue()"
             );
 

--- a/processor/src/main/java/org/mapstruct/ap/model/MappingBuilderContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MappingBuilderContext.java
@@ -80,6 +80,7 @@ public class MappingBuilderContext {
          * @param targetPropertyName name of the target property
          * @param dateFormat used for formatting dates in build in methods that need context information
          * @param qualifiers used for further select the appropriate mapping method based on class and name
+         * @param resultType used for further select the appropriate mapping method based on class and name
          * @param sourceReference call to source type as string
          *
          * @return an assignment to a method parameter, which can either be:
@@ -92,7 +93,7 @@ public class MappingBuilderContext {
          */
         Assignment getTargetAssignment(Method mappingMethod, String mappedElement, Type sourceType, Type targetType,
                                        String targetPropertyName, String dateFormat, List<TypeMirror> qualifiers,
-                                       String sourceReference);
+                                       TypeMirror resultType, String sourceReference);
 
         /**
          * returns a no arg factory method

--- a/processor/src/main/java/org/mapstruct/ap/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/PropertyMapping.java
@@ -70,6 +70,7 @@ public class PropertyMapping extends ModelElement {
         private String targetPropertyName;
         private String dateFormat;
         private List<TypeMirror> qualifiers;
+        private TypeMirror resultType;
         private SourceReference sourceReference;
 
         public PropertyMappingBuilder mappingContext(MappingBuilderContext mappingContext) {
@@ -99,6 +100,11 @@ public class PropertyMapping extends ModelElement {
 
         public PropertyMappingBuilder qualifiers(List<TypeMirror> qualifiers) {
             this.qualifiers = qualifiers;
+            return this;
+        }
+
+        public PropertyMappingBuilder resultType(TypeMirror resultType) {
+            this.resultType = resultType;
             return this;
         }
 
@@ -142,6 +148,7 @@ public class PropertyMapping extends ModelElement {
                 targetPropertyName,
                 dateFormat,
                 qualifiers,
+                resultType,
                 sourceRefStr
             );
 
@@ -450,6 +457,7 @@ public class PropertyMapping extends ModelElement {
         private ExecutableElement targetAccessor;
         private String dateFormat;
         private List<TypeMirror> qualifiers;
+        private TypeMirror resultType;
 
         public ConstantMappingBuilder mappingContext(MappingBuilderContext mappingContext) {
             this.ctx = mappingContext;
@@ -481,6 +489,11 @@ public class PropertyMapping extends ModelElement {
             return this;
         }
 
+        public ConstantMappingBuilder resultType(TypeMirror resultType) {
+            this.resultType = resultType;
+            return this;
+        }
+
         public PropertyMapping build() {
 
             // source
@@ -506,6 +519,7 @@ public class PropertyMapping extends ModelElement {
                 targetPropertyName,
                 dateFormat,
                 qualifiers,
+                resultType,
                 constantExpression
             );
 

--- a/processor/src/main/java/org/mapstruct/ap/model/source/IterableMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/IterableMapping.java
@@ -23,6 +23,7 @@ import javax.annotation.processing.Messager;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 
@@ -37,6 +38,7 @@ public class IterableMapping {
 
     private final String dateFormat;
     private final List<TypeMirror> qualifiers;
+    private final TypeMirror qualifyingElementTargetType;
     private final AnnotationMirror mirror;
     private final AnnotationValue dateFormatAnnotationValue;
 
@@ -46,10 +48,13 @@ public class IterableMapping {
             return null;
         }
 
-        if ( iterableMapping.dateFormat().isEmpty() && iterableMapping.qualifiedBy().isEmpty() ) {
+        boolean elementTargetTypeIsDefined = !TypeKind.VOID.equals( iterableMapping.elementTargetType().getKind() );
+        if ( !elementTargetTypeIsDefined
+            && iterableMapping.dateFormat().isEmpty()
+            && iterableMapping.qualifiedBy().isEmpty() ) {
             messager.printMessage(
                 Diagnostic.Kind.ERROR,
-                "'dateformat' and 'qualifiedBy' are undefined in @IterableMapping, "
+                "'dateformat', 'qualifiedBy' and 'elementTargetType' are undefined in @IterableMapping, "
                     + "define at least one of them.",
                 method
             );
@@ -58,6 +63,7 @@ public class IterableMapping {
         return new IterableMapping(
             iterableMapping.dateFormat(),
             iterableMapping.qualifiedBy(),
+            elementTargetTypeIsDefined ? iterableMapping.elementTargetType() : null,
             iterableMapping.mirror,
             iterableMapping.values.dateFormat()
         );
@@ -66,10 +72,12 @@ public class IterableMapping {
     private IterableMapping(
             String dateFormat,
             List<TypeMirror> qualifiers,
+            TypeMirror resultType,
             AnnotationMirror mirror,
-            AnnotationValue dateFormatAnnotationValue) {
+            AnnotationValue dateFormatAnnotationValue ) {
         this.dateFormat = dateFormat;
         this.qualifiers = qualifiers;
+        this.qualifyingElementTargetType = resultType;
         this.mirror = mirror;
         this.dateFormatAnnotationValue = dateFormatAnnotationValue;
     }
@@ -80,6 +88,10 @@ public class IterableMapping {
 
     public List<TypeMirror> getQualifiers() {
         return qualifiers;
+    }
+
+    public TypeMirror getQualifyingElementTargetType() {
+        return qualifyingElementTargetType;
     }
 
     public AnnotationMirror getMirror() {

--- a/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
@@ -55,6 +55,7 @@ public class Mapping {
     private final String targetName;
     private final String dateFormat;
     private final List<TypeMirror> qualifiers;
+    private final TypeMirror resultType;
     private final boolean isIgnored;
 
     private final AnnotationMirror mirror;
@@ -135,6 +136,9 @@ public class Mapping {
         String expression = getExpression( mappingPrism, element, messager );
         String dateFormat = mappingPrism.dateFormat().isEmpty() ? null : mappingPrism.dateFormat();
 
+        boolean resultTypeIsDefined = !TypeKind.VOID.equals( mappingPrism.resultType().getKind() );
+        TypeMirror resultType = resultTypeIsDefined ? mappingPrism.resultType() : null;
+
         return new Mapping(
             source,
             constant,
@@ -145,14 +149,17 @@ public class Mapping {
             mappingPrism.ignore(),
             mappingPrism.mirror,
             mappingPrism.values.source(),
-            mappingPrism.values.target()
+            mappingPrism.values.target(),
+            resultType
         );
     }
 
+    @SuppressWarnings( "checkstyle:parameternumber" )
     private Mapping(String sourceName, String constant, String javaExpression, String targetName,
                     String dateFormat, List<TypeMirror> qualifiers,
                     boolean isIgnored, AnnotationMirror mirror,
-                    AnnotationValue sourceAnnotationValue, AnnotationValue targetAnnotationValue) {
+                    AnnotationValue sourceAnnotationValue, AnnotationValue targetAnnotationValue,
+                    TypeMirror resultType ) {
         this.sourceName = sourceName;
         this.constant = constant;
         this.javaExpression = javaExpression;
@@ -163,6 +170,7 @@ public class Mapping {
         this.mirror = mirror;
         this.sourceAnnotationValue = sourceAnnotationValue;
         this.targetAnnotationValue = targetAnnotationValue;
+        this.resultType = resultType;
     }
 
     private static String getExpression(MappingPrism mappingPrism, ExecutableElement element, Messager messager) {
@@ -257,6 +265,10 @@ public class Mapping {
         return targetReference;
     }
 
+    public TypeMirror getResultType() {
+        return resultType;
+    }
+
     private boolean hasPropertyInReverseMethod(String name, SourceMethod method) {
         CollectionMappingStrategyPrism cms = method.getConfig().getCollectionMappingStrategy();
         return method.getResultType().getTargetAccessors( cms ).containsKey( name );
@@ -303,7 +315,8 @@ public class Mapping {
             isIgnored,
             mirror,
             sourceAnnotationValue,
-            targetAnnotationValue
+            targetAnnotationValue,
+            null
         );
 
         reverse.init( method, messager, typeFactory );

--- a/processor/src/main/java/org/mapstruct/ap/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/SourceMethod.java
@@ -170,7 +170,7 @@ public class SourceMethod implements Method {
         }
     }
 
-    //CHECKSTYLE:OFF
+    @SuppressWarnings( "checkstyle:parameternumber" )
     private SourceMethod( Type declaringMapper, ExecutableElement executable, List<Parameter> parameters,
                          Type returnType, List<Type> exceptionTypes, Map<String, List<Mapping>> mappings,
                          IterableMapping iterableMapping, MapMapping mapMapping, Types typeUtils,
@@ -192,7 +192,6 @@ public class SourceMethod implements Method {
         this.messager = messager;
         this.config = config;
     }
-    //CHECKSTYLE:ON
 
     private Parameter determineTargetParameter(Iterable<Parameter> parameters) {
         for ( Parameter parameter : parameters ) {

--- a/processor/src/main/java/org/mapstruct/ap/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/MapperCreationProcessor.java
@@ -271,9 +271,11 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
 
                 String dateFormat = null;
                 List<TypeMirror> qualifiers = null;
+                TypeMirror qualifyingElementTargetType = null;
                 if ( method.getIterableMapping() != null ) {
                     dateFormat = method.getIterableMapping().getDateFormat();
                     qualifiers = method.getIterableMapping().getQualifiers();
+                    qualifyingElementTargetType = method.getIterableMapping().getQualifyingElementTargetType();
                 }
 
                 IterableMappingMethod iterableMappingMethod = builder
@@ -281,6 +283,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
                     .method( method )
                     .dateFormat( dateFormat )
                     .qualifiers( qualifiers )
+                    .qualifyingElementTargetType( qualifyingElementTargetType )
                     .build();
 
                 hasFactoryMethod = iterableMappingMethod.getFactoryMethod() != null;
@@ -302,11 +305,15 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
                 String valueDateFormat = null;
                 List<TypeMirror> keyQualifiers = null;
                 List<TypeMirror> valueQualifiers = null;
+                TypeMirror keyQualifyingTargetType = null;
+                TypeMirror valueQualifyingTargetType = null;
                 if ( method.getMapMapping() != null ) {
                     keyDateFormat = method.getMapMapping().getKeyFormat();
                     valueDateFormat = method.getMapMapping().getValueFormat();
                     keyQualifiers = method.getMapMapping().getKeyQualifiers();
                     valueQualifiers = method.getMapMapping().getValueQualifiers();
+                    keyQualifyingTargetType = method.getMapMapping().getKeyQualifyingTargetType();
+                    valueQualifyingTargetType = method.getMapMapping().getValueQualifyingTargetType();
                 }
 
                 MapMappingMethod mapMappingMethod = builder
@@ -316,6 +323,8 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
                     .valueDateFormat( valueDateFormat )
                     .keyQualifiers( keyQualifiers )
                     .valueQualifiers( valueQualifiers )
+                    .keyQualifyingTargetType( keyQualifyingTargetType )
+                    .valueQualifyingTargetType( valueQualifyingTargetType )
                     .build();
 
                 hasFactoryMethod = mapMappingMethod.getFactoryMethod() != null;

--- a/processor/src/main/java/org/mapstruct/ap/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/creation/MappingResolverImpl.java
@@ -124,9 +124,10 @@ public class MappingResolverImpl implements MappingResolver {
         String targetPropertyName,
         String dateFormat,
         List<TypeMirror> qualifiers,
+        TypeMirror resultType,
         String sourceReference) {
 
-        SelectionCriteria criteria = new SelectionCriteria(qualifiers, targetPropertyName, null );
+        SelectionCriteria criteria = new SelectionCriteria(qualifiers, targetPropertyName, resultType );
 
         ResolvingAttempt attempt = new ResolvingAttempt(
             sourceModel,

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionMappingTest.java
@@ -65,8 +65,8 @@ public class ErroneousCollectionMappingTest {
             @Diagnostic(type = EmptyItererableMappingMapper.class,
                 kind = Kind.ERROR,
                 line = 35,
-                messageRegExp = "'dateformat' and 'qualifiedBy' are undefined in @IterableMapping, "
-                    + "define at least one of them.")
+                messageRegExp = "'dateformat', 'qualifiedBy' and 'elementTargetType' are undefined in "
+                    + "@IterableMapping, define at least one of them.")
         }
     )
     public void shouldFailOnEmptyIterableAnnotation() {
@@ -81,8 +81,9 @@ public class ErroneousCollectionMappingTest {
             @Diagnostic(type = EmptyMapMappingMapper.class,
                 kind = Kind.ERROR,
                 line = 34,
-                messageRegExp = "'keyDateFormat', 'keyQualifiedBy', 'valueDateFormat' and 'valueQualfiedBy' are all "
-                    + "undefined in @MapMapping, define at least one of them.")
+                messageRegExp = "'keyDateFormat', 'keyQualifiedBy', 'keyTargetType', 'valueDateFormat', "
+                    + "'valueQualfiedBy' and 'valueTargetType' are all undefined in @MapMapping, define at least "
+                    + "one of them.")
         }
     )
     public void shouldFailOnEmptyMapAnnotation() {

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/Apple.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/Apple.java
@@ -16,15 +16,15 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.selection.inheritance;
+package org.mapstruct.ap.test.selection.resulttype;
 
 /**
  *
  * @author Sjaak Derksen
  */
-public class BananaDto extends FruitDto {
+public class Apple extends Fruit {
 
-    public BananaDto(String type) {
+    public Apple(String type) {
         super( type );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/AppleDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/AppleDto.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.resulttype;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class AppleDto extends FruitDto {
+
+    public AppleDto(String type) {
+        super( type );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/AppleFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/AppleFactory.java
@@ -16,16 +16,19 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.selection.inheritance;
+package org.mapstruct.ap.test.selection.resulttype;
 
 /**
  *
  * @author Sjaak Derksen
  */
-public class Banana extends Fruit {
+public class AppleFactory {
 
-    public Banana(String type) {
-        super( type );
+    public Apple createApple() {
+        return new Apple( "apple" );
     }
 
+    public GoldenDelicious createGoldenDelicious() {
+        return new GoldenDelicious( "GoldenDelicious" );
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/AppleFamily.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/AppleFamily.java
@@ -16,25 +16,22 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.selection.inheritance;
-
-import org.mapstruct.BeanMapping;
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
+package org.mapstruct.ap.test.selection.resulttype;
 
 /**
  *
  * @author Sjaak Derksen
  */
-@Mapper(uses = ConflictingFruitFactory.class)
+public class AppleFamily {
 
-public interface TargetTypeSelectingFruitMapper {
+    private Apple apple;
 
-    TargetTypeSelectingFruitMapper INSTANCE = Mappers.getMapper( TargetTypeSelectingFruitMapper.class );
+    public Apple getApple() {
+        return apple;
+    }
 
-    @BeanMapping(resultType = Apple.class)
-    @Mapping(target = "type", ignore = true)
-    Fruit map(FruitDto source);
+    public void setApple(Apple apple) {
+        this.apple = apple;
+    }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/AppleFamilyDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/AppleFamilyDto.java
@@ -16,27 +16,22 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.selection.inheritance;
+package org.mapstruct.ap.test.selection.resulttype;
 
 /**
  *
  * @author Sjaak Derksen
  */
-public class FruitDto {
+public class AppleFamilyDto {
 
-    private String type;
+    private AppleDto apple;
 
-    public FruitDto(String type) {
-        this.type = type;
+    public AppleDto getApple() {
+        return apple;
     }
 
-    public String getType() {
-        return type;
+    public void setApple(AppleDto apple) {
+        this.apple = apple;
     }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/Banana.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/Banana.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.resulttype;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Banana extends Fruit {
+
+    public Banana(String type) {
+        super( type );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/BananaDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/BananaDto.java
@@ -16,23 +16,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.selection.inheritance;
-
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
+package org.mapstruct.ap.test.selection.resulttype;
 
 /**
  *
  * @author Sjaak Derksen
  */
-@Mapper(uses = ConflictingFruitFactory.class)
+public class BananaDto extends FruitDto {
 
-public interface ErroneousFruitMapper {
-
-    ErroneousFruitMapper INSTANCE = Mappers.getMapper( ErroneousFruitMapper.class );
-
-    @Mapping(target = "type", ignore = true)
-    Fruit map(FruitDto source);
+    public BananaDto(String type) {
+        super( type );
+    }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/ConflictingFruitFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/ConflictingFruitFactory.java
@@ -16,27 +16,20 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.selection.inheritance;
+package org.mapstruct.ap.test.selection.resulttype;
 
 /**
  *
  * @author Sjaak Derksen
  */
-public class Fruit {
+public class ConflictingFruitFactory {
 
-    private String type;
-
-    public Fruit(String type) {
-        this.type = type;
+    public Apple createApple() {
+        return new Apple( "apple" );
     }
 
-    public String getType() {
-        return type;
+    public Banana createBanana() {
+        return new Banana( "banana" );
     }
-
-    public void setType(String type) {
-        this.type = type;
-    }
-
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/ErroneousFruitMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/ErroneousFruitMapper.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.resulttype;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper(uses = ConflictingFruitFactory.class)
+
+public interface ErroneousFruitMapper {
+
+    ErroneousFruitMapper INSTANCE = Mappers.getMapper( ErroneousFruitMapper.class );
+
+    @Mapping(target = "type", ignore = true)
+    Fruit map(FruitDto source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/Fruit.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/Fruit.java
@@ -16,19 +16,27 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.selection.inheritance;
+package org.mapstruct.ap.test.selection.resulttype;
 
 /**
  *
  * @author Sjaak Derksen
  */
-public class ConflictingFruitFactory {
+public class Fruit {
 
-    public Apple createApple() {
-        return new Apple( "apple" );
+    private String type;
+
+    public Fruit(String type) {
+        this.type = type;
     }
 
-    public Banana createBanana() {
-        return new Banana( "banana" );
+    public String getType() {
+        return type;
     }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/FruitDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/FruitDto.java
@@ -16,16 +16,27 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.selection.inheritance;
+package org.mapstruct.ap.test.selection.resulttype;
 
 /**
  *
  * @author Sjaak Derksen
  */
-public class AppleDto extends FruitDto {
+public class FruitDto {
 
-    public AppleDto(String type) {
-        super( type );
+    private String type;
+
+    public FruitDto(String type) {
+        this.type = type;
     }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/FruitFamilyMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/FruitFamilyMapper.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.resulttype;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper(uses = AppleFactory.class)
+public interface FruitFamilyMapper {
+
+    FruitFamilyMapper INSTANCE = Mappers.getMapper( FruitFamilyMapper.class );
+
+    @Mapping(target = "apple", resultType = GoldenDelicious.class)
+    AppleFamily map(AppleFamilyDto source);
+
+    GoldenDelicious mapToGoldenDelicious(AppleDto source);
+
+    @BeanMapping(resultType = Apple.class)
+    Apple mapToApple(AppleDto source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/FruitFamilyMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/FruitFamilyMapper.java
@@ -18,7 +18,11 @@
  */
 package org.mapstruct.ap.test.selection.resulttype;
 
+import java.util.List;
+import java.util.Map;
 import org.mapstruct.BeanMapping;
+import org.mapstruct.IterableMapping;
+import org.mapstruct.MapMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
@@ -34,6 +38,12 @@ public interface FruitFamilyMapper {
 
     @Mapping(target = "apple", resultType = GoldenDelicious.class)
     AppleFamily map(AppleFamilyDto source);
+
+    @IterableMapping( elementTargetType = GoldenDelicious.class )
+    List<Apple> mapToGoldenDeliciousList(List<AppleDto> source);
+
+    @MapMapping( keyTargetType = GoldenDelicious.class, valueTargetType = Apple.class )
+    Map<Apple, Apple> mapToGoldenDeliciousMap(Map<AppleDto, AppleDto> source);
 
     GoldenDelicious mapToGoldenDelicious(AppleDto source);
 

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/GoldenDelicious.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/GoldenDelicious.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.resulttype;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class GoldenDelicious extends Apple {
+
+    public GoldenDelicious(String type) {
+        super( type );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/GoldenDeliciousDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/GoldenDeliciousDto.java
@@ -16,15 +16,15 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.selection.inheritance;
+package org.mapstruct.ap.test.selection.resulttype;
 
 /**
  *
  * @author Sjaak Derksen
  */
-public class Apple extends Fruit {
+public class GoldenDeliciousDto extends AppleDto {
 
-    public Apple(String type) {
+    public GoldenDeliciousDto(String type) {
         super( type );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
@@ -18,6 +18,10 @@
  */
 package org.mapstruct.ap.test.selection.resulttype;
 
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import javax.tools.Diagnostic.Kind;
 import static org.fest.assertions.Assertions.assertThat;
 import org.junit.Test;
@@ -95,4 +99,53 @@ public class InheritanceSelectionTest {
 
     }
 
+    @Test
+    @IssueKey("433")
+    @WithClasses( {
+        FruitFamilyMapper.class,
+        GoldenDeliciousDto.class,
+        GoldenDelicious.class,
+        AppleFamily.class,
+        AppleFamilyDto.class,
+        AppleFactory.class,
+        Banana.class
+    } )
+    public void testShouldSelectResultTypeInCaseOfAmbiguityForIterable() {
+
+        List<AppleDto> source = Arrays.asList( new AppleDto( "AppleDto" ) );
+
+        List<Apple> result = FruitFamilyMapper.INSTANCE.mapToGoldenDeliciousList( source );
+        assertThat( result ).isNotNull();
+        assertThat( result ).isNotEmpty();
+        assertThat( result.get( 0 ) ).isInstanceOf( GoldenDelicious.class );
+        assertThat( result.get( 0 ).getType() ).isEqualTo( "AppleDto" );
+    }
+
+    @Test
+    @IssueKey("433")
+    @WithClasses( {
+        FruitFamilyMapper.class,
+        GoldenDeliciousDto.class,
+        GoldenDelicious.class,
+        AppleFamily.class,
+        AppleFamilyDto.class,
+        AppleFactory.class,
+        Banana.class
+    } )
+    public void testShouldSelectResultTypeInCaseOfAmbiguityForMap() {
+
+        Map<AppleDto, AppleDto> source = new HashMap<AppleDto, AppleDto>();
+        source.put( new AppleDto( "GoldenDelicious" ), new AppleDto( "AppleDto" ) );
+
+        Map<Apple, Apple> result = FruitFamilyMapper.INSTANCE.mapToGoldenDeliciousMap( source );
+        assertThat( result ).isNotNull();
+        assertThat( result ).isNotEmpty();
+        Map.Entry<Apple, Apple> entry = result.entrySet().iterator().next();
+
+        assertThat( entry.getKey() ).isInstanceOf( GoldenDelicious.class );
+        assertThat( entry.getKey().getType() ).isEqualTo( "GoldenDelicious" );
+        assertThat( entry.getValue() ).isInstanceOf( Apple.class );
+        assertThat( entry.getValue().getType() ).isEqualTo( "AppleDto" );
+
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
@@ -16,7 +16,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.selection.inheritance;
+package org.mapstruct.ap.test.selection.resulttype;
 
 import javax.tools.Diagnostic.Kind;
 import static org.fest.assertions.Assertions.assertThat;
@@ -68,6 +68,30 @@ public class InheritanceSelectionTest {
         Fruit fruit = TargetTypeSelectingFruitMapper.INSTANCE.map( fruitDto );
         assertThat( fruit ).isNotNull();
         assertThat( fruit.getType() ).isEqualTo( "apple" );
+
+    }
+
+    @Test
+    @IssueKey("433")
+    @WithClasses( {
+        FruitFamilyMapper.class,
+        GoldenDeliciousDto.class,
+        GoldenDelicious.class,
+        AppleFamily.class,
+        AppleFamilyDto.class,
+        AppleFactory.class,
+        Banana.class
+    } )
+    public void testShouldSelectResultTypeInCaseOfAmbiguity() {
+
+        AppleFamilyDto appleFamilyDto = new AppleFamilyDto();
+        appleFamilyDto.setApple( new AppleDto("AppleDto") );
+
+        AppleFamily result = FruitFamilyMapper.INSTANCE.map( appleFamilyDto );
+        assertThat( result ).isNotNull();
+        assertThat( result.getApple() ).isNotNull();
+        assertThat( result.getApple() ).isInstanceOf( GoldenDelicious.class );
+        assertThat( result.getApple().getType() ).isEqualTo( "AppleDto" );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/TargetTypeSelectingFruitMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/TargetTypeSelectingFruitMapper.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.resulttype;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper(uses = ConflictingFruitFactory.class)
+
+public interface TargetTypeSelectingFruitMapper {
+
+    TargetTypeSelectingFruitMapper INSTANCE = Mappers.getMapper( TargetTypeSelectingFruitMapper.class );
+
+    @BeanMapping(resultType = Apple.class)
+    @Mapping(target = "type", ignore = true)
+    Fruit map(FruitDto source);
+
+}


### PR DESCRIPTION
* Introduction of resultType in `@Mapping`
* Doubting if it makes sense to do the same for `@IterableMapping` and `@MapMapping`
* Renaming package `org.mapstruct.ap.test.selection.inheritance` with `org.mapstruct.ap.test.selection.resulttype`
* Bonus: `@SuppressWarnings( "checkstyle:parameternumber" )` in `SourceMethod`