### PR TITLE
#751, making used mappers available

### DIFF
--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -465,6 +465,11 @@ private CarMapper mapper;
 
 A mapper which uses other mapper classes (see <<invoking-other-mappers>>) will obtain these mappers using the configured component model. So if `CarMapper` from the previous example was using another mapper, this other mapper would have to be an injectable CDI bean as well.
 
+[TIP]
+====
+The used mapper can be made accessible (e.g. for initialization), by simply adding a getter to the mapper that returns the used mapper.
+====
+
 [[datatype-conversions]]
 == Data type conversions
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ReferenceAccessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ReferenceAccessor.java
@@ -1,0 +1,55 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.Collections;
+import java.util.Set;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.source.Method;
+
+/**
+ * While this is no mapping method, it makes use of the same mechanism.
+ *
+ * @author Sjaak Derksen
+ */
+public class ReferenceAccessor extends MappingMethod {
+
+    private final String variableName;
+
+    /**
+     * constructor
+     *
+     * @param method method
+     * @param field
+     */
+    public ReferenceAccessor(Method method, Field field) {
+        super( method );
+        this.variableName = field.getVariableName();
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        // there should be no new type to introduce
+        return Collections.emptySet();
+    }
+
+    public String getVariableName() {
+        return variableName;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -47,6 +47,7 @@ import org.mapstruct.ap.internal.model.Mapper;
 import org.mapstruct.ap.internal.model.MapperReference;
 import org.mapstruct.ap.internal.model.MappingBuilderContext;
 import org.mapstruct.ap.internal.model.MappingMethod;
+import org.mapstruct.ap.internal.model.ReferenceAccessor;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.model.source.MappingOptions;
@@ -144,6 +145,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
         List<MappingMethod> mappingMethods = getMappingMethods( mapperConfig, methods );
         mappingMethods.addAll( mappingContext.getUsedVirtualMappings() );
         mappingMethods.addAll( mappingContext.getMappingsToGenerate() );
+        mappingMethods.addAll( getMapperReferenceAccessors( mapperReferences, methods ) );
 
         Mapper mapper = new Mapper.Builder()
             .element( element )
@@ -258,6 +260,10 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
                 continue;
             }
 
+            if ( method.getSourceParameters().isEmpty() ) {
+                continue;
+            }
+
             mergeInheritedOptions( method, mapperConfig, methods, new ArrayList<SourceMethod>() );
 
             MappingOptions mappingOptions = method.getMappingOptions();
@@ -363,6 +369,35 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
             }
         }
         return mappingMethods;
