### PR TITLE
#581 Prevent multiple imports of similar simple class name from different packages

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -405,7 +405,8 @@ public class TypeFactory {
     }
 
     private boolean isImported(String name, String qualifiedName) {
-        String importedType = importedQualifiedTypesBySimpleName.get( name );
+        String trimmedName = TypeFactory.trimSimpleClassName( name );
+        String importedType = importedQualifiedTypesBySimpleName.get( trimmedName );
 
         boolean imported = false;
         if ( importedType != null ) {
@@ -414,7 +415,7 @@ public class TypeFactory {
             }
         }
         else {
-            importedQualifiedTypesBySimpleName.put( name, qualifiedName );
+            importedQualifiedTypesBySimpleName.put( trimmedName, qualifiedName );
             imported = true;
         }
         return imported;
@@ -464,6 +465,17 @@ public class TypeFactory {
         }
 
         return collectionOrMap;
+    }
+
+    static String trimSimpleClassName(String className) {
+        if ( className == null ) {
+            return null;
+        }
+        String trimmedClassName = className;
+        while ( trimmedClassName.endsWith( "[]" ) ) {
+            trimmedClassName = trimmedClassName.substring( 0, trimmedClassName.length() - 2 );
+        }
+        return trimmedClassName;
     }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/TypeFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/TypeFactoryTest.java
@@ -1,0 +1,63 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model.common;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+
+public class TypeFactoryTest {
+
+    @Test
+    public void shouldReturnNullIfNoClassNameIsProvided() {
+        String result = TypeFactory.trimSimpleClassName( null );
+
+        assertThat( result ).isNull();
+    }
+
+    @Test
+    public void shouldNotModifyClassNameIfNotAnArray() {
+        String className = "SimpleClass";
+
+        String result = TypeFactory.trimSimpleClassName( className );
+
+        assertThat( result ).isEqualTo( className );
+    }
+
+    @Test
+    public void shouldTrimOneDimensionalArray() {
+        String result = TypeFactory.trimSimpleClassName( "SimpleClass[]" );
+
+        assertThat( result ).isEqualTo( "SimpleClass" );
+    }
+
+    @Test
+    public void shouldTrimTwoDimensionalArray() {
+        String result = TypeFactory.trimSimpleClassName( "SimpleClass[][]" );
+
+        assertThat( result ).isEqualTo( "SimpleClass" );
+    }
+
+    @Test
+    public void shouldTrimMultiDimensionalArray() {
+        String result = TypeFactory.trimSimpleClassName( "SimpleClass[][][][][]" );
+
+        assertThat( result ).isEqualTo( "SimpleClass" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_581/Issue581Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_581/Issue581Test.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._581;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.bugs._581.source.Car;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+@IssueKey( "581" )
+@WithClasses({ Car.class, org.mapstruct.ap.test.bugs._581._target.Car.class, SourceTargetMapper.class })
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue581Test {
+
+    @Test
+    public void shouldMapSourceAndTargetWithTheSameClassName() {
+        Car source = new Car();
+
+        org.mapstruct.ap.test.bugs._581._target.Car target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFoo() ).isEqualTo( source.getFoo() );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_581/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_581/SourceTargetMapper.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._581;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.bugs._581.source.Car;
+import org.mapstruct.factory.Mappers;
+
+import java.util.List;
+
+@Mapper
+public interface SourceTargetMapper {
+
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    org.mapstruct.ap.test.bugs._581._target.Car[] sourceToTarget( List<Car> source );
+
+    org.mapstruct.ap.test.bugs._581._target.Car sourceToTarget( Car source );
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_581/_target/Car.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_581/_target/Car.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._581._target;
+
+public class Car {
+
+    private String foo;
+
+    public String getFoo() {
+        return foo;
+    }
+
+    public void setFoo(String foo) {
+        this.foo = foo;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_581/source/Car.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_581/source/Car.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._581.source;
+
+public class Car {
+
+    private String foo;
+
+    public String getFoo() {
+        return foo;
+    }
+
+    public void setFoo(String foo) {
+        this.foo = foo;
+    }
+}


### PR DESCRIPTION
Hello,

As discussed in bug ticket, I've finalized fix for #581 issue.
Few topics you might want to review, since I don't know yet, if you accept few code conventions I usually follow.

1. I consider good practice to not modify method parameters, to consider it final. Therefore when I need to modify it, I usually introduce new local variable and use it from there. That's the reason for adding *String trimmedName* in *isImported()* and use it instead of method parameter.

2. I moved code responsible for handling array brackets in simple class names to separate utility class, so I could add unit tests for it.