### PR TITLE
#540 use name() instead of toString() for enum to String conversion

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/conversion/EnumStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/conversion/EnumStringConversion.java
@@ -34,7 +34,7 @@ public class EnumStringConversion extends SimpleConversion {
 
     @Override
     public String getToExpression(ConversionContext conversionContext) {
-        return "<SOURCE>.toString()";
+        return "<SOURCE>.name()";
     }
 
     @Override


### PR DESCRIPTION
Reason for change:
name() is safer than toString() because it always returns the enum name exactly as declared, whereas toString() can be overridden and may return any value.