### PR TITLE
664 - annotate mapper implementations with @Singleton when using jsr330.

### DIFF
--- a/core-common/src/main/java/org/mapstruct/DecoratedWith.java
+++ b/core-common/src/main/java/org/mapstruct/DecoratedWith.java
@@ -123,9 +123,9 @@ import java.lang.annotation.Target;
  * <p>
  * JSR 330 doesn't specify qualifiers and only allows to specifically name the beans. Hence, the generated
  * implementation of the original mapper is annotated with {@code @Named("fully-qualified-name-of-generated-impl")}
- * (please note that when using a decorator, the class name of the mapper implementation ends with an underscore). To
- * inject that bean in your decorator, add the same annotation to the delegate field (e.g. by copy/pasting it from the
- * generated class):
+ * and {@code @Singleton} (please note that when using a decorator, the class name of the mapper implementation ends
+ * with an underscore). To inject that bean in your decorator, add the same annotation to the delegate field (e.g. by
+ * copy/pasting it from the generated class):
  *
  * <pre>
  * public abstract class PersonMapperDecorator implements PersonMapper {

--- a/core-common/src/main/java/org/mapstruct/Mapper.java
+++ b/core-common/src/main/java/org/mapstruct/Mapper.java
@@ -75,7 +75,7 @@ public @interface Mapper {
      * can be retrieved via {@code @Autowired}</li>
      * <li>
      * {@code jsr330}: the generated mapper is annotated with {@code @Named} and
-     * can be retrieved via {@code @Inject}</li>
+     * {@code @Singleton}, and can be retrieved via {@code @Inject}</li>
      * </ul>
      * The method overrides an unmappedTargetPolicy set in a central configuration set
      * by {@link #config() }

--- a/core-common/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core-common/src/main/java/org/mapstruct/MapperConfig.java
@@ -77,7 +77,7 @@ public @interface MapperConfig {
      * can be retrieved via {@code @Autowired}</li>
      * <li>
      * {@code jsr330}: the generated mapper is annotated with {@code @Named} and
-     * can be retrieved via {@code @Inject}</li>
+     * {@code @Singleton}, and can be retrieved via {@code @Inject}</li>
      * </ul>
      *
      * @return The component model for the generated mapper.

--- a/integrationtest/src/test/resources/jsr330Test/src/main/java/org/mapstruct/itest/jsr330/other/DateMapper.java
+++ b/integrationtest/src/test/resources/jsr330Test/src/main/java/org/mapstruct/itest/jsr330/other/DateMapper.java
@@ -23,7 +23,9 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 import javax.inject.Named;
+import javax.inject.Singleton;
 
+@Singleton
 @Named
 public class DateMapper {
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/Jsr330ComponentProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/Jsr330ComponentProcessor.java
@@ -42,16 +42,16 @@ public class Jsr330ComponentProcessor extends AnnotationBasedComponentModelProce
     @Override
     protected List<Annotation> getTypeAnnotations(Mapper mapper) {
         if ( mapper.getDecorator() == null ) {
-            return Collections.singletonList( named() );
+            return Arrays.asList( singleton(), named() );
         }
         else {
-            return Collections.singletonList( namedDelegate( mapper ) );
+            return Arrays.asList( singleton(), namedDelegate( mapper ) );
         }
     }
 
     @Override
     protected List<Annotation> getDecoratorAnnotations() {
-        return Collections.singletonList( named() );
+        return Arrays.asList( singleton(), named() );
     }
 
     @Override
@@ -67,6 +67,10 @@ public class Jsr330ComponentProcessor extends AnnotationBasedComponentModelProce
     @Override
     protected boolean requiresGenerationOfDecoratorClass() {
         return true;
+    }
+
+    private Annotation singleton() {
+        return new Annotation( getTypeFactory().getType( "javax.inject.Singleton" ) );
     }
 
     private Annotation named() {


### PR DESCRIPTION
First attempt at implementing #664. Simply put, some dependency injection frameworks (e.g. `blueprint-maven-plugin` which generates a blueprint xml file) that use JSR330 annotations require beans to be annotated with `@Singleton`, whereas mapstruct currently only applies the `@Named` annotation. 

This commit applies the `@Singleton` annotation when using JSR330 annotations to mapper classes in addition to the `@Named` annotation, which is used by `blueprint-maven-plugin` as a qualifier for bean injection.

I couldn't find any tests which verified that the `@Named` annotation was applied, so I didn't add any tests for verifying the application of `@Singleton`. Similarly the integration test doesn't require the `@Singleton` annotation to work, so currently the content of this commit is untested (except by hand) which isn't good.

Options for testing:
1.  Add a unit test class for `Jsr330ComponentProcessor` to verify that the `@Named` and `@Singleton` annotations are returned where expected.
2. Add an integration test that uses `blueprint-maven-plugin` to generate an xml file (which requires the `@Singleton` annotation) and verify that a mapper class was successfully configured, for example by using http://aries.apache.org/modules/blueprintnoosgi.html to check that the mapper class can be retrieved as a bean.

I'm happy to implement either or all of those options, but I'll wait for someone to say whether or not this is a good approach.