### PR TITLE
#770 Update retention-policy of custom qualifier annotations in docs and tests

### DIFF
--- a/core-common/src/main/java/org/mapstruct/Qualifier.java
+++ b/core-common/src/main/java/org/mapstruct/Qualifier.java
@@ -35,11 +35,13 @@ import java.lang.annotation.Target;
  * <li>{@link MapMapping#valueQualifiedBy() }</li>
  * </ul>
  * Example:
+ *
  * <pre>
  * &#64;Qualifier
  * &#64;Target(ElementType.METHOD)
- * &#64;Retention(RetentionPolicy.SOURCE)
- * public &#64;interface EnglishToGerman {}
+ * &#64;Retention(RetentionPolicy.CLASS)
+ * public &#64;interface EnglishToGerman {
+ * }
  * </pre>
  *
  * @author Sjaak Derksen

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -749,7 +749,7 @@ Enter the qualifier approach:
 ----
 @Qualifier
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface TitleTranslator {
 }
 ----
@@ -764,7 +764,7 @@ And, some qualifiers to indicate which translator to use to map from source lang
 ----
 @Qualifier
 @Target(ElementType.METHOD)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface EnglishToGerman {
 }
 ----
@@ -773,7 +773,7 @@ public @interface EnglishToGerman {
 ----
 @Qualifier
 @Target(ElementType.METHOD)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface GermanToEnglish {
 }
 ----
@@ -796,7 +796,7 @@ public interface MovieMapper {
 
 }
 ----
-====  
+====
 
 .Custom mapper qualifying the methods it provides
 ====
@@ -865,7 +865,7 @@ public interface MovieMapper {
 
 }
 ----
-====  
+====
 
 [WARNING]
 ====

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/annotation/CreateGermanRelease.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/annotation/CreateGermanRelease.java
@@ -31,6 +31,6 @@ import org.mapstruct.Qualifier;
  */
 @Qualifier
 @Target(ElementType.METHOD)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface CreateGermanRelease {
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/annotation/EnglishToGerman.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/annotation/EnglishToGerman.java
@@ -31,6 +31,6 @@ import org.mapstruct.Qualifier;
  */
 @Qualifier
 @Target(ElementType.METHOD)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface EnglishToGerman {
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/annotation/NonQualifierAnnotated.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/annotation/NonQualifierAnnotated.java
@@ -28,6 +28,6 @@ import java.lang.annotation.Target;
  * @author Sjaak Derksen
  */
 @Target(ElementType.METHOD)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface NonQualifierAnnotated {
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/annotation/TitleTranslator.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/annotation/TitleTranslator.java
@@ -31,6 +31,6 @@ import org.mapstruct.Qualifier;
  */
 @Qualifier
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface TitleTranslator {
 }


### PR DESCRIPTION
… to `CLASS`, as retention policy `SOURCE` is not enough when working with multi-module projects or with incremental compilation.