### PR TITLE
Autodetect toolchain conf

### DIFF
--- a/integrationtest/src/test/java/org/mapstruct/itest/testutil/runner/ProcessorSuite.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/testutil/runner/ProcessorSuite.java
@@ -52,12 +52,12 @@ public @interface ProcessorSuite {
         /**
          * Use an Oracle JDK 1.6 (or 1.6.x) via toolchain support to perform the processing
          */
-        ORACLE_JAVA_6( "oracle-[1.6,1.7)", "javac", "1.6" ),
+        ORACLE_JAVA_6( new Toolchain( "oracle", "1.6", "1.7" ), "javac", "1.6" ),
 
         /**
          * Use an Oracle JDK 1.7 (or 1.7.x) via toolchain support to perform the processing
          */
-        ORACLE_JAVA_7( "oracle-[1.7,1.8)", "javac", "1.7" ),
+        ORACLE_JAVA_7( new Toolchain( "oracle", "1.7", "1.8" ), "javac", "1.7" ),
 
         /**
          * Use the same JDK that runs the mvn build to perform the processing
@@ -67,7 +67,7 @@ public @interface ProcessorSuite {
         /**
          * Use an Oracle JDK 1.9 (or 1.9.x) via toolchain support to perform the processing
          */
-        ORACLE_JAVA_9( "oracle-[1.9,1.10)", "javac", "1.9" ),
+        ORACLE_JAVA_9( new Toolchain( "oracle", "9", "10" ), "javac", "1.9" ),
 
         /**
          * Use the eclipse compiler with 1.7 source/target level from tycho-compiler-jdt to perform the build and
@@ -100,11 +100,11 @@ public @interface ProcessorSuite {
 
         private ProcessorType[] included = { };
 
-        private String toolchain;
+        private Toolchain toolchain;
         private String compilerId;
         private String sourceTargetVersion;
 
-        private ProcessorType(String toolchain, String compilerId, String sourceTargetVersion) {
+        private ProcessorType(Toolchain toolchain, String compilerId, String sourceTargetVersion) {
             this.toolchain = toolchain;
             this.compilerId = compilerId;
             this.sourceTargetVersion = sourceTargetVersion;
@@ -124,7 +124,7 @@ public @interface ProcessorSuite {
         /**
          * @return the toolchain
          */
-        public String getToolchain() {
+        public Toolchain getToolchain() {
             return toolchain;
         }
 

--- a/integrationtest/src/test/java/org/mapstruct/itest/testutil/runner/Toolchain.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/testutil/runner/Toolchain.java
@@ -1,0 +1,51 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.itest.testutil.runner;
+
+/**
+ * Describes a required entry in the Maven toolchains.xml file.
+ *
+ * @author Andreas Gudian
+ */
+class Toolchain {
+    private final String vendor;
+    private final String versionMinInclusive;
+    private final String versionMaxExclusive;
+
+    Toolchain(String vendor, String versionMinInclusive, String versionMaxExclusive) {
+        this.vendor = vendor;
+        this.versionMinInclusive = versionMinInclusive;
+        this.versionMaxExclusive = versionMaxExclusive;
+    }
+
+    String getVendor() {
+        return vendor;
+    }
+
+    String getVersionMinInclusive() {
+        return versionMinInclusive;
+    }
+
+    /**
+     * @return the version range string to be used in the Maven execution to select the toolchain
+     */
+    String getVersionRangeString() {
+        return "[" + versionMinInclusive + "," + versionMaxExclusive + ")";
+    }
+}

--- a/integrationtest/src/test/java/org/mapstruct/itest/testutil/runner/xml/Toolchains.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/testutil/runner/xml/Toolchains.java
@@ -1,0 +1,87 @@
+/**
+ *  Copyright 2012-2015 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.itest.testutil.runner.xml;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * JAXB representation of some of the parts in the Maven toolchains.xml file.
+ *
+ * @author Andreas Gudian
+ */
+@XmlRootElement
+public class Toolchains {
+    @XmlElement(name = "toolchain")
+    private List<Toolchain> toolchains = new ArrayList<>();
+
+    public List<Toolchain> getToolchains() {
+        return toolchains;
+    }
+
+    @Override
+    public String toString() {
+        return "Toolchains [toolchains=" + toolchains + "]";
+    }
+
+    public static class Toolchain {
+        @XmlElement
+        private String type;
+
+        @XmlElement(name = "provides")
+        private ProviderDescription providerDescription;
+
+        public String getType() {
+            return type;
+        }
+
+        public ProviderDescription getProviderDescription() {
+            return providerDescription;
+        }
+
+        @Override
+        public String toString() {
+            return "Toolchain [type=" + type + ", providerDescription=" + providerDescription + "]";
+        }
+    }
+
+    public static class ProviderDescription {
+        @XmlElement
+        private String version;
+
+        @XmlElement
+        private String vendor;
+
+        public String getVersion() {
+            return version;
+        }
+
+        public String getVendor() {
+            return vendor;
+        }
+
+        @Override
+        public String toString() {
+            return "ProviderDescription [version=" + version + ", vendor=" + vendor + "]";
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
@@ -57,7 +57,7 @@ public class JodaConversionTest {
         src.setDateTime( new DateTime( 2014, 1, 1, 0, 0, 0, DateTimeZone.UTC ) );
         Target target = SourceTargetMapper.INSTANCE.sourceToTargetDateTimeMapped( src );
         assertThat( target ).isNotNull();
-        assertThat( target.getDateTime() ).isEqualTo( "01.01.2014 00:00 UTC" );
+        assertThat( target.getDateTime() ).isIn( "01.01.2014 00:00 UTC", "01.01.2014 00:00 +00:00" );
     }
 
     @Test
@@ -99,7 +99,7 @@ public class JodaConversionTest {
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( src );
 
         assertThat( target ).isNotNull();
-        assertThat( target.getDateTime() ).isEqualTo( "01.01.2014 00:00 UTC" );
+        assertThat( target.getDateTime() ).isIn( "01.01.2014 00:00 UTC", "01.01.2014 00:00 +00:00" );
         assertThat( target.getLocalDateTime() ).isEqualTo( "01.01.2014 00:00" );
         assertThat( target.getLocalDate() ).isEqualTo( "01.01.2014" );
         assertThat( target.getLocalTime() ).isEqualTo( "00:00" );
@@ -107,7 +107,7 @@ public class JodaConversionTest {
         // and now with default mappings
         target = SourceTargetMapper.INSTANCE.sourceToTargetDefaultMapping( src );
         assertThat( target ).isNotNull();
-        assertThat( target.getDateTime() ).isEqualTo( "1. Januar 2014 00:00:00 UTC" );
+        assertThat( target.getDateTime() ).isIn( "1. Januar 2014 00:00:00 UTC", "1. Januar 2014 00:00:00 +00:00" );
         assertThat( target.getLocalDateTime() ).isEqualTo( "1. Januar 2014 00:00:00" );
         assertThat( target.getLocalDate() ).isEqualTo( "1. Januar 2014" );
         assertThat( target.getLocalTime() ).isEqualTo( "00:00:00" );


### PR DESCRIPTION
This fixes #642 and makes the handling of the toolchains-file a bit better. No need to activate the JDK 9 tests by using a VM-parameter anymore... :wink:

Also, I had to change one of the Joda-Tests, as it fails now on my machine (no idea if it's due to Windows 10 or JDK 1.8.0_60 or both...).