### PR TITLE
Fix IndexOutOfBounds exception during mapping two arrays to collections.

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -302,8 +302,10 @@ public class IterableMappingMethod extends MappingMethod {
         }
 
         for ( int i = 0; i < getSourceParameters().size(); i++ ) {
-            if ( !getSourceParameters().get( i ).getType().getTypeParameters().get( 0 )
-                .equals( other.getSourceParameters().get( i ).getType().getTypeParameters().get( 0 ) ) ) {
+            List<Type> thisTypeParameters = getSourceParameters().get( i ).getType().getTypeParameters();
+            List<Type> otherTypeParameters = other.getSourceParameters().get( i ).getType().getTypeParameters();
+
+            if ( !thisTypeParameters.equals( otherTypeParameters ) ) {
                 return false;
             }
         }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_577/Issue577Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_577/Issue577Test.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._577;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+@IssueKey( "577" )
+@WithClasses({ Source.class, Target.class, SourceTargetMapper.class })
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue577Test {
+
+    @Test
+    public void shouldMapTwoArraysToCollections() {
+        Source source = new Source();
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_577/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_577/Source.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._577;
+
+public class Source {
+
+    private int[] first;
+
+    private int[] second;
+
+    public int[] getFirst() {
+        return first;
+    }
+
+    public void setFirst(int[] first) {
+        this.first = first;
+    }
+
+    public int[] getSecond() {
+        return second;
+    }
+
+    public void setSecond(int[] second) {
+        this.second = second;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_577/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_577/SourceTargetMapper.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._577;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface SourceTargetMapper {
+
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    Target sourceToTarget(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_577/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_577/Target.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._577;
+
+import java.util.List;
+
+public class Target {
+
+    private List<Integer> first;
+
+    private List<Integer> second;
+
+    public List<Integer> getFirst() {
+        return first;
+    }
+
+    public void setFirst(List<Integer> first) {
+        this.first = first;
+    }
+
+    public List<Integer> getSecond() {
+        return second;
+    }
+
+    public void setSecond(List<Integer> second) {
+        this.second = second;
+    }
+}


### PR DESCRIPTION
Hello,

I'm not sure if issue 577 reported recently should be fixed in IterableMappingMethod:equals() method. Maybe getTypeParameters() should never be empty and fix is needed elsewhere. But if it is indeed just missing check for empty collection, then I prepared fix for this issue.