### PR TITLE
Javadoc and OSGi

### DIFF
--- a/core-jdk8/pom.xml
+++ b/core-jdk8/pom.xml
@@ -149,6 +149,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/core-jdk8/src/main/java/org/mapstruct/ValueMapping.java
+++ b/core-jdk8/src/main/java/org/mapstruct/ValueMapping.java
@@ -33,6 +33,7 @@ import java.lang.annotation.Target;
  * </ol>
  * <p>
  * <B>Example 1:</B>
+ *
  * <pre>
  * <code>
  * public enum OrderType { RETAIL, B2B, EXTRA, STANDARD, NORMAL }
@@ -45,21 +46,23 @@ import java.lang.annotation.Target;
  * ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
  * </code>
  * Mapping result:
- * ╔═════════════════════╦════════════════════════════╗
- * ║ OrderType           ║ ExternalOrderType          ║
- * ╠═════════════════════╬════════════════════════════╣
- * ║ null                ║ null                       ║
- * ║ OrderType.EXTRA     ║ ExternalOrderType.SPECIAL  ║
- * ║ OrderType.STANDARD  ║ ExternalOrderType.DEFAULT  ║
- * ║ OrderType.NORMAL    ║ ExternalOrderType.DEFAULT  ║
- * ║ OrderType.RETAIL    ║ ExternalOrderType.RETAIL   ║
- * ║ OrderType.B2B       ║ ExternalOrderType.B2B      ║
- * ╚═════════════════════╩════════════════════════════╝
+ * +---------------------+----------------------------+
+ * | OrderType           | ExternalOrderType          |
+ * +---------------------+----------------------------+
+ * | null                | null                       |
+ * | OrderType.EXTRA     | ExternalOrderType.SPECIAL  |
+ * | OrderType.STANDARD  | ExternalOrderType.DEFAULT  |
+ * | OrderType.NORMAL    | ExternalOrderType.DEFAULT  |
+ * | OrderType.RETAIL    | ExternalOrderType.RETAIL   |
+ * | OrderType.B2B       | ExternalOrderType.B2B      |
+ * +---------------------+----------------------------+
  * </pre>
+ *
  * MapStruct will <B>WARN</B> on incomplete mappings. However, if for some reason no match is found an
  * {@link java.lang.IllegalStateException} will be thrown.
  * <p>
  * <B>Example 2:</B>
+ *
  * <pre>
  * <code>
  * &#64;ValueMapping( source = "&lt;NULL&gt;", target = "DEFAULT" ),
@@ -68,16 +71,16 @@ import java.lang.annotation.Target;
  * ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
  * </code>
  * Mapping result:
- * ╔═════════════════════╦════════════════════════════╗
- * ║ OrderType           ║ ExternalOrderType          ║
- * ╠═════════════════════╬════════════════════════════╣
- * ║ null                ║ ExternalOrderType.DEFAULT  ║
- * ║ OrderType.STANDARD  ║ null                       ║
- * ║ OrderType.RETAIL    ║ ExternalOrderType.RETAIL   ║
- * ║ OrderType.B2B       ║ ExternalOrderType.B2B      ║
- * ║ OrderType.NORMAL    ║ ExternalOrderType.SPECIAL  ║
- * ║ OrderType.EXTRA     ║ ExternalOrderType.SPECIAL  ║
- * ╚═════════════════════╩════════════════════════════╝
+ * +---------------------+----------------------------+
+ * | OrderType           | ExternalOrderType          |
+ * +---------------------+----------------------------+
+ * | null                | ExternalOrderType.DEFAULT  |
+ * | OrderType.STANDARD  | null                       |
+ * | OrderType.RETAIL    | ExternalOrderType.RETAIL   |
+ * | OrderType.B2B       | ExternalOrderType.B2B      |
+ * | OrderType.NORMAL    | ExternalOrderType.SPECIAL  |
+ * | OrderType.EXTRA     | ExternalOrderType.SPECIAL  |
+ * +---------------------+----------------------------+
  * </pre>
  *
  * @author Sjaak Derksen

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -140,6 +140,18 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/core/src/main/java/org/mapstruct/ValueMapping.java
+++ b/core/src/main/java/org/mapstruct/ValueMapping.java
@@ -32,6 +32,7 @@ import java.lang.annotation.Target;
  * </ol>
  * <p>
  * <B>Example 1:</B>
