### PR TITLE
Allow to select only one compiler in a processor test class

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
@@ -193,8 +193,6 @@ public class Mapper extends GeneratedType {
 
     /**
      * Checks if the mapper has a custom implementation that is a custom suffix of an explicit destination package.
-     *
-     * @return
      */
     public boolean hasCustomImplementation() {
         return customImplName || customPackage;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
@@ -55,11 +55,6 @@ public abstract class MappingMethod extends ModelElement {
     /**
      * constructor to be overloaded when local variable names are required prior to calling this constructor. (e.g. for
      * property mappings). It is supposed to be initialized with at least the parameter names.
-     *
-     * @param method method
-     * @param existingVariableNames existingVariableNames
-     * @param beforeMappingReferences
-     * @param afterMappingReferences
      */
     protected MappingMethod(Method method, Collection<String> existingVariableNames,
                             List<LifecycleCallbackMethodReference> beforeMappingReferences,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -31,7 +31,6 @@ import java.util.Set;
 
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.DeclaredType;
-import javax.lang.model.type.TypeMirror;
 
 import org.mapstruct.ap.internal.model.assignment.AdderWrapper;
 import org.mapstruct.ap.internal.model.assignment.ArrayCopyWrapper;
@@ -169,9 +168,6 @@ public class PropertyMapping extends ModelElement {
         // initial properties
         private String dateFormat;
         private String defaultValue;
-        private List<TypeMirror> qualifiers;
-        private List<String> qualifyingNames;
-        private TypeMirror resultType;
         private SourceReference sourceReference;
         private SelectionParameters selectionParameters;
 
@@ -181,11 +177,6 @@ public class PropertyMapping extends ModelElement {
         }
 
         public PropertyMappingBuilder selectionParameters(SelectionParameters selectionParameters) {
-            if ( selectionParameters != null ) {
-                this.qualifiers = selectionParameters.getQualifiers();
-                this.qualifyingNames = selectionParameters.getQualifyingNames();
-                this.resultType = selectionParameters.getResultType();
-            }
             this.selectionParameters = selectionParameters;
             return this;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/CreateOrUpdateSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/CreateOrUpdateSelector.java
@@ -46,7 +46,6 @@ public class CreateOrUpdateSelector implements MethodSelector {
                                                          Type sourceType, Type targetType,
                                                          SelectionCriteria criteria) {
 
-        boolean isCreateMethod = mappingMethod.getMappingTargetParameter() == null;
         List<T> createCandidates = new ArrayList<T>();
         List<T> updateCandidates = new ArrayList<T>();
         for ( T method : methods ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/TypeHierarchyErroneousException.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/TypeHierarchyErroneousException.java
@@ -27,6 +27,7 @@ import javax.lang.model.element.TypeElement;
  *
  */
 public class TypeHierarchyErroneousException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
 
     private TypeElement element;
 

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/AnnotationProcessorTestRunner.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/AnnotationProcessorTestRunner.java
@@ -60,7 +60,18 @@ public class AnnotationProcessorTestRunner extends ParentRunner<Runner> {
     public AnnotationProcessorTestRunner(Class<?> klass) throws Exception {
         super( klass );
 
-        runners = Arrays.<Runner> asList(
+        runners = createRunners( klass );
+    }
+
+    @SuppressWarnings("deprecation")
+    private List<Runner> createRunners(Class<?> klass) throws Exception {
+        WithSingleCompiler singleCompiler = klass.getAnnotation( WithSingleCompiler.class );
+
+        if (singleCompiler != null) {
+            return Arrays.<Runner> asList( new InnerAnnotationProcessorRunner( klass, singleCompiler.value() ) );
+        }
+
+        return Arrays.<Runner> asList(
             new InnerAnnotationProcessorRunner( klass, Compiler.JDK ),
             new InnerAnnotationProcessorRunner( klass, Compiler.ECLIPSE ) );
     }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/WithSingleCompiler.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/WithSingleCompiler.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.testutil.runner;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Temporarily only use the specified compiler for the test during debugging / implementation.
+ * <p>
+ * Do not commit tests with this annotation present!
+ *
+ * @deprecated Do not commit tests with this annotation present. Tests are expected to work with all compilers.
+ * @author Andreas Gudian
+ */
+@Deprecated
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithSingleCompiler {
+    /**
+     * @return The compiler to use.
+     */
+    Compiler value();
+}


### PR DESCRIPTION
* Also fixes some compiler warnings that I got in Eclipse.

To use it, just add `@WithSingleCompiler(Compiler.JDK)` or `@WithSingleCompiler(Compiler.ECLIPSE)`  to the test class. And remove it again before committing. :grin: