### PR TITLE
#684 Update joda-time to fix an incompatibility with JDK 1.8.0_60 and later

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -189,7 +189,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.3</version>
+                <version>2.9</version>
             </dependency>
 
             <!-- Project modules -->

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
@@ -57,7 +57,7 @@ public class JodaConversionTest {
         src.setDateTime( new DateTime( 2014, 1, 1, 0, 0, 0, DateTimeZone.UTC ) );
         Target target = SourceTargetMapper.INSTANCE.sourceToTargetDateTimeMapped( src );
         assertThat( target ).isNotNull();
-        assertThat( target.getDateTime() ).isIn( "01.01.2014 00:00 UTC", "01.01.2014 00:00 +00:00" );
+        assertThat( target.getDateTime() ).isEqualTo( "01.01.2014 00:00 UTC" );
     }
 
     @Test
@@ -99,7 +99,7 @@ public class JodaConversionTest {
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( src );
 
         assertThat( target ).isNotNull();
-        assertThat( target.getDateTime() ).isIn( "01.01.2014 00:00 UTC", "01.01.2014 00:00 +00:00" );
+        assertThat( target.getDateTime() ).isEqualTo( "01.01.2014 00:00 UTC" );
         assertThat( target.getLocalDateTime() ).isEqualTo( "01.01.2014 00:00" );
         assertThat( target.getLocalDate() ).isEqualTo( "01.01.2014" );
         assertThat( target.getLocalTime() ).isEqualTo( "00:00" );
@@ -107,7 +107,7 @@ public class JodaConversionTest {
         // and now with default mappings
         target = SourceTargetMapper.INSTANCE.sourceToTargetDefaultMapping( src );
         assertThat( target ).isNotNull();
-        assertThat( target.getDateTime() ).isIn( "1. Januar 2014 00:00:00 UTC", "1. Januar 2014 00:00:00 +00:00" );
+        assertThat( target.getDateTime() ).isEqualTo( "1. Januar 2014 00:00:00 UTC" );
         assertThat( target.getLocalDateTime() ).isEqualTo( "1. Januar 2014 00:00:00" );
         assertThat( target.getLocalDate() ).isEqualTo( "1. Januar 2014" );
         assertThat( target.getLocalTime() ).isEqualTo( "00:00:00" );


### PR DESCRIPTION
... and revert changes to JodaConversionTest from commit feb5e2f13b0eea3027000cc7f03d6b63690505c5, as described in #684.