### PR TITLE
#509 Add null mapping for enum mapping methods

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/EnumMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/EnumMappingMethod.java
@@ -149,7 +149,8 @@ public class EnumMappingMethod extends MappingMethod {
                         );
                         foundIncorrectMapping = true;
                     }
-                    else if ( !targetEnumConstants.contains( mappedConstant.getTargetName() ) ) {
+                    else if ( !targetEnumConstants.contains( mappedConstant.getTargetName() )
+                        && !mappedConstant.getTargetName().equals("null") ) {
                         ctx.getMessager().printMessage( method.getExecutable(),
                             mappedConstant.getMirror(),
                             mappedConstant.getTargetAnnotationValue(),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/EnumMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/EnumMappingMethod.ftl
@@ -34,8 +34,13 @@ public <@includeModel object=returnType/> ${name}(<@includeModel object=sourcePa
 
     switch ( ${sourceParameter.name} ) {
     <#list enumMappings as enumMapping>
+        <#if enumMapping.target.equals("null")>
+        case ${enumMapping.source}: ${resultName} = null;
+            break;
+        <#else>
         case ${enumMapping.source}: ${resultName} = <@includeModel object=returnType/>.${enumMapping.target};
             break;
+        </#if>
     </#list>
     default: throw new IllegalArgumentException( "Unexpected enum constant: " + ${sourceParameter.name} );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/enums/EnumMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/enums/EnumMappingTest.java
@@ -60,6 +60,9 @@ public class EnumMappingTest {
 
         target = OrderMapper.INSTANCE.orderTypeToExternalOrderType( OrderType.NORMAL );
         assertThat( target ).isEqualTo( ExternalOrderType.DEFAULT );
+
+        target = OrderMapper.INSTANCE.orderTypeToExternalOrderType( OrderType.NULLABLE );
+        assertThat( target ).isEqualTo( null );
     }
 
     @Test
@@ -79,7 +82,7 @@ public class EnumMappingTest {
         diagnostics = {
             @Diagnostic(type = ErroneousOrderMapperMappingSameConstantTwice.class,
                 kind = Kind.ERROR,
-                line = 42,
+                line = 43,
                 messageRegExp = "One enum constant must not be mapped to more than one target constant, but " +
                     "constant EXTRA is mapped to SPECIAL, DEFAULT\\.")
         }

--- a/processor/src/test/java/org/mapstruct/ap/test/enums/ErroneousOrderMapperMappingSameConstantTwice.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/enums/ErroneousOrderMapperMappingSameConstantTwice.java
@@ -37,7 +37,8 @@ public interface ErroneousOrderMapperMappingSameConstantTwice {
         @Mapping(source = "EXTRA", target = "SPECIAL"),
         @Mapping(source = "EXTRA", target = "DEFAULT"),
         @Mapping(source = "STANDARD", target = "DEFAULT"),
-        @Mapping(source = "NORMAL", target = "DEFAULT")
+        @Mapping(source = "NORMAL", target = "DEFAULT"),
+        @Mapping(source = "NULLABLE", target = "null")
     })
     ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/enums/OrderMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/enums/OrderMapper.java
@@ -36,7 +36,8 @@ public interface OrderMapper {
     @Mappings({
         @Mapping(source = "EXTRA", target = "SPECIAL"),
         @Mapping(source = "STANDARD", target = "DEFAULT"),
-        @Mapping(source = "NORMAL", target = "DEFAULT")
+        @Mapping(source = "NORMAL", target = "DEFAULT"),
+        @Mapping(source = "NULLABLE", target = "null")
     })
     ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/enums/OrderType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/enums/OrderType.java
@@ -23,5 +23,5 @@ package org.mapstruct.ap.test.enums;
  */
 public enum OrderType {
 
-    RETAIL, B2B, EXTRA, STANDARD, NORMAL
+    RETAIL, B2B, EXTRA, STANDARD, NORMAL, NULLABLE
 }


### PR DESCRIPTION
I implemented null mapping for enum mapping methods.
The following is an example of this feature, where "EXTRA" enum value is mapped to null.

```java
@Mapper
public interface OrderMapper {

    OrderMapper INSTANCE = Mappers.getMapper( OrderMapper.class );

    OrderDto orderEntityToDto(OrderEntity order);

    @Mappings({
        @Mapping(source = "EXTRA", target = "null"),
        @Mapping(source = "STANDARD", target = "DEFAULT"),
        @Mapping(source = "NORMAL", target = "DEFAULT")
    })
    ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
}
```