### PR TITLE
#626 Remove doubled blank lines on Windows

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/writer/IndentationCorrectingWriter.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/writer/IndentationCorrectingWriter.java
@@ -301,6 +301,9 @@ class IndentationCorrectingWriter extends Writer {
                         context.indentationLevel++;
                         return START_OF_LINE;
                     case '}':
+                        if ( context.consecutiveLineBreaks > 0 ) {
+                            context.consecutiveLineBreaks = 0; // remove previous blank lines
+                        }
                     case ')':
                         context.indentationLevel--;
                         return START_OF_LINE;

--- a/processor/src/main/java/org/mapstruct/ap/internal/writer/IndentationCorrectingWriter.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/writer/IndentationCorrectingWriter.java
@@ -71,7 +71,7 @@ class IndentationCorrectingWriter extends Writer {
             State newState = currentState.handleCharacter( c, context );
 
             if ( newState != currentState ) {
-                currentState.onExit( context );
+                currentState.onExit( context, newState );
                 newState.onEntry( context );
                 currentState = newState;
             }
@@ -89,7 +89,7 @@ class IndentationCorrectingWriter extends Writer {
 
     @Override
     public void close() throws IOException {
-        currentState.onExit( context );
+        currentState.onExit( context, null );
         context.writer.close();
     }
 
@@ -150,7 +150,7 @@ class IndentationCorrectingWriter extends Writer {
              * Writes out the current text.
              */
             @Override
-            void onExit(StateContext context) throws IOException {
+            void onExit(StateContext context, State nextState) throws IOException {
                 flush( context );
             }
 
@@ -194,7 +194,7 @@ class IndentationCorrectingWriter extends Writer {
              * Writes out the current text.
              */
             @Override
-            void onExit(StateContext context) throws IOException {
+            void onExit(StateContext context, State nextState) throws IOException {
                 flush( context );
             }
 
@@ -229,7 +229,7 @@ class IndentationCorrectingWriter extends Writer {
              * Writes out the current text.
              */
             @Override
-            void onExit(StateContext context) throws IOException {
+            void onExit(StateContext context, State nextState) throws IOException {
                 flush( context );
             }
 
@@ -259,7 +259,7 @@ class IndentationCorrectingWriter extends Writer {
              * Writes out the current text.
              */
             @Override
-            void onExit(StateContext context) throws IOException {
+            void onExit(StateContext context, State nextState) throws IOException {
                 flush( context );
             }
 
@@ -320,19 +320,21 @@ class IndentationCorrectingWriter extends Writer {
              * Writes out the current line-breaks, avoiding more than one consecutive empty line
              */
             @Override
-            void onExit(StateContext context) throws IOException {
+            void onExit(StateContext context, State nextState) throws IOException {
                 context.consecutiveLineBreaks++;
-                int lineBreaks = Math.min( context.consecutiveLineBreaks, 2 );
+                if ( nextState != IN_LINE_BREAK ) {
+                    int lineBreaks = Math.min( context.consecutiveLineBreaks, 2 );
 
-                for ( int i = 0; i < lineBreaks; i++ ) {
-                    context.writer.append( LINE_SEPARATOR );
+                    for ( int i = 0; i < lineBreaks; i++ ) {
+                        context.writer.append( LINE_SEPARATOR );
 
-                    if ( DEBUG ) {
-                        System.out.print( "\\n" + LINE_SEPARATOR );
+                        if ( DEBUG ) {
+                            System.out.print( "\\n" + LINE_SEPARATOR );
+                        }
                     }
-                }
 
-                context.consecutiveLineBreaks = 0;
+                    context.consecutiveLineBreaks = 0;
+                }
             }
         };
 
@@ -352,7 +354,7 @@ class IndentationCorrectingWriter extends Writer {
         void doOnEntry(StateContext context) throws IOException {
         }
 
-        void onExit(StateContext context) throws IOException {
+        void onExit(StateContext context, State nextState) throws IOException {
         }
 
         void onBufferFinished(StateContext context) throws IOException {

--- a/processor/src/test/resources/checkstyle-for-generated-sources.xml
+++ b/processor/src/test/resources/checkstyle-for-generated-sources.xml
@@ -39,6 +39,10 @@
         <property name="format" value="\S\z" />
         <property name="message" value="There is no new line at the end of file" />
     </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="(\r\n\r\n\r\n|\r\r\r|\n\n\n)" />
+        <property name="message" value="There are multiple blank lines" />
+    </module>
 
     <module name="RegexpSingleline">
         <!-- \s matches whitespace character, $ matches end of line. -->
@@ -90,7 +94,6 @@
         <module name="TypecastParenPad"/>
         <module name="WhitespaceAfter"/>
         <module name="WhitespaceAround"/>
-
 
         <!-- Modifier Checks                                    -->
         <!-- See http://checkstyle.sf.net/config_modifiers.html -->

--- a/processor/src/test/resources/checkstyle-for-generated-sources.xml
+++ b/processor/src/test/resources/checkstyle-for-generated-sources.xml
@@ -43,6 +43,10 @@
         <property name="format" value="(\r\n\r\n\r\n|\r\r\r|\n\n\n)" />
         <property name="message" value="There are multiple blank lines" />
     </module>
+    <module name="RegexpMultiline">
+        <property name="format" value="(\r\n\r\n\ *\}|\r\r *\}|\n\n *\})" />
+        <property name="message" value="There are blank lines before a closing bracket" />
+    </module>
 
     <module name="RegexpSingleline">
         <!-- \s matches whitespace character, $ matches end of line. -->


### PR DESCRIPTION
Removing the doubled blank lines was easy enough. For the unecessary newlines before closing brackets, I have no idea how to fix that in a simple way.

@gunnarmorling, perhaps you have an idea? :wink: 