### PR TITLE
515 Negative array index in indentation writer

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_515/Issue515Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_515/Issue515Mapper.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._515;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class Issue515Mapper {
+
+    public static final Issue515Mapper INSTANCE = Mappers.getMapper( Issue515Mapper.class );
+
+    @Mapping( target = "id", expression = "java(\"blah)\\\"\")" )
+    public abstract Target map(Source source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_515/Issue515Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_515/Issue515Test.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._515;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Reproducer for https://github.com/mapstruct/mapstruct/issues/515.
+ *
+ * @author Sjaak Derksen
+ */
+@IssueKey( "515" )
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue515Test {
+
+    @Test
+    @WithClasses( { Issue515Mapper.class, Source.class, Target.class } )
+    public void shouldIgnoreParanthesesOpenInStringDefinition() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_515/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_515/Source.java
@@ -1,0 +1,23 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._515;
+
+public class Source {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_515/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_515/Target.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._515;
+
+
+public class Target {
+
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+}


### PR DESCRIPTION
In expressions (and presumably also in contstants) its possible to create Strings definitions in the generated code. Indentation should therefore not be increased / decreased when braces (curly or round) are encountered inside a String definition (so between " "). 

Decreasing due to an unbalanced round brace inside a String definition led to the problem above.

Likewise, escaped '"' should be ignored.

The enum-state pattern (one of my favourites :+1: ) has been updated with a couple of extra states to handle this. 
 