### PR TITLE
#761 using fully qualified names in javadoc for conflicting annotations

### DIFF
--- a/core-common/src/main/java/org/mapstruct/DecoratedWith.java
+++ b/core-common/src/main/java/org/mapstruct/DecoratedWith.java
@@ -89,13 +89,14 @@ import java.lang.annotation.Target;
  * <h4>Referencing the original mapper in the decorator</h4>
  * <p>
  * The generated implementation of the original mapper is annotated with the Spring annotation
- * {@code @Qualifier("delegate")}. To autowire that bean in your decorator, add that qualifier annotation as well:
+ * {@code @org.springframework.beans.factory.annotation.Qualifier("delegate")}. To autowire that bean in your decorator,
+ * add that qualifier annotation as well:
  *
  * <pre>
  * public abstract class PersonMapperDecorator implements PersonMapper {
  *
  *     &#64;Autowired
- *     &#64;Qualifier("delegate")
+ *     &#64;org.springframework.beans.factory.annotation.Qualifier("delegate")
  *     private PersonMapper delegate;
  *
  *     &#64;Override
@@ -122,16 +123,16 @@ import java.lang.annotation.Target;
  * <h4>Referencing the original mapper</h4>
  * <p>
  * JSR 330 doesn't specify qualifiers and only allows to specifically name the beans. Hence, the generated
- * implementation of the original mapper is annotated with {@code @Named("fully-qualified-name-of-generated-impl")}
- * and {@code @Singleton} (please note that when using a decorator, the class name of the mapper implementation ends
- * with an underscore). To inject that bean in your decorator, add the same annotation to the delegate field (e.g. by
- * copy/pasting it from the generated class):
+ * implementation of the original mapper is annotated with
+ * {@code @javax.inject.Named("fully-qualified-name-of-generated-impl")} and {@code @Singleton} (please note that when
+ * using a decorator, the class name of the mapper implementation ends with an underscore). To inject that bean in your
+ * decorator, add the same annotation to the delegate field (e.g. by copy/pasting it from the generated class):
  *
  * <pre>
  * public abstract class PersonMapperDecorator implements PersonMapper {
  *
  *     &#64;Inject
- *     &#64;Named("org.examples.PersonMapperImpl_")
+ *     &#64;javax.inject.Named("org.examples.PersonMapperImpl_")
  *     private PersonMapper delegate;
  *
  *     &#64;Override
@@ -147,12 +148,12 @@ import java.lang.annotation.Target;
  * <h4>Using the decorated mapper in the decorator</h4>
  * <p>
  * Unlike with the other component models, the usage site must be aware if a mapper is decorated or not, as for
- * decorated mappers, the parameterless {@code @Named} annotation must be added to select the <em>decorator</em> to be
- * injected:
+ * decorated mappers, the parameterless {@code @javax.inject.Named} annotation must be added to select the
+ * <em>decorator</em> to be injected:
  *
  * <pre>
  * &#64;Inject
- * &#64;Named
+ * &#64;javax.inject.Named
  * private PersonMapper personMapper; // injects the decorator, with the injected original mapper
  * </pre>
  * <p>

--- a/core-common/src/main/java/org/mapstruct/MapMapping.java
+++ b/core-common/src/main/java/org/mapstruct/MapMapping.java
@@ -93,9 +93,9 @@ public @interface MapMapping {
     Class<? extends Annotation>[] valueQualifiedBy() default { };
 
     /**
-     * String-based form of qualifiers; When looking for a suitable mapping method to map this map mapping method's value
-     * type, MapStruct will only consider those methods carrying directly or indirectly (i.e. on the class-level) a
-     * {@link Named} annotation for each of the specified qualifier names.
+     * String-based form of qualifiers; When looking for a suitable mapping method to map this map mapping method's
+     * value type, MapStruct will only consider those methods carrying directly or indirectly (i.e. on the class-level)
+     * a {@link Named} annotation for each of the specified qualifier names.
      * <p>
      * Note that annotation-based qualifiers are generally preferable as they allow more easily to find references and
      * are safe for refactorings, but name-based qualifiers can be a less verbose alternative when requiring a large

--- a/core-common/src/main/java/org/mapstruct/Mapper.java
+++ b/core-common/src/main/java/org/mapstruct/Mapper.java
@@ -74,7 +74,7 @@ public @interface Mapper {
      * {@code spring}: the generated mapper is a Spring bean and
      * can be retrieved via {@code @Autowired}</li>
      * <li>
-     * {@code jsr330}: the generated mapper is annotated with {@code @Named} and
+     * {@code jsr330}: the generated mapper is annotated with {@code @javax.inject.Named} and
      * {@code @Singleton}, and can be retrieved via {@code @Inject}</li>
      * </ul>
      * The method overrides an unmappedTargetPolicy set in a central configuration set

--- a/core-common/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core-common/src/main/java/org/mapstruct/MapperConfig.java
@@ -76,7 +76,7 @@ public @interface MapperConfig {
      * {@code spring}: the generated mapper is a Spring bean and
      * can be retrieved via {@code @Autowired}</li>
      * <li>
-     * {@code jsr330}: the generated mapper is annotated with {@code @Named} and
+     * {@code jsr330}: the generated mapper is annotated with {@code @javax.inject.Named} and
      * {@code @Singleton}, and can be retrieved via {@code @Inject}</li>
      * </ul>
      *


### PR DESCRIPTION
Ok. A small one.. Just to avoid mis-interpretation. 

Perhaps we should do this for all external annotations..