+ *
  * <pre>
  * <code>
  * public enum OrderType { RETAIL, B2B, EXTRA, STANDARD, NORMAL }
@@ -46,21 +47,23 @@ import java.lang.annotation.Target;
  * ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
  * </code>
  * Mapping result:
- * ╔═════════════════════╦════════════════════════════╗
- * ║ OrderType           ║ ExternalOrderType          ║
- * ╠═════════════════════╬════════════════════════════╣
- * ║ null                ║ null                       ║
- * ║ OrderType.EXTRA     ║ ExternalOrderType.SPECIAL  ║
- * ║ OrderType.STANDARD  ║ ExternalOrderType.DEFAULT  ║
- * ║ OrderType.NORMAL    ║ ExternalOrderType.DEFAULT  ║
- * ║ OrderType.RETAIL    ║ ExternalOrderType.RETAIL   ║
- * ║ OrderType.B2B       ║ ExternalOrderType.B2B      ║
- * ╚═════════════════════╩════════════════════════════╝
+ * +---------------------+----------------------------+
+ * | OrderType           | ExternalOrderType          |
+ * +---------------------+----------------------------+
+ * | null                | null                       |
+ * | OrderType.EXTRA     | ExternalOrderType.SPECIAL  |
+ * | OrderType.STANDARD  | ExternalOrderType.DEFAULT  |
+ * | OrderType.NORMAL    | ExternalOrderType.DEFAULT  |
+ * | OrderType.RETAIL    | ExternalOrderType.RETAIL   |
+ * | OrderType.B2B       | ExternalOrderType.B2B      |
+ * +---------------------+----------------------------+
  * </pre>
+ *
  * MapStruct will <B>WARN</B> on incomplete mappings. However, if for some reason no match is found an
  * {@link java.lang.IllegalStateException} will be thrown.
  * <p>
  * <B>Example 2:</B>
+ *
  * <pre>
  * <code>
  * &#64;ValueMappings({
@@ -71,16 +74,16 @@ import java.lang.annotation.Target;
  * ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
  * </code>
  * Mapping result:
- * ╔═════════════════════╦════════════════════════════╗
- * ║ OrderType           ║ ExternalOrderType          ║
- * ╠═════════════════════╬════════════════════════════╣
- * ║ null                ║ ExternalOrderType.DEFAULT  ║
- * ║ OrderType.STANDARD  ║ null                       ║
- * ║ OrderType.RETAIL    ║ ExternalOrderType.RETAIL   ║
- * ║ OrderType.B2B       ║ ExternalOrderType.B2B      ║
- * ║ OrderType.NORMAL    ║ ExternalOrderType.SPECIAL  ║
- * ║ OrderType.EXTRA     ║ ExternalOrderType.SPECIAL  ║
- * ╚═════════════════════╩════════════════════════════╝
+ * +---------------------+----------------------------+
+ * | OrderType           | ExternalOrderType          |
+ * +---------------------+----------------------------+
+ * | null                | ExternalOrderType.DEFAULT  |
+ * | OrderType.STANDARD  | null                       |
+ * | OrderType.RETAIL    | ExternalOrderType.RETAIL   |
+ * | OrderType.B2B       | ExternalOrderType.B2B      |
+ * | OrderType.NORMAL    | ExternalOrderType.SPECIAL  |
+ * | OrderType.EXTRA     | ExternalOrderType.SPECIAL  |
+ * +---------------------+----------------------------+
  * </pre>
  *
  * @author Sjaak Derksen

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -329,7 +329,20 @@
                         </dependency>
                     </dependencies>
                 </plugin>
-
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>3.0.1</version>
+                    <executions>
+                        <execution>
+                            <id>bundle-manifest</id>
+                            <phase>process-classes</phase>
+                            <goals>
+                                <goal>manifest</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-install-plugin</artifactId>


### PR DESCRIPTION
That's two small build related issues in one pull-request:

* #805 use basic ASCII chars in the javadoc ASCII art tables (I didn't find a proper way to get it to work otherwise...)
* #27 Add OSGi metadata to manifests of mapstruct.jar and mapstruct-jdk8.jar
