### PR TITLE
Make destination package and name configurable

### DIFF
--- a/core-common/src/main/java/org/mapstruct/Mapper.java
+++ b/core-common/src/main/java/org/mapstruct/Mapper.java
@@ -85,6 +85,28 @@ public @interface Mapper {
     String componentModel() default "default";
 
     /**
+     * Specifies the name of the implementation class. A single {@code *} wildcard can be used and will be replaced
+     * by the interface's or abstract class' name.
+     * <p>
+     * Defaults to postfixing the name with {@code Impl}
+     *
+     * @return The implementation suffix.
+     * @see #implementationPackage()
+     */
+    String implementationName() default "default";
+
+    /**
+     * Specifies the target package for the generated implementation.  A single {@code *} wildcard can be used and will
+     * be replaced by the interface's or abstract class' package.
+     * <p>
+     * Defaults to using the same package as the mapper interface/abstract class
+     *
+     * @return the destination package.
+     * @see #implementationName()
+     */
+    String implementationPackage() default "default";
+
+    /**
      * A class annotated with {@link MapperConfig} which should be used as configuration template. Any settings given
      * via {@link Mapper} will take precedence over the settings from the referenced configuration source. The list of
      * referenced mappers will contain all mappers given via {@link Mapper#uses()} and {@link MapperConfig#uses()}.

--- a/core-common/src/main/java/org/mapstruct/Mapper.java
+++ b/core-common/src/main/java/org/mapstruct/Mapper.java
@@ -85,26 +85,26 @@ public @interface Mapper {
     String componentModel() default "default";
 
     /**
-     * Specifies the name of the implementation class. A single {@code *} wildcard can be used and will be replaced
-     * by the interface's or abstract class' name.
+     * Specifies the name of the implementation class. The {@code <CLASS_NAME>} will be replaced by the
+     * interface/abstract class name.
      * <p>
-     * Defaults to postfixing the name with {@code Impl}
+     * Defaults to postfixing the name with {@code Impl}: {@code <CLASS_NAME>Impl}
      *
-     * @return The implementation suffix.
+     * @return The implementation name.
      * @see #implementationPackage()
      */
-    String implementationName() default "default";
+    String implementationName() default "<CLASS_NAME>Impl";
 
     /**
-     * Specifies the target package for the generated implementation.  A single {@code *} wildcard can be used and will
-     * be replaced by the interface's or abstract class' package.
+     * Specifies the target package for the generated implementation. The {@code <CLASS_NAME>} will be replaced
+     * by the interface's or abstract class' package.
      * <p>
      * Defaults to using the same package as the mapper interface/abstract class
      *
-     * @return the destination package.
+     * @return the implementation package.
      * @see #implementationName()
      */
-    String implementationPackage() default "default";
+    String implementationPackage() default "<PACKAGE_NAME>";
 
     /**
      * A class annotated with {@link MapperConfig} which should be used as configuration template. Any settings given

--- a/core-common/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core-common/src/main/java/org/mapstruct/MapperConfig.java
@@ -85,26 +85,26 @@ public @interface MapperConfig {
     String componentModel() default "default";
 
     /**
-     * Specifies the name of the implementation class. A single {@code *} wildcard can be used and will be replaced
-     * by the interface's or abstract class' name.
+     * Specifies the name of the implementation class. The {@code <CLASS_NAME>} will be replaced by the
+     * interface/abstract class name.
      * <p>
-     * Defaults to postfixing the name with {@code Impl}
+     * Defaults to postfixing the name with {@code Impl}: {@code <CLASS_NAME>Impl}
      *
-     * @return The implementation suffix.
+     * @return The implementation name.
      * @see #implementationPackage()
      */
-    String implementationName() default "default";
+    String implementationName() default "<CLASS_NAME>Impl";
 
     /**
-     * Specifies the target package for the generated implementation.  A single {@code *} wildcard can be used and will
-     * be replaced by the interface's or abstract class' package.
+     * Specifies the target package for the generated implementation. The {@code <CLASS_NAME>} will be replaced
+     * by the interface's or abstract class' package.
      * <p>
      * Defaults to using the same package as the mapper interface/abstract class
      *
-     * @return the destination package.
+     * @return the implementation package.
      * @see #implementationName()
      */
-    String implementationPackage() default "default";
+    String implementationPackage() default "<PACKAGE_NAME>";
 
     /**
      * The strategy to be applied when propagating the value of collection-typed properties. By default, only JavaBeans

--- a/core-common/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core-common/src/main/java/org/mapstruct/MapperConfig.java
@@ -85,6 +85,28 @@ public @interface MapperConfig {
     String componentModel() default "default";
 
     /**
+     * Specifies the name of the implementation class. A single {@code *} wildcard can be used and will be replaced
+     * by the interface's or abstract class' name.
+     * <p>
+     * Defaults to postfixing the name with {@code Impl}
+     *
+     * @return The implementation suffix.
+     * @see #implementationPackage()
+     */
+    String implementationName() default "default";
+
+    /**
+     * Specifies the target package for the generated implementation.  A single {@code *} wildcard can be used and will
+     * be replaced by the interface's or abstract class' package.
+     * <p>
+     * Defaults to using the same package as the mapper interface/abstract class
+     *
+     * @return the destination package.
+     * @see #implementationName()
+     */
+    String implementationPackage() default "default";
+
+    /**
      * The strategy to be applied when propagating the value of collection-typed properties. By default, only JavaBeans
      * accessor methods (setters or getters) will be used, but it is also possible to invoke a corresponding adder
      * method for each element of the source collection (e.g. {@code orderDto.addOrderLine()}).

--- a/core-common/src/main/java/org/mapstruct/factory/Mappers.java
+++ b/core-common/src/main/java/org/mapstruct/factory/Mappers.java
@@ -75,20 +75,24 @@ public class Mappers {
                 classLoader = Mappers.class.getClassLoader();
             }
 
-            ServiceLoader<T> loader = ServiceLoader.load( clazz, classLoader );
+            try {
+                @SuppressWarnings("unchecked")
+                T mapper = (T) classLoader.loadClass( clazz.getName() + IMPLEMENTATION_SUFFIX ).newInstance();
+                return mapper;
+            }
+            catch (ClassNotFoundException e) {
+                ServiceLoader<T> loader = ServiceLoader.load( clazz, classLoader );
 
-            if ( loader != null ) {
-                for ( T mapper : loader ) {
-                    if ( mapper != null ) {
-                        return mapper;
+                if ( loader != null ) {
+                    for ( T mapper : loader ) {
+                        if ( mapper != null ) {
+                            return mapper;
+                        }
                     }
                 }
+
+                throw new ClassNotFoundException("Cannot find implementation for " + clazz.getName());
             }
-
-            @SuppressWarnings("unchecked")
-            T mapper = (T) classLoader.loadClass( clazz.getName() + IMPLEMENTATION_SUFFIX ).newInstance();
-
-            return mapper;
         }
         catch ( Exception e ) {
             throw new RuntimeException( e );

--- a/core-common/src/main/java/org/mapstruct/factory/Mappers.java
+++ b/core-common/src/main/java/org/mapstruct/factory/Mappers.java
@@ -20,6 +20,8 @@ package org.mapstruct.factory;
 
 import org.mapstruct.Mapper;
 
+import java.util.ServiceLoader;
+
 /**
  * Factory for obtaining mapper instances if no explicit component model such as CDI is configured via
  * {@link Mapper#componentModel()}.
@@ -71,6 +73,16 @@ public class Mappers {
 
             if ( classLoader == null ) {
                 classLoader = Mappers.class.getClassLoader();
+            }
+
+            ServiceLoader<T> loader = ServiceLoader.load( clazz, classLoader );
+
+            if ( loader != null ) {
+                for ( T mapper : loader ) {
+                    if ( mapper != null ) {
+                        return mapper;
+                    }
+                }
             }
 
             @SuppressWarnings("unchecked")

--- a/core-common/src/test/java/org/mapstruct/factory/MappersTest.java
+++ b/core-common/src/test/java/org/mapstruct/factory/MappersTest.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.factory;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.mapstruct.test.model.Foo;
+
+/**
+ * Unit test for {@link Mappers}.
+ *
+ * @author Gunnar Morling
+ */
+public class MappersTest {
+
+    @Test
+    public void shouldReturnImplementationInstance() {
+
+        Foo mapper = Mappers.getMapper( Foo.class );
+        assertThat( mapper ).isNotNull();
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
@@ -101,6 +101,7 @@ public class MappingProcessor extends AbstractProcessor {
         "mapstruct.suppressGeneratorVersionInfoComment";
     protected static final String UNMAPPED_TARGET_POLICY = "mapstruct.unmappedTargetPolicy";
     protected static final String DEFAULT_COMPONENT_MODEL = "mapstruct.defaultComponentModel";
+    protected static final String ALWAYS_GENERATE_SPI = "mapstruct.alwaysGenerateSpi";
 
     private Options options;
 
@@ -113,12 +114,14 @@ public class MappingProcessor extends AbstractProcessor {
 
     private Options createOptions() {
         String unmappedTargetPolicy = processingEnv.getOptions().get( UNMAPPED_TARGET_POLICY );
+        String defaultComponentModel = processingEnv.getOptions().get( DEFAULT_COMPONENT_MODEL );
 
         return new Options(
             Boolean.valueOf( processingEnv.getOptions().get( SUPPRESS_GENERATOR_TIMESTAMP ) ),
             Boolean.valueOf( processingEnv.getOptions().get( SUPPRESS_GENERATOR_VERSION_INFO_COMMENT ) ),
             unmappedTargetPolicy != null ? ReportingPolicy.valueOf( unmappedTargetPolicy ) : null,
-            processingEnv.getOptions().get( DEFAULT_COMPONENT_MODEL )
+            defaultComponentModel == null ? "default" : defaultComponentModel,
+            Boolean.valueOf( processingEnv.getOptions().get( ALWAYS_GENERATE_SPI ) )
         );
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
@@ -101,7 +101,7 @@ public class MappingProcessor extends AbstractProcessor {
         "mapstruct.suppressGeneratorVersionInfoComment";
     protected static final String UNMAPPED_TARGET_POLICY = "mapstruct.unmappedTargetPolicy";
     protected static final String DEFAULT_COMPONENT_MODEL = "mapstruct.defaultComponentModel";
-    protected static final String ALWAYS_GENERATE_SPI = "mapstruct.alwaysGenerateSpi";
+    protected static final String ALWAYS_GENERATE_SERVICE_FILE = "mapstruct.alwaysGenerateServicesFile";
 
     private Options options;
 
@@ -121,7 +121,7 @@ public class MappingProcessor extends AbstractProcessor {
             Boolean.valueOf( processingEnv.getOptions().get( SUPPRESS_GENERATOR_VERSION_INFO_COMMENT ) ),
             unmappedTargetPolicy != null ? ReportingPolicy.valueOf( unmappedTargetPolicy ) : null,
             defaultComponentModel == null ? "default" : defaultComponentModel,
-            Boolean.valueOf( processingEnv.getOptions().get( ALWAYS_GENERATE_SPI ) )
+            Boolean.valueOf( processingEnv.getOptions().get( ALWAYS_GENERATE_SERVICE_FILE ) )
         );
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Decorator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Decorator.java
@@ -18,20 +18,19 @@
  */
 package org.mapstruct.ap.internal.model;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.SortedSet;
-
-import javax.lang.model.element.ElementKind;
-import javax.lang.model.element.TypeElement;
-import javax.lang.model.util.Elements;
-
 import org.mapstruct.ap.internal.model.common.Accessibility;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.option.Options;
 import org.mapstruct.ap.internal.prism.DecoratedWithPrism;
 import org.mapstruct.ap.internal.version.VersionInformation;
+
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.util.Elements;
+import java.util.Arrays;
+import java.util.List;
+import java.util.SortedSet;
 
 /**
  * Represents a decorator applied to a generated mapper type.
@@ -95,12 +94,12 @@ public class Decorator extends GeneratedType {
         }
 
         public Builder implName(String implName) {
-            this.implName = "default".equals( implName ) ? "*Impl" : implName;
+            this.implName = "default".equals( implName ) ? Mapper.DEFAULT_IMPLEMENTATION_CLASS : implName;
             return this;
         }
 
         public Builder implPackage(String implPackage) {
-            this.implPackage = "default".equals( implPackage ) ? "*" : implPackage;
+            this.implPackage = "default".equals( implPackage ) ? Mapper.DEFAULT_IMPLEMENTATION_PACKAGE : implPackage;
             return this;
         }
 
@@ -110,7 +109,8 @@ public class Decorator extends GeneratedType {
         }
 
         public Decorator build() {
-            String implementationName = implName.replace( "*", mapperElement.getSimpleName() );
+            String implementationName = implName.replace( Mapper.CLASS_NAME_PLACEHOLDER,
+                                                          mapperElement.getSimpleName() );
 
             Type decoratorType = typeFactory.getType( decoratorPrism.value() );
             DecoratorConstructor decoratorConstructor = new DecoratorConstructor(
@@ -120,7 +120,7 @@ public class Decorator extends GeneratedType {
 
 
             String elementPackage = elementUtils.getPackageOf( mapperElement ).getQualifiedName().toString();
-            String packageName = implPackage.replace( "*", elementPackage );
+            String packageName = implPackage.replace( Mapper.PACKAGE_NAME_PLACEHOLDER, elementPackage );
 
             return new Decorator(
                 typeFactory,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Decorator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Decorator.java
@@ -21,7 +21,6 @@ package org.mapstruct.ap.internal.model;
 import java.util.Arrays;
 import java.util.List;
 import java.util.SortedSet;
-import java.util.TreeSet;
 
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
@@ -41,8 +40,6 @@ import org.mapstruct.ap.internal.version.VersionInformation;
  */
 public class Decorator extends GeneratedType {
 
-    private static final String IMPLEMENTATION_SUFFIX = "Impl";
-
     public static class Builder {
 
         private Elements elementUtils;
@@ -53,6 +50,9 @@ public class Decorator extends GeneratedType {
         private Options options;
         private VersionInformation versionInformation;
         private boolean hasDelegateConstructor;
+        private String implName;
+        private String implPackage;
+        private SortedSet<Type> extraImportedTypes;
 
         public Builder elementUtils(Elements elementUtils) {
             this.elementUtils = elementUtils;
@@ -94,25 +94,47 @@ public class Decorator extends GeneratedType {
             return this;
         }
 
+        public Builder implName(String implName) {
+            this.implName = "default".equals( implName ) ? "*Impl" : implName;
+            return this;
+        }
+
+        public Builder implPackage(String implPackage) {
+            this.implPackage = "default".equals( implPackage ) ? "*" : implPackage;
+            return this;
+        }
+
+        public Builder extraImports(SortedSet<Type> extraImportedTypes) {
+            this.extraImportedTypes = extraImportedTypes;
+            return this;
+        }
+
         public Decorator build() {
+            String implementationName = implName.replace( "*", mapperElement.getSimpleName() );
+
             Type decoratorType = typeFactory.getType( decoratorPrism.value() );
             DecoratorConstructor decoratorConstructor = new DecoratorConstructor(
-                        mapperElement.getSimpleName().toString() + IMPLEMENTATION_SUFFIX,
-                        mapperElement.getSimpleName().toString() + "Impl_",
+                        implementationName,
+                        implementationName + "_",
                         hasDelegateConstructor );
 
 
+            String elementPackage = elementUtils.getPackageOf( mapperElement ).getQualifiedName().toString();
+            String packageName = implPackage.replace( "*", elementPackage );
+
             return new Decorator(
                 typeFactory,
-                elementUtils.getPackageOf( mapperElement ).getQualifiedName().toString(),
-                mapperElement.getSimpleName().toString() + IMPLEMENTATION_SUFFIX,
+                packageName,
+                implementationName,
                 decoratorType,
+                elementPackage,
                 mapperElement.getKind() == ElementKind.INTERFACE ? mapperElement.getSimpleName().toString() : null,
                 methods,
                 Arrays.asList(  new Field( typeFactory.getType( mapperElement ), "delegate", true ) ) ,
                 options,
                 versionInformation,
                 Accessibility.fromModifiers( mapperElement.getModifiers() ),
+                extraImportedTypes,
                 decoratorConstructor
             );
         }
@@ -122,21 +144,23 @@ public class Decorator extends GeneratedType {
 
     @SuppressWarnings( "checkstyle:parameternumber" )
     private Decorator(TypeFactory typeFactory, String packageName, String name, Type decoratorType,
-                     String interfaceName, List<MappingMethod> methods, List<? extends Field> fields,
-                     Options options, VersionInformation versionInformation, Accessibility accessibility,
-                     DecoratorConstructor decoratorConstructor) {
+                      String interfacePackage, String interfaceName, List<MappingMethod> methods,
+                      List<? extends Field> fields, Options options, VersionInformation versionInformation,
+                      Accessibility accessibility, SortedSet<Type> extraImports,
+                      DecoratorConstructor decoratorConstructor) {
         super(
             typeFactory,
             packageName,
             name,
             decoratorType.getName(),
+            interfacePackage,
             interfaceName,
             methods,
             fields,
             options,
             versionInformation,
             accessibility,
-            new TreeSet<Type>(),
+            extraImports,
             decoratorConstructor
         );
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -45,6 +45,7 @@ public abstract class GeneratedType extends ModelElement {
     private final String packageName;
     private final String name;
     private final String superClassName;
+    private final String interfacePackage;
     private final String interfaceName;
 
     private final List<Annotation> annotations;
@@ -65,7 +66,7 @@ public abstract class GeneratedType extends ModelElement {
 
     // CHECKSTYLE:OFF
     protected GeneratedType(TypeFactory typeFactory, String packageName, String name, String superClassName,
-                            String interfaceName,
+                            String interfacePackage, String interfaceName,
                             List<MappingMethod> methods,
                             List<? extends Field> fields,
                             Options options,
@@ -76,6 +77,7 @@ public abstract class GeneratedType extends ModelElement {
         this.packageName = packageName;
         this.name = name;
         this.superClassName = superClassName;
+        this.interfacePackage = interfacePackage;
         this.interfaceName = interfaceName;
         this.extraImportedTypes = extraImportedTypes;
 
@@ -104,6 +106,10 @@ public abstract class GeneratedType extends ModelElement {
 
     public String getSuperClassName() {
         return superClassName;
+    }
+
+    public String getInterfacePackage() {
+        return interfacePackage;
     }
 
     public String getInterfaceName() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
@@ -39,6 +39,11 @@ import org.mapstruct.ap.internal.version.VersionInformation;
  */
 public class Mapper extends GeneratedType {
 
+    static final String CLASS_NAME_PLACEHOLDER = "<CLASS_NAME>";
+    static final String PACKAGE_NAME_PLACEHOLDER = "<PACKAGE_NAME>";
+    static final String DEFAULT_IMPLEMENTATION_CLASS = CLASS_NAME_PLACEHOLDER + "Impl";
+    static final String DEFAULT_IMPLEMENTATION_PACKAGE = PACKAGE_NAME_PLACEHOLDER;
+
     private final boolean customPackage;
     private final boolean customImplName;
     private final List<MapperReference> referencedMappers;
@@ -136,23 +141,23 @@ public class Mapper extends GeneratedType {
         }
 
         public Builder implName(String implName) {
-            this.implName = "default".equals( implName ) ? "*Impl" : implName;
-            this.customName = !"*Impl".equals( this.implName );
+            this.implName = "default".equals( implName ) ? DEFAULT_IMPLEMENTATION_CLASS : implName;
+            this.customName = !DEFAULT_IMPLEMENTATION_CLASS.equals( this.implName );
             return this;
         }
 
         public Builder implPackage(String implPackage) {
-            this.implPackage = "default".equals( implPackage ) ? "*" : implPackage;
-            this.customPackage = !"*".equals( this.implPackage );
+            this.implPackage = "default".equals( implPackage ) ? DEFAULT_IMPLEMENTATION_PACKAGE : implPackage;
+            this.customPackage = !DEFAULT_IMPLEMENTATION_PACKAGE.equals( this.implPackage );
             return this;
         }
 
         public Mapper build() {
-            String implementationName = implName.replace( "*", element.getSimpleName() ) +
+            String implementationName = implName.replace( CLASS_NAME_PLACEHOLDER, element.getSimpleName() ) +
                     ( decorator == null ? "" : "_" );
 
             String elementPackage = elementUtils.getPackageOf( element ).getQualifiedName().toString();
-            String packageName = implPackage.replace( "*", elementPackage );
+            String packageName = implPackage.replace( PACKAGE_NAME_PLACEHOLDER, elementPackage );
 
             return new Mapper(
                 typeFactory,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
@@ -141,13 +141,13 @@ public class Mapper extends GeneratedType {
         }
 
         public Builder implName(String implName) {
-            this.implName = "default".equals( implName ) ? DEFAULT_IMPLEMENTATION_CLASS : implName;
+            this.implName = implName;
             this.customName = !DEFAULT_IMPLEMENTATION_CLASS.equals( this.implName );
             return this;
         }
 
         public Builder implPackage(String implPackage) {
-            this.implPackage = "default".equals( implPackage ) ? DEFAULT_IMPLEMENTATION_PACKAGE : implPackage;
+            this.implPackage = implPackage;
             this.customPackage = !DEFAULT_IMPLEMENTATION_PACKAGE.equals( this.implPackage );
             return this;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ServicesEntry.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ServicesEntry.java
@@ -1,0 +1,66 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model;
+
+import org.mapstruct.ap.internal.model.common.ModelElement;
+import org.mapstruct.ap.internal.model.common.Type;
+
+import java.util.Collections;
+import java.util.Set;
+
+/**
+ * @author Christophe Labouisse on 14/07/2015.
+ */
+public class ServicesEntry extends ModelElement {
+    private final String packageName;
+
+    private final String name;
+
+    private final String implementationPackage;
+
+    private final String implementationName;
+
+    public ServicesEntry(String packageName, String name, String implementationPackage, String implementationName) {
+        this.packageName = packageName;
+        this.name = name;
+        this.implementationPackage = implementationPackage;
+        this.implementationName = implementationName;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return Collections.emptySet();
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getImplementationPackage() {
+        return implementationPackage;
+    }
+
+    public String getImplementationName() {
+        return implementationName;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/option/Options.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/option/Options.java
@@ -29,15 +29,17 @@ public class Options {
     private final boolean suppressGeneratorTimestamp;
     private final boolean suppressGeneratorVersionComment;
     private final ReportingPolicy unmappedTargetPolicy;
+    private final boolean alwaysGenerateSpi;
     private final String defaultComponentModel;
 
     public Options(boolean suppressGeneratorTimestamp, boolean suppressGeneratorVersionComment,
                    ReportingPolicy unmappedTargetPolicy,
-                   String defaultComponentModel) {
+                   String defaultComponentModel, boolean alwaysGenerateSpi) {
         this.suppressGeneratorTimestamp = suppressGeneratorTimestamp;
         this.suppressGeneratorVersionComment = suppressGeneratorVersionComment;
         this.unmappedTargetPolicy = unmappedTargetPolicy;
         this.defaultComponentModel = defaultComponentModel;
+        this.alwaysGenerateSpi = alwaysGenerateSpi;
     }
 
     public boolean isSuppressGeneratorTimestamp() {
@@ -54,5 +56,9 @@ public class Options {
 
     public String getDefaultComponentModel() {
         return defaultComponentModel;
+    }
+
+    public boolean isAlwaysGenerateSpi() {
+        return alwaysGenerateSpi;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -242,7 +242,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
         }
 
         // Add original package if a dest package has been set
-        if ( !"*".equals( mapperConfiguration.implementationPackage() ) ) {
+        if ( !"default".equals( mapperConfiguration.implementationPackage() ) ) {
             extraImports.add( typeFactory.getType( element ) );
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -150,16 +150,20 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
             .mapperReferences( mapperReferences )
             .options( options )
             .versionInformation( versionInformation )
-            .decorator( getDecorator( element, methods ) )
+            .decorator( getDecorator( element, methods, mapperConfig.implementationName(),
+                        mapperConfig.implementationPackage() ) )
             .typeFactory( typeFactory )
             .elementUtils( elementUtils )
             .extraImports( getExtraImports( element ) )
+            .implName( mapperConfig.implementationName() )
+            .implPackage( mapperConfig.implementationPackage() )
             .build();
 
         return mapper;
     }
 
-    private Decorator getDecorator(TypeElement element, List<SourceMethod> methods) {
+    private Decorator getDecorator(TypeElement element, List<SourceMethod> methods, String implName,
+                                   String implPackage) {
         DecoratedWithPrism decoratorPrism = DecoratedWithPrism.getInstanceOn( element );
 
         if ( decoratorPrism == null ) {
@@ -219,6 +223,9 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
              .hasDelegateConstructor( hasDelegateConstructor )
              .options( options )
              .versionInformation( versionInformation )
+            .implName( implName )
+            .implPackage( implPackage )
+            .extraImports( getExtraImports( element ) )
              .build();
 
         return decorator;
@@ -232,6 +239,11 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
         for ( TypeMirror extraImport : mapperConfiguration.imports() ) {
             Type type = typeFactory.getType( extraImport );
             extraImports.add( type );
+        }
+
+        // Add original package if a dest package has been set
+        if ( !"*".equals( mapperConfiguration.implementationPackage() ) ) {
+            extraImports.add( typeFactory.getType( element ) );
         }
 
         return extraImports;

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperRenderingProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperRenderingProcessor.java
@@ -72,6 +72,6 @@ public class MapperRenderingProcessor implements ModelElementProcessor<Mapper, M
 
     @Override
     public int getPriority() {
-        return 10000;
+        return 9999;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperServiceProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperServiceProcessor.java
@@ -32,6 +32,12 @@ import javax.tools.StandardLocation;
 import java.io.IOException;
 
 /**
+ * A {@link ModelElementProcessor} which creates files in the {@code META-INF/services}
+ * hierarchy for classes with custom implementation class or package name.
+ *
+ * Service files will only be generated for mappers with the default component model
+ * unless force using the {@code mapstruct.alwaysGenerateServicesFile} option.
+ *
  * @author Christophe Labouisse on 12/07/2015.
  */
 public class MapperServiceProcessor  implements ModelElementProcessor<Mapper, Void> {
@@ -60,7 +66,7 @@ public class MapperServiceProcessor  implements ModelElementProcessor<Mapper, Vo
 
     @Override
     public int getPriority() {
-        return 100000;
+        return 10000;
     }
 
     private void writeToSourceFile(Filer filer, Mapper model) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
@@ -35,16 +35,6 @@ import org.mapstruct.ap.internal.prism.MapperPrism;
 import org.mapstruct.ap.internal.prism.MappingInheritanceStrategyPrism;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
 
-import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.Element;
-import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeKind;
-import javax.lang.model.type.TypeMirror;
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
-
 /**
  * Provides an aggregated view to the settings given via {@link org.mapstruct.Mapper} and
  * {@link org.mapstruct.MapperConfig} for a specific mapper class.

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
@@ -18,22 +18,21 @@
  */
 package org.mapstruct.ap.internal.util;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Set;
+import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
+import org.mapstruct.ap.internal.prism.MapperConfigPrism;
+import org.mapstruct.ap.internal.prism.MapperPrism;
+import org.mapstruct.ap.internal.prism.MappingInheritanceStrategyPrism;
+import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-
-import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
-import org.mapstruct.ap.internal.prism.MapperConfigPrism;
-import org.mapstruct.ap.internal.prism.MapperPrism;
-import org.mapstruct.ap.internal.prism.MappingInheritanceStrategyPrism;
-import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 
 /**
  * Provides an aggregated view to the settings given via {@link org.mapstruct.Mapper} and
@@ -66,23 +65,21 @@ public class MapperConfiguration {
     }
 
     public String implementationName() {
-        if ( !mapperPrism.implementationName().equals( "default" ) ) {
-            return mapperPrism.implementationName();
-        }
-        else if ( mapperConfigPrism != null ) {
+        if ( mapperConfigPrism != null && mapperPrism.values.implementationName() == null ) {
             return mapperConfigPrism.implementationName();
         }
-        return "default";
+        else {
+            return mapperPrism.implementationName();
+        }
     }
 
     public String implementationPackage() {
-        if ( !mapperPrism.implementationPackage().equals( "default" ) ) {
-            return mapperPrism.implementationPackage();
-        }
-        else if ( ( mapperConfigPrism != null ) ) {
+        if ( mapperConfigPrism != null && mapperPrism.values.implementationPackage() == null ) {
             return mapperConfigPrism.implementationPackage();
         }
-        return "default";
+        else {
+            return mapperPrism.implementationPackage();
+        }
     }
 
     public List<TypeMirror> uses() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
@@ -35,6 +35,16 @@ import org.mapstruct.ap.internal.prism.MapperPrism;
 import org.mapstruct.ap.internal.prism.MappingInheritanceStrategyPrism;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
 
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
 /**
  * Provides an aggregated view to the settings given via {@link org.mapstruct.Mapper} and
  * {@link org.mapstruct.MapperConfig} for a specific mapper class.
@@ -63,6 +73,26 @@ public class MapperConfiguration {
         else {
             this.mapperConfigPrism = null;
         }
+    }
+
+    public String implementationName() {
+        if ( !mapperPrism.implementationName().equals( "default" ) ) {
+            return mapperPrism.implementationName();
+        }
+        else if ( mapperConfigPrism != null ) {
+            return mapperConfigPrism.implementationName();
+        }
+        return "default";
+    }
+
+    public String implementationPackage() {
+        if ( !mapperPrism.implementationPackage().equals( "default" ) ) {
+            return mapperPrism.implementationPackage();
+        }
+        else if ( ( mapperConfigPrism != null ) ) {
+            return mapperConfigPrism.implementationPackage();
+        }
+        return "default";
     }
 
     public List<TypeMirror> uses() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/writer/ModelWriter.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/writer/ModelWriter.java
@@ -29,7 +29,7 @@ import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.tools.JavaFileObject;
+import javax.tools.FileObject;
 
 import org.mapstruct.ap.internal.writer.Writable.Context;
 
@@ -74,7 +74,7 @@ public class ModelWriter {
         CONFIGURATION.setLocalizedLookup( false );
     }
 
-    public void writeModel(JavaFileObject sourceFile, Writable model) {
+    public void writeModel(FileObject sourceFile, Writable model) {
         try {
             BufferedWriter writer = new BufferedWriter( new IndentationCorrectingWriter( sourceFile.openWriter() ) );
 

--- a/processor/src/main/resources/META-INF/services/org.mapstruct.ap.internal.processor.ModelElementProcessor
+++ b/processor/src/main/resources/META-INF/services/org.mapstruct.ap.internal.processor.ModelElementProcessor
@@ -21,3 +21,4 @@ org.mapstruct.ap.internal.processor.MapperCreationProcessor
 org.mapstruct.ap.internal.processor.MapperRenderingProcessor
 org.mapstruct.ap.internal.processor.MethodRetrievalProcessor
 org.mapstruct.ap.internal.processor.SpringComponentProcessor
+org.mapstruct.ap.internal.processor.MapperServiceProcessor

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ServicesEntry.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ServicesEntry.ftl
@@ -1,0 +1,21 @@
+<#--
+
+     Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+     and/or other contributors as indicated by the @authors tag. See the
+     copyright.txt file in the distribution for a full listing of all
+     contributors.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+${implementationPackage}.${implementationName}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapper.java
@@ -24,7 +24,7 @@ import org.mapstruct.factory.Mappers;
 /**
  * @author Christophe Labouisse on 27/05/2015.
  */
-@Mapper(implementationName = "My*CustomImpl")
+@Mapper(implementationName = "My<CLASS_NAME>CustomImpl")
 public interface DestinationClassNameMapper {
     DestinationClassNameMapper INSTANCE = Mappers.getMapper( DestinationClassNameMapper.class );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapper.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Christophe Labouisse on 27/05/2015.
+ */
+@Mapper(implementationName = "My*CustomImpl")
+public interface DestinationClassNameMapper {
+    DestinationClassNameMapper INSTANCE = Mappers.getMapper( DestinationClassNameMapper.class );
+
+    String intToString(Integer source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperConfig.java
@@ -23,6 +23,6 @@ import org.mapstruct.MapperConfig;
 /**
  * @author Christophe Labouisse on 30/05/2015.
  */
-@MapperConfig(implementationName = "My*ConfigImpl")
+@MapperConfig(implementationName = "My<CLASS_NAME>ConfigImpl")
 public interface DestinationClassNameMapperConfig {
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperConfig.java
@@ -1,0 +1,28 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.mapstruct.MapperConfig;
+
+/**
+ * @author Christophe Labouisse on 30/05/2015.
+ */
+@MapperConfig(implementationName = "My*ConfigImpl")
+public interface DestinationClassNameMapperConfig {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperDecorated.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperDecorated.java
@@ -25,7 +25,7 @@ import org.mapstruct.factory.Mappers;
 /**
  * @author Christophe Labouisse on 27/05/2015.
  */
-@Mapper(implementationName = "My*CustomImpl")
+@Mapper(implementationName = "My<CLASS_NAME>CustomImpl")
 @DecoratedWith(DestinationClassNameMapperDecorator.class)
 public interface DestinationClassNameMapperDecorated {
     DestinationClassNameMapperDecorated INSTANCE = Mappers.getMapper( DestinationClassNameMapperDecorated.class );

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperDecorated.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperDecorated.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.mapstruct.DecoratedWith;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Christophe Labouisse on 27/05/2015.
+ */
+@Mapper(implementationName = "My*CustomImpl")
+@DecoratedWith(DestinationClassNameMapperDecorator.class)
+public interface DestinationClassNameMapperDecorated {
+    DestinationClassNameMapperDecorated INSTANCE = Mappers.getMapper( DestinationClassNameMapperDecorated.class );
+
+    String intToString(Integer source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperDecorator.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperDecorator.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+/**
+ * @author Christophe Labouisse on 31/05/2015.
+ */
+public abstract class DestinationClassNameMapperDecorator implements DestinationClassNameMapperDecorated {
+    final DestinationClassNameMapperDecorated delegate;
+
+    protected DestinationClassNameMapperDecorator(DestinationClassNameMapperDecorated delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String intToString(Integer source) {
+        return delegate.intToString( source );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperWithConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperWithConfig.java
@@ -16,25 +16,17 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct;
+package org.mapstruct.ap.test.destination;
 
-import static org.fest.assertions.Assertions.assertThat;
-
-import org.junit.Test;
+import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
-import org.mapstruct.test.model.Foo;
 
 /**
- * Unit test for {@link Mappers}.
- *
- * @author Gunnar Morling
+ * @author Christophe Labouisse on 27/05/2015.
  */
-public class MappersTest {
+@Mapper(config = DestinationClassNameMapperConfig.class)
+public interface DestinationClassNameMapperWithConfig {
+    DestinationClassNameMapperWithConfig INSTANCE = Mappers.getMapper( DestinationClassNameMapperWithConfig.class );
 
-    @Test
-    public void shouldReturnImplementationInstance() {
-
-        Foo mapper = Mappers.getMapper( Foo.class );
-        assertThat( mapper ).isNotNull();
-    }
+    String intToString(Integer source);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperWithConfigOverride.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperWithConfigOverride.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Christophe Labouisse on 27/05/2015.
+ */
+@Mapper(config = DestinationClassNameMapperConfig.class, implementationName = "Custom*MyImpl")
+public interface DestinationClassNameMapperWithConfigOverride {
+    DestinationClassNameMapperWithConfigOverride INSTANCE =
+            Mappers.getMapper( DestinationClassNameMapperWithConfigOverride.class );
+
+    String intToString(Integer source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperWithConfigOverride.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameMapperWithConfigOverride.java
@@ -24,7 +24,7 @@ import org.mapstruct.factory.Mappers;
 /**
  * @author Christophe Labouisse on 27/05/2015.
  */
-@Mapper(config = DestinationClassNameMapperConfig.class, implementationName = "Custom*MyImpl")
+@Mapper(config = DestinationClassNameMapperConfig.class, implementationName = "Custom<CLASS_NAME>MyImpl")
 public interface DestinationClassNameMapperWithConfigOverride {
     DestinationClassNameMapperWithConfigOverride INSTANCE =
             Mappers.getMapper( DestinationClassNameMapperWithConfigOverride.class );

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameTest.java
@@ -1,0 +1,66 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Christophe Labouisse on 27/05/2015.
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+public class DestinationClassNameTest {
+    @Test
+    @WithClasses({ DestinationClassNameMapper.class })
+    public void shouldGenerateRightName() throws Exception {
+        DestinationClassNameMapper instance = DestinationClassNameMapper.INSTANCE;
+        assertThat( instance.getClass().getSimpleName() ).isEqualTo( "MyDestinationClassNameMapperCustomImpl" );
+    }
+
+    @Test
+    @WithClasses({ DestinationClassNameMapperConfig.class, DestinationClassNameMapperWithConfig.class })
+    public void shouldGenerateRightNameWithConfig() throws Exception {
+        DestinationClassNameMapperWithConfig instance = DestinationClassNameMapperWithConfig.INSTANCE;
+        assertThat( instance.getClass().getSimpleName() )
+                .isEqualTo( "MyDestinationClassNameMapperWithConfigConfigImpl" );
+    }
+
+    @Test
+    @WithClasses({ DestinationClassNameMapperConfig.class, DestinationClassNameMapperWithConfigOverride.class })
+    public void shouldGenerateRightNameWithConfigOverride() throws Exception {
+        DestinationClassNameMapperWithConfigOverride instance = DestinationClassNameMapperWithConfigOverride.INSTANCE;
+        assertThat( instance.getClass().getSimpleName() )
+                .isEqualTo( "CustomDestinationClassNameMapperWithConfigOverrideMyImpl" );
+    }
+
+    @Test
+    @WithClasses({ DestinationClassNameMapperDecorated.class, DestinationClassNameMapperDecorator.class })
+    public void shouldGenerateRightNameWithDecorator() throws Exception {
+        DestinationClassNameMapperDecorated instance = DestinationClassNameMapperDecorated.INSTANCE;
+        assertThat( instance.getClass().getSimpleName() )
+                .isEqualTo( "MyDestinationClassNameMapperDecoratedCustomImpl" );
+        assertThat( instance ).isInstanceOf( DestinationClassNameMapperDecorator.class );
+        assertThat( ( (DestinationClassNameMapperDecorator) instance ).delegate.getClass().getSimpleName() )
+                .isEqualTo( "MyDestinationClassNameMapperDecoratedCustomImpl_" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameTest.java
@@ -18,10 +18,12 @@
  */
 package org.mapstruct.ap.test.destination;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.factory.Mappers;
 
 import static org.fest.assertions.Assertions.assertThat;
 
@@ -35,6 +37,26 @@ public class DestinationClassNameTest {
     public void shouldGenerateRightName() throws Exception {
         DestinationClassNameMapper instance = DestinationClassNameMapper.INSTANCE;
         assertThat( instance.getClass().getSimpleName() ).isEqualTo( "MyDestinationClassNameMapperCustomImpl" );
+    }
+
+    @Test
+    @WithClasses({ DestinationClassNameWithJsr330Mapper.class })
+    public void shouldNotGenerateSpi() throws Exception {
+
+        Class<DestinationClassNameWithJsr330Mapper> clazz = DestinationClassNameWithJsr330Mapper.class;
+        try {
+            Mappers.getMapper( clazz );
+            Assert.fail( "Should have thrown an ClassNotFoundException" );
+        }
+        catch ( RuntimeException e ) {
+            assertThat( e.getCause() ).isNotNull()
+                    .isExactlyInstanceOf( ClassNotFoundException.class )
+                    .hasMessage( "Cannot find implementation for " + clazz.getName() );
+        }
+
+        DestinationClassNameWithJsr330Mapper instance = (DestinationClassNameWithJsr330Mapper) Class
+                .forName( clazz.getName() + "Jsr330Impl" ).newInstance();
+        assertThat( instance.getClass().getSimpleName() ).isEqualTo( "DestinationClassNameWithJsr330MapperJsr330Impl" );
     }
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameWithJsr330Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameWithJsr330Mapper.java
@@ -1,0 +1,29 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Christophe Labouisse on 27/05/2015.
+ */
+@Mapper(implementationName = "<CLASS_NAME>Jsr330Impl", componentModel = "jsr330")
+public interface DestinationClassNameWithJsr330Mapper {
+    String intToString(Integer source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapper.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Christophe Labouisse on 27/05/2015.
+ */
+@Mapper(implementationPackage = "*.dest")
+public interface DestinationPackageNameMapper {
+    DestinationPackageNameMapper INSTANCE = Mappers.getMapper( DestinationPackageNameMapper.class );
+
+    String intToString(Integer source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapper.java
@@ -24,7 +24,7 @@ import org.mapstruct.factory.Mappers;
 /**
  * @author Christophe Labouisse on 27/05/2015.
  */
-@Mapper(implementationPackage = "*.dest")
+@Mapper(implementationPackage = "<PACKAGE_NAME>.dest")
 public interface DestinationPackageNameMapper {
     DestinationPackageNameMapper INSTANCE = Mappers.getMapper( DestinationPackageNameMapper.class );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperConfig.java
@@ -1,0 +1,28 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.mapstruct.MapperConfig;
+
+/**
+ * @author Christophe Labouisse on 30/05/2015.
+ */
+@MapperConfig(implementationPackage = "*.dest")
+public interface DestinationPackageNameMapperConfig {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperConfig.java
@@ -23,6 +23,6 @@ import org.mapstruct.MapperConfig;
 /**
  * @author Christophe Labouisse on 30/05/2015.
  */
-@MapperConfig(implementationPackage = "*.dest")
+@MapperConfig(implementationPackage = "<PACKAGE_NAME>.dest")
 public interface DestinationPackageNameMapperConfig {
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperDecorated.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperDecorated.java
@@ -25,7 +25,7 @@ import org.mapstruct.factory.Mappers;
 /**
  * @author Christophe Labouisse on 27/05/2015.
  */
-@Mapper(implementationPackage = "*.dest")
+@Mapper(implementationPackage = "<PACKAGE_NAME>.dest")
 @DecoratedWith(DestinationPackageNameMapperDecorator.class)
 public interface DestinationPackageNameMapperDecorated {
     DestinationPackageNameMapperDecorated INSTANCE = Mappers.getMapper( DestinationPackageNameMapperDecorated.class );

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperDecorated.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperDecorated.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.mapstruct.DecoratedWith;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Christophe Labouisse on 27/05/2015.
+ */
+@Mapper(implementationPackage = "*.dest")
+@DecoratedWith(DestinationPackageNameMapperDecorator.class)
+public interface DestinationPackageNameMapperDecorated {
+    DestinationPackageNameMapperDecorated INSTANCE = Mappers.getMapper( DestinationPackageNameMapperDecorated.class );
+
+    String intToString(Integer source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperDecorator.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperDecorator.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+/**
+ * @author Christophe Labouisse on 31/05/2015.
+ */
+public abstract class DestinationPackageNameMapperDecorator implements DestinationPackageNameMapperDecorated {
+    final DestinationPackageNameMapperDecorated delegate;
+
+    protected DestinationPackageNameMapperDecorator(DestinationPackageNameMapperDecorated delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String intToString(Integer source) {
+        return delegate.intToString( source );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperWithConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperWithConfig.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Christophe Labouisse on 27/05/2015.
+ */
+@Mapper(config = DestinationPackageNameMapperConfig.class)
+public interface DestinationPackageNameMapperWithConfig {
+    DestinationPackageNameMapperWithConfig INSTANCE = Mappers.getMapper( DestinationPackageNameMapperWithConfig.class );
+
+    String intToString(Integer source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperWithConfigOverride.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperWithConfigOverride.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Christophe Labouisse on 27/05/2015.
+ */
+@Mapper(config = DestinationPackageNameMapperConfig.class, implementationPackage = "*.my_dest")
+public interface DestinationPackageNameMapperWithConfigOverride {
+    DestinationPackageNameMapperWithConfigOverride INSTANCE =
+            Mappers.getMapper( DestinationPackageNameMapperWithConfigOverride.class );
+
+    String intToString(Integer source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperWithConfigOverride.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperWithConfigOverride.java
@@ -24,7 +24,7 @@ import org.mapstruct.factory.Mappers;
 /**
  * @author Christophe Labouisse on 27/05/2015.
  */
-@Mapper(config = DestinationPackageNameMapperConfig.class, implementationPackage = "*.my_dest")
+@Mapper(config = DestinationPackageNameMapperConfig.class, implementationPackage = "<PACKAGE_NAME>.my_dest")
 public interface DestinationPackageNameMapperWithConfigOverride {
     DestinationPackageNameMapperWithConfigOverride INSTANCE =
             Mappers.getMapper( DestinationPackageNameMapperWithConfigOverride.class );

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperWithSuffix.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperWithSuffix.java
@@ -24,7 +24,7 @@ import org.mapstruct.factory.Mappers;
 /**
  * @author Christophe Labouisse on 27/05/2015.
  */
-@Mapper(implementationName = "*MyImpl", implementationPackage = "*.dest")
+@Mapper(implementationName = "<CLASS_NAME>MyImpl", implementationPackage = "<PACKAGE_NAME>.dest")
 public interface DestinationPackageNameMapperWithSuffix {
     DestinationPackageNameMapperWithSuffix INSTANCE = Mappers.getMapper( DestinationPackageNameMapperWithSuffix.class );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperWithSuffix.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameMapperWithSuffix.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Christophe Labouisse on 27/05/2015.
+ */
+@Mapper(implementationName = "*MyImpl", implementationPackage = "*.dest")
+public interface DestinationPackageNameMapperWithSuffix {
+    DestinationPackageNameMapperWithSuffix INSTANCE = Mappers.getMapper( DestinationPackageNameMapperWithSuffix.class );
+
+    String intToString(Integer source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameTest.java
@@ -34,7 +34,7 @@ import static org.fest.assertions.Assertions.assertThat;
 public class DestinationPackageNameTest {
     @Test
     @WithClasses({ DestinationPackageNameMapper.class })
-    public void shouldGeneratedInRightPackage() throws Exception {
+    public void shouldGenerateInRightPackage() throws Exception {
         DestinationPackageNameMapper instance = DestinationPackageNameMapper.INSTANCE;
         assertThat( instance.getClass().getName() )
                 .isEqualTo( "org.mapstruct.ap.test.destination.dest.DestinationPackageNameMapperImpl" );
@@ -42,7 +42,7 @@ public class DestinationPackageNameTest {
 
     @Test
     @WithClasses({ DestinationPackageNameMapperWithSuffix.class })
-    public void shouldGeneratedInRightPackageWithSuffix() throws Exception {
+    public void shouldGenerateInRightPackageWithSuffix() throws Exception {
         DestinationPackageNameMapperWithSuffix instance = DestinationPackageNameMapperWithSuffix.INSTANCE;
         assertThat( instance.getClass().getName() )
                 .isEqualTo( "org.mapstruct.ap.test.destination.dest.DestinationPackageNameMapperWithSuffixMyImpl" );

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameTest.java
@@ -1,0 +1,80 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.destination;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+/**
+ * @author Christophe Labouisse on 27/05/2015.
+ */
+@IssueKey( "556" )
+@RunWith(AnnotationProcessorTestRunner.class)
+public class DestinationPackageNameTest {
+    @Test
+    @WithClasses({ DestinationPackageNameMapper.class })
+    public void shouldGeneratedInRightPackage() throws Exception {
+        DestinationPackageNameMapper instance = DestinationPackageNameMapper.INSTANCE;
+        assertThat( instance.getClass().getName() )
+                .isEqualTo( "org.mapstruct.ap.test.destination.dest.DestinationPackageNameMapperImpl" );
+    }
+
+    @Test
+    @WithClasses({ DestinationPackageNameMapperWithSuffix.class })
+    public void shouldGeneratedInRightPackageWithSuffix() throws Exception {
+        DestinationPackageNameMapperWithSuffix instance = DestinationPackageNameMapperWithSuffix.INSTANCE;
+        assertThat( instance.getClass().getName() )
+                .isEqualTo( "org.mapstruct.ap.test.destination.dest.DestinationPackageNameMapperWithSuffixMyImpl" );
+    }
+
+    @Test
+    @WithClasses({ DestinationPackageNameMapperConfig.class, DestinationPackageNameMapperWithConfig.class })
+    public void shouldGenerateRightSuffixWithConfig() throws Exception {
+        DestinationPackageNameMapperWithConfig instance = DestinationPackageNameMapperWithConfig.INSTANCE;
+        assertThat( instance.getClass().getName() )
+                .isEqualTo( "org.mapstruct.ap.test.destination.dest.DestinationPackageNameMapperWithConfigImpl" );
+    }
+
+    @Test
+    @WithClasses({ DestinationPackageNameMapperConfig.class, DestinationPackageNameMapperWithConfigOverride.class })
+    public void shouldGenerateRightSuffixWithConfigOverride() throws Exception {
+        DestinationPackageNameMapperWithConfigOverride instance =
+                DestinationPackageNameMapperWithConfigOverride.INSTANCE;
+        assertThat( instance.getClass().getName() )
+                .isEqualTo(
+                    "org.mapstruct.ap.test.destination.my_dest.DestinationPackageNameMapperWithConfigOverrideImpl"
+                );
+    }
+
+    @Test
+    @WithClasses({ DestinationPackageNameMapperDecorated.class, DestinationPackageNameMapperDecorator.class })
+    public void shouldGenerateRightSuffixWithDecorator() throws Exception {
+        DestinationPackageNameMapperDecorated instance = DestinationPackageNameMapperDecorated.INSTANCE;
+        assertThat( instance.getClass().getName() )
+                .isEqualTo( "org.mapstruct.ap.test.destination.dest.DestinationPackageNameMapperDecoratedImpl" );
+        assertThat( instance ).isInstanceOf( DestinationPackageNameMapperDecorator.class );
+        assertThat( ( (DestinationPackageNameMapperDecorator) instance ).delegate.getClass().getName() )
+                .isEqualTo( "org.mapstruct.ap.test.destination.dest.DestinationPackageNameMapperDecoratedImpl_" );
+    }
+}


### PR DESCRIPTION
Fix #472 
- Add interfacePackage` to `GeneratedType`
- Add new `destPackage` to `Mapper` and `MapperConfig'
