### PR TITLE
#600 added defaultValue feature

### DIFF
--- a/core-jdk8/src/main/java/org/mapstruct/Mapping.java
+++ b/core-jdk8/src/main/java/org/mapstruct/Mapping.java
@@ -154,4 +154,16 @@ public @interface Mapping {
      * @return the dependencies of the mapped property
      */
     String[] dependsOn() default { };
+
+    /**
+     * <p>
+     * In case the source property is null the provided default {@link String} value is set.
+     * If the designated target
+     * property is not of type {@code String}, the value will be converted by applying a matching conversion method or
+     * built-in conversion.
+     * </p>
+     * Either this attribute or {@link #constant()} or {@link #expression()} may be specified for a given mapping.
+     * @return Default value to set in case the source property is null.
+     */
+    String defaultValue() default "";
 }

--- a/core/src/main/java/org/mapstruct/Mapping.java
+++ b/core/src/main/java/org/mapstruct/Mapping.java
@@ -151,4 +151,16 @@ public @interface Mapping {
      * @return the dependencies of the mapped property
      */
     String[] dependsOn() default { };
+
+    /**
+     * <p>
+     * In case the source property is null the provided default {@link String} value is set.
+     * If the designated target
+     * property is not of type {@code String}, the value will be converted by applying a matching conversion method or
+     * built-in conversion.
+     * </p>
+     * Either this attribute or {@link #constant()} or {@link #expression()} may be specified for a given mapping.
+     * @return Default value to set in case the source property is null.
+     */
+    String defaultValue() default "";
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -302,6 +302,7 @@ public class BeanMappingMethod extends MappingMethod {
                                     .dateFormat( mapping.getDateFormat() )
                                     .existingVariableNames( existingVariableNames )
                                     .dependsOn( mapping.getDependsOn() )
+                                    .defaultValue( mapping.getDefaultValue() )
                                     .build();
                                 handledTargets.add( mapping.getTargetName() );
                                 unprocessedSourceParameters.remove( sourceRef.getParameter() );
@@ -424,6 +425,7 @@ public class BeanMappingMethod extends MappingMethod {
                                 .qualifiers( mapping != null ? mapping.getQualifiers() : null )
                                 .resultType( mapping != null ? mapping.getResultType() : null )
                                 .dateFormat( mapping != null ? mapping.getDateFormat() : null )
+                                .defaultValue( mapping != null ? mapping.getDefaultValue() : null )
                                 .existingVariableNames( existingVariableNames )
                                 .dependsOn( mapping != null ? mapping.getDependsOn() : Collections.<String>emptyList() )
                                 .build();

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -44,6 +44,8 @@ public enum Message {
     PROPERTYMAPPING_SOURCE_AND_CONSTANT_BOTH_DEFINED( "Source and constant are both defined in @Mapping, either define a source or a constant." ),
     PROPERTYMAPPING_SOURCE_AND_EXPRESSION_BOTH_DEFINED( "Source and expression are both defined in @Mapping, either define a source or an expression." ),
     PROPERTYMAPPING_EXPRESSION_AND_CONSTANT_BOTH_DEFINED( "Expression and constant are both defined in @Mapping, either define an expression or a constant." ),
+    PROPERTYMAPPING_EXPRESSION_AND_DEFAULT_VALUE_BOTH_DEFINED( "Expression and default value are both defined in @Mapping, either define a defaultValue or an expression." ),
+    PROPERTYMAPPING_CONSTANT_AND_DEFAULT_VALUE_BOTH_DEFINED( "Constant and default value are both defined in @Mapping, either define a defaultValue or a constant." ),
     PROPERTYMAPPING_INVALID_EXPRESSION( "Value must be given in the form \"java(<EXPRESSION>)\"." ),
     PROPERTYMAPPING_REVERSAL_PROBLEM( "Parameter %s cannot be reversed." ),
     PROPERTYMAPPING_INVALID_PARAMETER_NAME( "Method has no parameter named \"%s\"." ),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -47,7 +47,7 @@
             <#if (propertyMappingsByParameter[sourceParam.name]?size > 0)>
                 if ( ${sourceParam.name} != null ) {
                     <#list propertyMappingsByParameter[sourceParam.name] as propertyMapping>
-                        <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping/>
+                        <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
                     </#list>
                 }
             </#if>
@@ -55,14 +55,14 @@
         <#list sourcePrimitiveParameters as sourceParam>
             <#if (propertyMappingsByParameter[sourceParam.name]?size > 0)>
                 <#list propertyMappingsByParameter[sourceParam.name] as propertyMapping>
-                    <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping/>
+                    <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
                 </#list>
             </#if>
         </#list>
     <#else>
         <#if mapNullToDefault>if ( ${sourceParameters[0].name} != null ) {</#if>
         <#list propertyMappingsByParameter[sourceParameters[0].name] as propertyMapping>
-            <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping/>
+            <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
         </#list>
         <#if mapNullToDefault>}</#if>
     </#if>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/PropertyMapping.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/PropertyMapping.ftl
@@ -23,4 +23,5 @@
                existingInstanceMapping=ext.existingInstanceMapping
                targetReadAccessorName=targetReadAccessorName
                targetWriteAccessorName=targetWriteAccessorName
-               targetType=targetType/>
+               targetType=targetType
+               defaultValueAssignment=defaultValueAssignment />

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/NullCheckWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/NullCheckWrapper.ftl
@@ -24,5 +24,16 @@ if ( ${sourceReference} != null ) {
                 existingInstanceMapping=ext.existingInstanceMapping
                 targetReadAccessorName=ext.targetReadAccessorName
                 targetWriteAccessorName=ext.targetWriteAccessorName
+                targetType=ext.targetType
+                defaultValue=ext.defaultValueAssignment/>
+}
+<#if ext.defaultValueAssignment?? >
+else {
+    <@includeModel object=ext.defaultValueAssignment
+                targetBeanName=ext.targetBeanName
+                existingInstanceMapping=ext.existingInstanceMapping
+                targetReadAccessorName=ext.targetReadAccessorName
+                targetWriteAccessorName=ext.targetWriteAccessorName
                 targetType=ext.targetType/>
 }
+</#if>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapper.ftl
@@ -19,10 +19,10 @@
 
 -->
 <#if (thrownTypes?size == 0) >
-        ${ext.targetBeanName}.${ext.targetWriteAccessorName}( <@_assignment/> );
+    <@assignment_w_defaultValue/>
 <#else>
     try {
-        ${ext.targetBeanName}.${ext.targetWriteAccessorName}( <@_assignment/> );
+        <@assignment_w_defaultValue/>
     }
     <#list thrownTypes as exceptionType>
     catch ( <@includeModel object=exceptionType/> e ) {
@@ -30,11 +30,31 @@
     }
     </#list>
 </#if>
+
 <#macro _assignment>
     <@includeModel object=assignment
                targetBeanName=ext.targetBeanName
                existingInstanceMapping=ext.existingInstanceMapping
                targetReadAccessorName=ext.targetReadAccessorName
                targetWriteAccessorName=ext.targetWriteAccessorName
+               targetType=ext.targetType
+               defaultValueAssignment=ext.defaultValueAssignment/>
+</#macro>
+
+<#macro _defaultValueAssignment>
+    <@includeModel object=ext.defaultValueAssignment.assignment
+               targetBeanName=ext.targetBeanName
+               existingInstanceMapping=ext.existingInstanceMapping
+               targetWriteAccessorName=ext.targetWriteAccessorName
                targetType=ext.targetType/>
+</#macro>
+
+<#macro assignment_w_defaultValue>
+    ${ext.targetBeanName}.${ext.targetWriteAccessorName}( <@_assignment/> );
+    <#-- if the assignee property is a primitive, defaulValueAssignment will not be set -->
+    <#if ext.defaultValueAssignment?? >
+    if ( ${sourceReference} == null ) {
+        ${ext.targetBeanName}.${ext.targetWriteAccessorName}( <@_defaultValueAssignment/> );
+    }
+    </#if>
 </#macro>

--- a/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/CountryDts.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/CountryDts.java
@@ -1,0 +1,58 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.defaultvalue;
+
+public class CountryDts {
+    private String code;
+    private int id;
+    private long zipcode;
+    private String region;
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public long getZipcode() {
+        return zipcode;
+    }
+
+    public void setZipcode(long zipcode) {
+        this.zipcode = zipcode;
+    }
+
+    public String getRegion() {
+        return region;
+    }
+
+    public void setRegion(String region) {
+        this.region = region;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/CountryEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/CountryEntity.java
@@ -1,0 +1,59 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.defaultvalue;
+
+public class CountryEntity {
+    private String code;
+    private Integer id;
+    private long zipcode;
+    private Region region;
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(Integer id) {
+        this.id = id;
+    }
+
+    public long getZipcode() {
+        return zipcode;
+    }
+
+    public void setZipcode(long zipcode) {
+        this.zipcode = zipcode;
+    }
+
+    public Region getRegion() {
+        return region;
+    }
+
+    public void setRegion(Region region) {
+        this.region = region;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/CountryMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/CountryMapper.java
@@ -1,0 +1,60 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.defaultvalue;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class CountryMapper {
+    public static final CountryMapper INSTANCE = Mappers.getMapper( CountryMapper.class );
+
+    @Mappings( {
+            @Mapping( target = "code", defaultValue = "DE" ),
+            @Mapping( target = "id", defaultValue = "42" ),
+            @Mapping( target = "zipcode", defaultValue = "1337" ),
+            @Mapping( target = "region", defaultValue = "someRegion" ),
+    } )
+    public abstract CountryDts mapToCountryDts(CountryEntity country);
+
+    @Mappings( {
+            @Mapping( target = "code", defaultValue = "DE" ),
+            @Mapping( target = "id", defaultValue = "42" ),
+            @Mapping( target = "zipcode", defaultValue = "1337" ),
+            @Mapping( target = "region", ignore = true )
+
+    } )
+    public abstract void mapToCountryDts(CountryDts countryDts, @MappingTarget CountryEntity country);
+
+    @Mappings( {
+            @Mapping( target = "code", defaultValue = "DE" ),
+            @Mapping( target = "id", defaultValue = "42" ),
+            @Mapping( target = "zipcode", defaultValue = "1337" ),
+            @Mapping( target = "region", ignore = true )
+
+    } )
+    public abstract void mapToCountryDts(CountryEntity source, @MappingTarget CountryEntity target);
+
+    protected String mapToString(Region region) {
+        return ( region != null ) ? region.getCode() : null;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/DefaultValueTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/DefaultValueTest.java
@@ -1,0 +1,162 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.defaultvalue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import java.text.ParseException;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+@IssueKey( "600" )
+@RunWith( AnnotationProcessorTestRunner.class )
+@WithClasses( {
+        CountryEntity.class,
+        CountryDts.class
+} )
+public class DefaultValueTest {
+    @Test
+    @WithClasses( {
+            Region.class,
+            CountryMapper.class
+    } )
+    /**
+     * Checks:
+     * <ul>
+     *     <li>On code: Using defaultValue without type conversion</li>
+     *     <li>On id: Type conversion of the defaultValue (string expr to int)</li>
+     *     <li>On name: Using ConstantExpression instead of defaultValue</li>
+     *     <li>On zipcode: Ignoring defaultValue on primitive target types</li>
+     *     <li>On region: Using defaultValue before the assignment by an intern method (mapToString)</li>
+     * </ul>
+     */
+    public void shouldDefaultValueAndUseConstantExpression() {
+        CountryEntity countryEntity = new CountryEntity();
+
+        CountryDts countryDts = CountryMapper.INSTANCE.mapToCountryDts( countryEntity );
+
+        // id is null so it should fall back to the default value
+        assertThat( countryDts.getId() ).isEqualTo( 42 );
+
+        // code is null so it should fall back to the default value
+        assertThat( countryDts.getCode() ).isEqualTo( "DE" );
+
+        assertThat( countryDts.getZipcode() ).isEqualTo( 0 );
+
+        assertThat( countryDts.getRegion() ).isEqualTo( "someRegion" );
+    }
+
+    @Test
+    @WithClasses( {
+            Region.class,
+            CountryMapper.class
+    } )
+    public void shouldIgnoreDefaultValue() {
+        CountryEntity countryEntity = new CountryEntity();
+        countryEntity.setCode( "US" );
+        Region region = new Region();
+        region.setCode( "foobar" );
+        countryEntity.setRegion( region );
+
+        CountryDts countryDts = CountryMapper.INSTANCE.mapToCountryDts( countryEntity );
+
+        // the source entity had a code set, so the default value shouldn't be used
+        assertThat( countryDts.getCode() ).isEqualTo( "US" );
+        assertThat( countryDts.getRegion() ).isEqualTo( "foobar" );
+    }
+
+    @Test
+    @WithClasses( {
+            Region.class,
+            CountryMapper.class
+    } )
+    public void shouldHandleUpdateMethodsFromDtsToEntity() {
+        CountryEntity countryEntity = new CountryEntity();
+        CountryDts countryDts = new CountryDts();
+
+        CountryMapper.INSTANCE.mapToCountryDts( countryDts, countryEntity );
+
+        assertThat( countryEntity.getId() ).isEqualTo( 0 );
+        // no code is set, so fall back to default value
+        assertThat( countryEntity.getCode() ).isEqualTo( "DE" );
+        assertThat( countryEntity.getZipcode() ).isEqualTo( 0 );
+    }
+
+    @Test
+    @WithClasses( {
+            Region.class,
+            CountryMapper.class
+    } )
+    public void shouldHandleUpdateMethodsFromEntityToEntity() {
+        CountryEntity source = new CountryEntity();
+        CountryEntity target = new CountryEntity();
+
+        CountryMapper.INSTANCE.mapToCountryDts( source, target );
+
+        // no id is set, so fall back to default value
+        assertThat( target.getId() ).isEqualTo( 42 );
+        // no code is set, so fall back to default value
+        assertThat( target.getCode() ).isEqualTo( "DE" );
+        assertThat( target.getZipcode() ).isEqualTo( 0 );
+    }
+
+    @Test
+    @WithClasses( {
+            ErroneousMapper.class,
+            Region.class,
+    } )
+    @ExpectedCompilationOutcome(
+            value = CompilationResult.FAILED,
+            diagnostics = {
+                    @Diagnostic( type = ErroneousMapper.class,
+                            kind = javax.tools.Diagnostic.Kind.ERROR,
+                            line = 33,
+                            messageRegExp = "Constant and default value are both defined in @Mapping,"
+                                    + " either define a defaultValue or a constant." ),
+            }
+    )
+    public void errorOnDefaultValueAndConstant() throws ParseException {
+    }
+
+    @Test
+    @WithClasses( {
+            ErroneousMapper2.class,
+            Region.class,
+    } )
+    @ExpectedCompilationOutcome(
+            value = CompilationResult.FAILED,
+            diagnostics = {
+                    @Diagnostic( type = ErroneousMapper2.class,
+                            kind = javax.tools.Diagnostic.Kind.ERROR,
+                            line = 33,
+                            messageRegExp = "Expression and default value are both defined in @Mapping,"
+                                    + " either define a defaultValue or an expression." ),
+            }
+    )
+    public void errorOnDefaultValueAndExpression() throws ParseException {
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/ErroneousMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/ErroneousMapper.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.defaultvalue;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class ErroneousMapper {
+    public static final ErroneousMapper INSTANCE = Mappers.getMapper( ErroneousMapper.class );
+
+    @Mappings( {
+            @Mapping( target = "code", defaultValue = "DE", constant = "FOOBAR" ),
+    } )
+    public abstract CountryDts mapToCountryDts(CountryEntity country);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/ErroneousMapper2.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/ErroneousMapper2.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.defaultvalue;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class ErroneousMapper2 {
+    public static final ErroneousMapper2 INSTANCE = Mappers.getMapper( ErroneousMapper2.class );
+
+    @Mappings( {
+            @Mapping( target = "code", defaultValue = "DE", expression = "java(;)" ),
+    } )
+    public abstract CountryDts mapToCountryDts(CountryEntity country);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/Region.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/Region.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.defaultvalue;
+
+public class Region {
+    private String code;
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+}


### PR DESCRIPTION
A quick overview:

* Added a `defaultValue` property for the Mapping annotation (also for java8)
* If the `defaultValue` is set and the source type is not a primitive, the defaultValueAssignment is built
  - This is done by using the `ConstantMappingBuilder`. I bet that this is a overkill but I wasn't sure what I need really to build the assignment
* Adapted the BeanMappingMethod.ftl, PropertyMapping.ftl, NullCheckWrapper.ftl and SetterWrapper.ftl to render the assignment in case the defaultValueAssignment is available