### PR TITLE
#640 - applying Mapper or Mapperconfig NullValueMappingStrategy to fo…

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -51,6 +51,7 @@ import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentTy
 import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType.MAPPED_TYPE_CONVERTED;
 import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType.TYPE_CONVERTED;
 import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType.TYPE_CONVERTED_MAPPED;
+import org.mapstruct.ap.internal.util.MapperConfiguration;
 
 /**
  * Represents the mapping between a source and target property, e.g. from {@code String Source#foo} to
@@ -429,6 +430,9 @@ public class PropertyMapping extends ModelElement {
             else {
                 PropertyEntry lastPropertyEntry = propertyEntries.get( propertyEntries.size() - 1 );
 
+                // copy mapper configuration from the source method, its the same mapper
+                MapperConfiguration config = method.getMapperConfiguration();
+
                 // forge a method from the parameter type to the last entry type.
                 String forgedName = Strings.joinAndCamelize( sourceReference.getElementNames() );
                 forgedName = Strings.getSaveVariableName( forgedName, ctx.getNamesOfMappingsToGenerate() );
@@ -436,6 +440,7 @@ public class PropertyMapping extends ModelElement {
                     forgedName,
                     sourceReference.getParameter().getType(),
                     lastPropertyEntry.getType(),
+                    config,
                     method.getExecutable()
                 );
                 NestedPropertyMappingMethod.Builder builder = new NestedPropertyMappingMethod.Builder();
@@ -515,7 +520,9 @@ public class PropertyMapping extends ModelElement {
             if ( ( sourceType.isCollectionType() || sourceType.isArrayType() )
                 && ( targetType.isCollectionType() || targetType.isArrayType() ) ) {
 
-                ForgedMethod methodRef = new ForgedMethod( name, sourceType, targetType, element );
+                // copy mapper configuration from the source method, its the same mapper
+                MapperConfiguration config = method.getMapperConfiguration();
+                ForgedMethod methodRef = new ForgedMethod( name, sourceType, targetType, config, element );
                 IterableMappingMethod.Builder builder = new IterableMappingMethod.Builder();
 
                 IterableMappingMethod iterableMappingMethod = builder
@@ -538,7 +545,9 @@ public class PropertyMapping extends ModelElement {
             }
             else if ( sourceType.isMapType() && targetType.isMapType() ) {
 
-                ForgedMethod methodRef = new ForgedMethod( name, sourceType, targetType, element );
+                // copy mapper configuration from the source method, its the same mapper
+                MapperConfiguration config = method.getMapperConfiguration();
+                ForgedMethod methodRef = new ForgedMethod( name, sourceType, targetType, config, element );
 
                 MapMappingMethod.Builder builder = new MapMappingMethod.Builder();
                 MapMappingMethod mapMappingMethod = builder

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
@@ -44,6 +44,7 @@ public class ForgedMethod implements Method {
     private final String name;
     private final ExecutableElement positionHintElement;
     private final List<Type> thrownTypes;
+    private final MapperConfiguration mapperConfiguration;
 
      /**
      * Creates a new forged method with the given name.
@@ -53,13 +54,15 @@ public class ForgedMethod implements Method {
      * @param targetType the target type.
      * @param positionHintElement element used to for reference to the position in the source file.
      */
