### PR TITLE
#431 add JDK 9 to integration tests and remove processor_plugin_java_7...

### DIFF
--- a/etc/toolchains-example.xml
+++ b/etc/toolchains-example.xml
@@ -33,4 +33,15 @@
             <jdkHome>C:\Program Files\Java\jdk1.8.0_11</jdkHome>
         </configuration>
     </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.9.0</version>
+            <vendor>oracle</vendor>
+            <id>jdk1.9</id>
+        </provides>
+        <configuration>
+            <jdkHome>C:\Program Files\Java\jdk1.9.0</jdkHome>
+        </configuration>
+    </toolchain>
 </toolchains>

--- a/integrationtest/src/test/java/org/mapstruct/itest/testutil/runner/ProcessorSuite.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/testutil/runner/ProcessorSuite.java
@@ -65,6 +65,11 @@ public @interface ProcessorSuite {
         ORACLE_JAVA_8( null, "javac", "1.8" ),
 
         /**
+         * Use an Oracle JDK 1.9 (or 1.9.x) via toolchain support to perform the processing
+         */
+        ORACLE_JAVA_9( "oracle-[1.9,1.10)", "javac", "1.9" ),
+
+        /**
          * Use the eclipse compiler with 1.7 source/target level from tycho-compiler-jdt to perform the build and
          * processing
          */
@@ -77,12 +82,6 @@ public @interface ProcessorSuite {
         ECLIPSE_JDT_JAVA_8( null, "jdt", "1.8" ),
 
         /**
-         * Use the maven-processor-plugin with 1.7 source/target level with the same JDK that runs the mvn build to
-         * perform the processing
-         */
-        PROCESSOR_PLUGIN_JAVA_7( null, null, "1.7" ),
-
-        /**
          * Use the maven-processor-plugin with 1.8 source/target level with the same JDK that runs the mvn build to
          * perform the processing
          */
@@ -91,8 +90,8 @@ public @interface ProcessorSuite {
         /**
          * Use all available processing variants
          */
-        ALL( ORACLE_JAVA_6, ORACLE_JAVA_7, ORACLE_JAVA_8, ECLIPSE_JDT_JAVA_7, ECLIPSE_JDT_JAVA_8,
-            PROCESSOR_PLUGIN_JAVA_7, PROCESSOR_PLUGIN_JAVA_8 ),
+        ALL( ORACLE_JAVA_6, ORACLE_JAVA_7, ORACLE_JAVA_8, ORACLE_JAVA_9, ECLIPSE_JDT_JAVA_7, ECLIPSE_JDT_JAVA_8,
+            PROCESSOR_PLUGIN_JAVA_8 ),
 
         /**
          * Use all JDK8 compatible processing variants


### PR DESCRIPTION
...tests (processor_plugin_java_7 did exactly the same as the _java_8 variant, for what we are concerned).

Use -DprocessorIntegrationTest.canUseJdk9=false in case no JDK9 is configured in the toolchains.xml file (I've already configured that for the cloudbees builds).

@sjaakd and @gunnarmorling, you may want to install the JDK 9 preview build and add it to your toolchains file (example below was extended)... https://jdk9.java.net/download/

Btw, building MapStruct with JDK 9 almost works - some Tests in the processor fail because the error messages are not what is expected.