### PR TITLE
#481 Only add JaxbElement if the class exists

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/model/source/builtin/BuiltInMappingMethods.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/builtin/BuiltInMappingMethods.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.mapstruct.ap.model.common.TypeFactory;
 import org.mapstruct.ap.util.Collections;
 import org.mapstruct.ap.util.JavaTimeConstants;
+import org.mapstruct.ap.util.JaxbConstants;
 
 /**
  * Registry for all built-in methods.
@@ -35,7 +36,6 @@ public class BuiltInMappingMethods {
 
     public BuiltInMappingMethods(TypeFactory typeFactory) {
         builtInMethods = Collections.newArrayList(
-            new JaxbElemToValue( typeFactory ),
             new DateToXmlGregorianCalendar( typeFactory ),
             new XmlGregorianCalendarToDate( typeFactory ),
             new StringToXmlGregorianCalendar( typeFactory ),
@@ -45,10 +45,18 @@ public class BuiltInMappingMethods {
 
         );
 
+        if ( isJaxbAvailable( typeFactory ) ) {
+            builtInMethods.add( new JaxbElemToValue( typeFactory ) );
+        }
+
         if ( isJava8TimeAvailable( typeFactory ) ) {
             builtInMethods.add( new ZonedDateTimeToCalendar( typeFactory ) );
             builtInMethods.add( new CalendarToZonedDateTime( typeFactory ) );
         }
+    }
+
+    private static boolean isJaxbAvailable(TypeFactory typeFactory) {
+        return typeFactory.isTypeAvailable( JaxbConstants.JAXB_ELEMENT_FQN );
     }
 
     private static boolean isJava8TimeAvailable(TypeFactory typeFactory) {

--- a/processor/src/main/java/org/mapstruct/ap/util/JaxbConstants.java
+++ b/processor/src/main/java/org/mapstruct/ap/util/JaxbConstants.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.util;
+
+/**
+ * Helper holding JAXB time full qualified class names for conversion registration
+ */
+public final class JaxbConstants {
+
+    public static final String JAXB_ELEMENT_FQN = "javax.xml.bind.JAXBElement";
+
+    private JaxbConstants() {
+    }
+}


### PR DESCRIPTION
Android doesn't JaxbElement, so we should only include it if we can create an instance of it.