### PR TITLE
#272 Proposed solution for support of decorators with CDI and Spring

### DIFF
--- a/integrationtest/src/test/resources/cdiTest/src/main/java/org/mapstruct/itest/cdi/DecoratedSourceTargetMapper.java
+++ b/integrationtest/src/test/resources/cdiTest/src/main/java/org/mapstruct/itest/cdi/DecoratedSourceTargetMapper.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.itest.cdi;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.DecoratedWith;
+import org.mapstruct.itest.cdi.other.DateMapper;
+
+@Mapper( componentModel = "cdi", uses = DateMapper.class )
+@DecoratedWith( SourceTargetMapperDecorator.class )
+public interface DecoratedSourceTargetMapper {
+
+    Target sourceToTarget(Source source);
+}

--- a/integrationtest/src/test/resources/cdiTest/src/main/java/org/mapstruct/itest/cdi/SourceTargetMapperDecorator.java
+++ b/integrationtest/src/test/resources/cdiTest/src/main/java/org/mapstruct/itest/cdi/SourceTargetMapperDecorator.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.itest.cdi;
+
+import javax.decorator.Decorator;
+import javax.decorator.Delegate;
+import javax.inject.Inject;
+
+@Decorator
+public class SourceTargetMapperDecorator implements DecoratedSourceTargetMapper {
+
+    @Delegate
+    @Inject
+    private DecoratedSourceTargetMapper delegate;
+
+    public SourceTargetMapperDecorator() {
+    }
+
+    @Override
+    public Target sourceToTarget(Source source) {
+        Target t = delegate.sourceToTarget( source );
+        t.setFoo( 43L );
+        return t;
+    }
+}

--- a/integrationtest/src/test/resources/springTest/src/main/java/org/mapstruct/itest/spring/DecoratedSourceTargetMapper.java
+++ b/integrationtest/src/test/resources/springTest/src/main/java/org/mapstruct/itest/spring/DecoratedSourceTargetMapper.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.itest.spring;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.DecoratedWith;
+import org.mapstruct.itest.spring.other.DateMapper;
+
+@Mapper( componentModel = "spring", uses = DateMapper.class )
+@DecoratedWith( SourceTargetMapperDecorator.class )
+public interface DecoratedSourceTargetMapper {
+
+    Target sourceToTarget(Source source);
+}

--- a/integrationtest/src/test/resources/springTest/src/main/java/org/mapstruct/itest/spring/SourceTargetMapperDecorator.java
+++ b/integrationtest/src/test/resources/springTest/src/main/java/org/mapstruct/itest/spring/SourceTargetMapperDecorator.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.itest.spring;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SourceTargetMapperDecorator implements DecoratedSourceTargetMapper {
+
+    @Autowired
+    @Qualifier( "decoratedSourceTargetMapperImpl_" )
+    private DecoratedSourceTargetMapper delegate;
+
+    public SourceTargetMapperDecorator() {
+    }
+
+    @Override
+    public Target sourceToTarget(Source source) {
+        Target t = delegate.sourceToTarget( source );
+        t.setFoo( 43L );
+        return t;
+    }
+}

--- a/integrationtest/src/test/resources/springTest/src/test/java/org/mapstruct/itest/spring/SpringBasedMapperTest.java
+++ b/integrationtest/src/test/resources/springTest/src/test/java/org/mapstruct/itest/spring/SpringBasedMapperTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.itest.spring.SpringBasedMapperTest.SpringTestConfig;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
@@ -45,6 +46,9 @@ public class SpringBasedMapperTest {
     @Autowired
     private SourceTargetMapper mapper;
 
+    @Autowired
+    @Qualifier( "sourceTargetMapperDecorator" )
+    private DecoratedSourceTargetMapper decoratedMapper;
 
     @Test
     public void shouldCreateSpringBasedMapper() {
@@ -56,4 +60,15 @@ public class SpringBasedMapperTest {
         assertThat( target.getFoo() ).isEqualTo( Long.valueOf( 42 ) );
         assertThat( target.getDate() ).isEqualTo( "1980" );
     }
+
+    @Test
+    public void shouldInjectDecorator() {
+        Source source = new Source();
+
+        Target target = decoratedMapper.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFoo() ).isEqualTo( Long.valueOf( 43 ) );
+    }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/model/Mapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/Mapper.java
@@ -43,7 +43,7 @@ public class Mapper extends GeneratedType {
     private static final String DECORATED_IMPLEMENTATION_SUFFIX = "Impl_";
 
     private final List<MapperReference> referencedMappers;
-    private final Decorator decorator;
+    private Decorator decorator;
 
     @SuppressWarnings( "checkstyle:parameternumber" )
     private Mapper(TypeFactory typeFactory, String packageName, String name, String superClassName,
@@ -156,6 +156,10 @@ public class Mapper extends GeneratedType {
 
     public Decorator getDecorator() {
         return decorator;
+    }
+
+    public void removeDecorator() {
+        this.decorator = null;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/processor/AnnotationBasedComponentModelProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/AnnotationBasedComponentModelProcessor.java
@@ -55,6 +55,10 @@ public abstract class AnnotationBasedComponentModelProcessor implements ModelEle
             return mapper;
         }
 
+        if ( shouldDecoratorBeRemoved() ) {
+            mapper.removeDecorator();
+        }
+
         mapper.addAnnotation( getTypeAnnotation() );
 
         ListIterator<MapperReference> iterator = mapper.getReferencedMappers().listIterator();
@@ -95,6 +99,11 @@ public abstract class AnnotationBasedComponentModelProcessor implements ModelEle
      * @return the annotation of the field for the mapper reference
      */
     protected abstract Annotation getMapperReferenceAnnotation();
+
+    /**
+     * @return if generated decorator class should be removed
+     */
+    protected abstract boolean shouldDecoratorBeRemoved();
 
     @Override
     public int getPriority() {

--- a/processor/src/main/java/org/mapstruct/ap/processor/CdiComponentProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/CdiComponentProcessor.java
@@ -44,4 +44,9 @@ public class CdiComponentProcessor extends AnnotationBasedComponentModelProcesso
     protected Annotation getMapperReferenceAnnotation() {
         return new Annotation( getTypeFactory().getType( "javax.inject.Inject" ) );
     }
+
+    @Override
+    protected boolean shouldDecoratorBeRemoved() {
+        return true;
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/processor/Jsr330ComponentProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/Jsr330ComponentProcessor.java
@@ -44,4 +44,9 @@ public class Jsr330ComponentProcessor extends AnnotationBasedComponentModelProce
     protected Annotation getMapperReferenceAnnotation() {
         return new Annotation( getTypeFactory().getType( "javax.inject.Inject" ) );
     }
+
+    @Override
+    protected boolean shouldDecoratorBeRemoved() {
+        return false;
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/processor/SpringComponentProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/processor/SpringComponentProcessor.java
@@ -44,4 +44,9 @@ public class SpringComponentProcessor extends AnnotationBasedComponentModelProce
     protected Annotation getMapperReferenceAnnotation() {
         return new Annotation( getTypeFactory().getType( "org.springframework.beans.factory.annotation.Autowired" ) );
     }
+
+    @Override
+    protected boolean shouldDecoratorBeRemoved() {
+        return true;
+    }
 }


### PR DESCRIPTION
This solution just throws away the decorator definition, if annotation based mappers are created. This gives support in CDI and Spring, with minimal code changes.

The solution for Spring is not very good (using `@Qualifier` with Impl_) but it works. Please feel free to comment.

Referenced issue: #272 