### PR TITLE
#574 determine property type from getter/setter methods only in combination with ExecutableType

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -33,6 +33,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
 import javax.tools.Diagnostic;
 
@@ -404,9 +405,11 @@ public class BeanMappingMethod extends MappingMethod {
                         if ( sourceAccessor != null ) {
                             Mapping mapping = method.getSingleMappingByTargetPropertyName( targetProperty.getKey() );
 
+                            TypeElement sourceType = sourceParameter.getType().getTypeElement();
+
                             SourceReference sourceRef = new SourceReference.BuilderFromProperty()
                                 .sourceParameter( sourceParameter )
-                                .type( ctx.getTypeFactory().getReturnType( sourceAccessor ) )
+                                .type( ctx.getTypeFactory().getReturnType( sourceType, sourceAccessor ) )
                                 .accessor( sourceAccessor )
                                 .name( targetProperty.getKey() )
                                 .build();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -454,10 +454,14 @@ public class PropertyMapping extends ModelElement {
             switch ( targetAccessorType ) {
                 case ADDER:
                 case SETTER:
-                    return ctx.getTypeFactory().getSingleParameter( targetWriteAccessor ).getType();
+                    return ctx.getTypeFactory().getSingleParameter(
+                        method.getResultType().getTypeElement(),
+                        targetWriteAccessor ).getType();
                 case GETTER:
                 default:
-                    return ctx.getTypeFactory().getReturnType( targetWriteAccessor );
+                    return ctx.getTypeFactory().getReturnType(
+                        method.getResultType().getTypeElement(),
+                        targetWriteAccessor );
             }
         }
 
@@ -570,10 +574,14 @@ public class PropertyMapping extends ModelElement {
             // target
             Type targetType;
             if ( Executables.isSetterMethod( targetWriteAccessor ) ) {
-                targetType = ctx.getTypeFactory().getSingleParameter( targetWriteAccessor ).getType();
+                targetType = ctx.getTypeFactory().getSingleParameter(
+                    method.getResultType().getTypeElement(),
+                    targetWriteAccessor ).getType();
             }
             else {
-                targetType = ctx.getTypeFactory().getReturnType( targetWriteAccessor );
+                targetType = ctx.getTypeFactory().getReturnType(
+                    method.getResultType().getTypeElement(),
+                    targetWriteAccessor );
             }
 
             Assignment assignment = ctx.getMappingResolver().getTargetAssignment(
@@ -659,10 +667,14 @@ public class PropertyMapping extends ModelElement {
             if ( Executables.isSetterMethod( targetWriteAccessor ) ) {
                 // setter, so wrap in setter
                 assignment = new SetterWrapper( assignment, method.getThrownTypes() );
-                targetType = ctx.getTypeFactory().getSingleParameter( targetWriteAccessor ).getType();
+                targetType = ctx.getTypeFactory().getSingleParameter(
+                    method.getResultType().getTypeElement(),
+                    targetWriteAccessor ).getType();
             }
             else {
-                targetType = ctx.getTypeFactory().getReturnType( targetWriteAccessor );
+                targetType = ctx.getTypeFactory().getReturnType(
+                    method.getResultType().getTypeElement(),
+                    targetWriteAccessor );
                 // target accessor is getter, so wrap the setter in getter map/ collection handling
                 assignment = new GetterWrapperForCollectionsAndMaps(
                     assignment,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -398,7 +398,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                 // first check if there's a setter method.
                 ExecutableElement adderMethod = null;
                 if ( Executables.isSetterMethod( candidate ) ) {
-                    Type targetType = typeFactory.getSingleParameter( candidate ).getType();
+                    Type targetType = typeFactory.getSingleParameter( typeElement, candidate ).getType();
                     // ok, the current accessor is a setter. So now the strategy determines what to use
                     if ( cmStrategy == CollectionMappingStrategyPrism.ADDER_PREFERRED ) {
                         adderMethod = getAdderForType( targetType, targetPropertyName );
@@ -407,7 +407,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                 else if ( Executables.isGetterMethod( candidate ) ) {
                         // the current accessor is a getter (no setter available). But still, an add method is according
                     // to the above strategy (SETTER_PREFERRED || ADDER_PREFERRED) preferred over the getter.
-                    Type targetType = typeFactory.getReturnType( candidate );
+                    Type targetType = typeFactory.getReturnType( typeFactory.getMethodType( typeElement, candidate ) );
                     adderMethod = getAdderForType( targetType, targetPropertyName );
                 }
                 if ( adderMethod != null ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -181,7 +181,7 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
 
         ExecutableType methodType = typeFactory.getMethodType( usedMapper, method );
         List<Parameter> parameters = typeFactory.getParameters( methodType, method );
-        Type returnType = typeFactory.getReturnType( method );
+        Type returnType = typeFactory.getReturnType( methodType );
 
         boolean methodRequiresImplementation = method.getModifiers().contains( Modifier.ABSTRACT );
         boolean containsTargetTypeParameter = SourceMethod.containsTargetTypeParameter( parameters );

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/AbstractIdHoldingTo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/AbstractIdHoldingTo.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.generics;
+
+/**
+ * @author Andreas Gudian
+ */
+public abstract class AbstractIdHoldingTo<ID> {
+    private ID id;
+
+    public ID getId() {
+        return this.id;
+    }
+
+    public void setId(ID id) {
+        this.id = id;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/AbstractTo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/AbstractTo.java
@@ -1,0 +1,26 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.generics;
+
+
+/**
+ * @author Andreas Gudian
+ */
+public abstract class AbstractTo extends AbstractIdHoldingTo<Long> {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/GenericsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/GenericsTest.java
@@ -1,0 +1,50 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.generics;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Andreas Gudian
+ *
+ */
+@WithClasses({
+    AbstractTo.class,
+    AbstractIdHoldingTo.class,
+    Source.class,
+    SourceTargetMapper.class,
+    TargetTo.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class GenericsTest {
+
+    @Test
+    @IssueKey("574")
+    public void mapsIdCorrectly() {
+        TargetTo target = new TargetTo();
+        target.setId( 41L );
+        assertThat( SourceTargetMapper.INSTANCE.toSource( target ).getId() ).isEqualTo( 41L );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/Source.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.generics;
+
+/**
+ * @author Andreas Gudian
+ *
+ */
+public class Source {
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/SourceTargetMapper.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.generics;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Andreas Gudian
+ *
+ */
+@Mapper
+public abstract class SourceTargetMapper {
+
+    public static final SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    public abstract Source toSource(TargetTo target);
+
+    public abstract TargetTo toTarget(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/TargetTo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/TargetTo.java
@@ -1,0 +1,29 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.generics;
+
+
+/**
+ * @author Andreas Gudian
+ *
+ */
+public class TargetTo extends AbstractTo {
+
+
+}


### PR DESCRIPTION
… i.e. using asMemberOf to determine the type with any generics being resolved.

One thing that might still be open is the handling of lower/upper bounds, in case the generic type variables are not resolved completely. But that' s an improvement that can wait for 1.1, I'd say...