### PR TITLE
#631 fix for parameterized source / target types

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -377,6 +377,18 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
             return false;
         }
 
+      for ( Parameter sourceParameter : sourceParameters ) {
+            if ( sourceParameter.getType().isTypeVar() ) {
+                messager.printMessage( method, Message.RETRIEVAL_TYPE_VAR_SOURCE );
+                return false;
+            }
+        }
+
+        if ( returnType.isTypeVar() || resultType.isTypeVar() ) {
+                messager.printMessage( method, Message.RETRIEVAL_TYPE_VAR_RESULT );
+                return false;
+        }
+
         Type parameterType = sourceParameters.get( 0 ).getType();
 
         if ( parameterType.isIterableType() && !resultType.isIterableType() ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_631/Base1.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_631/Base1.java
@@ -1,0 +1,27 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._631;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Base1 {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_631/Base2.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_631/Base2.java
@@ -1,0 +1,27 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._631;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Base2 {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_631/Issue631Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_631/Issue631Test.java
@@ -1,0 +1,57 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._631;
+
+
+import javax.tools.Diagnostic.Kind;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Sjaak Derksen
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue631Test {
+
+    @Test
+    @IssueKey("631")
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = SourceTargetMapper.class,
+                kind = Kind.ERROR,
+                line = 35,
+                messageRegExp = "Can't generate mapping method for a generic type variable target."),
+            @Diagnostic(type = SourceTargetMapper.class,
+                kind = Kind.ERROR,
+                line = 37,
+                messageRegExp = "Can't generate mapping method for a generic type variable source.")
+        }
+    )
+    @WithClasses({SourceTargetMapper.class, Base1.class, Base2.class})
+    public void showsCantMapPropertyError() {
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_631/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_631/SourceTargetMapper.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._631;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ * @param <X>
+ * @param <Y>
+ */
+@Mapper
+public interface SourceTargetMapper<X extends Base1, Y extends Base2> {
+
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    X mapIntegerToBase1(Integer obj);
+
+    Integer mapBase2ToInteger(Y obj);
+}


### PR DESCRIPTION
Hi guys,

I'm not sure this is the way forward, so this one needs some more tests. What I've done is work with the type bound iso the type itself (in Parameter, MappingMethod). Its a bit crude. We should perhaps (if this is the way forward) these model elements in this way in stead of putting it on the getter. 

I also would like to add some test case in which the type bounds are coming from another package (make sure imports are handled correctly).

But first.. Is this the way forward? I'll extend the solution if we agree..

Cheers,
Sjaak