### PR TITLE
Detect unspecified annotation attributes

### DIFF
--- a/core-common/src/main/java/org/mapstruct/BeanMapping.java
+++ b/core-common/src/main/java/org/mapstruct/BeanMapping.java
@@ -61,5 +61,5 @@ public @interface BeanMapping {
      *
      * @return The strategy to be applied when {@code null} is passed as source value to the methods of this mapping.
      */
-    NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.DEFAULT;
+    NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.RETURN_NULL;
 }

--- a/core-common/src/main/java/org/mapstruct/CollectionMappingStrategy.java
+++ b/core-common/src/main/java/org/mapstruct/CollectionMappingStrategy.java
@@ -51,12 +51,5 @@ public enum CollectionMappingStrategy {
      * Identical to {@link #SETTER_PREFERRED}, only that adder methods will be preferred over setter methods, if both
      * are present for a given collection-typed property.
      */
-    ADDER_PREFERRED,
-
-    /**
-     * If given via {@link Mapper#collectionMappingStrategy()}, causes the setting specified via
-     * {@link MapperConfig#collectionMappingStrategy()} to be applied, if present. Otherwise causes
-     * {@link #ACCESSOR_ONLY} to be applied.
-     */
-    DEFAULT;
+    ADDER_PREFERRED;
 }

--- a/core-common/src/main/java/org/mapstruct/IterableMapping.java
+++ b/core-common/src/main/java/org/mapstruct/IterableMapping.java
@@ -73,5 +73,5 @@ public @interface IterableMapping {
      *
      * @return The strategy to be applied when {@code null} is passed as source value to the methods of this mapping.
      */
-    NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.DEFAULT;
+    NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.RETURN_NULL;
 }

--- a/core-common/src/main/java/org/mapstruct/MapMapping.java
+++ b/core-common/src/main/java/org/mapstruct/MapMapping.java
@@ -104,5 +104,5 @@ public @interface MapMapping {
      *
      * @return The strategy to be applied when {@code null} is passed as source value to the methods of this mapping.
      */
-    NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.DEFAULT;
+    NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.RETURN_NULL;
 }

--- a/core-common/src/main/java/org/mapstruct/Mapper.java
+++ b/core-common/src/main/java/org/mapstruct/Mapper.java
@@ -59,7 +59,7 @@ public @interface Mapper {
      *
      * @return The reporting policy for unmapped target properties.
      */
-    ReportingPolicy unmappedTargetPolicy() default ReportingPolicy.DEFAULT;
+    ReportingPolicy unmappedTargetPolicy() default ReportingPolicy.WARN;
 
     /**
      * Specifies the component model to which the generated mapper should
@@ -103,7 +103,7 @@ public @interface Mapper {
      *
      * @return The strategy applied when propagating the value of collection-typed properties.
      */
-    CollectionMappingStrategy collectionMappingStrategy() default CollectionMappingStrategy.DEFAULT;
+    CollectionMappingStrategy collectionMappingStrategy() default CollectionMappingStrategy.ACCESSOR_ONLY;
 
     /**
      * The strategy to be applied when {@code null} is passed as source value to the methods of this mapper. If no
@@ -112,7 +112,7 @@ public @interface Mapper {
      *
      * @return The strategy to be applied when {@code null} is passed as source value to the methods of this mapper.
      */
-    NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.DEFAULT;
+    NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.RETURN_NULL;
 
     /**
      * The strategy to use for applying method-level configuration annotations of prototype methods in the interface
@@ -125,5 +125,5 @@ public @interface Mapper {
      * @return The strategy to use for applying {@code @Mapping} configurations of prototype methods in the interface
      * specified with {@link #config()}.
      */
-    MappingInheritanceStrategy mappingInheritanceStrategy() default MappingInheritanceStrategy.DEFAULT;
+    MappingInheritanceStrategy mappingInheritanceStrategy() default MappingInheritanceStrategy.EXPLICIT;
 }

--- a/core-common/src/main/java/org/mapstruct/MappingInheritanceStrategy.java
+++ b/core-common/src/main/java/org/mapstruct/MappingInheritanceStrategy.java
@@ -35,13 +35,5 @@ public enum MappingInheritanceStrategy {
      * Inherit the method-level configuration annotations automatically if source and target types of the prototype
      * method are assignable from the types of a given mapping method.
      */
-    AUTO_INHERIT_FROM_CONFIG,
-
-    /**
-     * When given via {@link Mapper#mappingInheritanceStrategy()}, the value specified via
-     * {@link MapperConfig#mappingInheritanceStrategy()} will be applied, if present.
-     * <p>
-     * When given via {@link MapperConfig#mappingInheritanceStrategy()}, the strategy {@link #EXPLICIT} will be applied.
-     */
-    DEFAULT;
+    AUTO_INHERIT_FROM_CONFIG;
 }

--- a/core-common/src/main/java/org/mapstruct/NullValueMappingStrategy.java
+++ b/core-common/src/main/java/org/mapstruct/NullValueMappingStrategy.java
@@ -43,16 +43,5 @@ public enum NullValueMappingStrategy {
      * <li>For map mapping methods an empty map will be returned.</li>
      * </ul>
      */
-    RETURN_DEFAULT,
-
-    /**
-     * When given via {@link Mapper#nullValueMappingStrategy()}, causes the setting specified via
-     * {@link MapperConfig#nullValueMappingStrategy()} to be applied, if present.
-     * <p>
-     * When given on specific mapping methods (e.g. via @ BeanMapping#nullValueMappingStrategy()}), causes the setting
-     * specified via {@link Mapper#nullValueMappingStrategy() ()} to be applied, if present.
-     * <p>
-     * Otherwise causes {@link #RETURN_NULL} to be applied.
-     */
-    DEFAULT;
+    RETURN_DEFAULT;
 }

--- a/core-common/src/main/java/org/mapstruct/ReportingPolicy.java
+++ b/core-common/src/main/java/org/mapstruct/ReportingPolicy.java
@@ -42,15 +42,5 @@ public enum ReportingPolicy {
      * A report with {@link Kind#ERROR} will be created for the given issue,
      * causing the compilation to fail.
      */
-    ERROR,
-
-    /**
-     * When given as value for {@link Mapper#unmappedTargetPolicy()}, the setting from the configuration source
-     * referenced via {@link Mapper#config()} will be applied.
-     * <p>
-     * Otherwise (no configuration source is referenced, or this value is given via
-     * {@link MapperConfig#unmappedTargetPolicy()}), a report with {@link Kind#WARNING} will be created for the given
-     * issue.
-     */
-    DEFAULT;
+    ERROR;
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
@@ -50,11 +50,13 @@ public class BeanMapping {
 
         boolean resultTypeIsDefined = !TypeKind.VOID.equals( beanMapping.resultType().getKind() );
 
-        NullValueMappingStrategyPrism nullValueMappingStrategy
-            = NullValueMappingStrategyPrism.valueOf( beanMapping.nullValueMappingStrategy() );
+        NullValueMappingStrategyPrism nullValueMappingStrategy =
+            null == beanMapping.values.nullValueMappingStrategy()
+                            ? null
+                            : NullValueMappingStrategyPrism.valueOf( beanMapping.nullValueMappingStrategy() );
 
         if ( !resultTypeIsDefined && beanMapping.qualifiedBy().isEmpty()
-            && ( nullValueMappingStrategy == NullValueMappingStrategyPrism.DEFAULT ) ) {
+            && ( nullValueMappingStrategy == null ) ) {
 
             messager.printMessage( method, Message.BEANMAPPING_NO_ELEMENTS );
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/IterableMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/IterableMapping.java
@@ -53,13 +53,15 @@ public class IterableMapping {
 
         boolean elementTargetTypeIsDefined = !TypeKind.VOID.equals( iterableMapping.elementTargetType().getKind() );
 
-        NullValueMappingStrategyPrism nullValueMappingStrategy
-            = NullValueMappingStrategyPrism.valueOf( iterableMapping.nullValueMappingStrategy() );
+        NullValueMappingStrategyPrism nullValueMappingStrategy =
+            iterableMapping.values.nullValueMappingStrategy() == null
+                            ? null
+                            : NullValueMappingStrategyPrism.valueOf( iterableMapping.nullValueMappingStrategy() );
 
         if ( !elementTargetTypeIsDefined
             && iterableMapping.dateFormat().isEmpty()
             && iterableMapping.qualifiedBy().isEmpty()
-            && ( nullValueMappingStrategy == NullValueMappingStrategyPrism.DEFAULT ) ) {
+            && ( nullValueMappingStrategy == null ) ) {
 
             messager.printMessage( method, Message.ITERABLEMAPPING_NO_ELEMENTS );
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapMapping.java
@@ -52,8 +52,10 @@ public class MapMapping {
             return null;
         }
 
-        NullValueMappingStrategyPrism nullValueMappingStrategy
-            = NullValueMappingStrategyPrism.valueOf( mapMapping.nullValueMappingStrategy() );
+        NullValueMappingStrategyPrism nullValueMappingStrategy =
+            mapMapping.values.nullValueMappingStrategy() == null
+                            ? null
+                            : NullValueMappingStrategyPrism.valueOf( mapMapping.nullValueMappingStrategy() );
 
 
         boolean keyTargetTypeIsDefined = !TypeKind.VOID.equals( mapMapping.keyTargetType().getKind() );
@@ -64,7 +66,7 @@ public class MapMapping {
             && mapMapping.valueQualifiedBy().isEmpty()
             && !keyTargetTypeIsDefined
             && !valueTargetTypeIsDefined
-            && ( nullValueMappingStrategy == NullValueMappingStrategyPrism.DEFAULT ) ) {
+            && ( nullValueMappingStrategy == null ) ) {
 
             messager.printMessage( method, Message.MAPMAPPING_NO_ELEMENTS );
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
@@ -18,12 +18,13 @@
  */
 package org.mapstruct.ap.internal.model.source;
 
-import org.mapstruct.ap.internal.model.common.TypeFactory;
-import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
-import org.mapstruct.ap.internal.prism.MappingPrism;
-import org.mapstruct.ap.internal.prism.MappingsPrism;
-import org.mapstruct.ap.internal.util.FormattingMessager;
-import org.mapstruct.ap.internal.util.Message;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
@@ -32,13 +33,13 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import org.mapstruct.ap.internal.model.common.TypeFactory;
+import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
+import org.mapstruct.ap.internal.prism.MappingPrism;
+import org.mapstruct.ap.internal.prism.MappingsPrism;
+import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.Message;
 
 /**
  * Represents a property mapping as configured via {@code @Mapping}.
@@ -106,34 +107,34 @@ public class Mapping {
             return null;
         }
 
-        if ( !mappingPrism.source().isEmpty() && !mappingPrism.constant().isEmpty() ) {
+        if ( !mappingPrism.source().isEmpty() && mappingPrism.values.constant() != null ) {
             messager.printMessage( element, Message.PROPERTYMAPPING_SOURCE_AND_CONSTANT_BOTH_DEFINED );
             return null;
         }
-        else if ( !mappingPrism.source().isEmpty() && !mappingPrism.expression().isEmpty() ) {
+        else if ( !mappingPrism.source().isEmpty() && mappingPrism.values.expression() != null ) {
             messager.printMessage( element, Message.PROPERTYMAPPING_SOURCE_AND_EXPRESSION_BOTH_DEFINED );
             return null;
         }
-        else if ( !mappingPrism.expression().isEmpty() && !mappingPrism.constant().isEmpty() ) {
+        else if ( mappingPrism.values.expression() != null && mappingPrism.values.constant() != null ) {
             messager.printMessage( element, Message.PROPERTYMAPPING_EXPRESSION_AND_CONSTANT_BOTH_DEFINED );
             return null;
         }
-        else if ( !mappingPrism.expression().isEmpty() && !mappingPrism.defaultValue().isEmpty() ) {
+        else if ( mappingPrism.values.expression() != null && mappingPrism.values.defaultValue() != null ) {
             messager.printMessage( element, Message.PROPERTYMAPPING_EXPRESSION_AND_DEFAULT_VALUE_BOTH_DEFINED );
             return null;
         }
-        else if ( !mappingPrism.constant().isEmpty() && !mappingPrism.defaultValue().isEmpty() ) {
+        else if ( mappingPrism.values.constant() != null && mappingPrism.values.defaultValue() != null ) {
             messager.printMessage( element, Message.PROPERTYMAPPING_CONSTANT_AND_DEFAULT_VALUE_BOTH_DEFINED );
             return null;
         }
 
         String source = mappingPrism.source().isEmpty() ? null : mappingPrism.source();
-        String constant = mappingPrism.constant().isEmpty() ? null : mappingPrism.constant();
+        String constant = mappingPrism.values.constant() == null ? null : mappingPrism.constant();
         String expression = getExpression( mappingPrism, element, messager );
-        String dateFormat = mappingPrism.dateFormat().isEmpty() ? null : mappingPrism.dateFormat();
-        String defaultValue = mappingPrism.defaultValue().isEmpty() ? null : mappingPrism.defaultValue();
+        String dateFormat = mappingPrism.values.dateFormat() == null ? null : mappingPrism.dateFormat();
+        String defaultValue = mappingPrism.values.defaultValue() == null ? null : mappingPrism.defaultValue();
 
-        boolean resultTypeIsDefined = !TypeKind.VOID.equals( mappingPrism.resultType().getKind() );
+        boolean resultTypeIsDefined = mappingPrism.values.resultType() != null;
         TypeMirror resultType = resultTypeIsDefined ? mappingPrism.resultType() : null;
         List<String> dependsOn =
             mappingPrism.dependsOn() != null ? mappingPrism.dependsOn() : Collections.<String>emptyList();

--- a/processor/src/main/java/org/mapstruct/ap/internal/option/ReportingPolicy.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/option/ReportingPolicy.java
@@ -31,8 +31,7 @@ public enum ReportingPolicy {
 
     IGNORE( null, false, false ),
     WARN( Kind.WARNING, true, false ),
-    ERROR( Kind.ERROR, true, true ),
-    DEFAULT( Kind.WARNING, true, false );
+    ERROR( Kind.ERROR, true, true );
 
     private final Diagnostic.Kind diagnosticKind;
     private final boolean requiresReport;

--- a/processor/src/main/java/org/mapstruct/ap/internal/prism/CollectionMappingStrategyPrism.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/prism/CollectionMappingStrategyPrism.java
@@ -27,6 +27,5 @@ public enum CollectionMappingStrategyPrism {
 
     ACCESSOR_ONLY,
     SETTER_PREFERRED,
-    ADDER_PREFERRED,
-    DEFAULT;
+    ADDER_PREFERRED;
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/prism/MappingInheritanceStrategyPrism.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/prism/MappingInheritanceStrategyPrism.java
@@ -26,6 +26,5 @@ package org.mapstruct.ap.internal.prism;
  */
 public enum MappingInheritanceStrategyPrism {
     EXPLICIT,
-    AUTO_INHERIT_FROM_CONFIG,
-    DEFAULT;
+    AUTO_INHERIT_FROM_CONFIG;
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/prism/NullValueMappingStrategyPrism.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/prism/NullValueMappingStrategyPrism.java
@@ -26,6 +26,5 @@ package org.mapstruct.ap.internal.prism;
 public enum NullValueMappingStrategyPrism {
 
     RETURN_NULL,
-    RETURN_DEFAULT,
-    DEFAULT;
+    RETURN_DEFAULT;
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
@@ -29,7 +29,6 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
-import org.mapstruct.ap.internal.option.ReportingPolicy;
 import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
 import org.mapstruct.ap.internal.prism.MapperConfigPrism;
 import org.mapstruct.ap.internal.prism.MapperPrism;
@@ -79,65 +78,37 @@ public class MapperConfiguration {
     }
 
     public String unmappedTargetPolicy() {
-        if ( ReportingPolicy.valueOf( mapperPrism.unmappedTargetPolicy() ) != ReportingPolicy.DEFAULT ) {
-            // it is not the default configuration
-            return mapperPrism.unmappedTargetPolicy();
-        }
-        else if ( mapperConfigPrism != null &&
-            ReportingPolicy.valueOf( mapperConfigPrism.unmappedTargetPolicy() ) != ReportingPolicy.DEFAULT ) {
+        if ( mapperConfigPrism != null && mapperPrism.values.unmappedTargetPolicy() == null ) {
             return mapperConfigPrism.unmappedTargetPolicy();
         }
         else {
-            return ReportingPolicy.WARN.name();
+            return mapperPrism.unmappedTargetPolicy();
         }
     }
 
     public CollectionMappingStrategyPrism getCollectionMappingStrategy() {
-        CollectionMappingStrategyPrism mapperPolicy =
-            CollectionMappingStrategyPrism.valueOf( mapperPrism.collectionMappingStrategy() );
-
-        if ( mapperPolicy != CollectionMappingStrategyPrism.DEFAULT ) {
-            // it is not the default mapper configuration, so return the mapper configured value
-            return mapperPolicy;
+        if ( mapperConfigPrism != null && mapperPrism.values.collectionMappingStrategy() == null ) {
+            return CollectionMappingStrategyPrism.valueOf( mapperConfigPrism.collectionMappingStrategy() );
         }
-        else if ( mapperConfigPrism != null ) {
-            // try the config mapper configuration
-            CollectionMappingStrategyPrism configPolicy =
-                CollectionMappingStrategyPrism.valueOf( mapperConfigPrism.collectionMappingStrategy() );
-            if ( configPolicy != CollectionMappingStrategyPrism.DEFAULT ) {
-                // its not the default configuration, so return the mapper config configured value
-                return configPolicy;
-            }
+        else {
+            return CollectionMappingStrategyPrism.valueOf( mapperPrism.collectionMappingStrategy() );
         }
-        // when nothing specified, return ACCESSOR_ONLY (default option)
-        return CollectionMappingStrategyPrism.ACCESSOR_ONLY;
     }
 
     public MappingInheritanceStrategyPrism getMappingInheritanceStrategy() {
-        MappingInheritanceStrategyPrism mapperPolicy =
-            MappingInheritanceStrategyPrism.valueOf( mapperPrism.mappingInheritanceStrategy() );
-
-        if ( mapperPolicy != MappingInheritanceStrategyPrism.DEFAULT ) {
-            return mapperPolicy;
+        if ( mapperConfigPrism != null && mapperPrism.values.mappingInheritanceStrategy() == null ) {
+            return MappingInheritanceStrategyPrism.valueOf( mapperConfigPrism.mappingInheritanceStrategy() );
         }
-        else if ( mapperConfigPrism != null ) {
-            MappingInheritanceStrategyPrism configPolicy =
-                MappingInheritanceStrategyPrism.valueOf( mapperConfigPrism.mappingInheritanceStrategy() );
-            if ( configPolicy != MappingInheritanceStrategyPrism.DEFAULT ) {
-                return configPolicy;
-            }
+        else {
+            return MappingInheritanceStrategyPrism.valueOf( mapperPrism.mappingInheritanceStrategy() );
         }
-
-        return MappingInheritanceStrategyPrism.EXPLICIT;
     }
 
     public boolean isMapToDefault(NullValueMappingStrategyPrism mapNullToDefault) {
 
         // check on method level
         if ( mapNullToDefault != null ) {
-            if ( mapNullToDefault != NullValueMappingStrategyPrism.DEFAULT ) {
-                return mapNullToDefault == NullValueMappingStrategyPrism.RETURN_DEFAULT;
-            }
+            return mapNullToDefault == NullValueMappingStrategyPrism.RETURN_DEFAULT;
         }
 
         return isMapToDefaultOnMapperAndMappingConfigLevel();
@@ -145,40 +116,24 @@ public class MapperConfiguration {
     }
 
     private boolean isMapToDefaultOnMapperAndMappingConfigLevel() {
-
-        // check on mapper level
-        NullValueMappingStrategyPrism mapperPolicy =
-            NullValueMappingStrategyPrism.valueOf( mapperPrism.nullValueMappingStrategy() );
-
-        if ( mapperPolicy != NullValueMappingStrategyPrism.DEFAULT ) {
-            // it is not the default mapper configuration, so return the mapper configured value
-            return mapperPolicy == NullValueMappingStrategyPrism.RETURN_DEFAULT;
+        final NullValueMappingStrategyPrism strategy;
+        if ( mapperConfigPrism != null && mapperPrism.values.nullValueMappingStrategy() == null ) {
+            strategy = NullValueMappingStrategyPrism.valueOf( mapperConfigPrism.nullValueMappingStrategy() );
+        }
+        else {
+            strategy = NullValueMappingStrategyPrism.valueOf( mapperPrism.nullValueMappingStrategy() );
         }
 
-        // check on mapping config level
-        else if ( mapperConfigPrism != null ) {
-            // try the config mapper configuration
-            NullValueMappingStrategyPrism configPolicy =
-                NullValueMappingStrategyPrism.valueOf( mapperConfigPrism.nullValueMappingStrategy() );
-            if ( configPolicy != NullValueMappingStrategyPrism.DEFAULT ) {
-                // its not the default configuration, so return the mapper config configured value
-                return configPolicy == NullValueMappingStrategyPrism.RETURN_DEFAULT;
-            }
-        }
-        // when nothing specified, return RETURN_NULL (default option)
-        return false;
+        return NullValueMappingStrategyPrism.RETURN_DEFAULT == strategy;
     }
 
 
     public String componentModel() {
-        if ( !mapperPrism.componentModel().equals( "default" ) ) {
-            return mapperPrism.componentModel();
-        }
-        else if ( mapperConfigPrism != null ) {
+        if ( mapperConfigPrism != null && mapperPrism.values.componentModel() == null ) {
             return mapperConfigPrism.componentModel();
         }
         else {
-            return "default";
+            return mapperPrism.componentModel();
         }
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperSettingOnConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperSettingOnConfig.java
@@ -21,9 +21,9 @@ package org.mapstruct.ap.test.nullvaluemapping;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+
 import org.mapstruct.IterableMapping;
 import org.mapstruct.MapMapping;
-
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
@@ -45,7 +45,7 @@ public interface CarMapperSettingOnConfig {
     CarDto carToCarDto(Car car);
 
 
-    @IterableMapping(nullValueMappingStrategy = NullValueMappingStrategy.DEFAULT, dateFormat = "dummy")
+    @IterableMapping(dateFormat = "dummy")
     List<CarDto> carsToCarDtos(List<Car> cars);
 
 

--- a/processor/src/test/java/org/mapstruct/ap/test/source/constants/ErroneousMapper1.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/constants/ErroneousMapper1.java
@@ -33,6 +33,7 @@ public interface ErroneousMapper1 {
 
     @Mappings({
         @Mapping(target = "stringConstant", constant = "stringConstant"),
+        @Mapping(target = "emptyStringConstant", constant = ""),
         @Mapping(source = "test", target = "integerConstant", constant = "14"),
         @Mapping(target = "longWrapperConstant", constant = "3001"),
         @Mapping(target = "dateConstant", dateFormat = "dd-MM-yyyy", constant = "09-01-2014"),

--- a/processor/src/test/java/org/mapstruct/ap/test/source/constants/ErroneousMapper3.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/constants/ErroneousMapper3.java
@@ -33,6 +33,7 @@ public interface ErroneousMapper3 {
 
     @Mappings({
         @Mapping(target = "stringConstant", constant = "stringConstant"),
+        @Mapping(target = "emptyStringConstant", constant = ""),
         @Mapping(target = "integerConstant", expression = "java('test')", constant = "14"),
         @Mapping(target = "longWrapperConstant", constant = "3001"),
         @Mapping(target = "dateConstant", dateFormat = "dd-MM-yyyy", constant = "09-01-2014"),

--- a/processor/src/test/java/org/mapstruct/ap/test/source/constants/ErroneousMapper4.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/constants/ErroneousMapper4.java
@@ -33,6 +33,7 @@ public interface ErroneousMapper4 {
 
     @Mappings({
         @Mapping(target = "stringConstant", constant = "stringConstant"),
+        @Mapping(target = "emptyStringConstant", constant = ""),
         @Mapping(source = "test", target = "integerConstant", expression = "java('test')"),
         @Mapping(target = "longWrapperConstant", constant = "3001"),
         @Mapping(target = "dateConstant", dateFormat = "dd-MM-yyyy", constant = "09-01-2014"),

--- a/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceConstantsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceConstantsTest.java
@@ -22,6 +22,7 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+
 import javax.tools.Diagnostic.Kind;
 
 import org.junit.Test;
@@ -60,6 +61,7 @@ public class SourceConstantsTest {
         assertThat( target ).isNotNull();
         assertThat( target.getPropertyThatShouldBeMapped() ).isEqualTo( "SomeProperty" );
         assertThat( target.getStringConstant() ).isEqualTo( "stringConstant" );
+        assertThat( target.getEmptyStringConstant() ).isEqualTo( "" );
         assertThat( target.getIntegerConstant() ).isEqualTo( 14 );
         assertThat( target.getLongWrapperConstant() ).isEqualTo( new Long( 3001L ) );
         assertThat( target.getDateConstant() ).isEqualTo( getDate( "dd-MM-yyyy", "09-01-2014" ) );
@@ -97,12 +99,12 @@ public class SourceConstantsTest {
         diagnostics = {
             @Diagnostic(type = ErroneousMapper1.class,
                 kind = Kind.ERROR,
-                line = 41,
+                line = 42,
                 messageRegExp = "Source and constant are both defined in @Mapping, either define a source or a "
                     + "constant"),
             @Diagnostic(type = ErroneousMapper1.class,
                 kind = Kind.WARNING,
-                line = 41,
+                line = 42,
                 messageRegExp = "Unmapped target property: \"integerConstant\"")
         }
     )
@@ -122,13 +124,13 @@ public class SourceConstantsTest {
         diagnostics = {
             @Diagnostic(type = ErroneousMapper3.class,
                 kind = Kind.ERROR,
-                line = 41,
+                line = 42,
                 messageRegExp =
                     "Expression and constant are both defined in @Mapping, either define an expression or a "
                         + "constant"),
             @Diagnostic(type = ErroneousMapper3.class,
                 kind = Kind.WARNING,
-                line = 41,
+                line = 42,
                 messageRegExp = "Unmapped target property: \"integerConstant\"")
         }
     )
@@ -148,12 +150,12 @@ public class SourceConstantsTest {
         diagnostics = {
             @Diagnostic(type = ErroneousMapper4.class,
                 kind = Kind.ERROR,
-                line = 41,
+                line = 42,
                 messageRegExp = "Source and expression are both defined in @Mapping, either define a source or an "
                     + "expression"),
             @Diagnostic(type = ErroneousMapper4.class,
                 kind = Kind.WARNING,
-                line = 41,
+                line = 42,
                 messageRegExp = "Unmapped target property: \"integerConstant\"")
         }
     )

--- a/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceTargetMapper.java
@@ -33,6 +33,7 @@ public interface SourceTargetMapper {
 
     @Mappings({
         @Mapping(target = "stringConstant", constant = "stringConstant"),
+        @Mapping(target = "emptyStringConstant", constant = ""),
         @Mapping(target = "integerConstant", constant = "14"),
         @Mapping(target = "longWrapperConstant", constant = "3001"),
         @Mapping(target = "dateConstant", dateFormat = "dd-MM-yyyy", constant = "09-01-2014"),

--- a/processor/src/test/java/org/mapstruct/ap/test/source/constants/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/constants/Target.java
@@ -29,6 +29,7 @@ public class Target {
 
     private String propertyThatShouldBeMapped;
     private String stringConstant;
+    private String emptyStringConstant;
     private int integerConstant;
     private Long longWrapperConstant;
     private Date dateConstant;
@@ -76,6 +77,14 @@ public class Target {
 
     public List<String> getNameConstants() {
         return nameConstants;
+    }
+
+    public String getEmptyStringConstant() {
+        return emptyStringConstant;
+    }
+
+    public void setEmptyStringConstant(String emptyStringConstant) {
+        this.emptyStringConstant = emptyStringConstant;
     }
 
 }


### PR DESCRIPTION
This fixes #618 and #588 (and the duplicate #622).

#602 (configurable destination packages and implementations) should be aligned to this solution as well. See examples in MapperConfiguration: https://github.com/mapstruct/mapstruct/pull/623/files#diff-edd112063ebfe5afe8f83d4a0ad78377L81