### PR TITLE
Add @WithServiceImplementation annotation in testutil to register SPI implementations in processor tests

### DIFF
--- a/integrationtest/src/test/resources/fullFeatureTest/pom.xml
+++ b/integrationtest/src/test/resources/fullFeatureTest/pom.xml
@@ -51,6 +51,7 @@
                         <exclude>**/*Erroneous*.java</exclude>
                         <exclude>**/*Test.java</exclude>
                         <exclude>**/testutil/**/*.java</exclude>
+                        <exclude>**/spi/**/*.java</exclude>
                         <exclude>${additionalExclude0}</exclude>
                         <exclude>${additionalExclude1}</exclude>
                         <exclude>${additionalExclude2}</exclude>

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomAccessorNamingStrategy.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomAccessorNamingStrategy.java
@@ -1,0 +1,84 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.naming.spi;
+
+import java.beans.Introspector;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeKind;
+
+import org.mapstruct.ap.spi.AccessorNamingStrategy;
+import org.mapstruct.ap.spi.MethodType;
+
+/**
+ * A custom {@link AccessorNamingStrategy} recognizing getters in the form of {@code property()} and setters in the
+ * form of {@code withProperty(value)}.
+ *
+ * @author Gunnar Morling
+ */
+public class CustomAccessorNamingStrategy implements AccessorNamingStrategy {
+
+    @Override
+    public MethodType getMethodType(ExecutableElement method) {
+        if ( isGetterMethod( method ) ) {
+            return MethodType.GETTER;
+        }
+        else if ( isSetterMethod( method ) ) {
+            return MethodType.SETTER;
+        }
+        else if ( isAdderMethod( method ) ) {
+            return MethodType.ADDER;
+        }
+        else {
+            return MethodType.OTHER;
+        }
+    }
+
+    private boolean isGetterMethod(ExecutableElement method) {
+        return method.getReturnType().getKind() != TypeKind.VOID;
+    }
+
+    public boolean isSetterMethod(ExecutableElement method) {
+        String methodName = method.getSimpleName().toString();
+
+        return methodName.startsWith( "with" ) && methodName.length() > 4;
+    }
+
+    public boolean isAdderMethod(ExecutableElement method) {
+        String methodName = method.getSimpleName().toString();
+        return methodName.startsWith( "add" ) && methodName.length() > 3;
+    }
+
+    @Override
+    public String getPropertyName(ExecutableElement getterOrSetterMethod) {
+        String methodName = getterOrSetterMethod.getSimpleName().toString();
+        return Introspector.decapitalize( methodName.startsWith( "with" ) ? methodName.substring(  4 ) : methodName );
+    }
+
+    @Override
+    public String getElementName(ExecutableElement adderMethod) {
+        String methodName = adderMethod.getSimpleName().toString();
+        return Introspector.decapitalize( methodName.substring( 3 ) );
+    }
+
+    @Override
+    public String getCollectionGetterName(String property) {
+        return property.substring( 0, 1 ).toUpperCase() + property.substring( 1 );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomNamingStrategyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomNamingStrategyTest.java
@@ -1,0 +1,51 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.naming.spi;
+
+import static org.fest.assertions.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.spi.AccessorNamingStrategy;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithServiceImplementation;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Test do demonstrate the usage of custom implementations of {@link AccessorNamingStrategy}.
+ *
+ * @author Andreas Gudian
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({ GolfPlayer.class, GolfPlayerDto.class, GolfPlayerMapper.class })
+@WithServiceImplementation(CustomAccessorNamingStrategy.class)
+public class CustomNamingStrategyTest {
+    @Test
+    public void shouldApplyCustomNamingStrategy() {
+        GolfPlayer player = new GolfPlayer()
+            .withName( "Jared" )
+            .withHandicap( 9.2D );
+
+        GolfPlayerDto dto = GolfPlayerMapper.INSTANCE.golfPlayerToDto( player );
+
+        assertThat( dto ).isNotNull();
+        assertThat( dto.name() ).isEqualTo( "Jared" );
+        assertThat( dto.handicap() ).isEqualTo( 9.2D );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/spi/GolfPlayer.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/spi/GolfPlayer.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.naming.spi;
+
+/**
+ * @author Gunnar Morling
+ */
+public class GolfPlayer {
+
+    private double handicap;
+    private String name;
+
+    public double handicap() {
+        return handicap;
+    }
+
+    public GolfPlayer withHandicap(double handicap) {
+        this.handicap = handicap;
+        return this;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public GolfPlayer withName(String name) {
+        this.name = name;
+        return this;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/spi/GolfPlayerDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/spi/GolfPlayerDto.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.naming.spi;
+
+/**
+ * @author Gunnar Morling
+ */
+public class GolfPlayerDto {
+
+    private double handicap;
+    private String name;
+
+    public double handicap() {
+        return handicap;
+    }
+
+    public void withHandicap(double handicap) {
+        this.handicap = handicap;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public void withName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/spi/GolfPlayerMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/spi/GolfPlayerMapper.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.naming.spi;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface GolfPlayerMapper {
+
+    GolfPlayerMapper INSTANCE = Mappers.getMapper( GolfPlayerMapper.class );
+
+    GolfPlayerDto golfPlayerToDto(GolfPlayer player);
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithServiceImplementation.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithServiceImplementation.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.testutil;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies an implementation of an SPI to be used during the annotation processing.
+ *
+ * @author Andreas Gudian
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface WithServiceImplementation {
+    /**
+     * @return The service implementation class that is to be made available during the annotation processing.
+     */
+    Class<?> value();
+
+    /**
+     * @return The SPI that the service implementation provides. If omitted, then {@link #value()} is expected to
+     *         implement exactly one interface which will be considered the provided SPI implementation.
+     */
+    Class<?> provides() default Object.class;
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithServiceImplementations.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithServiceImplementations.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.testutil;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies implementations of SPIs to be used during the annotation processing.
+ *
+ * @author Andreas Gudian
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface WithServiceImplementations {
+
+    /**
+     * @return The SPI implementations to use.
+     */
+    WithServiceImplementation[] value();
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilationRequest.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilationRequest.java
@@ -19,17 +19,20 @@
 package org.mapstruct.ap.testutil.runner;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 /**
  * Represents a compilation task for a number of sources with given processor options.
  */
-class CompilationRequest {
+public class CompilationRequest {
     private final Set<Class<?>> sourceClasses;
+    private final Map<Class<?>, Class<?>> services;
     private final List<String> processorOptions;
 
-    CompilationRequest(Set<Class<?>> sourceClasses, List<String> processorOptions) {
+    CompilationRequest(Set<Class<?>> sourceClasses, Map<Class<?>, Class<?>> services, List<String> processorOptions) {
         this.sourceClasses = sourceClasses;
+        this.services = services;
         this.processorOptions = processorOptions;
     }
 
@@ -38,6 +41,7 @@ class CompilationRequest {
         final int prime = 31;
         int result = 1;
         result = prime * result + ( ( processorOptions == null ) ? 0 : processorOptions.hashCode() );
+        result = prime * result + ( ( services == null ) ? 0 : services.hashCode() );
         result = prime * result + ( ( sourceClasses == null ) ? 0 : sourceClasses.hashCode() );
         return result;
     }
@@ -55,7 +59,9 @@ class CompilationRequest {
         }
         CompilationRequest other = (CompilationRequest) obj;
 
-        return processorOptions.equals( other.processorOptions ) && sourceClasses.equals( other.sourceClasses );
+        return processorOptions.equals( other.processorOptions )
+            && services.equals( other.services )
+            && sourceClasses.equals( other.sourceClasses );
     }
 
     public Set<Class<?>> getSourceClasses() {
@@ -64,5 +70,9 @@ class CompilationRequest {
 
     public List<String> getProcessorOptions() {
         return processorOptions;
+    }
+
+    public Map<Class<?>, Class<?>> getServices() {
+        return services;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/FilteringParentClassLoader.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/FilteringParentClassLoader.java
@@ -1,0 +1,73 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.testutil.runner;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+
+/**
+ * A ClassLoader that can be used to hide packages or classes from its default parent ClassLoader so that the
+ * ClassLoader using this as its parent can load the class on its own.
+ *
+ * @author Andreas Gudian
+ */
+final class FilteringParentClassLoader extends ClassLoader {
+    private Collection<String> excludedPrefixes;
+
+    /**
+     * @param excludedPrefixes class name prefixes to exclude
+     */
+    FilteringParentClassLoader(String... excludedPrefixes) {
+        this.excludedPrefixes = new ArrayList<String>( Arrays.asList( excludedPrefixes ) );
+    }
+
+    /**
+     * @param classes The classes to hide (inner classes are hidden as well)
+     * @return {@code this}
+     */
+    FilteringParentClassLoader hidingClasses(Collection<Class<?>> classes) {
+        for ( Class<?> clazz : classes ) {
+            hidingClass( clazz );
+        }
+
+        return this;
+    }
+
+    /**
+     * @param clazz The class to hide (inner classes are hidden as well)
+     * @return {@code this}
+     */
+    FilteringParentClassLoader hidingClass(Class<?> clazz) {
+        excludedPrefixes.add( clazz.getName() );
+
+        return this;
+    }
+
+    @Override
+    protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        for ( String excluded : excludedPrefixes ) {
+            if ( name.startsWith( excluded ) ) {
+                return null;
+            }
+        }
+
+        return super.loadClass( name, resolve );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/InnerAnnotationProcessorRunner.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/InnerAnnotationProcessorRunner.java
@@ -18,8 +18,6 @@
  */
 package org.mapstruct.ap.testutil.runner;
 
-import java.net.URL;
-
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.model.FrameworkMethod;
 import org.junit.runners.model.Statement;
@@ -70,13 +68,7 @@ class InnerAnnotationProcessorRunner extends BlockJUnit4ClassRunner {
     }
 
     private static void replaceContextClassLoader(Class<?> klass) {
-        String classFileName = klass.getName().replace( ".", "/" ) + ".class";
-        URL classResource = klass.getClassLoader().getResource( classFileName );
-        String fullyQualifiedUrl = classResource.toExternalForm();
-        String basePath = fullyQualifiedUrl.substring( 0, fullyQualifiedUrl.length() - classFileName.length() );
-
-        ModifiableURLClassLoader testClassLoader = new ModifiableURLClassLoader();
-        testClassLoader.addURL( basePath );
+        ModifiableURLClassLoader testClassLoader = new ModifiableURLClassLoader().withOriginOf( klass );
 
         Thread.currentThread().setContextClassLoader( testClassLoader );
     }


### PR DESCRIPTION
I've also added the test case for the accessor naming strategy from the integration-tests module to the processor test to demonstrate the new feature. We should keep that one integration test, though.

Speaking of integration tests: our `FullFeatureCompilationTest` needs to ignore any test mappers that rely on special SPI implementations. Thus, let's put those tests in a package `.spi.` to allow the `FullFeatureCompilationTest` to ignore them.

@sjaakd: As you can see, this now works without having to modify something in the processor classes. If you revert everything in `org.mapstruct.ap.testutil.*` and `Services` and the related change in `Executables` on your branch, it should be rebasable to this. Well, plus the changed name of the annotations... :wink: