### PR TITLE
#512, more descriptive error message for forged collection and map ma…

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/IterableMappingMethod.java
@@ -118,7 +118,13 @@ public class IterableMappingMethod extends MappingMethod {
             );
 
             if ( assignment == null ) {
-                ctx.getMessager().printMessage( method.getExecutable(), Message.ITERABLEMAPPING_MAPPING_NOT_FOUND );
+                if ( method instanceof ForgedMethod ) {
+                    // leave messaging to calling property mapping
+                    return null;
+                }
+                else {
+                    ctx.getMessager().printMessage( method.getExecutable(), Message.ITERABLEMAPPING_MAPPING_NOT_FOUND );
+                }
             }
             else {
                 if ( method instanceof ForgedMethod ) {

--- a/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/MapMappingMethod.java
@@ -131,7 +131,14 @@ public class MapMappingMethod extends MappingMethod {
             );
 
             if ( keyAssignment == null ) {
-                ctx.getMessager().printMessage( method.getExecutable(), Message.MAPMAPPING_KEY_MAPPING_NOT_FOUND );
+                if ( method instanceof ForgedMethod ) {
+                    // leave messaging to calling property mapping
+                    return null;
+                }
+                else {
+                    ctx.getMessager().printMessage( method.getExecutable(),
+                        Message.MAPMAPPING_KEY_MAPPING_NOT_FOUND );
+                }
             }
 
             // find mapping method or conversion for value
@@ -162,7 +169,14 @@ public class MapMappingMethod extends MappingMethod {
             }
 
             if ( valueAssignment == null ) {
-                ctx.getMessager().printMessage( method.getExecutable(), Message.MAPMAPPING_VALUE_MAPPING_NOT_FOUND );
+                if ( method instanceof ForgedMethod ) {
+                    // leave messaging to calling property mapping
+                    return null;
+                }
+                else {
+                    ctx.getMessager().printMessage( method.getExecutable(),
+                        Message.MAPMAPPING_VALUE_MAPPING_NOT_FOUND );
+                }
             }
 
             // mapNullToDefault

--- a/processor/src/main/java/org/mapstruct/ap/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/model/PropertyMapping.java
@@ -467,17 +467,18 @@ public class PropertyMapping extends ModelElement {
                     .method( methodRef )
                     .build();
 
-                if ( !ctx.getMappingsToGenerate().contains( iterableMappingMethod ) ) {
-                    ctx.getMappingsToGenerate().add( iterableMappingMethod );
-                }
-                else {
-                    String existingName = ctx.getExistingMappingMethod( iterableMappingMethod ).getName();
-                    methodRef = new ForgedMethod( existingName, methodRef );
-                }
+                if ( iterableMappingMethod != null ) {
+                    if ( !ctx.getMappingsToGenerate().contains( iterableMappingMethod ) ) {
+                        ctx.getMappingsToGenerate().add( iterableMappingMethod );
+                    }
+                    else {
+                        String existingName = ctx.getExistingMappingMethod( iterableMappingMethod ).getName();
+                        methodRef = new ForgedMethod( existingName, methodRef );
+                    }
 
-                assignment = AssignmentFactory.createMethodReference( methodRef, null, targetType );
-                assignment.setAssignment( AssignmentFactory.createDirect( sourceReference ) );
-
+                    assignment = AssignmentFactory.createMethodReference( methodRef, null, targetType );
+                    assignment.setAssignment( AssignmentFactory.createDirect( sourceReference ) );
+                }
             }
             else if ( sourceType.isMapType() && targetType.isMapType() ) {
 
@@ -489,15 +490,17 @@ public class PropertyMapping extends ModelElement {
                     .method( methodRef )
                     .build();
 
-                if ( !ctx.getMappingsToGenerate().contains( mapMappingMethod ) ) {
-                    ctx.getMappingsToGenerate().add( mapMappingMethod );
+                if ( mapMappingMethod != null ) {
+                    if ( !ctx.getMappingsToGenerate().contains( mapMappingMethod ) ) {
+                        ctx.getMappingsToGenerate().add( mapMappingMethod );
+                    }
+                    else {
+                        String existingName = ctx.getExistingMappingMethod( mapMappingMethod ).getName();
+                        methodRef = new ForgedMethod( existingName, methodRef );
+                    }
+                    assignment = AssignmentFactory.createMethodReference( methodRef, null, targetType );
+                    assignment.setAssignment( AssignmentFactory.createDirect( sourceReference ) );
                 }
-                else {
-                    String existingName = ctx.getExistingMappingMethod( mapMappingMethod ).getName();
-                    methodRef = new ForgedMethod( existingName, methodRef );
-                }
-                assignment = AssignmentFactory.createMethodReference( methodRef, null, targetType );
-                assignment.setAssignment( AssignmentFactory.createDirect( sourceReference ) );
             }
             return assignment;
         }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/Bar.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/Bar.java
@@ -1,0 +1,27 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.forged;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Bar {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/CollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/CollectionMappingTest.java
@@ -21,11 +21,15 @@ package org.mapstruct.ap.test.collection.forged;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
+import javax.tools.Diagnostic.Kind;
 import static org.fest.assertions.Assertions.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 import org.mapstruct.ap.util.Collections;
 
@@ -71,5 +75,47 @@ public class CollectionMappingTest {
         assertThat( source2 ).isNotNull();
         assertThat( source2.getBarMap() ).isEqualTo( sourceMap );
     }
+
+    @Test
+    @WithClasses({ ErroneousCollectionNonMappableSetMapper.class,
+        ErroneousNonMappableSetSource.class,
+        ErroneousNonMappableSetTarget.class,
+        Foo.class,
+        Bar.class
+    })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousCollectionNonMappableSetMapper.class,
+                kind = Kind.ERROR,
+                line = 30,
+                messageRegExp = "Can't map property \".* nonMappableSet\" to \".* nonMappableSet\". "
+                    + "Consider to declare/implement a mapping method: .*."),
+        }
+    )
+    public void shouldGenerateNonMappleMethodForSetMapping() {
+    }
+
+   @Test
+    @WithClasses({ ErroneousCollectionNonMappableMapMapper.class,
+        ErroneousNonMappableMapSource.class,
+        ErroneousNonMappableMapTarget.class,
+        Foo.class,
+        Bar.class
+    })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousCollectionNonMappableMapMapper.class,
+                kind = Kind.ERROR,
+                line = 30,
+                messageRegExp = "Can't map property \".* nonMappableMap\" to \".* nonMappableMap\". "
+                    + "Consider to declare/implement a mapping method: .*."),
+        }
+    )
+    public void shouldGenerateNonMappleMethodForMapMapping() {
+    }
+
+
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousCollectionNonMappableMapMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousCollectionNonMappableMapMapper.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.forged;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ErroneousCollectionNonMappableMapMapper {
+
+    ErroneousCollectionNonMappableMapMapper INSTANCE =
+        Mappers.getMapper( ErroneousCollectionNonMappableMapMapper.class );
+
+    ErroneousNonMappableMapTarget sourceToTarget(ErroneousNonMappableMapSource source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousCollectionNonMappableSetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousCollectionNonMappableSetMapper.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.forged;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ErroneousCollectionNonMappableSetMapper {
+
+    ErroneousCollectionNonMappableSetMapper INSTANCE =
+        Mappers.getMapper( ErroneousCollectionNonMappableSetMapper.class );
+
+    ErroneousNonMappableSetTarget sourceToTarget(ErroneousNonMappableSetSource source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousNonMappableMapSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousNonMappableMapSource.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.forged;
+
+import java.util.Map;
+
+public class ErroneousNonMappableMapSource {
+
+    private Map<Foo, Foo> nonMappableMap;
+
+    public Map<Foo, Foo> getNonMappableMap() {
+        return nonMappableMap;
+    }
+
+    public void setNonMappableMap(Map<Foo, Foo> nonMappableMap) {
+        this.nonMappableMap = nonMappableMap;
+    }
+
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousNonMappableMapTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousNonMappableMapTarget.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.forged;
+
+import java.util.Map;
+
+public class ErroneousNonMappableMapTarget {
+
+    private Map<Bar, Bar> nonMappableMap;
+
+    public Map<Bar, Bar> getNonMappableMap() {
+        return nonMappableMap;
+    }
+
+    public void setNonMappableMap(Map<Bar, Bar> nonMappableMap) {
+        this.nonMappableMap = nonMappableMap;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousNonMappableSetSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousNonMappableSetSource.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.forged;
+
+import java.util.Set;
+
+public class ErroneousNonMappableSetSource {
+
+    private Set<Foo> nonMappableSet;
+
+    public Set<Foo> getNonMappableSet() {
+        return nonMappableSet;
+    }
+
+    public void setNonMappableSet(Set<Foo> nonMappableSet) {
+        this.nonMappableSet = nonMappableSet;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousNonMappableSetTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/ErroneousNonMappableSetTarget.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.forged;
+
+import java.util.Set;
+
+public class ErroneousNonMappableSetTarget {
+
+    private Set<Bar> nonMappableSet;
+
+    public Set<Bar> getNonMappableSet() {
+        return nonMappableSet;
+    }
+
+    public void setNonMappableSet(Set<Bar> nonMappableSet) {
+        this.nonMappableSet = nonMappableSet;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/Foo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/Foo.java
@@ -1,0 +1,27 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.forged;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Foo {
+
+}


### PR DESCRIPTION
…ppings

The error handling for forging methods is now handled by the property mapping. At that spot was already a good message. For 'plain' Iterable and MapMappings the error stays the same, since the location hint is sufficient in that case 