### PR TITLE
#636 Fix default methods

### DIFF
--- a/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Source.java
+++ b/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Source.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._636;
+
+public class Source {
+    private int value;
+
+    public int getValue() {
+        return value;
+    }
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+}

--- a/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/SourceTargetMapper.java
+++ b/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/SourceTargetMapper.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._636;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface SourceTargetMapper {
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    @Mapping(source = "value", target = "inner")
+    Target mapSourceToTarget(Source source);
+
+    default Target.Inner map(int value) {
+        Target.Inner wrapped = new Target.Inner();
+        wrapped.setValue(String.valueOf(value));
+        return wrapped;
+    }
+}

--- a/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Target.java
+++ b/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Target.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._636;
+
+public class Target {
+    private Inner inner;
+
+    public Inner getInner() {
+        return inner;
+    }
+
+    public void setInner(Inner inner) {
+        this.inner = inner;
+    }
+
+    public static class Inner {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+}

--- a/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_636/Issue636Test.java
+++ b/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_636/Issue636Test.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._636;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class Issue636Test {
+
+    @Test
+    public void shouldDelegateToDefaultInterfaceMethod() {
+
+        final Source source = new Source();
+        source.setValue(1);
+
+        final Target target = SourceTargetMapper.INSTANCE.mapSourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getInner() ).isNotNull();
+        assertThat( target.getInner().getValue() ).isEqualTo( "1" );
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
@@ -18,8 +18,6 @@
  */
 package org.mapstruct.ap.internal.util;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -48,19 +46,6 @@ import static org.mapstruct.ap.internal.util.SpecificCompilerWorkarounds.replace
  * @author Gunnar Morling
  */
 public class Executables {
-
-    private static final Method DEFAULT_METHOD;
-
-    static {
-        Method method;
-        try {
-            method = ExecutableElement.class.getMethod( "isDefault" );
-        }
-        catch ( NoSuchMethodException e ) {
-            method = null;
-        }
-        DEFAULT_METHOD = method;
-    }
 
     private static final AccessorNamingStrategy ACCESSOR_NAMING_STRATEGY = Services.get(
         AccessorNamingStrategy.class,
@@ -94,18 +79,6 @@ public class Executables {
 
     public static String getPropertyName(ExecutableElement getterOrSetterMethod) {
         return ACCESSOR_NAMING_STRATEGY.getPropertyName( getterOrSetterMethod );
-    }
-
-    public static boolean isDefaultMethod(ExecutableElement method) {
-        try {
-            return DEFAULT_METHOD != null && Boolean.TRUE.equals( DEFAULT_METHOD.invoke( method ) );
-        }
-        catch ( IllegalAccessException e ) {
-            return false;
-        }
-        catch ( InvocationTargetException e ) {
-            return false;
-        }
     }
 
     /**
@@ -188,7 +161,6 @@ public class Executables {
         List<ExecutableElement> safeToAdd = new ArrayList<ExecutableElement>( methodsToAdd.size() );
         for ( ExecutableElement toAdd : methodsToAdd ) {
             if ( isNotStaticMethodInInterface( toAdd, parentType )
-                && isNotInterfaceDefaultMethod( toAdd, parentType )
                 && isNotObjectEquals( toAdd )
                 && wasNotYetOverridden( elementUtils, alreadyCollected, toAdd, parentType ) ) {
                 safeToAdd.add( toAdd );
@@ -202,12 +174,6 @@ public class Executables {
         return !( parentType.getKind().isInterface() &&
             element.getKind() == ElementKind.METHOD &&
             element.getModifiers().containsAll( Arrays.asList( Modifier.PUBLIC, Modifier.STATIC ) ) );
-    }
-
-    private static boolean isNotInterfaceDefaultMethod(ExecutableElement element, TypeElement parentType) {
-        return !( parentType.getKind().isInterface() &&
-            element.getKind() == ElementKind.METHOD &&
-            isDefaultMethod( element ) );
     }
 
     /**


### PR DESCRIPTION
It seems like fixing of #603 triggered this bug by assuming that static
interface methods and default interface methods should be treated the
same way. Reverted the behaviour on default methods and added a test
case for it.