### PR TITLE
#160 allow selection of update methods by refactoring MethodMatcher but ...

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MappingMethod.java
@@ -50,7 +50,7 @@ public abstract class MappingMethod extends ModelElement {
         this.name = method.getName();
         this.parameters = method.getParameters();
         this.returnType = method.getReturnType();
-        this.targetParameter = method.getTargetParameter();
+        this.targetParameter = method.getMappingTargetParameter();
         this.accessibility = method.getAccessibility();
         this.thrownTypes = method.getThrownTypes();
         this.isStatic = method.isStatic();

--- a/processor/src/main/java/org/mapstruct/ap/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/ForgedMethod.java
@@ -71,19 +71,18 @@ public class ForgedMethod implements Method {
     }
 
     @Override
-    public boolean matches(List<Type> sourceTypes, Type targetType) {
+    public boolean matches(Type sourceTypes, Type targetType) {
 
         if ( !targetType.equals( returnType ) ) {
             return false;
         }
 
-        if ( sourceTypes.size() == parameters.size() ) {
+        if ( parameters.size() != 1 ) {
             return false;
         }
-        for ( int i = 0; i < sourceTypes.size(); i++ ) {
-            if ( !sourceTypes.get( i ).equals( parameters.get( i ).getType() ) ) {
-                return false;
-            }
+
+        if ( !sourceTypes.equals( parameters.get( 0 ).getType() ) ) {
+            return false;
         }
 
         return true;
@@ -110,7 +109,12 @@ public class ForgedMethod implements Method {
     }
 
     @Override
-    public Parameter getTargetParameter() {
+    public Parameter getMappingTargetParameter() {
+        return null;
+    }
+
+    @Override
+    public Parameter getTargetTypeParameter() {
         return null;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/model/source/Method.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/Method.java
@@ -40,12 +40,12 @@ public interface Method {
      * Checks whether the provided sourceType and provided targetType match with the parameter respectively return type
      * of the method. The check also should incorporate wild card and generic type variables
      *
-     * @param sourceTypes the sourceTypes to match to the parameter
+     * @param sourceType the sourceType to match to the parameter
      * @param targetType the targetType to match to the returnType
      *
      * @return true when match
      */
-    boolean matches(List<Type> sourceTypes, Type targetType);
+    boolean matches(Type sourceType, Type targetType );
 
     /**
      * Returns the mapper type declaring this method if it is not declared by the mapper interface currently processed
@@ -71,18 +71,26 @@ public interface Method {
 
     /**
      * returns the list of 'true' source parameters excluding the parameter(s) that is designated as
-     * target by means of the target annotation {@link  #getTargetParameter() }.
+     * target by means of the target annotation {@link  #getMappingTargetParameter() }.
      *
      * @return list of 'true' source parameters
      */
     List<Parameter> getSourceParameters();
 
     /**
-     * Returns the parameter designated as target parameter (if present) {@link #getSourceParameters() }
+     * Returns the parameter designated as mapping target (if present) {@link  org.mapstruct.MappingTarget }
      *
-     * @return target parameter (when present) null otherwise.
+     * @return mapping target parameter (when present) null otherwise.
      */
-    Parameter getTargetParameter();
+    Parameter getMappingTargetParameter();
+
+    /**
+     * Returns the parameter designated as target type (if present) {@link org.mapstruct.TargetType }
+     *
+     * @return target type parameter (when present) null otherwise.
+     */
+    Parameter getTargetTypeParameter();
+
 
     /**
      * Returns the {@link Accessibility} of this method.

--- a/processor/src/main/java/org/mapstruct/ap/model/source/builtin/BuiltInMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/builtin/BuiltInMethod.java
@@ -71,11 +71,7 @@ public abstract class BuiltInMethod implements Method {
      * excluding generic type variables. When the implementor sees a need for this, this method can be overridden.
      */
     @Override
-    public boolean matches(List<Type> sourceTypes, Type targetType) {
-        if ( sourceTypes.size() > 1 ) {
-            return false;
-        }
-        Type sourceType = sourceTypes.iterator().next();
+    public boolean matches(Type sourceType, Type targetType) {
 
         if ( getReturnType().isAssignableTo( targetType.erasure() )
             && sourceType.erasure().isAssignableTo( getParameter().getType() ) ) {
@@ -118,12 +114,22 @@ public abstract class BuiltInMethod implements Method {
     }
 
     /**
-     * target parameter mechanism not supported for built-in methods
+     * mapping target parameter mechanism not supported for built-in methods
      *
      * @return {@code null}
      */
     @Override
-    public Parameter getTargetParameter() {
+    public Parameter getMappingTargetParameter() {
+        return null;
+    }
+
+    /**
+     * target type parameter mechanism not supported for built-in methods
+     *
+     * @return {@code null}
+     */
+    @Override
+    public Parameter getTargetTypeParameter() {
         return null;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/CreateOrUpdateSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/CreateOrUpdateSelector.java
@@ -26,24 +26,26 @@ import org.mapstruct.ap.model.source.Method;
 import org.mapstruct.ap.model.source.MethodMatcher;
 
 /**
- * Selects those methods from the given input set which match the given source and target types (via
+ * Selects only create method candidates (so methods not containing {@link @MappingTarget} )
  * {@link MethodMatcher}).
  *
  * @author Sjaak Derksen
  */
-public class TypeSelector implements MethodSelector {
+public class CreateOrUpdateSelector implements MethodSelector {
 
     @Override
     public <T extends Method> List<T> getMatchingMethods(Method mappingMethod, List<T> methods,
                                                          Type sourceType, Type targetType,
                                                          SelectionCriteria criteria) {
 
-        List<T> result = new ArrayList<T>();
+        List<T> createCandidates = new ArrayList<T>();
         for ( T method : methods ) {
-            if ( method.matches( sourceType, targetType ) ) {
-                result.add( method );
+            boolean isCreateCandidate = method.getMappingTargetParameter() == null;
+            if ( isCreateCandidate ) {
+                createCandidates.add( method );
             }
         }
-        return result;
+        return createCandidates;
+
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/source/selector/MethodSelectors.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/selector/MethodSelectors.java
@@ -24,7 +24,6 @@ import java.util.List;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
-import org.mapstruct.ap.model.common.Parameter;
 import org.mapstruct.ap.model.common.Type;
 import org.mapstruct.ap.model.common.TypeFactory;
 import org.mapstruct.ap.model.source.Method;
@@ -41,11 +40,12 @@ public class MethodSelectors implements MethodSelector {
     public MethodSelectors(Types typeUtils, Elements elementUtils, TypeFactory typeFactory) {
         selectors =
             Arrays.<MethodSelector>asList(
-                new TypeSelector( typeFactory ),
+                new TypeSelector(),
                 new QualifierSelector( typeUtils, elementUtils ),
                 new TargetTypeSelector( typeUtils, elementUtils ),
                 new XmlElementDeclSelector( typeUtils ),
-                new InheritanceSelector()
+                new InheritanceSelector(),
+                new CreateOrUpdateSelector()
             );
     }
 
@@ -66,31 +66,5 @@ public class MethodSelectors implements MethodSelector {
             );
         }
         return candidates;
-    }
-
-    /**
-     * @param typeFactory the type factory to use
-     * @param parameters the parameters to map the types for
-     * @param sourceType the source type
-     * @param returnType the return type
-     *
-     * @return the list of actual parameter types
-     */
-    public static List<Type> getParameterTypes(TypeFactory typeFactory, List<Parameter> parameters, Type sourceType,
-                                               Type returnType) {
-        List<Type> result = new ArrayList<Type>();
-        for ( Parameter param : parameters ) {
-            if ( param.isTargetType() ) {
-                result.add( typeFactory.classTypeOf( returnType ) );
-            }
-            else {
-                if ( sourceType != null ) {
-                    /* for factory methods (sourceType==null), no parameter must be added */
-                    result.add( sourceType );
-                }
-            }
-        }
-
-        return result;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/MethodRetrievalProcessor.java
@@ -204,6 +204,7 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
                 .setReturnType( returnType )
                 .setExceptionTypes( exceptionTypes )
                 .setTypeUtils( typeUtils )
+                .setTypeFactory( typeFactory )
                 .createSourceMethod();
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/creation/MappingResolverImpl.java
@@ -444,9 +444,19 @@ public class MappingResolverImpl implements MappingResolver {
         }
 
         private boolean isCandidateForMapping(Method methodCandidate) {
+            return isCreateMethodForMapping( methodCandidate ) || isUpdateMethodForMapping( methodCandidate );
+        }
+
+        private boolean isCreateMethodForMapping(Method methodCandidate) {
+            // a create method may not return void and has no target parameter
             return methodCandidate.getSourceParameters().size() == 1 && !methodCandidate.getReturnType().isVoid()
-                && methodCandidate.getTargetParameter() == null; // @MappingTarget is not yet supported for property
-                                                                 // mappings
+                && methodCandidate.getMappingTargetParameter() == null;
+        }
+
+        private boolean isUpdateMethodForMapping(Method methodCandidate) {
+            // an update method may, or may not return void and has a target parameter
+            return methodCandidate.getSourceParameters().size() == 1
+                && methodCandidate.getMappingTargetParameter() != null;
         }
 
         private <T extends Method> T getBestMatch(List<T> methods, Type sourceType, Type returnType) {


### PR DESCRIPTION
...stopping selection of update method at new filter

This is the first step for #160: making sure that update methods are actually selected.  I cut this one into smaller  steps to make it more manageable for reviewing.

There's also some refactoring in this PR. Idea being: `MethodMatcher` is responsible for all the method matching (there was some stuff, like `@TargetType`  outside this class) and there was the suggestion that we could make mappings on more than 1 source parameter. That has been fixed.

The following things are still on my list for #160:
1. Updating the templates / wrappers, (which turns out more difficult than I though).  
2. Limiting: I don't think we can support nested (2 step) mappings for update methods, so method(method) or conversion(method). 
3. Iterable / MapMappings.
4. Forged methods.