### PR TITLE
#323 make order of fields for used mappers stable

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/util/MapperConfig.java
+++ b/processor/src/main/java/org/mapstruct/ap/util/MapperConfig.java
@@ -19,9 +19,10 @@
 package org.mapstruct.ap.util;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.DeclaredType;
@@ -73,7 +74,7 @@ public class MapperConfig {
     }
 
     public List<TypeMirror> uses() {
-        Set<TypeMirror> uses = new HashSet<TypeMirror>( mapperPrism.uses() );
+        Set<TypeMirror> uses = new LinkedHashSet<TypeMirror>( mapperPrism.uses() );
         if ( mapperConfigPrism != null ) {
             uses.addAll( mapperConfigPrism.uses() );
         }


### PR DESCRIPTION
ordered as given in @...Mapper#uses and then @MapperConfig#uses, omitting duplicates.

I'm cleaning out stuff from my GlobalMapping PR and this code block was there to fix #323 (before I even created that issue). I've now finally pulled out that little piece - as I guess I'll have to throw away most of the other PR anyway now (I'll start with that soon-ish).