### PR TITLE
jaxb underscores in schema element names

### DIFF
--- a/integrationtest/src/test/resources/jaxbTest/pom.xml
+++ b/integrationtest/src/test/resources/jaxbTest/pom.xml
@@ -50,6 +50,7 @@
                     <schemaDirectory>\${project.build.resources[0].directory}/schema/</schemaDirectory>
                     <schemaIncludes>
                         <include>**/test1.xsd</include>
+                        <include>**/underscores.xsd</include>
                     </schemaIncludes>
                     <bindingDirectory>\${project.build.resources[0].directory}/binding</bindingDirectory>
                     <bindingIncludes>

--- a/integrationtest/src/test/resources/jaxbTest/src/main/java/org/mapstruct/itest/jaxb/SourceTargetMapper.java
+++ b/integrationtest/src/test/resources/jaxbTest/src/main/java/org/mapstruct/itest/jaxb/SourceTargetMapper.java
@@ -24,6 +24,7 @@ import org.mapstruct.itest.jaxb.xsd.test1.OrderDetailsType;
 import org.mapstruct.itest.jaxb.xsd.test1.OrderType;
 import org.mapstruct.itest.jaxb.xsd.test2.OrderStatusType;
 import org.mapstruct.itest.jaxb.xsd.test2.ShippingAddressType;