-    public ForgedMethod(String name, Type sourceType, Type targetType, ExecutableElement positionHintElement) {
+    public ForgedMethod(String name, Type sourceType, Type targetType, MapperConfiguration mapperConfiguration,
+        ExecutableElement positionHintElement) {
         String sourceParamName = Strings.decapitalize( sourceType.getName().replace( "[]", "" ) );
         String sourceParamSafeName = Strings.getSaveVariableName( sourceParamName );
         this.parameters = Arrays.asList( new Parameter( sourceParamSafeName, sourceType ) );
         this.returnType = targetType;
         this.thrownTypes = new ArrayList<Type>();
         this.name = name;
+        this.mapperConfiguration = mapperConfiguration;
         this.positionHintElement = positionHintElement;
     }
 
@@ -72,6 +75,7 @@ public class ForgedMethod implements Method {
         this.parameters = forgedMethod.parameters;
         this.returnType = forgedMethod.returnType;
         this.thrownTypes = new ArrayList<Type>();
+        this.mapperConfiguration = forgedMethod.mapperConfiguration;
         this.positionHintElement = forgedMethod.positionHintElement;
         this.name = name;
     }
@@ -204,7 +208,7 @@ public class ForgedMethod implements Method {
 
     @Override
     public MapperConfiguration getMapperConfiguration() {
-        return null;
+        return mapperConfiguration;
     }
 
     @Override

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/CollectionMapperNullValueMappingReturnDefault.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/CollectionMapperNullValueMappingReturnDefault.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.forged;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValueMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper( nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT )
+public interface CollectionMapperNullValueMappingReturnDefault {
+
+    CollectionMapperNullValueMappingReturnDefault INSTANCE =
+        Mappers.getMapper( CollectionMapperNullValueMappingReturnDefault.class );
+
+    Target sourceToTarget( Source source );
+    Source targetToSource( Target target );
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/CollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/CollectionMappingTest.java
@@ -121,5 +121,72 @@ public class CollectionMappingTest {
     }
 
 
+    @Test
+    @IssueKey( "640" )
+    @WithClasses({ CollectionMapper.class, Source.class, Target.class })
+    public void shouldForgeNewIterableMappingMethodReturnNullOnNullSource() {
+
+        Source source = new Source();
+        source.setFooSet( null );
+
+        Target target = CollectionMapper.INSTANCE.sourceToTarget( source );
+        assertThat( target ).isNotNull();
+        assertThat( target.getFooSet() ).isNull();
+
+        Source source2 = CollectionMapper.INSTANCE.targetToSource( target );
+        assertThat( source2 ).isNotNull();
+        assertThat( source2.getFooSet() ).isNull();
+    }
+
+    @Test
+    @IssueKey( "640" )
+    @WithClasses({ CollectionMapper.class, Source.class, Target.class })
+    public void shouldForgeNewMapMappingMethodReturnNullOnNullSource() {
+
+        Source source = new Source();
+        source.setBarMap( null );
+
+        Target target = CollectionMapper.INSTANCE.sourceToTarget( source );
+        assertThat( target ).isNotNull();
+        assertThat( target.getBarMap() ).isNull();
+
+        Source source2 = CollectionMapper.INSTANCE.targetToSource( target );
+        assertThat( source2 ).isNotNull();
+        assertThat( source2.getBarMap() ).isNull();
+    }
+
+    @Test
+    @IssueKey( "640" )
+    @WithClasses({ CollectionMapperNullValueMappingReturnDefault.class, Source.class, Target.class })
+    public void shouldForgeNewIterableMappingMethodReturnEmptyOnNullSource() {
+
+        Source source = new Source();
+        source.setFooSet( null );
+
+        Target target = CollectionMapperNullValueMappingReturnDefault.INSTANCE.sourceToTarget( source );
+        assertThat( target ).isNotNull();
+        assertThat( target.getFooSet() ).isEmpty();
+
+        Source source2 = CollectionMapperNullValueMappingReturnDefault.INSTANCE.targetToSource( target );
+        assertThat( source2 ).isNotNull();
+        assertThat( source2.getFooSet() ).isEmpty();
+    }
+
+    @Test
+    @IssueKey( "640" )
+    @WithClasses({ CollectionMapperNullValueMappingReturnDefault.class, Source.class, Target.class })
+    public void shouldForgeNewMapMappingMethodReturnEmptyOnNullSource() {
+
+        Source source = new Source();
+        source.setBarMap( null );
+
+        Target target = CollectionMapperNullValueMappingReturnDefault.INSTANCE.sourceToTarget( source );
+        assertThat( target ).isNotNull();
+        assertThat( target.getBarMap() ).isEmpty();
+
+        Source source2 = CollectionMapperNullValueMappingReturnDefault.INSTANCE.targetToSource( target );
+        assertThat( source2 ).isNotNull();
+        assertThat( source2.getBarMap() ).isEmpty();
+    }
 
 }


### PR DESCRIPTION
…rged methods

Solution is straightforward. `MapperConfiguration` contains all enums on the `Mapper` and `MapperConfig`. The `MapperConfiguration` is copied from the calling `SourceMethod` which is in the same `Mapper` as the forged method. 

Added 4 test cases to test all scenarios. Validation of `MapperConfig` should not be needed, since thats already tested in the NullValueMapping test cases.