### PR TITLE
#516 Add NP check on adder property mapping including reproducer

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/PropertyMapping.java
@@ -277,6 +277,7 @@ public class PropertyMapping extends ModelElement {
                         getSourceRef(),
                         sourceType
                     );
+                    result = new NullCheckWrapper( result );
                 }
                 else {
                     // Possibly adding null to a target collection. So should be surrounded by an null check.

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/Issue516Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/Issue516Test.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._516;
+
+import static org.fest.assertions.Assertions.assertThat;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Reproducer for https://github.com/mapstruct/mapstruct/issues/516.
+ *
+ * @author Sjaak Derksen
+ */
+@IssueKey( "516" )
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue516Test {
+
+    @Test
+    @WithClasses( { SourceTargetMapper.class, Source.class, Target.class } )
+    public void shouldAddNullPtrCheckAroundSourceForAdder() {
+
+        Source source = new Source();
+
+        Target target = SourceTargetMapper.STM.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getElements() ).isNull();
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/Source.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._516;
+
+import java.util.List;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Source {
+
+    private List<String> elements;
+
+    public List<String> getElements() {
+        return elements;
+    }
+
+    public void setElements(List<String> elements) {
+        this.elements = elements;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/SourceTargetMapper.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._516;
+
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper( collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED )
+public interface SourceTargetMapper {
+
+    SourceTargetMapper STM = Mappers.getMapper( SourceTargetMapper.class );
+
+    Target map(Source source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/Target.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._516;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Target {
+
+    private List<String> elements;
+
+    public List<String> getElements() {
+        return elements;
+    }
+
+    public void setElements(List<String> elements) {
+        this.elements = elements;
+    }
+
+    public void addElement(String element) {
+        if ( elements == null ) {
+            elements = new ArrayList<String>();
+        }
+        elements.add( element );
+    }
+}


### PR DESCRIPTION
Wraps a call to an add method on the target object in an null check + reproducer