+import org.mapstruct.itest.jaxb.xsd.underscores.SubType;
 
 
 /**
@@ -32,6 +33,7 @@ import org.mapstruct.itest.jaxb.xsd.test2.ShippingAddressType;
 @Mapper(uses = {
     org.mapstruct.itest.jaxb.xsd.test1.ObjectFactory.class,
     org.mapstruct.itest.jaxb.xsd.test2.ObjectFactory.class,
+    org.mapstruct.itest.jaxb.xsd.underscores.ObjectFactory.class,
     JaxbMapper.class
 })
 public interface SourceTargetMapper {
@@ -47,6 +49,8 @@ public interface SourceTargetMapper {
 
     ShippingAddressDto shippingAddressToDto(ShippingAddressType source);
 
+    SubTypeDto subTypeToDto(SubType source);
+
     // target 2 source methods
     OrderType targetToSource(OrderDto target);
 
@@ -55,4 +59,6 @@ public interface SourceTargetMapper {
     OrderStatusType dtoToStatus(OrderStatusDto target);
 
     ShippingAddressType dtoToShippingAddress(ShippingAddressDto source);
+
+    SubType dtoToSubType(SubTypeDto source);
 }

--- a/integrationtest/src/test/resources/jaxbTest/src/main/java/org/mapstruct/itest/jaxb/SubTypeDto.java
+++ b/integrationtest/src/test/resources/jaxbTest/src/main/java/org/mapstruct/itest/jaxb/SubTypeDto.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.itest.jaxb;
+
+public class SubTypeDto extends SuperTypeDto{
+    private String declaredCamelCase;
+    private String declaredUnderscore;
+
+    public String getDeclaredCamelCase() {
+        return declaredCamelCase;
+    }
+
+    public void setDeclaredCamelCase(String declaredCamelCase) {
+        this.declaredCamelCase = declaredCamelCase;
+    }
+
+    public String getDeclaredUnderscore() {
+        return declaredUnderscore;
+    }
+
+    public void setDeclaredUnderscore(String declaredUnderscore) {
+        this.declaredUnderscore = declaredUnderscore;
+    }
+}

--- a/integrationtest/src/test/resources/jaxbTest/src/main/java/org/mapstruct/itest/jaxb/SuperTypeDto.java
+++ b/integrationtest/src/test/resources/jaxbTest/src/main/java/org/mapstruct/itest/jaxb/SuperTypeDto.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.itest.jaxb;
+
+public class SuperTypeDto {
+    private String inheritedCamelCase;
+    private String inheritedUnderscore;
+
+    public String getInheritedCamelCase() {
+        return inheritedCamelCase;
+    }
+
+    public void setInheritedCamelCase(String inheritedCamelCase) {
+        this.inheritedCamelCase = inheritedCamelCase;
+    }
+
+    public String getInheritedUnderscore() {
+        return inheritedUnderscore;
+    }
+
+    public void setInheritedUnderscore(String inheritedUnderscore) {
+        this.inheritedUnderscore = inheritedUnderscore;
+    }
+}

--- a/integrationtest/src/test/resources/jaxbTest/src/main/resources/schema/underscores.xsd
+++ b/integrationtest/src/test/resources/jaxbTest/src/main/resources/schema/underscores.xsd
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+     Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+     and/or other contributors as indicated by the @authors tag. See the
+     copyright.txt file in the distribution for a full listing of all
+     contributors.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+		xmlns:underscores="http://www.mapstruct.org/itest/jaxb/xsd/underscores"
+		targetNamespace="http://www.mapstruct.org/itest/jaxb/xsd/underscores"
+		elementFormDefault="qualified" version="1.0.0">
+
+    <element name="Super" type="underscores:SuperType" />
+    <complexType name="SuperType">
+	<sequence>
+	    <element name="inheritedCamelCase" type="string"/>
+	    <element name="inherited_underscore" type="string"/>
+	</sequence>
+    </complexType>
+
+	<element name="Sub" type="underscores:SubType" />
+	<complexType name="SubType">
+		<complexContent>
+			<extension base="underscores:SuperType">
+				<sequence>
+					<element name="declaredCamelCase" type="string"/>
+					<element name="declared_underscore" type="string"/>
+				</sequence>
+			</extension>
+		</complexContent>
+	</complexType>
+
+</schema>

--- a/integrationtest/src/test/resources/jaxbTest/src/test/java/org/mapstruct/itest/jaxb/JaxbBasedMapperTest.java
+++ b/integrationtest/src/test/resources/jaxbTest/src/test/java/org/mapstruct/itest/jaxb/JaxbBasedMapperTest.java
@@ -34,6 +34,7 @@ import javax.xml.bind.Marshaller;
 import org.junit.Test;
 import org.mapstruct.itest.jaxb.xsd.test1.ObjectFactory;
 import org.mapstruct.itest.jaxb.xsd.test1.OrderType;
+import org.mapstruct.itest.jaxb.xsd.underscores.SubType;
 
 /**
  * Test for generation of JAXB based mapper implementations.
@@ -89,6 +90,27 @@ public class JaxbBasedMapperTest {
         );
         assertThat( source2.getOrderDetails().getName() ).isEqualTo( source1.getOrderDetails().getName() );
         assertThat( source2.getOrderDetails().getStatus() ).isEqualTo( source1.getOrderDetails().getStatus() );
+    }
+
+    @Test
+    public void underscores() throws ParseException, JAXBException {
+
+        SourceTargetMapper mapper = SourceTargetMapper.INSTANCE;
+
+        SubTypeDto source1 = new SubTypeDto();
+        source1.setInheritedCamelCase("InheritedCamelCase");
+        source1.setInheritedUnderscore("InheritedUnderscore");
+        source1.setDeclaredCamelCase("DeclaredCamelCase");
+        source1.setDeclaredUnderscore("DeclaredUnderscore");
+
+        SubType target = mapper.dtoToSubType( source1 );
+
+        SubTypeDto source2 = mapper.subTypeToDto( target );
+
+        assertThat( source2.getInheritedCamelCase() ).isEqualTo( source1.getInheritedCamelCase() );
+        assertThat( source2.getInheritedUnderscore() ).isEqualTo( source1.getInheritedUnderscore() );
+        assertThat( source2.getDeclaredCamelCase() ).isEqualTo( source1.getDeclaredCamelCase() );
+        assertThat( source2.getDeclaredUnderscore() ).isEqualTo( source1.getDeclaredUnderscore() );
     }
 
     private Date createDate(String date) throws ParseException {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/MethodSelectors.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/MethodSelectors.java
@@ -44,7 +44,7 @@ public class MethodSelectors implements MethodSelector {
                 new TypeSelector(),
                 new QualifierSelector( typeUtils, elementUtils ),
                 new TargetTypeSelector( typeUtils, elementUtils ),
-                new XmlElementDeclSelector( typeUtils ),
+                new XmlElementDeclSelector( typeUtils, elementUtils ),
                 new InheritanceSelector(),
                 new CreateOrUpdateSelector()
             );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/XmlElementDeclSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/XmlElementDeclSelector.java
@@ -21,18 +21,25 @@ package org.mapstruct.ap.internal.model.source.selector;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 import javax.xml.bind.annotation.XmlElementDecl;
+import javax.xml.bind.annotation.XmlElementRef;
 
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SourceMethod;
 import org.mapstruct.ap.internal.prism.XmlElementDeclPrism;
+import org.mapstruct.ap.internal.prism.XmlElementRefPrism;
 
 /**
- * Selects those methods with matching {@code name} and {@code scope} attributes of the {@link XmlElementDecl}
- * annotation, if that is present. Matching happens in the following order:
+ * Finds the {@link XmlElementRef} annotation on a field (of the mapping result type or its super types) matching the
+ * target property name. Then selects those methods with matching {@code name} and {@code scope} attributes of the
+ * {@link XmlElementDecl} annotation, if that is present. Matching happens in the following order:
  * <ol>
  * <li>Name and Scope matches</li>
  * <li>Scope matches</li>
@@ -46,9 +53,11 @@ import org.mapstruct.ap.internal.prism.XmlElementDeclPrism;
 public class XmlElementDeclSelector implements MethodSelector {
 
     private final Types typeUtils;
+    private final Elements elementUtils;
 
-    public XmlElementDeclSelector(Types typeUtils) {
+    public XmlElementDeclSelector( Types typeUtils, Elements elementUtils) {
         this.typeUtils = typeUtils;
+        this.elementUtils = elementUtils;
     }
 
     @Override
@@ -66,6 +75,8 @@ public class XmlElementDeclSelector implements MethodSelector {
         List<T> nameMatches = new ArrayList<T>();
         List<T> scopeMatches = new ArrayList<T>();
         List<T> nameAndScopeMatches = new ArrayList<T>();
+        XmlElementRefInfo xmlElementRefInfo =
+            findXmlElementRef( sourceMappingMethod.getResultType(), criteria.getTargetPropertyName() );
 
         for ( T candidate : methods ) {
             if ( !( candidate instanceof SourceMethod ) ) {
@@ -81,10 +92,10 @@ public class XmlElementDeclSelector implements MethodSelector {
 
             String name = xmlElememtDecl.name();
             TypeMirror scope = xmlElememtDecl.scope();
-            TypeMirror target = sourceMappingMethod.getExecutable().getReturnType();
 
-            boolean nameIsSetAndMatches = name != null && name.equals( criteria.getTargetPropertyName() );
-            boolean scopeIsSetAndMatches = scope != null && typeUtils.isSameType( scope, target );
+            boolean nameIsSetAndMatches = name != null && name.equals( xmlElementRefInfo.nameValue() );
+            boolean scopeIsSetAndMatches =
+                scope != null && typeUtils.isSameType( scope, xmlElementRefInfo.sourceType() );
 
             if ( nameIsSetAndMatches ) {
                 if ( scopeIsSetAndMatches ) {
@@ -110,6 +121,74 @@ public class XmlElementDeclSelector implements MethodSelector {
         }
         else {
             return methods;
+        }
+    }
+
+    /**
+     * Iterate through resultType and its super types to find a field named targetPropertyName and return information
+     * about:
+     * <ul>
+     * <li>what the value of the name property of the XmlElementRef annotation on that field was</li>
+     * <li>on which type the field was found</li>
+     * </ul>
+     *
+     * @param resultType starting point of the iteration
+     * @param targetPropertyName name of the field we are looking for
+     * @return an XmlElementRefInfo containing the information
+     */
+    private XmlElementRefInfo findXmlElementRef(Type resultType, String targetPropertyName) {
+        TypeMirror startingMirror = resultType.getTypeMirror();
+        XmlElementRefInfo defaultInfo = new XmlElementRefInfo( targetPropertyName, startingMirror );
+        if ( targetPropertyName == null ) {
+            /*
+             * sometimes MethodSelectors seem to be called with criteria.getTargetPropertyName() == null so we need to
+             * avoid NPEs for that case.
+             */
+            return defaultInfo;
+        }
+
+        TypeMirror currentMirror = startingMirror;
+        TypeElement currentElement = resultType.getTypeElement();
+
+        /*
+         * Outer loop for resultType and its super types. "currentElement" will be null once we reach Object and try to
+         * get a TypeElement for its super type.
+         */
+        while ( currentElement != null ) {
+            /*
+             * Inner loop tries to find a field with the targetPropertyName and assumes that where the XmlElementRef is
+             * set
+             */
+            for ( Element enclosed : currentElement.getEnclosedElements() ) {
+                if ( enclosed.getKind().equals( ElementKind.FIELD )
+                    && enclosed.getSimpleName().contentEquals( targetPropertyName ) ) {
+                    XmlElementRefPrism xmlElementRef = XmlElementRefPrism.getInstanceOn( enclosed );
+                    if ( xmlElementRef != null ) {
+                        return new XmlElementRefInfo( xmlElementRef.name(), currentMirror );
+                    }
+                }
+            }
+            currentMirror = currentElement.getSuperclass();
+            currentElement = elementUtils.getTypeElement( currentMirror.toString() );
+        }
+        return defaultInfo;
+    }
+
+    private static class XmlElementRefInfo {
+        private final String nameValue;
+        private final TypeMirror sourceType;
+
+        XmlElementRefInfo(String nameValue, TypeMirror sourceType) {
+            this.nameValue = nameValue;
+            this.sourceType = sourceType;
+        }
+
+        public String nameValue() {
+            return nameValue;
+        }
+
+        public TypeMirror sourceType() {
+            return sourceType;
         }
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/prism/PrismGenerator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/prism/PrismGenerator.java
@@ -19,6 +19,7 @@
 package org.mapstruct.ap.internal.prism;
 
 import javax.xml.bind.annotation.XmlElementDecl;
+import javax.xml.bind.annotation.XmlElementRef;
 
 import org.mapstruct.AfterMapping;
 import org.mapstruct.BeanMapping;
@@ -62,7 +63,8 @@ import net.java.dev.hickory.prism.GeneratePrisms;
     @GeneratePrism(value = BeforeMapping.class, publicAccess = true),
 
     // external types
-    @GeneratePrism(value = XmlElementDecl.class, publicAccess = true)
+    @GeneratePrism(value = XmlElementDecl.class, publicAccess = true),
+    @GeneratePrism(value = XmlElementRef.class, publicAccess = true)
 })
 public class PrismGenerator {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/UnderscoreSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/UnderscoreSelectionTest.java
@@ -1,0 +1,57 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.jaxb;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.selection.jaxb.underscores.ObjectFactory;
+import org.mapstruct.ap.test.selection.jaxb.underscores.SubType;
+import org.mapstruct.ap.test.selection.jaxb.underscores.SuperType;
+import org.mapstruct.ap.test.selection.jaxb.underscores.UnderscoreMapper;
+import org.mapstruct.ap.test.selection.jaxb.underscores.UnderscoreType;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Ensure factory method selection works for classes generated from schemas using element names with underscores
+ *
+ * @author Vincent Alexander Beelte
+ */
+@IssueKey( "726" )
+@WithClasses( { UnderscoreType.class, ObjectFactory.class, SuperType.class, SubType.class, UnderscoreMapper.class } )
+@RunWith( AnnotationProcessorTestRunner.class )
+public class UnderscoreSelectionTest {
+
+    @Test
+    public void selectingUnderscorePropertiesWorks() {
+        SubType target = UnderscoreMapper.INSTANCE.map( createSource() );
+        assertThat( target.getInheritedUnderscore().getValue() ).isEqualTo( "hi" );
+        assertThat( target.getDeclaredUnderscore().getValue() ).isEqualTo( "there" );
+    }
+
+    private UnderscoreType createSource() {
+        UnderscoreType type = new UnderscoreType();
+        type.setInheritedUnderscore( "hi" );
+        type.setDeclaredUnderscore( "there" );
+        return type;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/ObjectFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/ObjectFactory.java
@@ -1,0 +1,69 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.jaxb.underscores;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlElementDecl;
+import javax.xml.bind.annotation.XmlRegistry;
+import javax.xml.namespace.QName;
+
+@XmlRegistry
+public class ObjectFactory {
+
+    private static final QName SUPER_QNAME =
+        new QName( "http://www.mapstruct.org/itest/jaxb/xsd/underscores", "Super" );
+    private static final QName SUB_QNAME = new QName( "http://www.mapstruct.org/itest/jaxb/xsd/underscores", "Sub" );
+    private static final QName SUPER_TYPE_INHERITED_UNDERSCORE_QNAME =
+        new QName( "http://www.mapstruct.org/itest/jaxb/xsd/underscores", "inherited_underscore" );
+    private static final QName SUB_TYPE_DECLARED_UNDERSCORE_QNAME =
+        new QName( "http://www.mapstruct.org/itest/jaxb/xsd/underscores", "declared_underscore" );
+
+    public ObjectFactory() {
+    }
+
+    public SubType createSubType() {
+        return new SubType();
+    }
+
+    public SuperType createSuperType() {
+        return new SuperType();
+    }
+
+    @XmlElementDecl( namespace = "http://www.mapstruct.org/itest/jaxb/xsd/underscores", name = "Super" )
+    public JAXBElement<SuperType> createSuper(SuperType value) {
+        return new JAXBElement<SuperType>(SUPER_QNAME, SuperType.class, null, value );
+    }
+
+    @XmlElementDecl( namespace = "http://www.mapstruct.org/itest/jaxb/xsd/underscores", name = "Sub" )
+    public JAXBElement<SubType> createSub(SubType value) {
+        return new JAXBElement<SubType>(SUB_QNAME, SubType.class, null, value );
+    }
+
+    @XmlElementDecl( namespace = "http://www.mapstruct.org/itest/jaxb/xsd/underscores",
+            name = "inherited_underscore", scope = SuperType.class )
+    public JAXBElement<String> createSuperTypeInheritedUnderscore(String value) {
+        return new JAXBElement<String>(SUPER_TYPE_INHERITED_UNDERSCORE_QNAME, String.class, SuperType.class, value );
+    }
+
+    @XmlElementDecl( namespace = "http://www.mapstruct.org/itest/jaxb/xsd/underscores",
+            name = "declared_underscore", scope = SubType.class )
+    public JAXBElement<String> createSubTypeDeclaredUnderscore(String value) {
+        return new JAXBElement<String>(SUB_TYPE_DECLARED_UNDERSCORE_QNAME, String.class, SubType.class, value );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/SubType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/SubType.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.jaxb.underscores;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElementRef;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType( XmlAccessType.FIELD )
+@XmlType( name = "SubType", propOrder = { "declaredUnderscore" } )
+public class SubType extends SuperType {
+
+    @XmlElementRef( name = "declared_underscore",
+            namespace = "http://www.mapstruct.org/itest/jaxb/xsd/underscores", type = JAXBElement.class )
+    protected JAXBElement<String> declaredUnderscore;
+
+    public JAXBElement<String> getDeclaredUnderscore() {
+        return declaredUnderscore;
+    }
+
+    public void setDeclaredUnderscore(JAXBElement<String> value) {
+        this.declaredUnderscore = value;
+    }
+
+    public boolean isSetDeclaredUnderscore() {
+        return ( this.declaredUnderscore != null );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/SuperType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/SuperType.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.jaxb.underscores;
+
+import javax.xml.bind.JAXBElement;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElementRef;
+import javax.xml.bind.annotation.XmlSeeAlso;
+import javax.xml.bind.annotation.XmlType;
+
+@XmlAccessorType( XmlAccessType.FIELD )
+@XmlType( name = "SuperType", propOrder = { "inheritedUnderscore" } )
+@XmlSeeAlso( { SubType.class } )
+public class SuperType {
+
+    @XmlElementRef( name = "inherited_underscore",
+            namespace = "http://www.mapstruct.org/itest/jaxb/xsd/underscores", type = JAXBElement.class )
+    protected JAXBElement<String> inheritedUnderscore;
+
+    public JAXBElement<String> getInheritedUnderscore() {
+        return inheritedUnderscore;
+    }
+
+    public void setInheritedUnderscore(JAXBElement<String> value) {
+        this.inheritedUnderscore = value;
+    }
+
+    public boolean isSetInheritedUnderscore() {
+        return ( this.inheritedUnderscore != null );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/UnderscoreMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/UnderscoreMapper.java
@@ -1,0 +1,29 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.jaxb.underscores;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper( uses = { ObjectFactory.class } )
+public interface UnderscoreMapper {
+    UnderscoreMapper INSTANCE = Mappers.getMapper( UnderscoreMapper.class );
+
+    SubType map(UnderscoreType underscoreType);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/UnderscoreType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/UnderscoreType.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.jaxb.underscores;
+
+public class UnderscoreType {
+    protected String inheritedUnderscore;
+    protected String declaredUnderscore;
+
+    public String getInheritedUnderscore() {
+        return inheritedUnderscore;
+    }
+
+    public void setInheritedUnderscore(String inheritedUnderscore) {
+        this.inheritedUnderscore = inheritedUnderscore;
+    }
+
+    public String getDeclaredUnderscore() {
+        return declaredUnderscore;
+    }
+
+    public void setDeclaredUnderscore(String declaredUnderscore) {
+        this.declaredUnderscore = declaredUnderscore;
+    }
+}


### PR DESCRIPTION
Hi,
since I have only been working with jaxb, xml schemas and soap for about 2 weeks there is a lot I still don't know about the problem I "solved" in this PR.

I have a wsdl of a third party soap service. Some of the elements have names using underscores instead of camel case like this:
```xml
<element name="planet_name" type="string"/>
```
which is perfectly ok.

When generating code from that wsdl with the "cxf-codegen-plugin" I get Code mit mostly "javaified" names (camel case with no underscores)
In the "ObjectFactory" the factory methods have @XmlElementDecl annotations that use the underscore names to set their "name" properties. Which might look like this:
 ```java
    @XmlElementDecl(namespace = "http://foo.bar", name = "planet_name", scope = TypeName.class)
    public JAXBElement<FieldType> createTypeNamePlanetName(FieldType value) {
        return new JAXBElement<FieldType>(_TypeNamePlanetName_QNAME, FieldType.class, TypeName.class, value);
    }
```

Still kind of ok until I am trying to map my classes to the generated jaxb classes. For the cases where there is more than one property of the same type and one of them was generated from an underscore name in the schema I get a "Ambiguous mapping methods found for mapping property" compile error.

That seems to be because the XmlElementDeclSelector tries to exactly match the camel case name with the underscore name in the annotation. Failing that is falls back to only matching the scope, which result in too many candidates.

**What I changed** was add a third match on a method suffix. It seemed to me the generated code in ObjectFactory always followed the pattern of "TypeNamePropertyName" in the method names, so using the property name and match it as a suffix seemed like it might work.