+    }
+
+    private List<ReferenceAccessor> getMapperReferenceAccessors(List<MapperReference> mapperReferences,
+        List<SourceMethod> sourceMethods ) {
+
+
+        List<ReferenceAccessor> mapperReferenceAccessor = new ArrayList<ReferenceAccessor>();
+        for ( SourceMethod sourceMethod : sourceMethods ) {
+
+            if ( !sourceMethod.overridesMethod() ) {
+                continue;
+            }
+
+            if ( !sourceMethod.getParameters().isEmpty() ) {
+                continue;
+            }
+
+            for ( MapperReference mapperReference : mapperReferences ) {
+                if ( sourceMethod.getReturnType().equals( mapperReference.getType() ) ) {
+                    if ( mapperReference.isUsed() ) {
+                        mapperReferenceAccessor.add( new ReferenceAccessor( sourceMethod, mapperReference ) );
+                    }
+                    else {
+                        // TODO emit warning
+                    }
+                }
+            }
+        }
+        return  mapperReferenceAccessor;
     }
 
     private void mergeInheritedOptions(SourceMethod method, MapperConfiguration mapperConfig,

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -388,16 +388,16 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
 
             for ( MapperReference mapperReference : mapperReferences ) {
                 if ( sourceMethod.getReturnType().equals( mapperReference.getType() ) ) {
-                    if ( mapperReference.isUsed() ) {
-                        mapperReferenceAccessor.add( new ReferenceAccessor( sourceMethod, mapperReference ) );
+                    if ( !mapperReference.isUsed() ) {
+                        messager.printMessage(
+                            sourceMethod.getExecutable(),
+                            Message.GENERATING_NON_USED_GETTER );
                     }
-                    else {
-                        // TODO emit warning
-                    }
+                    mapperReferenceAccessor.add( new ReferenceAccessor( sourceMethod, mapperReference ) );
                 }
             }
         }
-        return  mapperReferenceAccessor;
+        return mapperReferenceAccessor;
     }
 
     private void mergeInheritedOptions(SourceMethod method, MapperConfiguration mapperConfig,

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -95,7 +95,7 @@ public enum Message {
     RETRIEVAL_WILDCARD_SUPER_BOUND_SOURCE( "Can't generate mapping method for a wildcard super bound source." ),
     RETRIEVAL_WILDCARD_EXTENDS_BOUND_RESULT( "Can't generate mapping method for a wildcard extends bound result." ),
 
-
+    GENERATING_NON_USED_GETTER( "The getter method is refering a used mapper which is not acually used in the mappings." ),
 
     INHERITCONFIGURATION_BOTH( "Method cannot be annotated with both a @InheritConfiguration and @InheritInverseConfiguration." ),
     INHERITINVERSECONFIGURATION_DUPLICATES( "Several matching inverse methods exist: %s(). Specify a name explicitly." ),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ReferenceAccessor.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ReferenceAccessor.ftl
@@ -1,0 +1,24 @@
+<#--
+
+     Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+     and/or other contributors as indicated by the @authors tag. See the
+     copyright.txt file in the distribution for a full listing of all
+     contributors.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+@Override
+public <@includeModel object=returnType/> ${name}() {
+    return ${variableName};
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/AccessingMappersTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/AccessingMappersTest.java
@@ -1,0 +1,62 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+import java.math.BigDecimal;
+import java.util.Arrays;
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@IssueKey("751")
+@WithClasses({InventoryDto.class, RadioDto.class, RadioEntity.class, RadioMapper.class, TVDto.class, TVEntity.class,
+    TvMapper.class, InventoryMapper.class, InventoryEntity.class, InventorySequence.class, InventoryItemEntity.class })
+@RunWith(AnnotationProcessorTestRunner.class)
+public class AccessingMappersTest {
+
+    @Test
+    public void shouldMapTwoArraysToCollections() {
+        InventoryDto inventory = new InventoryDto();
+        RadioDto radio = new RadioDto();
+        radio.setSerialNumber( "54321" );
+        inventory.setRadios( Arrays.asList( radio ) );
+        TVDto tv = new TVDto();
+        tv.setSerialNumber( "12345" );
+        inventory.setTvs( Arrays.asList( tv ) );
+
+        InventoryEntity target = InventoryMapper.INSTANCE.mapInventory( inventory );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getRadios() ).isNotEmpty();
+        assertThat( target.getRadios().get( 0 ).getSerialNumber() ).isEqualTo( new BigDecimal( "54321" ) );
+        assertThat( target.getTvs() ).isNotEmpty();
+        assertThat( target.getTvs().get( 0 ).getSerialNumber() ).isEqualTo( new BigDecimal( "12345" ) );
+        assertThat( target.getTvs().get( 0 ).getInventorySequenceItem() )
+            .isNotEqualTo( target.getRadios().get( 0 ).getInventorySequenceItem() );
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/AccessingMappersTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/AccessingMappersTest.java
@@ -67,7 +67,7 @@ public class AccessingMappersTest {
     @ExpectedCompilationOutcome(
             value = CompilationResult.FAILED,
             diagnostics = {
-                @Diagnostic( type = RadioMapperWithNonUsedReferenceMapper.class,
+                @Diagnostic( type = ErroneousMapperWithNonUsedReferenceMapper.class,
                         kind = javax.tools.Diagnostic.Kind.ERROR,
                         line = 45,
                         messageRegExp = "The getter method is refering a used mapper which is not acually used in "
@@ -75,7 +75,7 @@ public class AccessingMappersTest {
             }
     )
     @Test
-    @WithClasses( RadioMapperWithNonUsedReferenceMapper.class )
+    @WithClasses( ErroneousMapperWithNonUsedReferenceMapper.class )
     public void shouldEmitWaringOnNonUsedMapper() {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/AccessingMappersTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/AccessingMappersTest.java
@@ -26,6 +26,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
@@ -58,5 +61,21 @@ public class AccessingMappersTest {
         assertThat( target.getTvs().get( 0 ).getInventorySequenceItem() )
             .isNotEqualTo( target.getRadios().get( 0 ).getInventorySequenceItem() );
 
+    }
+
+
+    @ExpectedCompilationOutcome(
+            value = CompilationResult.FAILED,
+            diagnostics = {
+                @Diagnostic( type = RadioMapperWithNonUsedReferenceMapper.class,
+                        kind = javax.tools.Diagnostic.Kind.ERROR,
+                        line = 45,
+                        messageRegExp = "The getter method is refering a used mapper which is not acually used in "
+                            + "the mappings." )
+            }
+    )
+    @Test
+    @WithClasses( RadioMapperWithNonUsedReferenceMapper.class )
+    public void shouldEmitWaringOnNonUsedMapper() {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/ErroneousMapperWithNonUsedReferenceMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/ErroneousMapperWithNonUsedReferenceMapper.java
@@ -27,10 +27,10 @@ import org.mapstruct.factory.Mappers;
  * @author Sjaak Derksen
  */
 @Mapper( uses = TvMapper.class )
-public abstract class RadioMapperWithNonUsedReferenceMapper {
+public abstract class ErroneousMapperWithNonUsedReferenceMapper {
 
-    public static final RadioMapperWithNonUsedReferenceMapper INSTANCE =
-            Mappers.getMapper( RadioMapperWithNonUsedReferenceMapper.class );
+    public static final ErroneousMapperWithNonUsedReferenceMapper INSTANCE =
+            Mappers.getMapper( ErroneousMapperWithNonUsedReferenceMapper.class );
 
 
     protected InventorySequence sequence;

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/InventoryDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/InventoryDto.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+import java.util.List;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class InventoryDto {
+
+    private List<RadioDto> radios;
+    private List<TVDto> tvs;
+
+    public List<RadioDto> getRadios() {
+        return radios;
+    }
+
+    public void setRadios(List<RadioDto> radios) {
+        this.radios = radios;
+    }
+
+    public List<TVDto> getTvs() {
+        return tvs;
+    }
+
+    public void setTvs(List<TVDto> tvs) {
+        this.tvs = tvs;
+    }
+
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/InventoryEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/InventoryEntity.java
@@ -1,0 +1,48 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+import java.util.List;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class InventoryEntity {
+
+    private List<RadioEntity> radios;
+    private List<TVEntity> tvs;
+
+    public List<RadioEntity> getRadios() {
+        return radios;
+    }
+
+    public void setRadios(List<RadioEntity> radios) {
+        this.radios = radios;
+    }
+
+    public List<TVEntity> getTvs() {
+        return tvs;
+    }
+
+    public void setTvs(List<TVEntity> tvs) {
+        this.tvs = tvs;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/InventoryItemEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/InventoryItemEntity.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class InventoryItemEntity {
+
+    private int inventorySequenceItem;
+
+    public int getInventorySequenceItem() {
+        return inventorySequenceItem;
+    }
+
+    public void setInventorySequenceItem(int inventorySequenceItem) {
+        this.inventorySequenceItem = inventorySequenceItem;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/InventoryMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/InventoryMapper.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper(uses = { RadioMapper.class, TvMapper.class } )
+public abstract class InventoryMapper {
+
+    public static final InventoryMapper INSTANCE = Mappers.getMapper( InventoryMapper.class );
+
+    private final InventorySequence inventorySequence = new InventorySequence();
+
+    public  InventoryEntity mapInventory(InventoryDto source) {
+        getRadioMapper().init( inventorySequence );
+        getTVMapper().init( inventorySequence );
+        return handleMapInventory( source );
+    }
+
+    protected abstract InventoryEntity handleMapInventory(InventoryDto source);
+
+    protected abstract RadioMapper getRadioMapper();
+
+    protected abstract TvMapper getTVMapper();
+
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/InventorySequence.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/InventorySequence.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class InventorySequence {
+
+    private final AtomicInteger sequenceNr = new AtomicInteger();
+
+    public int nextNr() {
+        return sequenceNr.getAndIncrement();
+    }
+
+
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/RadioDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/RadioDto.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class RadioDto {
+
+    private String serialNumber;
+
+    public String getSerialNumber() {
+        return serialNumber;
+    }
+
+    public void setSerialNumber(String serialNumber) {
+        this.serialNumber = serialNumber;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/RadioEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/RadioEntity.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+import java.math.BigDecimal;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class RadioEntity extends InventoryItemEntity {
+
+    private BigDecimal serialNumber;
+
+    public BigDecimal getSerialNumber() {
+        return serialNumber;
+    }
+
+    public void setSerialNumber(BigDecimal serialNumber) {
+        this.serialNumber = serialNumber;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/RadioMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/RadioMapper.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper
+public abstract class RadioMapper {
+
+    protected InventorySequence sequence;
+
+    public void init( InventorySequence sequence ) {
+        this.sequence = sequence;
+    }
+
+    @Mapping( target = "inventorySequenceItem", expression = "java(sequence.nextNr())" )
+    public abstract RadioEntity map(RadioDto in);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/RadioMapperWithNonUsedReferenceMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/RadioMapperWithNonUsedReferenceMapper.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper( uses = TvMapper.class )
+public abstract class RadioMapperWithNonUsedReferenceMapper {
+
+    public static final RadioMapperWithNonUsedReferenceMapper INSTANCE =
+            Mappers.getMapper( RadioMapperWithNonUsedReferenceMapper.class );
+
+
+    protected InventorySequence sequence;
+
+    public void init( InventorySequence sequence ) {
+        this.sequence = sequence;
+    }
+
+    @Mapping( target = "inventorySequenceItem", expression = "java(sequence.nextNr())" )
+    public abstract RadioEntity map(RadioDto in);
+
+    public abstract TvMapper getTvMapper();
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/TVDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/TVDto.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class TVDto {
+
+    private String serialNumber;
+
+    public String getSerialNumber() {
+        return serialNumber;
+    }
+
+    public void setSerialNumber(String serialNumber) {
+        this.serialNumber = serialNumber;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/TVEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/TVEntity.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+import java.math.BigDecimal;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class TVEntity extends InventoryItemEntity {
+
+    private BigDecimal serialNumber;
+
+    public BigDecimal getSerialNumber() {
+        return serialNumber;
+    }
+
+    public void setSerialNumber(BigDecimal serialNumber) {
+        this.serialNumber = serialNumber;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/TvMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessingmappers/TvMapper.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.accessingmappers;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper
+public abstract class TvMapper {
+
+    protected InventorySequence sequence;
+
+    public void init( InventorySequence sequence ) {
+        this.sequence = sequence;
+    }
+
+    @Mapping( target = "inventorySequenceItem", expression = "java(sequence.nextNr())" )
+    public abstract TVEntity map(TVDto in);
+
+}


### PR DESCRIPTION
This PR makes the used mappers available for initialization or other state changes. The factory part of #751 is not addressed in this PR.