### PR TITLE
#513 forged methods should re-throw exceptions from used mapping methods

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/model/Direct.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/Direct.java
@@ -49,7 +49,7 @@ public class Direct extends ModelElement implements Assignment {
     }
 
     @Override
-    public List<Type> getExceptionTypes() {
+    public List<Type> getThrownTypes() {
         return Collections.emptyList();
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
@@ -123,7 +123,7 @@ public class IterableMappingMethod extends MappingMethod {
             else {
                 if ( method instanceof ForgedMethod ) {
                     ForgedMethod forgedMethod = (ForgedMethod) method;
-                    forgedMethod.addThrownTypes( assignment.getExceptionTypes() );
+                    forgedMethod.addThrownTypes( assignment.getThrownTypes() );
                 }
             }
             // target accessor is setter, so decorate assignment as setter

--- a/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
@@ -29,6 +29,7 @@ import org.mapstruct.ap.model.assignment.LocalVarWrapper;
 import org.mapstruct.ap.model.assignment.SetterWrapper;
 import org.mapstruct.ap.model.common.Parameter;
 import org.mapstruct.ap.model.common.Type;
+import org.mapstruct.ap.model.source.ForgedMethod;
 import org.mapstruct.ap.model.source.Method;
 import org.mapstruct.ap.prism.NullValueMappingStrategyPrism;
 import org.mapstruct.ap.util.Message;
@@ -119,7 +120,12 @@ public class IterableMappingMethod extends MappingMethod {
             if ( assignment == null ) {
                 ctx.getMessager().printMessage( method.getExecutable(), Message.ITERABLEMAPPING_MAPPING_NOT_FOUND );
             }
-
+            else {
+                if ( method instanceof ForgedMethod ) {
+                    ForgedMethod forgedMethod = (ForgedMethod) method;
+                    forgedMethod.addThrownTypes( assignment.getExceptionTypes() );
+                }
+            }
             // target accessor is setter, so decorate assignment as setter
             if ( resultType.isArrayType() ) {
                 assignment = new LocalVarWrapper( assignment, method.getThrownTypes() );

--- a/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
@@ -27,6 +27,7 @@ import org.mapstruct.ap.model.assignment.Assignment;
 import org.mapstruct.ap.model.assignment.LocalVarWrapper;
 import org.mapstruct.ap.model.common.Parameter;
 import org.mapstruct.ap.model.common.Type;
+import org.mapstruct.ap.model.source.ForgedMethod;
 import org.mapstruct.ap.model.source.Method;
 import org.mapstruct.ap.prism.NullValueMappingStrategyPrism;
 import org.mapstruct.ap.util.Message;
@@ -149,6 +150,16 @@ public class MapMappingMethod extends MappingMethod {
                 "entry.getValue()",
                 false
             );
+
+            if ( method instanceof ForgedMethod ) {
+                ForgedMethod forgedMethod = (ForgedMethod) method;
+                if ( keyAssignment != null ) {
+                    forgedMethod.addThrownTypes( keyAssignment.getExceptionTypes() );
+                }
+                if ( valueAssignment != null ) {
+                    forgedMethod.addThrownTypes( valueAssignment.getExceptionTypes() );
+                }
+            }
 
             if ( valueAssignment == null ) {
                 ctx.getMessager().printMessage( method.getExecutable(), Message.MAPMAPPING_VALUE_MAPPING_NOT_FOUND );

--- a/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
@@ -154,10 +154,10 @@ public class MapMappingMethod extends MappingMethod {
             if ( method instanceof ForgedMethod ) {
                 ForgedMethod forgedMethod = (ForgedMethod) method;
                 if ( keyAssignment != null ) {
-                    forgedMethod.addThrownTypes( keyAssignment.getExceptionTypes() );
+                    forgedMethod.addThrownTypes( keyAssignment.getThrownTypes() );
                 }
                 if ( valueAssignment != null ) {
-                    forgedMethod.addThrownTypes( valueAssignment.getExceptionTypes() );
+                    forgedMethod.addThrownTypes( valueAssignment.getThrownTypes() );
                 }
             }
 

--- a/processor/src/main/java/org/mapstruct/ap/model/MethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MethodReference.java
@@ -41,7 +41,7 @@ public class MethodReference extends MappingMethod implements Assignment {
 
     private final MapperReference declaringMapper;
     private final Set<Type> importTypes;
-    private final List<Type> exceptionTypes;
+    private final List<Type> thrownTypes;
     private final boolean isUpdateMethod;
 
     /**
@@ -78,7 +78,7 @@ public class MethodReference extends MappingMethod implements Assignment {
             imported.add( targetType );
         }
         this.importTypes = Collections.<Type>unmodifiableSet( imported );
-        this.exceptionTypes = method.getThrownTypes();
+        this.thrownTypes = method.getThrownTypes();
         this.isUpdateMethod = method.getMappingTargetParameter() != null;
    }
 
@@ -87,7 +87,7 @@ public class MethodReference extends MappingMethod implements Assignment {
         this.declaringMapper = null;
         this.contextParam = method.getContextParameter( contextParam );
         this.importTypes = Collections.emptySet();
-        this.exceptionTypes = Collections.emptyList();
+        this.thrownTypes = Collections.emptyList();
         this.isUpdateMethod = method.getMappingTargetParameter() != null;
     }
 
@@ -139,11 +139,11 @@ public class MethodReference extends MappingMethod implements Assignment {
     }
 
     @Override
-    public List<Type> getExceptionTypes() {
+    public List<Type> getThrownTypes() {
         List<Type> exceptions = new ArrayList<Type>();
-        exceptions.addAll( exceptionTypes );
+        exceptions.addAll( thrownTypes );
         if ( assignment != null ) {
-            exceptions.addAll( assignment.getExceptionTypes() );
+            exceptions.addAll( assignment.getThrownTypes() );
         }
         return exceptions;
     }

--- a/processor/src/main/java/org/mapstruct/ap/model/TypeConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/TypeConversion.java
@@ -36,7 +36,7 @@ public class TypeConversion extends ModelElement implements Assignment {
     private static final String SOURCE_REFERENCE_PATTERN = "<SOURCE>";
 
     private final Set<Type> importTypes;
-    private final List<Type> exceptionTypes;
+    private final List<Type> thrownTypes;
     private final String openExpression;
     private final String closeExpression;
 
@@ -52,7 +52,7 @@ public class TypeConversion extends ModelElement implements Assignment {
             String expression ) {
         this.importTypes = new HashSet<Type>( importTypes );
         this.importTypes.addAll( exceptionTypes );
-        this.exceptionTypes = exceptionTypes;
+        this.thrownTypes = exceptionTypes;
 
         int patternIndex = expression.indexOf( SOURCE_REFERENCE_PATTERN );
         this.openExpression = expression.substring( 0, patternIndex );
@@ -65,8 +65,8 @@ public class TypeConversion extends ModelElement implements Assignment {
     }
 
     @Override
-    public List<Type> getExceptionTypes() {
-        return exceptionTypes;
+    public List<Type> getThrownTypes() {
+        return thrownTypes;
     }
 
     public String getOpenExpression() {

--- a/processor/src/main/java/org/mapstruct/ap/model/assignment/AdderWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/assignment/AdderWrapper.java
@@ -32,28 +32,28 @@ import org.mapstruct.ap.model.common.Type;
  */
 public class AdderWrapper extends AssignmentWrapper {
 
-    private final List<Type> exceptionTypesToExclude;
+    private final List<Type> thrownTypesToExclude;
     private final String sourceReference;
     private final Type sourceType;
 
     public AdderWrapper(
         Assignment decoratedAssignment,
-        List<Type> exceptionTypesToExclude,
+        List<Type> thrownTypesToExclude,
         String sourceReference,
         Type sourceType) {
         super( decoratedAssignment );
-        this.exceptionTypesToExclude = exceptionTypesToExclude;
+        this.thrownTypesToExclude = thrownTypesToExclude;
         this.sourceReference = sourceReference;
         this.sourceType = sourceType;
     }
 
     @Override
-    public List<Type> getExceptionTypes() {
-        List<Type> parentExceptionTypes = super.getExceptionTypes();
-        List<Type> result = new ArrayList<Type>( parentExceptionTypes );
-        for ( Type exceptionTypeToExclude : exceptionTypesToExclude ) {
-            for ( Type parentExceptionType : parentExceptionTypes ) {
-                if ( parentExceptionType.isAssignableTo( exceptionTypeToExclude ) ) {
+    public List<Type> getThrownTypes() {
+        List<Type> parentThrownTypes = super.getThrownTypes();
+        List<Type> result = new ArrayList<Type>( parentThrownTypes );
+        for ( Type thrownTypeToExclude : thrownTypesToExclude ) {
+            for ( Type parentExceptionType : parentThrownTypes ) {
+                if ( parentExceptionType.isAssignableTo( thrownTypeToExclude ) ) {
                     result.remove( parentExceptionType );
                 }
             }

--- a/processor/src/main/java/org/mapstruct/ap/model/assignment/Assignment.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/assignment/Assignment.java
@@ -57,7 +57,7 @@ public interface Assignment {
      *
      * @return exceptions thrown
      */
-    List<Type> getExceptionTypes();
+     List<Type> getThrownTypes();
 
     /**
      * An assignment in itself can wrap another assignment. E.g.:

--- a/processor/src/main/java/org/mapstruct/ap/model/assignment/AssignmentWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/assignment/AssignmentWrapper.java
@@ -42,8 +42,8 @@ public abstract class AssignmentWrapper extends ModelElement implements Assignme
     }
 
     @Override
-    public List<Type> getExceptionTypes() {
-        return decoratedAssignment.getExceptionTypes();
+    public List<Type> getThrownTypes() {
+        return decoratedAssignment.getThrownTypes();
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/model/assignment/GetterWrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/assignment/GetterWrapperForCollectionsAndMaps.java
@@ -42,28 +42,28 @@ import org.mapstruct.ap.util.Strings;
  */
 public class GetterWrapperForCollectionsAndMaps extends AssignmentWrapper {
 
-    private final List<Type> exceptionTypesToExclude;
+    private final List<Type> thrownTypesToExclude;
     private final Type localVarType;
     private final String localVarName;
 
 
-    public GetterWrapperForCollectionsAndMaps(Assignment decoratedAssignment, List<Type> exceptionTypesToExclude,
+    public GetterWrapperForCollectionsAndMaps(Assignment decoratedAssignment, List<Type> thrownTypesToExclude,
                                               Type localVarType, Collection<String> existingVariableNames) {
         super( decoratedAssignment );
-        this.exceptionTypesToExclude = exceptionTypesToExclude;
+        this.thrownTypesToExclude = thrownTypesToExclude;
         this.localVarType = localVarType;
         this.localVarName = Strings.getSaveVariableName( "target" + localVarType.getName(), existingVariableNames );
         existingVariableNames.add( localVarName );
    }
 
     @Override
-    public List<Type> getExceptionTypes() {
-        List<Type> parentExceptionTypes = super.getExceptionTypes();
-        List<Type> result = new ArrayList<Type>( parentExceptionTypes );
-        for ( Type exceptionTypeToExclude : exceptionTypesToExclude ) {
-            for ( Type parentExceptionType : parentExceptionTypes ) {
-                if ( parentExceptionType.isAssignableTo( exceptionTypeToExclude ) ) {
-                    result.remove( parentExceptionType );
+    public List<Type> getThrownTypes() {
+        List<Type> parentThrownTypes = super.getThrownTypes();
+        List<Type> result = new ArrayList<Type>( parentThrownTypes );
+        for ( Type thrownTypeToExclude : thrownTypesToExclude ) {
+            for ( Type parentThrownType : parentThrownTypes ) {
+                if ( parentThrownType.isAssignableTo( thrownTypeToExclude ) ) {
+                    result.remove( parentThrownType );
                 }
             }
         }

--- a/processor/src/main/java/org/mapstruct/ap/model/assignment/LocalVarWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/assignment/LocalVarWrapper.java
@@ -29,21 +29,21 @@ import org.mapstruct.ap.model.common.Type;
  */
 public class LocalVarWrapper extends AssignmentWrapper {
 
-    private final List<Type> exceptionTypesToExclude;
+    private final List<Type> thrownTypesToExclude;
 
-    public LocalVarWrapper( Assignment decoratedAssignment, List<Type> exceptionTypesToExclude ) {
+    public LocalVarWrapper( Assignment decoratedAssignment, List<Type> thrownTypesToExclude ) {
         super( decoratedAssignment );
-        this.exceptionTypesToExclude = exceptionTypesToExclude;
+        this.thrownTypesToExclude = thrownTypesToExclude;
     }
 
     @Override
-    public List<Type> getExceptionTypes() {
-        List<Type> parentExceptionTypes = super.getExceptionTypes();
-        List<Type> result = new ArrayList<Type>( parentExceptionTypes );
-        for ( Type exceptionTypeToExclude : exceptionTypesToExclude ) {
-            for ( Type parentExceptionType : parentExceptionTypes ) {
-                if ( parentExceptionType.isAssignableTo( exceptionTypeToExclude ) ) {
-                    result.remove( parentExceptionType );
+    public List<Type> getThrownTypes() {
+        List<Type> parentThrownTypes = super.getThrownTypes();
+        List<Type> result = new ArrayList<Type>( parentThrownTypes );
+        for ( Type thrownTypeToExclude : thrownTypesToExclude ) {
+            for ( Type parentThrownType : parentThrownTypes ) {
+                if ( parentThrownType.isAssignableTo( thrownTypeToExclude ) ) {
+                    result.remove( parentThrownType );
                 }
             }
         }

--- a/processor/src/main/java/org/mapstruct/ap/model/assignment/SetterWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/assignment/SetterWrapper.java
@@ -29,21 +29,21 @@ import org.mapstruct.ap.model.common.Type;
  */
 public class SetterWrapper extends AssignmentWrapper {
 
-    private final List<Type> exceptionTypesToExclude;
+    private final List<Type> thrownTypesToExclude;
 
-    public SetterWrapper( Assignment decoratedAssignment, List<Type> exceptionTypesToExclude ) {
+    public SetterWrapper( Assignment decoratedAssignment, List<Type> thrownTypesToExclude ) {
         super( decoratedAssignment );
-        this.exceptionTypesToExclude = exceptionTypesToExclude;
+        this.thrownTypesToExclude = thrownTypesToExclude;
     }
 
     @Override
-    public List<Type> getExceptionTypes() {
-        List<Type> parentExceptionTypes = super.getExceptionTypes();
-        List<Type> result = new ArrayList<Type>( parentExceptionTypes );
-        for ( Type exceptionTypeToExclude : exceptionTypesToExclude ) {
-            for ( Type parentExceptionType : parentExceptionTypes ) {
-                if ( parentExceptionType.isAssignableTo( exceptionTypeToExclude ) ) {
-                    result.remove( parentExceptionType );
+    public List<Type> getThrownTypes() {
+        List<Type> parentThrownTypes = super.getThrownTypes();
+        List<Type> result = new ArrayList<Type>( parentThrownTypes );
+        for ( Type thrownTypeToExclude : thrownTypesToExclude ) {
+            for ( Type parentThrownType : parentThrownTypes ) {
+                if ( parentThrownType.isAssignableTo( thrownTypeToExclude ) ) {
+                    result.remove( parentThrownType );
                 }
             }
         }

--- a/processor/src/main/java/org/mapstruct/ap/model/assignment/UpdateWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/assignment/UpdateWrapper.java
@@ -29,24 +29,23 @@ import org.mapstruct.ap.model.common.Type;
  */
 public class UpdateWrapper extends AssignmentWrapper {
 
-    private final List<Type> exceptionTypesToExclude;
+    private final List<Type> thrownTypesToExclude;
     private final Assignment factoryMethod;
 
-    public UpdateWrapper(Assignment decoratedAssignment, List<Type> exceptionTypesToExclude,
-        Assignment factoryMethod ) {
+    public UpdateWrapper(Assignment decoratedAssignment, List<Type> thrownTypesToExclude, Assignment factoryMethod ) {
         super( decoratedAssignment );
-        this.exceptionTypesToExclude = exceptionTypesToExclude;
+        this.thrownTypesToExclude = thrownTypesToExclude;
         this.factoryMethod = factoryMethod;
     }
 
     @Override
-    public List<Type> getExceptionTypes() {
-        List<Type> parentExceptionTypes = super.getExceptionTypes();
-        List<Type> result = new ArrayList<Type>( parentExceptionTypes );
-        for ( Type exceptionTypeToExclude : exceptionTypesToExclude ) {
-            for ( Type parentExceptionType : parentExceptionTypes ) {
-                if ( parentExceptionType.isAssignableTo( exceptionTypeToExclude ) ) {
-                    result.remove( parentExceptionType );
+    public List<Type> getThrownTypes() {
+        List<Type> parentThrownTypes = super.getThrownTypes();
+        List<Type> result = new ArrayList<Type>( parentThrownTypes );
+        for ( Type thrownTypeToExclude : thrownTypesToExclude ) {
+            for ( Type parentThrownType : parentThrownTypes ) {
+                if ( parentThrownType.isAssignableTo( thrownTypeToExclude ) ) {
+                    result.remove( parentThrownType );
                 }
             }
         }

--- a/processor/src/main/java/org/mapstruct/ap/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/source/ForgedMethod.java
@@ -20,7 +20,6 @@ package org.mapstruct.ap.model.source;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import javax.lang.model.element.ExecutableElement;
 
@@ -41,6 +40,7 @@ public class ForgedMethod implements Method {
     private final Type returnType;
     private final String name;
     private final ExecutableElement positionHintElement;
+    private final List<Type> thrownTypes;
 
      /**
      * Creates a new forged method with the given name.
@@ -55,6 +55,7 @@ public class ForgedMethod implements Method {
         String sourceParamSafeName = Strings.getSaveVariableName( sourceParamName );
         this.parameters = Arrays.asList( new Parameter( sourceParamSafeName, sourceType ) );
         this.returnType = targetType;
+        this.thrownTypes = new ArrayList<Type>();
         this.name = name;
         this.positionHintElement = positionHintElement;
     }
@@ -67,6 +68,7 @@ public class ForgedMethod implements Method {
     public ForgedMethod(String name, ForgedMethod forgedMethod) {
         this.parameters = forgedMethod.parameters;
         this.returnType = forgedMethod.returnType;
+        this.thrownTypes = new ArrayList<Type>();
         this.positionHintElement = forgedMethod.positionHintElement;
         this.name = name;
     }
@@ -131,7 +133,16 @@ public class ForgedMethod implements Method {
 
     @Override
     public List<Type> getThrownTypes() {
-        return Collections.<Type>emptyList();
+        return thrownTypes;
+    }
+
+    public void addThrownTypes(List<Type> thrownTypesToAdd) {
+        for ( Type thrownType : thrownTypesToAdd ) {
+            // make sure there are no duplicates coming from the keyAssignment thrown types.
+            if ( !thrownTypes.contains( thrownType ) ) {
+                thrownTypes.add( thrownType );
+            }
+        }
     }
 
     @Override

--- a/processor/src/main/resources/org.mapstruct.ap.model.BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.BeanMappingMethod.ftl
@@ -60,8 +60,7 @@
     </#if>
 }
 <#macro throws>
-    <@compress single_line=true>
-        <#if (thrownTypes?size > 0)> throws </#if>
+    <#if (thrownTypes?size > 0)><#lt> throws </#if><@compress single_line=true>
         <#list thrownTypes as exceptionType>
             <@includeModel object=exceptionType/>
             <#if exceptionType_has_next>, </#if>

--- a/processor/src/main/resources/org.mapstruct.ap.model.IterableMappingMethod.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.IterableMappingMethod.ftl
@@ -78,8 +78,7 @@
     </#if>
 }
 <#macro throws>
-    <@compress single_line=true>
-        <#if (thrownTypes?size > 0)> throws </#if>
+    <#if (thrownTypes?size > 0)><#lt> throws </#if><@compress single_line=true>
         <#list thrownTypes as exceptionType>
             <@includeModel object=exceptionType/>
             <#if exceptionType_has_next>, </#if>

--- a/processor/src/main/resources/org.mapstruct.ap.model.MapMappingMethod.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.MapMappingMethod.ftl
@@ -57,8 +57,7 @@
     </#if>
 }
 <#macro throws>
-    <@compress single_line=true>
-        <#if (thrownTypes?size > 0)> throws </#if>
+    <#if (thrownTypes?size > 0)><#lt> throws </#if><@compress single_line=true>
         <#list thrownTypes as exceptionType>
             <@includeModel object=exceptionType/>
             <#if exceptionType_has_next>, </#if>

--- a/processor/src/main/resources/org.mapstruct.ap.model.assignment.AdderWrapper.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.assignment.AdderWrapper.ftl
@@ -18,7 +18,7 @@
      limitations under the License.
 
 -->
-<#if (exceptionTypes?size == 0) >
+<#if (thrownTypes?size == 0) >
     for ( <@includeModel object=sourceType/> ${iteratorReference} : ${sourceReference} ) {
         ${ext.targetBeanName}.${ext.targetWriteAccessorName}( <@includeModel object=assignment
                 targetBeanName=ext.targetBeanName
@@ -38,7 +38,7 @@
                     targetType=ext.targetType/> );
         }
     }
-    <#list exceptionTypes as exceptionType>
+    <#list thrownTypes as exceptionType>
     catch ( <@includeModel object=exceptionType/> e ) {
         throw new RuntimeException( e );
     }

--- a/processor/src/main/resources/org.mapstruct.ap.model.assignment.ArrayCopyWrapper.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.assignment.ArrayCopyWrapper.ftl
@@ -18,7 +18,7 @@
      limitations under the License.
 
 -->
-<#if (exceptionTypes?size == 0) >
+<#if (thrownTypes?size == 0) >
     <@includeModel object=ext.targetType/> ${localVarName} = <@_assignment/>;
     ${ext.targetBeanName}.${ext.targetWriteAccessorName}( Arrays.copyOf( ${localVarName}, ${localVarName}.length ) );
 <#else>
@@ -26,7 +26,7 @@
         <@includeModel object=ext.targetType/> ${localVarName} = <@_assignment/>;
         ${ext.targetBeanName}.${ext.targetWriteAccessorName}( Arrays.copyOf( ${localVarName}, ${localVarName}.length ) );
     }
-    <#list exceptionTypes as exceptionType>
+    <#list thrownTypes as exceptionType>
     catch ( <@includeModel object=exceptionType/> e ) {
         throw new RuntimeException( e );
     }

--- a/processor/src/main/resources/org.mapstruct.ap.model.assignment.GetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.assignment.GetterWrapperForCollectionsAndMaps.ftl
@@ -22,13 +22,13 @@ if ( ${ext.targetBeanName}.${ext.targetWriteAccessorName}() != null ) {
     <#if ext.existingInstanceMapping>
         ${ext.targetBeanName}.${ext.targetWriteAccessorName}().clear();
     </#if>
-    <#if (exceptionTypes?size == 0) >
+    <#if (thrownTypes?size == 0) >
         <@_assignmentLine/>
         <#else>
         try {
             <@_assignmentLine/>
         }
-        <#list exceptionTypes as exceptionType>
+        <#list thrownTypes as exceptionType>
         catch ( <@includeModel object=exceptionType/> e ) {
             throw new RuntimeException( e );
         }

--- a/processor/src/main/resources/org.mapstruct.ap.model.assignment.LocalVarWrapper.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.assignment.LocalVarWrapper.ftl
@@ -18,14 +18,14 @@
      limitations under the License.
 
 -->
-<#if (exceptionTypes?size == 0) >
+<#if (thrownTypes?size == 0) >
     <#if !ext.isTargetDefined?? ><@includeModel object=ext.targetType/></#if> ${ext.targetWriteAccessorName} = <@_assignment/>;
 <#else>
     <#if !ext.isTargetDefined?? ><@includeModel object=ext.targetType/> ${ext.targetWriteAccessorName};</#if>
     try {
         ${ext.targetWriteAccessorName} = <@_assignment/>;
     }
-    <#list exceptionTypes as exceptionType>
+    <#list thrownTypes as exceptionType>
     catch ( <@includeModel object=exceptionType/> e ) {
        throw new RuntimeException( e );
     }

--- a/processor/src/main/resources/org.mapstruct.ap.model.assignment.SetterWrapper.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.assignment.SetterWrapper.ftl
@@ -18,13 +18,13 @@
      limitations under the License.
 
 -->
-<#if (exceptionTypes?size == 0) >
+<#if (thrownTypes?size == 0) >
         ${ext.targetBeanName}.${ext.targetWriteAccessorName}( <@_assignment/> );
 <#else>
     try {
         ${ext.targetBeanName}.${ext.targetWriteAccessorName}( <@_assignment/> );
     }
-    <#list exceptionTypes as exceptionType>
+    <#list thrownTypes as exceptionType>
     catch ( <@includeModel object=exceptionType/> e ) {
         throw new RuntimeException( e );
     }

--- a/processor/src/main/resources/org.mapstruct.ap.model.assignment.UpdateWrapper.ftl
+++ b/processor/src/main/resources/org.mapstruct.ap.model.assignment.UpdateWrapper.ftl
@@ -18,13 +18,13 @@
      limitations under the License.
 
 -->
-<#if (exceptionTypes?size == 0) >
+<#if (thrownTypes?size == 0) >
     <@_assignment/>;
 <#else>
     try {
         <@_assignment/>;
     }
-    <#list exceptionTypes as exceptionType>
+    <#list thrownTypes as exceptionType>
     catch ( <@includeModel object=exceptionType/> e ) {
         throw new RuntimeException( e );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/Issue513Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/Issue513Mapper.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue513Mapper {
+
+    Issue513Mapper INSTANCE = Mappers.getMapper( Issue513Mapper.class );
+
+
+    Target map(Source source) throws MappingException, MappingValueException, MappingKeyException;
+
+    TargetElement mapElement(SourceElement source) throws MappingException;
+
+    TargetKey mapKey(SourceKey source) throws MappingException, MappingKeyException;
+
+    TargetValue mapValue(SourceValue source) throws MappingException, MappingValueException;
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/Issue513Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/Issue513Test.java
@@ -1,0 +1,108 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Reproducer for https://github.com/mapstruct/mapstruct/issues/513.
+ *
+ * @author Sjaak Derksen
+ */
+@IssueKey( "513" )
+    @WithClasses( {
+        Issue513Mapper.class,
+        Source.class,
+        Target.class,
+        SourceElement.class,
+        TargetElement.class,
+        SourceKey.class,
+        TargetKey.class,
+        SourceValue.class,
+        TargetValue.class,
+        MappingException.class,
+        MappingKeyException.class,
+        MappingValueException.class
+    } )
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue513Test {
+
+    @Test( expected = MappingException.class )
+    public void shouldThrowMappingException() throws Exception {
+
+        Source source = new Source();
+        SourceElement sourceElement = new SourceElement();
+        sourceElement.setValue( "test" );
+        source.setCollection( Arrays.asList( new SourceElement[]{ sourceElement } ) );
+
+        Issue513Mapper.INSTANCE.map( source );
+
+    }
+
+    @Test( expected = MappingKeyException.class )
+    public void shouldThrowMappingKeyException() throws Exception {
+
+        Source source = new Source();
+        SourceKey sourceKey = new SourceKey();
+        sourceKey.setValue( MappingKeyException.class.getSimpleName() );
+        SourceValue sourceValue = new SourceValue();
+        HashMap<SourceKey, SourceValue> map = new HashMap<SourceKey, SourceValue>();
+        map.put( sourceKey, sourceValue );
+        source.setMap( map );
+
+        Issue513Mapper.INSTANCE.map( source );
+
+    }
+
+    @Test( expected = MappingValueException.class )
+    public void shouldThrowMappingValueException() throws Exception {
+
+        Source source = new Source();
+        SourceKey sourceKey = new SourceKey();
+        SourceValue sourceValue = new SourceValue();
+        sourceValue.setValue( MappingValueException.class.getSimpleName() );
+        HashMap<SourceKey, SourceValue> map = new HashMap<SourceKey, SourceValue>();
+        map.put( sourceKey, sourceValue );
+        source.setMap( map );
+
+        Issue513Mapper.INSTANCE.map( source );
+
+    }
+
+    @Test( expected = MappingException.class )
+    public void shouldThrowMappingCommonException() throws Exception {
+
+        Source source = new Source();
+        SourceKey sourceKey = new SourceKey();
+        SourceValue sourceValue = new SourceValue();
+        sourceValue.setValue( MappingException.class.getSimpleName() );
+        HashMap<SourceKey, SourceValue> map = new HashMap<SourceKey, SourceValue>();
+        map.put( sourceKey, sourceValue );
+        source.setMap( map );
+
+        Issue513Mapper.INSTANCE.map( source );
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/MappingException.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/MappingException.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class MappingException extends Exception {
+
+
+    public MappingException() {
+    }
+
+    public MappingException(String msg) {
+        super( msg );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/MappingKeyException.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/MappingKeyException.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class MappingKeyException extends Exception {
+
+
+    public MappingKeyException() {
+    }
+
+    public MappingKeyException(String msg) {
+        super( msg );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/MappingValueException.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/MappingValueException.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class MappingValueException extends Exception {
+
+
+    public MappingValueException() {
+    }
+
+    public MappingValueException(String msg) {
+        super( msg );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/Source.java
@@ -1,0 +1,50 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Source {
+
+    private Collection<SourceElement> collection;
+    private Map<SourceKey, SourceValue> map;
+
+
+    public Collection<SourceElement> getCollection() {
+        return collection;
+    }
+
+    public void setCollection(Collection<SourceElement> collection) {
+        this.collection = collection;
+    }
+
+    public Map<SourceKey, SourceValue> getMap() {
+        return map;
+    }
+
+    public void setMap(Map<SourceKey, SourceValue> map) {
+        this.map = map;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/SourceElement.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/SourceElement.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class SourceElement {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/SourceKey.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/SourceKey.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class SourceKey {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/SourceValue.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/SourceValue.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class SourceValue {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/Target.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+import java.util.Collection;
+import java.util.Map;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Target {
+
+    private  Collection<TargetElement> collection;
+    private Map<TargetKey, TargetValue> map;
+
+    public Collection<TargetElement> getCollection() {
+        return collection;
+    }
+
+    public void setCollection( Collection<TargetElement>  collection ) {
+        this.collection = collection;
+    }
+
+    public Map<TargetKey, TargetValue> getMap() {
+        return map;
+    }
+
+    public void setMap(Map<TargetKey, TargetValue> map) {
+        this.map = map;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/TargetElement.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/TargetElement.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class TargetElement {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) throws MappingException {
+        throw new MappingException();
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/TargetKey.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/TargetKey.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class TargetKey {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) throws MappingException, MappingKeyException {
+        if ( MappingKeyException.class.getSimpleName().equals( value ) ) {
+            throw new MappingKeyException();
+        }
+        else if ( MappingException.class.getSimpleName().equals( value ) ) {
+            throw new MappingException();
+        }
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/TargetValue.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/TargetValue.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._513;
+
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class TargetValue {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) throws MappingException, MappingValueException {
+        if ( MappingValueException.class.getSimpleName().equals( value ) ) {
+            throw new MappingValueException();
+        }
+        else if ( MappingException.class.getSimpleName().equals( value ) ) {
+            throw new MappingException();
+        }
+    }
+
+}


### PR DESCRIPTION
This PR contains the following commits:
1. reproducer
2. fix
3. code consistency: exceptions in a method signature are thrown types.
4. template improvement (guaranteed space before throws keyword in generated method signature)

The fix checks whether an iterable- or mapmappingmethod is forged  is forged. If so, it adds the thrown types of the used mapping methods. For mapmappingmethods it could be that an exception is already added by the key mapping. Hence the value mapping checks whether a type is already present.

I'll squash the first two commits later on.