### PR TITLE
#304: Ordering of property mappings

### DIFF
--- a/core-jdk8/src/main/java/org/mapstruct/Mapping.java
+++ b/core-jdk8/src/main/java/org/mapstruct/Mapping.java
@@ -137,10 +137,21 @@ public @interface Mapping {
      */
     Class<? extends Annotation>[] qualifiedBy() default { };
 
-   /**
+    /**
      * Specifies the result type of the mapping method to be used in case multiple mapping methods qualify.
      *
      * @return the resultType to select
      */
     Class<?> resultType() default void.class;
+
+    /**
+     * One or more properties of the result type on which the mapped property depends. The generated method
+     * implementation will invoke the setters of the result type ordered so that the given dependency relationship(s)
+     * are satisfied. Useful in case one property setter depends on the state of another property of the result type.
+     * <p>
+     * An error will be raised in case a cycle in the dependency relationships is detected.
+     *
+     * @return the dependencies of the mapped property
+     */
+    String[] dependsOn() default { };
 }

--- a/core/src/main/java/org/mapstruct/Mapping.java
+++ b/core/src/main/java/org/mapstruct/Mapping.java
@@ -141,4 +141,15 @@ public @interface Mapping {
      * @return the resultType to select
      */
     Class<?> resultType() default void.class;
+
+    /**
+     * One or more properties of the result type on which the mapped property depends. The generated method
+     * implementation will invoke the setters of the result type ordered so that the given dependency relationship(s)
+     * are satisfied. Useful in case one property setter depends on the state of another property of the result type.
+     * <p>
+     * An error will be raised in case a cycle in the dependency relationships is detected.
+     *
+     * @return the dependencies of the mapped property
+     */
+    String[] dependsOn() default { };
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
@@ -41,6 +41,7 @@ import org.mapstruct.ap.model.PropertyMapping.PropertyMappingBuilder;
 import org.mapstruct.ap.model.common.Parameter;
 import org.mapstruct.ap.model.common.Type;
 import org.mapstruct.ap.model.dependency.GraphAnalyzer;
+import org.mapstruct.ap.model.dependency.GraphAnalyzer.GraphAnalyzerBuilder;
 import org.mapstruct.ap.model.source.Mapping;
 import org.mapstruct.ap.model.source.SourceMethod;
 import org.mapstruct.ap.model.source.SourceReference;
@@ -175,16 +176,16 @@ public class BeanMappingMethod extends MappingMethod {
          * detected, an error is reported.
          */
         private void sortPropertyMappingsByDependencies() {
-            final GraphAnalyzer graphAnalyzer = new GraphAnalyzer();
+            GraphAnalyzerBuilder graphAnalyzerBuilder = GraphAnalyzer.builder();
 
             for ( PropertyMapping propertyMapping : propertyMappings ) {
-                graphAnalyzer.addNode( propertyMapping.getName(), propertyMapping.getDependsOn() );
+                graphAnalyzerBuilder.withNode( propertyMapping.getName(), propertyMapping.getDependsOn() );
             }
 
-            graphAnalyzer.analyze();
+            final GraphAnalyzer graphAnalyzer = graphAnalyzerBuilder.build();
 
             if ( !graphAnalyzer.getCycles().isEmpty() ) {
-                Set<String> cycles = new HashSet<String>( graphAnalyzer.getCycles().size() );
+                Set<String> cycles = new HashSet<String>();
                 for ( List<String> cycle : graphAnalyzer.getCycles() ) {
                     cycles.add( Strings.join( cycle, " -> " ) );
                 }

--- a/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
@@ -147,7 +147,8 @@ public class BeanMappingMethod extends MappingMethod {
                 if ( resultTypeMirror != null ) {
                     resultType = ctx.getTypeFactory().getType( resultTypeMirror );
                     if ( !resultType.isAssignableTo( method.getResultType() ) ) {
-                        ctx.getMessager().printMessage( method.getExecutable(),
+                        ctx.getMessager().printMessage(
+                            method.getExecutable(),
                             beanMappingPrism.mirror,
                             Message.BEANMAPPING_NOT_ASSIGNABLE, resultType, method.getResultType()
                         );
@@ -218,7 +219,8 @@ public class BeanMappingMethod extends MappingMethod {
                     // fetch the target property
                     ExecutableElement targetProperty = unprocessedTargetProperties.get( mapping.getTargetName() );
                     if ( targetProperty == null ) {
-                        ctx.getMessager().printMessage( method.getExecutable(),
+                        ctx.getMessager().printMessage(
+                            method.getExecutable(),
                             mapping.getMirror(),
                             mapping.getSourceAnnotationValue(),
                             Message.BEANMAPPING_UNKNOWN_PROPERTY_IN_RETURNTYPE,
@@ -383,7 +385,8 @@ public class BeanMappingMethod extends MappingMethod {
 
                         if ( propertyMapping != null && newPropertyMapping != null ) {
                             // TODO improve error message
-                            ctx.getMessager().printMessage( method.getExecutable(),
+                            ctx.getMessager().printMessage(
+                                method.getExecutable(),
                                 Message.BEANMAPPING_SEVERAL_POSSIBLE_SOURCES,
                                 targetProperty.getKey()
                             );
@@ -463,7 +466,8 @@ public class BeanMappingMethod extends MappingMethod {
             }
             // Should never really happen
             else {
-                ctx.getMessager().printMessage( method.getExecutable(),
+                ctx.getMessager().printMessage(
+                    method.getExecutable(),
                     Message.BEANMAPPING_SEVERAL_POSSIBLE_TARGET_ACCESSORS,
                     sourcePropertyName
                 );
@@ -506,7 +510,8 @@ public class BeanMappingMethod extends MappingMethod {
                 Message msg = unmappedTargetPolicy.getDiagnosticKind() == Diagnostic.Kind.ERROR ?
                     Message.BEANMAPPING_UNMAPPED_TARGETS_ERROR : Message.BEANMAPPING_UNMAPPED_TARGETS_WARNING;
 
-                ctx.getMessager().printMessage( method.getExecutable(),
+                ctx.getMessager().printMessage(
+                    method.getExecutable(),
                     msg,
                     MessageFormat.format(
                         "{0,choice,1#property|1<properties}: \"{1}\"",

--- a/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/BeanMappingMethod.java
@@ -177,23 +177,36 @@ public class BeanMappingMethod extends MappingMethod {
 
             graphAnalyzer.analyze();
 
-            Collections.sort(
-                propertyMappings, new Comparator<PropertyMapping>() {
+            if ( !graphAnalyzer.getCycles().isEmpty() ) {
+                Set<String> cycles = new HashSet<String>( graphAnalyzer.getCycles().size() );
+                for ( List<String> cycle : graphAnalyzer.getCycles() ) {
+                    cycles.add( Strings.join( cycle, " -> " ) );
+                }
 
-                    @Override
-                    public int compare(PropertyMapping o1, PropertyMapping o2) {
-                        if ( graphAnalyzer.getAllDescendants( o1.getName() ).contains( o2.getName() ) ) {
-                            return 1;
-                        }
-                        else if ( graphAnalyzer.getAllDescendants( o2.getName() ).contains( o1.getName() ) ) {
-                            return -1;
-                        }
-                        else {
-                            return 0;
+                ctx.getMessager().printMessage(
+                    method.getExecutable(),
+                    Message.BEANMAPPING_CYCLE_BETWEEN_PROPERTIES, Strings.join( cycles, ", " )
+                );
+            }
+            else {
+                Collections.sort(
+                    propertyMappings, new Comparator<PropertyMapping>() {
+
+                        @Override
+                        public int compare(PropertyMapping o1, PropertyMapping o2) {
+                            if ( graphAnalyzer.getAllDescendants( o1.getName() ).contains( o2.getName() ) ) {
+                                return 1;
+                            }
+                            else if ( graphAnalyzer.getAllDescendants( o2.getName() ).contains( o1.getName() ) ) {
+                                return -1;
+                            }
+                            else {
+                                return 0;
+                            }
                         }
                     }
-                }
-            );
+                );
+            }
         }
 
         /**

--- a/processor/src/main/java/org/mapstruct/ap/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/PropertyMapping.java
@@ -194,7 +194,8 @@ public class PropertyMapping extends ModelElement {
                 }
             }
             else {
-                ctx.getMessager().printMessage( method.getExecutable(),
+                ctx.getMessager().printMessage(
+                    method.getExecutable(),
                     Message.PROPERTYMAPPING_MAPPING_NOT_FOUND,
                     sourceElement,
                     targetType,
@@ -409,8 +410,8 @@ public class PropertyMapping extends ModelElement {
             String name = getName( sourceType, targetType );
             name = Strings.getSaveVariableName( name, ctx.getNamesOfMappingsToGenerate() );
 
-            if ( (sourceType.isCollectionType() || sourceType.isArrayType())
-                && (targetType.isCollectionType() || targetType.isArrayType()) ) {
+            if ( ( sourceType.isCollectionType() || sourceType.isArrayType() )
+                && ( targetType.isCollectionType() || targetType.isArrayType() ) ) {
 
                 ForgedMethod methodRef = new ForgedMethod( name, sourceType, targetType, element );
                 IterableMappingMethod.Builder builder = new IterableMappingMethod.Builder();
@@ -578,7 +579,8 @@ public class PropertyMapping extends ModelElement {
                 }
             }
             else {
-                ctx.getMessager().printMessage( method.getExecutable(),
+                ctx.getMessager().printMessage(
+                    method.getExecutable(),
                     Message.CONSTANTMAPPING_MAPPING_NOT_FOUND,
                     sourceType,
                     constantExpression,

--- a/processor/src/main/java/org/mapstruct/ap/model/dependency/GraphAnalyzer.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/dependency/GraphAnalyzer.java
@@ -1,0 +1,134 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.model.dependency;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.Stack;
+
+/**
+ * Analyzes graphs: Discovers all descendants of given nodes and detects cyclic dependencies between nodes if present.
+ *
+ * @author Gunnar Morling
+ */
+public class GraphAnalyzer {
+
+    private final Map<String, Node> nodes = new HashMap<String, Node>();
+    private final Set<List<String>> cycles = new HashSet<List<String>>();
+
+    private final Stack<Node> currentPath = new Stack<Node>();
+
+    public void addNode(String name, List<String> descendants) {
+        Node node = getNode( name );
+
+        for ( String descendant : descendants ) {
+            node.addDescendant( getNode( descendant ) );
+        }
+    }
+
+    public void addNode(String name, String... descendants) {
+        Node node = getNode( name );
+
+        for ( String descendant : descendants ) {
+            node.addDescendant( getNode( descendant ) );
+        }
+    }
+
+    /**
+     * Performs a full traversal of the graph, detecting potential cycles and calculates the full list of descendants of
+     * the nodes.
+     */
+    public void analyze() {
+        for ( Node node : nodes.values() ) {
+            depthFirstSearch( node );
+        }
+    }
+
+    /**
+     * Returns all the descendants of the given node, either direct or transitive ones.
+     * <p>
+     * <b>Note</b>:The list will only be complete if the graph contains no cycles.
+     */
+    public Set<String> getAllDescendants(String name) {
+        Node node = nodes.get( name );
+        return node != null ? node.getAllDescendants() : Collections.<String>emptySet();
+    }
+
+    public Set<List<String>> getCycles() {
+        return cycles;
+    }
+
+    private void depthFirstSearch(Node node) {
+        if ( node.isProcessed() ) {
+            return;
+        }
+
+        currentPath.push( node );
+
+        // the node is on the stack already -> cycle
+        if ( node.isVisited() ) {
+            cycles.add( getCurrentCycle( node ) );
+            currentPath.pop();
+            return;
+        }
+
+        node.setVisited( true );
+
+        for ( Node descendant : node.getDescendants() ) {
+            depthFirstSearch( descendant );
+            node.getAllDescendants().addAll( descendant.getAllDescendants() );
+        }
+
+        node.setProcessed( true );
+        currentPath.pop();
+    }
+
+    private List<String> getCurrentCycle(Node start) {
+        List<String> cycle = new ArrayList<String>();
+        boolean inCycle = false;
+
+        for ( Node n : currentPath ) {
+            if ( n.getName().equals( start.getName() ) ) {
+                inCycle = true;
+            }
+
+            if ( inCycle ) {
+                cycle.add( n.getName() );
+            }
+        }
+
+        return cycle;
+    }
+
+    private Node getNode(String name) {
+        Node node = nodes.get( name );
+
+        if ( node == null ) {
+            node = new Node( name );
+            nodes.put( name, node );
+        }
+
+        return node;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/model/dependency/Node.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/dependency/Node.java
@@ -1,0 +1,121 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.model.dependency;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * A node of a directed graph.
+ *
+ * @author Gunnar Morling
+ */
+class Node {
+
+    private final String name;
+    private boolean visited;
+    private boolean processed;
+
+    /**
+     * The direct descendants of this node.
+     */
+    private final List<Node> descendants;
+
+    /**
+     * All descendants of this node, direct and transitive ones, as discovered through graph traversal.
+     */
+    private final Set<String> allDescendants;
+
+    public Node(String name) {
+        this.name = name;
+        descendants = new ArrayList<Node>();
+        allDescendants = new HashSet<String>();
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public boolean isVisited() {
+        return visited;
+    }
+
+    public void setVisited(boolean visited) {
+        this.visited = visited;
+    }
+
+    public boolean isProcessed() {
+        return processed;
+    }
+
+    public void setProcessed(boolean processed) {
+        this.processed = processed;
+    }
+
+    public void addDescendant(Node node) {
+        descendants.add( node );
+        allDescendants.add( node.getName() );
+    }
+
+    public List<Node> getDescendants() {
+        return descendants;
+    }
+
+    public Set<String> getAllDescendants() {
+        return allDescendants;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        Node other = (Node) obj;
+        if ( name == null ) {
+            if ( other.name != null ) {
+                return false;
+            }
+        }
+        else if ( !name.equals( other.name ) ) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
@@ -81,7 +81,7 @@ public class Mapping {
                 mappingsOfProperty.add( mapping );
 
                 if ( mappingsOfProperty.size() > 1 && !isEnumType( method.getReturnType() ) ) {
-                    messager.printMessage( method,  Message.PROPERTYMAPPING_DUPLICATE_TARGETS, mappingPrism.target() );
+                    messager.printMessage( method, Message.PROPERTYMAPPING_DUPLICATE_TARGETS, mappingPrism.target() );
                 }
             }
         }
@@ -93,7 +93,8 @@ public class Mapping {
                                            FormattingMessager messager) {
 
         if ( mappingPrism.target().isEmpty() ) {
-            messager.printMessage( element,
+            messager.printMessage(
+                element,
                 mappingPrism.mirror,
                 mappingPrism.values.target(),
                 Message.PROPERTYMAPPING_EMPTY_TARGET
@@ -140,7 +141,7 @@ public class Mapping {
         );
     }
 
-    @SuppressWarnings( "checkstyle:parameternumber" )
+    @SuppressWarnings("checkstyle:parameternumber")
     private Mapping(String sourceName, String constant, String javaExpression, String targetName,
                     String dateFormat, List<TypeMirror> qualifiers,
                     boolean isIgnored, AnnotationMirror mirror,
@@ -169,8 +170,10 @@ public class Mapping {
         Matcher javaExpressionMatcher = JAVA_EXPRESSION.matcher( mappingPrism.expression() );
 
         if ( !javaExpressionMatcher.matches() ) {
-            messager.printMessage( element, mappingPrism.mirror, mappingPrism.values.expression(),
-                                   Message.PROPERTYMAPPING_INVALID_EXPRESSION );
+            messager.printMessage(
+                element, mappingPrism.mirror, mappingPrism.values.expression(),
+                Message.PROPERTYMAPPING_INVALID_EXPRESSION
+            );
             return null;
         }
 
@@ -280,8 +283,10 @@ public class Mapping {
         if ( sourceReference != null && sourceReference.getPropertyEntries().isEmpty() ) {
             // parameter mapping only, apparently the @InheritReverseConfiguration is intentional
             // but erroneous. Lets raise an error to warn.
-            messager.printMessage(  method.getExecutable(), Message.PROPERTYMAPPING_REVERSAL_PROBLEM,
-                                    sourceReference.getParameter() );
+            messager.printMessage(
+                method.getExecutable(), Message.PROPERTYMAPPING_REVERSAL_PROBLEM,
+                sourceReference.getParameter()
+            );
             return null;
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/Mapping.java
@@ -62,6 +62,8 @@ public class Mapping {
     private final AnnotationMirror mirror;
     private final AnnotationValue sourceAnnotationValue;
     private final AnnotationValue targetAnnotationValue;
+    private final AnnotationValue dependsOnAnnotationValue;
+
     private SourceReference sourceReference;
 
     public static Map<String, List<Mapping>> fromMappingsPrism(MappingsPrism mappingsAnnotation,
@@ -136,6 +138,7 @@ public class Mapping {
             mappingPrism.mirror,
             mappingPrism.values.source(),
             mappingPrism.values.target(),
+            mappingPrism.values.dependsOn(),
             resultType,
             dependsOn
         );
@@ -146,6 +149,7 @@ public class Mapping {
                     String dateFormat, List<TypeMirror> qualifiers,
                     boolean isIgnored, AnnotationMirror mirror,
                     AnnotationValue sourceAnnotationValue, AnnotationValue targetAnnotationValue,
+                    AnnotationValue dependsOnAnnotationValue,
                     TypeMirror resultType, List<String> dependsOn) {
         this.sourceName = sourceName;
         this.constant = constant;
@@ -157,6 +161,7 @@ public class Mapping {
         this.mirror = mirror;
         this.sourceAnnotationValue = sourceAnnotationValue;
         this.targetAnnotationValue = targetAnnotationValue;
+        this.dependsOnAnnotationValue = dependsOnAnnotationValue;
         this.resultType = resultType;
         this.dependsOn = dependsOn;
     }
@@ -243,6 +248,10 @@ public class Mapping {
         return targetAnnotationValue;
     }
 
+    public AnnotationValue getDependsOnAnnotationValue() {
+        return dependsOnAnnotationValue;
+    }
+
     public SourceReference getSourceReference() {
         return sourceReference;
     }
@@ -301,6 +310,7 @@ public class Mapping {
             mirror,
             sourceAnnotationValue,
             targetAnnotationValue,
+            dependsOnAnnotationValue,
             null,
             Collections.<String>emptyList()
         );
@@ -326,6 +336,7 @@ public class Mapping {
             mirror,
             sourceAnnotationValue,
             targetAnnotationValue,
+            dependsOnAnnotationValue,
             resultType,
             dependsOn
         );

--- a/processor/src/main/java/org/mapstruct/ap/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/util/Message.java
@@ -35,6 +35,7 @@ public enum Message {
     BEANMAPPING_SEVERAL_POSSIBLE_TARGET_ACCESSORS( "Found several matching getters for property \"%s\"." ),
     BEANMAPPING_UNMAPPED_TARGETS_WARNING( "Unmapped target %s.", Diagnostic.Kind.WARNING ),
     BEANMAPPING_UNMAPPED_TARGETS_ERROR( "Unmapped target %s." ),
+    BEANMAPPING_CYCLE_BETWEEN_PROPERTIES( "Cycle(s) between properties given via dependsOn(): %s." ),
 
     PROPERTYMAPPING_MAPPING_NOT_FOUND( "Can't map %s to \"%s %s\". Consider to declare/implement a mapping method: \"%s map(%s value)\"." ),
     PROPERTYMAPPING_DUPLICATE_TARGETS( "Target property \"%s\" must not be mapped more than once." ),

--- a/processor/src/main/java/org/mapstruct/ap/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/util/Message.java
@@ -36,6 +36,7 @@ public enum Message {
     BEANMAPPING_UNMAPPED_TARGETS_WARNING( "Unmapped target %s.", Diagnostic.Kind.WARNING ),
     BEANMAPPING_UNMAPPED_TARGETS_ERROR( "Unmapped target %s." ),
     BEANMAPPING_CYCLE_BETWEEN_PROPERTIES( "Cycle(s) between properties given via dependsOn(): %s." ),
+    BEANMAPPING_UNKNOWN_PROPERTY_IN_DEPENDS_ON( "\"%s\" is no property of the method return type." ),
 
     PROPERTYMAPPING_MAPPING_NOT_FOUND( "Can't map %s to \"%s %s\". Consider to declare/implement a mapping method: \"%s map(%s value)\"." ),
     PROPERTYMAPPING_DUPLICATE_TARGETS( "Target property \"%s\" must not be mapped more than once." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/Address.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/Address.java
@@ -1,0 +1,50 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.dependency;
+
+public class Address {
+
+    private String firstName;
+    private String middleName;
+    private String lastName;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/AddressDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/AddressDto.java
@@ -1,0 +1,58 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.dependency;
+
+public class AddressDto {
+
+    private String givenName;
+    private String middleName;
+    private String surName;
+    private String fullName;
+
+    public String getGivenName() {
+        return givenName;
+    }
+
+    public void setGivenName(String givenName) {
+        this.givenName = givenName;
+        this.fullName = givenName;
+    }
+
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+        this.fullName += " " + middleName;
+    }
+
+    public String getSurName() {
+        return surName;
+    }
+
+    public void setSurName(String surName) {
+        this.surName = surName;
+        this.fullName += " " + surName;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/AddressMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/AddressMapper.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.dependency;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface AddressMapper {
+
+    AddressMapper INSTANCE = Mappers.getMapper( AddressMapper.class );
+
+    @Mappings({
+        @Mapping(target = "surName", source = "lastName", dependsOn = "middleName"),
+        @Mapping(target = "middleName", dependsOn = "givenName"),
+        @Mapping(target = "givenName", source = "firstName")
+    })
+    AddressDto addressToDto(Address address);
+
+    @Mappings({
+        @Mapping(target = "lastName", dependsOn = { "firstName", "middleName" })
+    })
+    PersonDto personToDto(Person person);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/AddressMapperWithCyclicDependency.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/AddressMapperWithCyclicDependency.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.dependency;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface AddressMapperWithCyclicDependency {
+
+    AddressMapperWithCyclicDependency INSTANCE = Mappers.getMapper( AddressMapperWithCyclicDependency.class );
+
+    @Mappings({
+        @Mapping(target = "lastName", dependsOn = "middleName"),
+        @Mapping(target = "middleName", dependsOn = "firstName"),
+        @Mapping(target = "firstName", dependsOn = "lastName")
+    })
+    PersonDto personToDto(Person person);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/AddressMapperWithUnknownPropertyInDependsOn.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/AddressMapperWithUnknownPropertyInDependsOn.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.dependency;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface AddressMapperWithUnknownPropertyInDependsOn {
+
+    AddressMapperWithUnknownPropertyInDependsOn INSTANCE = Mappers.getMapper(
+        AddressMapperWithUnknownPropertyInDependsOn.class
+    );
+
+    @Mapping(target = "lastName", dependsOn = "doesnotexist")
+    PersonDto personToDto(Person person);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/GraphAnalyzerTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/GraphAnalyzerTest.java
@@ -1,0 +1,224 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.dependency;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mapstruct.ap.model.dependency.GraphAnalyzer;
+import org.mapstruct.ap.util.Strings;
+
+/**
+ * Unit test for {@link GraphAnalyzer}.
+ *
+ * @author Gunnar Morling
+ */
+public class GraphAnalyzerTest {
+
+    private GraphAnalyzer detector;
+
+    @Before
+    public void setUpDetector() {
+        detector = new GraphAnalyzer();
+    }
+
+    @Test
+    public void emptyGraph() {
+        detector.analyze();
+
+        assertThat( detector.getCycles() ).isEmpty();
+    }
+
+    @Test
+    public void singleNode() {
+        detector.addNode( "a" );
+        detector.analyze();
+
+        assertThat( detector.getCycles() ).isEmpty();
+        assertThat( detector.getAllDescendants( "a" ) ).isEmpty();
+    }
+
+    @Test
+    public void twoNodesWithoutCycle() {
+        detector.addNode( "a", "b" );
+        detector.addNode( "b" );
+
+        detector.analyze();
+
+        assertThat( detector.getCycles() ).isEmpty();
+        assertThat( detector.getAllDescendants( "a" ) ).containsOnly( "b" );
+        assertThat( detector.getAllDescendants( "b" ) ).isEmpty();
+    }
+
+    @Test
+    public void twoNodesWithCycle() {
+        detector.addNode( "a", "b" );
+        detector.addNode( "b", "a" );
+
+        detector.analyze();
+
+        assertThat( asStrings( detector.getCycles() ) ).containsOnly( "a -> b -> a" );
+    }
+
+    @Test
+    public void threeNodesWithCycleBetweenTwo() {
+        detector.addNode( "a", "b" );
+        detector.addNode( "b", "a", "c" );
+
+        detector.analyze();
+
+        assertThat( asStrings( detector.getCycles() ) ).containsOnly( "a -> b -> a" );
+    }
+
+    @Test
+    public void twoNodesWithSharedDescendantWithoutCycle() {
+        detector.addNode( "a", "b" );
+        detector.addNode( "b", "c" );
+        detector.addNode( "a", "c" );
+
+        detector.analyze();
+
+        assertThat( asStrings( detector.getCycles() ) ).isEmpty();
+        assertThat( detector.getAllDescendants( "a" ) ).containsOnly( "b", "c" );
+        assertThat( detector.getAllDescendants( "b" ) ).containsOnly( "c" );
+        assertThat( detector.getAllDescendants( "c" ) ).isEmpty();
+    }
+
+    @Test
+    public void threeNodesWithoutCycle() {
+        detector.addNode( "a", "b" );
+        detector.addNode( "c", "b" );
+
+        detector.analyze();
+
+        assertThat( asStrings( detector.getCycles() ) ).isEmpty();
+
+        assertThat( detector.getAllDescendants( "a" ) ).containsOnly( "b" );
+        assertThat( detector.getAllDescendants( "b" ) ).isEmpty();
+        assertThat( detector.getAllDescendants( "c" ) ).containsOnly( "b" );
+    }
+
+    @Test
+    public void fourNodesWithCycleBetweenThree() {
+        detector.addNode( "a", "b" );
+        detector.addNode( "b", "c" );
+        detector.addNode( "c", "d" );
+        detector.addNode( "d", "b" );
+
+        detector.analyze();
+
+        assertThat( asStrings( detector.getCycles() ) ).containsOnly( "b -> c -> d -> b" );
+    }
+
+    @Test
+    public void fourNodesWithTwoCycles() {
+        detector.addNode( "a", "b" );
+        detector.addNode( "b", "a" );
+        detector.addNode( "c", "d" );
+        detector.addNode( "d", "c" );
+
+        detector.analyze();
+
+        assertThat( asStrings( detector.getCycles() ) ).containsOnly( "a -> b -> a", "c -> d -> c" );
+    }
+
+    @Test
+    public void fourNodesWithoutCycle() {
+        detector.addNode( "a", "b1" );
+        detector.addNode( "a", "b2" );
+        detector.addNode( "b1", "c" );
+        detector.addNode( "b2", "c" );
+
+        detector.analyze();
+
+        assertThat( asStrings( detector.getCycles() ) ).isEmpty();
+        assertThat( detector.getAllDescendants( "a" ) ).containsOnly( "b1", "b2", "c" );
+        assertThat( detector.getAllDescendants( "b1" ) ).containsOnly( "c" );
+        assertThat( detector.getAllDescendants( "b2" ) ).containsOnly( "c" );
+        assertThat( detector.getAllDescendants( "c" ) ).isEmpty();
+    }
+
+    @Test
+    public void fourNodesWithCycle() {
+        detector.addNode( "a", "b1" );
+        detector.addNode( "a", "b2" );
+        detector.addNode( "b1", "c" );
+        detector.addNode( "b2", "c" );
+        detector.addNode( "c", "a" );
+
+        detector.analyze();
+
+        assertThat( asStrings( detector.getCycles() ) ).containsOnly( "a -> b1 -> c -> a", "a -> b2 -> c -> a" );
+    }
+
+    @Test
+    public void eightNodesWithoutCycle() {
+        detector.addNode( "a", "b1" );
+        detector.addNode( "a", "b2" );
+        detector.addNode( "b1", "c1" );
+        detector.addNode( "b1", "c2" );
+        detector.addNode( "b2", "c3" );
+        detector.addNode( "b2", "c4" );
+
+        detector.analyze();
+
+        assertThat( detector.getCycles() ).isEmpty();
+
+        assertThat( detector.getAllDescendants( "a" ) ).containsOnly( "b1", "b2", "c1", "c2", "c3", "c4" );
+        assertThat( detector.getAllDescendants( "b1" ) ).containsOnly( "c1", "c2" );
+        assertThat( detector.getAllDescendants( "b2" ) ).containsOnly( "c3", "c4" );
+    }
+
+    private Set<String> asStrings(Set<List<String>> cycles) {
+        Set<String> asStrings = new HashSet<String>();
+
+        for ( List<String> cycle : cycles ) {
+            asStrings.add( asString( cycle ) );
+        }
+
+        return asStrings;
+    }
+
+    private String asString(List<String> cycle) {
+        return Strings.join( normalize( cycle ), " -> " );
+    }
+
+    /**
+     * "Normalizes" a cycle so that the minimum element comes first. E.g. both the cycles {@code b -> c -> a -> b} and
+     * {@code c -> a -> b -> c} would be normalized to {@code a -> b -> c -> a}.
+     */
+    private List<String> normalize(List<String> cycle) {
+        // remove the first element
+        cycle = cycle.subList( 1, cycle.size() );
+
+        // rotate the cycle so the minimum element comes first
+        Collections.rotate( cycle, -cycle.indexOf( Collections.min( cycle ) ) );
+
+        // add the first element add the end to re-close the cycle
+        cycle.add( cycle.get( 0 ) );
+
+        return cycle;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/GraphAnalyzerTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/GraphAnalyzerTest.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.junit.Before;
 import org.junit.Test;
 import org.mapstruct.ap.model.dependency.GraphAnalyzer;
 import org.mapstruct.ap.util.Strings;
@@ -37,24 +36,15 @@ import org.mapstruct.ap.util.Strings;
  */
 public class GraphAnalyzerTest {
 
-    private GraphAnalyzer detector;
-
-    @Before
-    public void setUpDetector() {
-        detector = new GraphAnalyzer();
-    }
-
     @Test
     public void emptyGraph() {
-        detector.analyze();
-
+        GraphAnalyzer detector = GraphAnalyzer.builder().build();
         assertThat( detector.getCycles() ).isEmpty();
     }
 
     @Test
     public void singleNode() {
-        detector.addNode( "a" );
-        detector.analyze();
+        GraphAnalyzer detector = GraphAnalyzer.withNode( "a" ).build();
 
         assertThat( detector.getCycles() ).isEmpty();
         assertThat( detector.getAllDescendants( "a" ) ).isEmpty();
@@ -62,10 +52,9 @@ public class GraphAnalyzerTest {
 
     @Test
     public void twoNodesWithoutCycle() {
-        detector.addNode( "a", "b" );
-        detector.addNode( "b" );
-
-        detector.analyze();
+        GraphAnalyzer detector = GraphAnalyzer.withNode( "a", "b" )
+                .withNode( "b" )
+                .build();
 
         assertThat( detector.getCycles() ).isEmpty();
         assertThat( detector.getAllDescendants( "a" ) ).containsOnly( "b" );
@@ -74,31 +63,28 @@ public class GraphAnalyzerTest {
 
     @Test
     public void twoNodesWithCycle() {
-        detector.addNode( "a", "b" );
-        detector.addNode( "b", "a" );
-
-        detector.analyze();
+        GraphAnalyzer detector = GraphAnalyzer.withNode( "a", "b" )
+                .withNode( "b", "a" )
+                .build();
 
         assertThat( asStrings( detector.getCycles() ) ).containsOnly( "a -> b -> a" );
     }
 
     @Test
     public void threeNodesWithCycleBetweenTwo() {
-        detector.addNode( "a", "b" );
-        detector.addNode( "b", "a", "c" );
-
-        detector.analyze();
+        GraphAnalyzer detector = GraphAnalyzer.withNode( "a", "b" )
+                .withNode( "b", "a", "c" )
+                .build();
 
         assertThat( asStrings( detector.getCycles() ) ).containsOnly( "a -> b -> a" );
     }
 
     @Test
     public void twoNodesWithSharedDescendantWithoutCycle() {
-        detector.addNode( "a", "b" );
-        detector.addNode( "b", "c" );
-        detector.addNode( "a", "c" );
-
-        detector.analyze();
+        GraphAnalyzer detector = GraphAnalyzer.withNode( "a", "b" )
+                .withNode( "b", "c" )
+                .withNode( "a", "c" )
+                .build();
 
         assertThat( asStrings( detector.getCycles() ) ).isEmpty();
         assertThat( detector.getAllDescendants( "a" ) ).containsOnly( "b", "c" );
@@ -108,10 +94,9 @@ public class GraphAnalyzerTest {
 
     @Test
     public void threeNodesWithoutCycle() {
-        detector.addNode( "a", "b" );
-        detector.addNode( "c", "b" );
-
-        detector.analyze();
+        GraphAnalyzer detector = GraphAnalyzer.withNode( "a", "b" )
+                .withNode( "c", "b" )
+                .build();
 
         assertThat( asStrings( detector.getCycles() ) ).isEmpty();
 
@@ -122,36 +107,33 @@ public class GraphAnalyzerTest {
 
     @Test
     public void fourNodesWithCycleBetweenThree() {
-        detector.addNode( "a", "b" );
-        detector.addNode( "b", "c" );
-        detector.addNode( "c", "d" );
-        detector.addNode( "d", "b" );
-
-        detector.analyze();
+        GraphAnalyzer detector = GraphAnalyzer.withNode( "a", "b" )
+                .withNode( "b", "c" )
+                .withNode( "c", "d" )
+                .withNode( "d", "b" )
+                .build();
 
         assertThat( asStrings( detector.getCycles() ) ).containsOnly( "b -> c -> d -> b" );
     }
 
     @Test
     public void fourNodesWithTwoCycles() {
-        detector.addNode( "a", "b" );
-        detector.addNode( "b", "a" );
-        detector.addNode( "c", "d" );
-        detector.addNode( "d", "c" );
-
-        detector.analyze();
+        GraphAnalyzer detector = GraphAnalyzer.withNode( "a", "b" )
+                .withNode( "b", "a" )
+                .withNode( "c", "d" )
+                .withNode( "d", "c" )
+                .build();
 
         assertThat( asStrings( detector.getCycles() ) ).containsOnly( "a -> b -> a", "c -> d -> c" );
     }
 
     @Test
     public void fourNodesWithoutCycle() {
-        detector.addNode( "a", "b1" );
-        detector.addNode( "a", "b2" );
-        detector.addNode( "b1", "c" );
-        detector.addNode( "b2", "c" );
-
-        detector.analyze();
+        GraphAnalyzer detector = GraphAnalyzer.withNode( "a", "b1" )
+                .withNode( "a", "b2" )
+                .withNode( "b1", "c" )
+                .withNode( "b2", "c" )
+                .build();
 
         assertThat( asStrings( detector.getCycles() ) ).isEmpty();
         assertThat( detector.getAllDescendants( "a" ) ).containsOnly( "b1", "b2", "c" );
@@ -162,27 +144,25 @@ public class GraphAnalyzerTest {
 
     @Test
     public void fourNodesWithCycle() {
-        detector.addNode( "a", "b1" );
-        detector.addNode( "a", "b2" );
-        detector.addNode( "b1", "c" );
-        detector.addNode( "b2", "c" );
-        detector.addNode( "c", "a" );
-
-        detector.analyze();
+        GraphAnalyzer detector = GraphAnalyzer.withNode( "a", "b1" )
+                .withNode( "a", "b2" )
+                .withNode( "b1", "c" )
+                .withNode( "b2", "c" )
+                .withNode( "c", "a" )
+                .build();
 
         assertThat( asStrings( detector.getCycles() ) ).containsOnly( "a -> b1 -> c -> a", "a -> b2 -> c -> a" );
     }
 
     @Test
     public void eightNodesWithoutCycle() {
-        detector.addNode( "a", "b1" );
-        detector.addNode( "a", "b2" );
-        detector.addNode( "b1", "c1" );
-        detector.addNode( "b1", "c2" );
-        detector.addNode( "b2", "c3" );
-        detector.addNode( "b2", "c4" );
-
-        detector.analyze();
+        GraphAnalyzer detector = GraphAnalyzer.withNode( "a", "b1" )
+                .withNode( "a", "b2" )
+                .withNode( "b1", "c1" )
+                .withNode( "b1", "c2" )
+                .withNode( "b2", "c3" )
+                .withNode( "b2", "c4" )
+                .build();
 
         assertThat( detector.getCycles() ).isEmpty();
 

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/OrderingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/OrderingTest.java
@@ -23,6 +23,9 @@ import org.junit.runner.RunWith;
 import org.mapstruct.Mapping;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 import static org.fest.assertions.Assertions.assertThat;
@@ -62,5 +65,22 @@ public class OrderingTest {
 
         assertThat( target ).isNotNull();
         assertThat( target.getFullName() ).isEqualTo( "Bob J. McRobb" );
+    }
+
+    @Test
+    @IssueKey("304")
+    @WithClasses(AddressMapperWithCyclicDependency.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = AddressMapperWithCyclicDependency.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 36,
+                messageRegExp = "Cycle\\(s\\) between properties given via dependsOn\\(\\): firstName -> lastName -> "
+                    + "middleName -> firstName"
+            )
+        }
+    )
+    public void shouldReportErrorIfDependenciesContainCycle() {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/OrderingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/OrderingTest.java
@@ -1,0 +1,66 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.dependency;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.Mapping;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * Test for ordering mapped attributes by means of {@link Mapping#dependsOn()}.
+ *
+ * @author Gunnar Morling
+ */
+@WithClasses({ Person.class, PersonDto.class, Address.class, AddressDto.class, AddressMapper.class })
+@RunWith(AnnotationProcessorTestRunner.class)
+public class OrderingTest {
+
+    @Test
+    @IssueKey("304")
+    public void shouldApplyChainOfDependencies() {
+        Address source = new Address();
+        source.setFirstName( "Bob" );
+        source.setMiddleName( "J." );
+        source.setLastName( "McRobb" );
+
+        AddressDto target = AddressMapper.INSTANCE.addressToDto( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFullName() ).isEqualTo( "Bob J. McRobb" );
+    }
+
+    @Test
+    @IssueKey("304")
+    public void shouldApplySeveralDependenciesConfiguredForOneProperty() {
+        Person source = new Person();
+        source.setFirstName( "Bob" );
+        source.setMiddleName( "J." );
+        source.setLastName( "McRobb" );
+
+        PersonDto target = AddressMapper.INSTANCE.personToDto( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFullName() ).isEqualTo( "Bob J. McRobb" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/OrderingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/OrderingTest.java
@@ -83,4 +83,20 @@ public class OrderingTest {
     )
     public void shouldReportErrorIfDependenciesContainCycle() {
     }
+
+    @Test
+    @IssueKey("304")
+    @WithClasses(AddressMapperWithUnknownPropertyInDependsOn.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = AddressMapperWithUnknownPropertyInDependsOn.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 32,
+                messageRegExp = "\"doesnotexist\" is no property of the method return type"
+            )
+        }
+    )
+    public void shouldReportErrorIfPropertiyGivenInDependsOnDoesNotExist() {
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/Person.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/Person.java
@@ -1,0 +1,50 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.dependency;
+
+public class Person {
+
+    private String firstName;
+    private String middleName;
+    private String lastName;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/PersonDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/PersonDto.java
@@ -1,0 +1,56 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.dependency;
+
+public class PersonDto {
+
+    private String firstName;
+    private String middleName;
+    private String lastName;
+    private String fullName;
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getMiddleName() {
+        return middleName;
+    }
+
+    public void setMiddleName(String middleName) {
+        this.middleName = middleName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+        this.fullName = firstName + " " + middleName + " " + lastName;
+    }
+
+    public String getFullName() {
+        return fullName;
+    }
+}


### PR DESCRIPTION
This change allows to specify an order for invoking the setters of bean mapping result types.

I went for the approach of allowing to specify the properties upon which a given property depends as it's more convinient to handle than simple numeric orderings (e.g. when inserting a new element at the middle of a dependency relationship).