### PR TITLE
#636 - fix - default methods (Java 8) do not work anymore

### DIFF
--- a/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Bar.java
+++ b/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Bar.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._636;
+
+public class Bar {
+    private final String id;
+
+    public Bar(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Foo.java
+++ b/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Foo.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._636;
+
+public class Foo {
+    private final long id;
+
+    public Foo(long id) {
+        this.id = id;
+    }
+
+    public long getId() {
+        return id;
+    }
+}

--- a/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/MyMapper.java
+++ b/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/MyMapper.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._636;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public class MyMapper {
+    public BigDecimal mapBigIntToDecimal(BigInteger source) {
+        return source == null ? null : new BigDecimal( source );
+    }
+}

--- a/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Source.java
+++ b/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Source.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._636;
+
+import java.math.BigInteger;
+
+public class Source {
+    private final long idFoo;
+    private final String idBar;
+    private final BigInteger number;
+
+    public Source(long idFoo, String idBar, BigInteger number) {
+        this.idFoo = idFoo;
+        this.idBar = idBar;
+        this.number = number;
+    }
+
+    public long getIdFoo() {
+        return idFoo;
+    }
+
+    public String getIdBar() {
+        return idBar;
+    }
+
+    public BigInteger getNumber() {
+        return number;
+    }
+}

--- a/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/SourceTargetMapper.java
+++ b/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/SourceTargetMapper.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._636;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = MyMapper.class)
+public interface SourceTargetMapper {
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    @Mappings({
+        @Mapping(source = "idFoo", target = "foo"),
+        @Mapping(source = "idBar", target = "bar"),
+        @Mapping(source = "number", target = "number")
+    })
+    Target mapSourceToTarget(Source source);
+
+    default Foo fooFromId(long id) {
+        return new Foo(id);
+    }
+
+    static Bar barFromId(String id) {
+        return new Bar(id);
+    }
+}

--- a/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Target.java
+++ b/integrationtest/src/test/resources/java8Test/src/main/java/org/mapstruct/ap/test/bugs/_636/Target.java
@@ -1,0 +1,51 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._636;
+
+import java.math.BigDecimal;
+
+public class Target {
+    private Foo foo;
+    private Bar bar;
+    private BigDecimal number;
+
+    public Foo getFoo() {
+        return foo;
+    }
+
+    public void setFoo(Foo foo) {
+        this.foo = foo;
+    }
+
+    public Bar getBar() {
+        return bar;
+    }
+
+    public void setBar(Bar bar) {
+        this.bar = bar;
+    }
+
+    public BigDecimal getNumber() {
+        return number;
+    }
+
+    public void setNumber(BigDecimal number) {
+        this.number = number;
+    }
+}

--- a/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_636/Issue636Test.java
+++ b/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_636/Issue636Test.java
@@ -1,0 +1,48 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._636;
+
+import java.math.BigInteger;
+
+import org.junit.Test;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+public class Issue636Test {
+
+    @Test
+    public void shouldMapDataFromJava8Interface() {
+
+        final long idFoo = 123;
+        final String idBar = "Bar456";
+        final BigInteger number = BigInteger.valueOf( 789L );
+
+        final Source source = new Source( idFoo, idBar, number );
+
+        final Target target = SourceTargetMapper.INSTANCE.mapSourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFoo() ).isNotNull();
+        assertThat( target.getFoo().getId() ).isEqualTo( idFoo );
+        assertThat( target.getBar() ).isNotNull();
+        assertThat( target.getBar().getId() ).isEqualTo( idBar );
+        assertThat( target.getNumber() ).isNotNull();
+        assertThat( target.getNumber().toBigInteger() ).isEqualTo( number );
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
@@ -47,6 +47,7 @@ public abstract class MappingMethod extends ModelElement {
     private final Accessibility accessibility;
     private final List<Type> thrownTypes;
     private final boolean isStatic;
+    private final Type staticMethodFromInterfaceType;
     private final String resultName;
     private final List<LifecycleCallbackMethodReference> beforeMappingReferencesWithMappingTarget;
     private final List<LifecycleCallbackMethodReference> beforeMappingReferencesWithoutMappingTarget;
@@ -69,6 +70,7 @@ public abstract class MappingMethod extends ModelElement {
         this.accessibility = method.getAccessibility();
         this.thrownTypes = method.getThrownTypes();
         this.isStatic = method.isStatic();
+        this.staticMethodFromInterfaceType = method.getStaticMethodFromInterfaceType();
         this.resultName = initResultName( existingVariableNames );
         this.beforeMappingReferencesWithMappingTarget = filterMappingTarget( beforeMappingReferences, true );
         this.beforeMappingReferencesWithoutMappingTarget = filterMappingTarget( beforeMappingReferences, false );
@@ -144,6 +146,10 @@ public abstract class MappingMethod extends ModelElement {
         return isStatic;
     }
 
+    public Type getStaticMethodFromInterfaceType() {
+        return staticMethodFromInterfaceType;
+    }
+
     @Override
     public Set<Type> getImportTypes() {
         Set<Type> types = new HashSet<Type>();
@@ -154,6 +160,9 @@ public abstract class MappingMethod extends ModelElement {
 
         types.add( getReturnType() );
         types.addAll( thrownTypes );
+        if ( staticMethodFromInterfaceType != null ) {
+            types.add( staticMethodFromInterfaceType );
+        }
         return types;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
@@ -193,6 +193,16 @@ public class ForgedMethod implements Method {
     }
 
     @Override
+    public boolean isDefault() {
+        return false;
+    }
+
+    @Override
+    public Type getStaticMethodFromInterfaceType() {
+        return null;
+    }
+
+    @Override
     public MapperConfiguration getMapperConfiguration() {
         return null;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/Method.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/Method.java
@@ -145,6 +145,20 @@ public interface Method {
     boolean isStatic();
 
     /**
+     * Whether this method is Java 8 default method
+     *
+     * @return true when Java 8 default method
+     */
+    boolean isDefault();
+
+    /**
+     * Returns method's enclosing type if method is Java 8 static method
+     *
+     * @return type of static method from Java 8 interface
+     */
+    Type getStaticMethodFromInterfaceType();
+
+    /**
      *
      * @return the mapper config when this method needs to be implemented
      */

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -66,6 +66,8 @@ public class SourceMethod implements Method {
     private final MapperConfiguration config;
     private final MappingOptions mappingOptions;
     private final List<SourceMethod> prototypeMethods;
+    private final boolean defaultMethod;
+    private final Type staticMethodFromInterfaceType;
 
     private List<Parameter> sourceParameters;
 
@@ -89,6 +91,8 @@ public class SourceMethod implements Method {
         private FormattingMessager messager = null;
         private MapperConfiguration mapperConfig = null;
         private List<SourceMethod> prototypeMethods = Collections.emptyList();
+        private boolean defaultMethod;
+        private Type staticMethodFromInterfaceType;
 
         public Builder() {
         }
@@ -163,6 +167,16 @@ public class SourceMethod implements Method {
             return this;
         }
 
+        public Builder setDefaultMethod(boolean defaultMethod) {
+            this.defaultMethod = defaultMethod;
+            return this;
+        }
+
+        public Builder setStaticMethodFromInterfaceType(Type staticMethodFromInterfaceType) {
+            this.staticMethodFromInterfaceType = staticMethodFromInterfaceType;
+            return this;
+        }
+
         public SourceMethod build() {
 
             MappingOptions mappingOptions
@@ -178,7 +192,9 @@ public class SourceMethod implements Method {
                 typeUtils,
                 typeFactory,
                 mapperConfig,
-                prototypeMethods
+                prototypeMethods,
+                defaultMethod,
+                staticMethodFromInterfaceType
             );
 
             if ( mappings != null ) {
@@ -194,8 +210,9 @@ public class SourceMethod implements Method {
 
     @SuppressWarnings("checkstyle:parameternumber")
     private SourceMethod(Type declaringMapper, ExecutableElement executable, List<Parameter> parameters,
-        Type returnType, List<Type> exceptionTypes, MappingOptions mappingOptions, Types typeUtils,
-        TypeFactory typeFactory, MapperConfiguration config, List<SourceMethod> prototypeMethods) {
+                         Type returnType, List<Type> exceptionTypes, MappingOptions mappingOptions, Types typeUtils,
+                         TypeFactory typeFactory, MapperConfiguration config, List<SourceMethod> prototypeMethods,
+                         boolean defaultMethod, Type staticMethodFromInterfaceType) {
         this.declaringMapper = declaringMapper;
         this.executable = executable;
         this.parameters = parameters;
@@ -212,6 +229,8 @@ public class SourceMethod implements Method {
         this.typeFactory = typeFactory;
         this.config = config;
         this.prototypeMethods = prototypeMethods;
+        this.defaultMethod = defaultMethod;
+        this.staticMethodFromInterfaceType = staticMethodFromInterfaceType;
     }
 
     private Parameter determineMappingTargetParameter(Iterable<Parameter> parameters) {
@@ -511,6 +530,15 @@ public class SourceMethod implements Method {
         return executable.getModifiers().contains( Modifier.STATIC );
     }
 
+    @Override
+    public boolean isDefault() {
+        return defaultMethod;
+    }
+
+    @Override
+    public Type getStaticMethodFromInterfaceType() {
+        return staticMethodFromInterfaceType;
+    }
 
     @Override
     public MapperConfiguration getMapperConfiguration() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInMethod.java
@@ -240,6 +240,16 @@ public abstract class BuiltInMethod implements Method {
     }
 
     @Override
+    public boolean isDefault() {
+        return false;
+    }
+
+    @Override
+    public Type getStaticMethodFromInterfaceType() {
+        return null;
+    }
+
+    @Override
     public MapperConfiguration getMapperConfiguration() {
         return null;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -187,7 +187,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
                 }
             }
             Type declaringMapper = mappingMethod.getDeclaringMapper();
-            if ( implementationRequired ) {
+            if ( implementationRequired && !( mappingMethod.isDefault() || mappingMethod.isStatic()) ) {
                 if ( ( declaringMapper == null ) || declaringMapper.equals( typeFactory.getType( element ) ) ) {
                     mappingMethods.add( new DelegatingMethod( mappingMethod ) );
                 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
@@ -187,9 +187,7 @@ public class Executables {
                                             List<ExecutableElement> methodsToAdd, TypeElement parentType) {
         List<ExecutableElement> safeToAdd = new ArrayList<ExecutableElement>( methodsToAdd.size() );
         for ( ExecutableElement toAdd : methodsToAdd ) {
-            if ( isNotStaticMethodInInterface( toAdd, parentType )
-                && isNotInterfaceDefaultMethod( toAdd, parentType )
-                && isNotObjectEquals( toAdd )
+            if ( isNotObjectEquals( toAdd )
                 && wasNotYetOverridden( elementUtils, alreadyCollected, toAdd, parentType ) ) {
                 safeToAdd.add( toAdd );
             }
@@ -198,16 +196,16 @@ public class Executables {
         alreadyCollected.addAll( 0, safeToAdd );
     }
 
-    private static boolean isNotStaticMethodInInterface(ExecutableElement element, TypeElement parentType) {
-        return !( parentType.getKind().isInterface() &&
+    public static boolean isInterfaceDefaultMethod(ExecutableElement element, TypeElement parentType) {
+        return parentType.getKind().isInterface() &&
             element.getKind() == ElementKind.METHOD &&
-            element.getModifiers().containsAll( Arrays.asList( Modifier.PUBLIC, Modifier.STATIC ) ) );
+            isDefaultMethod( element );
     }
 
-    private static boolean isNotInterfaceDefaultMethod(ExecutableElement element, TypeElement parentType) {
-        return !( parentType.getKind().isInterface() &&
+    public static boolean isStaticFromInterfaceMethod(ExecutableElement element, TypeElement parentType) {
+        return parentType.getKind().isInterface() &&
             element.getKind() == ElementKind.METHOD &&
-            isDefaultMethod( element ) );
+            element.getModifiers().containsAll( Arrays.asList( Modifier.PUBLIC, Modifier.STATIC ) );
     }
 
     /**

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MethodReference.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MethodReference.ftl
@@ -20,7 +20,16 @@
 -->
 <@compress single_line=true>
     <#-- method is either internal to the mapper class, or external (via uses) declaringMapper!=null -->
-    <#if declaringMapper??><#if static><@includeModel object=declaringMapper.type/><#else>${mapperVariableName}</#if>.</#if>${name}<#if (parameters?size > 0)>( <@arguments/> )<#else>()</#if>
+    <#if declaringMapper??><#if static><@includeModel object=declaringMapper.type/><#else>${mapperVariableName}</#if>.<@params/>
+    <#elseif staticMethodFromInterfaceType??><@includeModel object=staticMethodFromInterfaceType/>.<@params/>
+    <#else>
+    <@params/>
+    </#if>
+    <#macro params>
+        <@compress>
+            ${name}<#if (parameters?size > 0)>( <@arguments/> )<#else>()</#if>
+        </@compress>
+    </#macro>
     <#macro arguments>
         <#list parameters as param>
             <#if param.targetType>


### PR DESCRIPTION
Hi,
I have created following fix. With current knowledge of MapStruct previous PR makes no sense :-) .
I have moved filtering of Static/Default methods from Java8 interface to org.mapstruct.ap.internal.processor.MapperCreationProcessor#getDecorator method. Second change is to support calling static method from interface. Interesting parts are org.mapstruct.ap.internal.processor.MethodRetrievalProcessor#findStaticMethodFromInterfaceType and MethodReference.ftl template.
Hope it will be OK now. Sorry for "regression".
Ivos