### PR TITLE
#580 Add null-check for mapped -> type-converted property mapping.

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -47,6 +47,7 @@ import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 
 import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType.DIRECT;
+import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType.MAPPED_TYPE_CONVERTED;
 import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType.TYPE_CONVERTED;
 import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType.TYPE_CONVERTED_MAPPED;
 
@@ -262,7 +263,8 @@ public class PropertyMapping extends ModelElement {
                     && !sourceReference.getPropertyEntries().isEmpty() /* parameter null taken care of by beanmapper */
                     && ( result.getType() == TYPE_CONVERTED
                     || result.getType() == TYPE_CONVERTED_MAPPED
-                    || result.getType() == DIRECT && targetType.isPrimitive() ) ) {
+                    || result.getType() == MAPPED_TYPE_CONVERTED
+                    || ( result.getType() == DIRECT && targetType.isPrimitive() ) ) ) {
                     // for primitive types null check is not possible at all, but a conversion needs
                     // a null check.
                     result = new NullCheckWrapper( result );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/UpdateNullCheckWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/UpdateNullCheckWrapper.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model.assignment;
+
+/**
+ * Wraps an update-assignment in a null check and sets the target property to {@code null}, if the source is
+ * {@code null}.
+ *
+ * @author Andreas Gudian
+ */
+public class UpdateNullCheckWrapper extends AssignmentWrapper {
+
+    public UpdateNullCheckWrapper( Assignment decoratedAssignment ) {
+        super( decoratedAssignment );
+    }
+}

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/UpdateNullCheckWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/UpdateNullCheckWrapper.ftl
@@ -1,0 +1,31 @@
+<#--
+
+     Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+     and/or other contributors as indicated by the @authors tag. See the
+     copyright.txt file in the distribution for a full listing of all
+     contributors.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+if ( ${sourceReference} != null ) {
+    <@includeModel object=assignment
+                targetBeanName=ext.targetBeanName
+                existingInstanceMapping=ext.existingInstanceMapping
+                targetReadAccessorName=ext.targetReadAccessorName
+                targetWriteAccessorName=ext.targetWriteAccessorName
+                targetType=ext.targetType/>
+}
+else {
+    ${ext.targetBeanName}.${ext.targetWriteAccessorName}( null );
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_580/Issue580Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_580/Issue580Test.java
@@ -1,0 +1,81 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._580;
+
+import java.time.LocalDate;
+
+import javax.xml.datatype.DatatypeConstants;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Andreas Gudian
+ */
+@IssueKey("580")
+@WithClasses({ Source.class, Target.class, SourceTargetMapper.class })
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue580Test {
+
+    @Test
+    public void shouldNullCheckOnBuiltinAndConversion() {
+        Target target = SourceTargetMapper.INSTANCE.toTarget( new Source() );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getDate() ).isNull();
+
+        Source source = SourceTargetMapper.INSTANCE.toSource( new Target() );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getDate() ).isNull();
+    }
+
+    @Test
+    public void shouldMapCorrectlyOnBuiltinAndConversion() throws Exception {
+        XMLGregorianCalendar calendarDate = DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
+            2007,
+            11,
+            14,
+            DatatypeConstants.FIELD_UNDEFINED );
+
+        LocalDate localDate = LocalDate.of( 2007, 11, 14 );
+
+        Source s1 = new Source();
+        s1.setDate( calendarDate );
+        Target target = SourceTargetMapper.INSTANCE.toTarget( s1 );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getDate() ).isEqualTo( localDate );
+
+
+        Target t1 = new Target();
+        t1.setDate( localDate );
+        Source source = SourceTargetMapper.INSTANCE.toSource( t1 );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getDate() ).isEqualTo( calendarDate );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_580/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_580/Source.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._580;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+
+/**
+ * @author Andreas Gudian
+ */
+public class Source {
+    private XMLGregorianCalendar date;
+
+    public XMLGregorianCalendar getDate() {
+        return date;
+    }
+
+    public void setDate(XMLGregorianCalendar date) {
+        this.date = date;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_580/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_580/SourceTargetMapper.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._580;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Andreas Gudian
+ */
+@Mapper
+public interface SourceTargetMapper {
+
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    Target toTarget(Source source);
+
+    Source toSource(Target target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_580/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_580/Target.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._580;
+
+import java.time.LocalDate;
+
+/**
+ * @author Andreas Gudian
+ */
+public class Target {
+
+    private LocalDate date;
+
+    public LocalDate getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDate date) {
+        this.date = date;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
@@ -20,15 +20,14 @@ package org.mapstruct.ap.test.updatemethods;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import static org.fest.assertions.Assertions.assertThat;
-
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.fest.assertions.Assertions.assertThat;
 
 /**
  *
@@ -85,6 +84,30 @@ public class UpdateMethodsTest {
     @WithClasses( {
         OrganizationMapper.class
     } )
+    public void testUpdateMethodClearsExistingValues() {
+
+        OrganizationEntity organizationEntity = new OrganizationEntity();
+        CompanyEntity companyEntity = new CompanyEntity();
+        organizationEntity.setCompany( companyEntity );
+        companyEntity.setName( "CocaCola" );
+        DepartmentEntity department = new DepartmentEntity( null );
+        department.setName( "recipies" );
+        companyEntity.setDepartment( department );
+
+        OrganizationDto organizationDto = new OrganizationDto();
+        organizationDto.setCompany( null );
+
+        OrganizationMapper.INSTANCE.toOrganizationEntity( organizationDto, organizationEntity );
+
+        assertThat( organizationEntity.getCompany() ).isNull();
+        assertThat( organizationEntity.getType().getType() ).isEqualTo( "commercial" );
+        assertThat( organizationEntity.getTypeNr().getNumber() ).isEqualTo( 5 );
+    }
+
+    @Test
+    @WithClasses({
+        OrganizationMapper.class
+    })
     public void testPreferUpdateMethodSourceObjectNotDefined() {
 
         OrganizationEntity organizationEntity = new OrganizationEntity();
@@ -105,7 +128,7 @@ public class UpdateMethodsTest {
         assertThat( organizationEntity.getCompany().getDepartment().getName() ).isEqualTo( "finance" );
     }
 
-  @Test
+    @Test
     @WithClasses( {
         CompanyMapper.class,
         DepartmentInBetween.class
@@ -156,7 +179,7 @@ public class UpdateMethodsTest {
     } )
     public void testShouldFailOnConstantMappingNoPropertyGetter() { }
 
-   @Test
+    @Test
     @WithClasses( {
         ErroneousCompanyMapper1.class,
         DepartmentInBetween.class


### PR DESCRIPTION
At least our built-in mapping methods return null for null input, which would break the type-conversion.

@sjaakd, I think this null-check was left out intentionally to give users the chance to manually map null-values to non-null values? Could you please give this a quick check?
