### PR TITLE
Fix for #775: Iterable forged methods and lower bounds

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -522,7 +522,7 @@ public class PropertyMapping extends ModelElement {
             name = Strings.getSaveVariableName( name, ctx.getNamesOfMappingsToGenerate() );
 
             if ( ( sourceType.isCollectionType() || sourceType.isArrayType() )
-                && ( targetType.isCollectionType() || targetType.isArrayType() ) ) {
+                && ( targetType.isIterableType() ) ) {
 
                 // copy mapper configuration from the source method, its the same mapper
                 MapperConfiguration config = method.getMapperConfiguration();

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableContainer.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableContainer.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._775;
+
+/**
+ * @author Andreas Gudian
+ */
+public class IterableContainer {
+    private Iterable<? extends Integer> values;
+
+    public void setValues(Iterable<? extends Integer> values) {
+        this.values = values;
+    }
+
+    public Iterable<? extends Integer> getValues() {
+        return values;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableWithBoundedElementTypeTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableWithBoundedElementTypeTest.java
@@ -1,0 +1,57 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._775;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Verifies:
+ * <ul>
+ * <li>For target properties of type {@link Iterable}, a forged method can be created.
+ * </ul>
+ *
+ * @author Andreas Gudian
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("775")
+@WithClasses({
+    MapperWithForgedIterableMapping.class,
+    ListContainer.class,
+    IterableContainer.class
+})
+public class IterableWithBoundedElementTypeTest {
+
+    @Test
+    public void createsForgedMethodForIterableLowerBoundInteger() {
+        ListContainer source = new ListContainer();
+
+        source.setValues( Arrays.asList( "42", "47" ) );
+        IterableContainer result = MapperWithForgedIterableMapping.INSTANCE.toContainerWithIterable( source );
+
+        assertThat( result.getValues() ).contains( Integer.valueOf( 42 ), Integer.valueOf( 47 ) );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableWithBoundedElementTypeTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableWithBoundedElementTypeTest.java
@@ -32,6 +32,8 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
  * Verifies:
  * <ul>
  * <li>For target properties of type {@link Iterable}, a forged method can be created.
+ * <li>For target properties of type {@code Iterable<? extends Integer>}, a custom mapping method that returns
+ * {@code List<Integer>} is chosen as property mapping method.
  * </ul>
  *
  * @author Andreas Gudian
@@ -40,6 +42,7 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 @IssueKey("775")
 @WithClasses({
     MapperWithForgedIterableMapping.class,
+    MapperWithCustomListMapping.class,
     ListContainer.class,
     IterableContainer.class
 })
@@ -53,5 +56,15 @@ public class IterableWithBoundedElementTypeTest {
         IterableContainer result = MapperWithForgedIterableMapping.INSTANCE.toContainerWithIterable( source );
 
         assertThat( result.getValues() ).contains( Integer.valueOf( 42 ), Integer.valueOf( 47 ) );
+    }
+
+    @Test
+    public void usesListIntegerMethodForIterableLowerBoundInteger() {
+        ListContainer source = new ListContainer();
+
+        source.setValues( Arrays.asList( "42", "47" ) );
+        IterableContainer result = MapperWithCustomListMapping.INSTANCE.toContainerWithIterable( source );
+
+        assertThat( result.getValues() ).contains( Integer.valueOf( 66 ), Integer.valueOf( 71 ) );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/ListContainer.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/ListContainer.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._775;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Andreas Gudian
+ */
+public class ListContainer {
+    private List<String> values = new ArrayList<String>();
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/MapperWithCustomListMapping.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/MapperWithCustomListMapping.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._775;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Andreas Gudian
+ */
+@Mapper
+public abstract class MapperWithCustomListMapping {
+    public static final MapperWithCustomListMapping INSTANCE =
+        Mappers.getMapper( MapperWithCustomListMapping.class );
+
+    public abstract IterableContainer toContainerWithIterable(ListContainer source);
+
+    protected List<Integer> hexListToIntList(Collection<String> source) {
+        List<Integer> iterable = new ArrayList<Integer>( source.size() );
+        for ( String string : source ) {
+            iterable.add( Integer.parseInt( string, 16 ) );
+        }
+
+        return iterable;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/MapperWithForgedIterableMapping.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/MapperWithForgedIterableMapping.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._775;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Andreas Gudian
+ */
+@Mapper
+public abstract class MapperWithForgedIterableMapping {
+    public static final MapperWithForgedIterableMapping INSTANCE =
+        Mappers.getMapper( MapperWithForgedIterableMapping.class );
+
+    public abstract IterableContainer toContainerWithIterable(ListContainer source);
+
+}


### PR DESCRIPTION
#775 actually uncovers two problems, I tried to fix them in two separate commits. The creation of the forged method for Iterables is straight forward I guess, but the lower-bound matching is a bit voodooish... I didn't get it to break though while trying around a bit. We still might have similar issues with upper-bounds, in case anyone wants to try that out in detail... :smirk: