### PR TITLE
#828 Fix NoClassDefFoundError when running in Eclipse Neon (4.6)

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/util/workarounds/EclipseAsMemberOfWorkaround.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/workarounds/EclipseAsMemberOfWorkaround.java
@@ -41,7 +41,7 @@ import org.eclipse.jdt.internal.compiler.lookup.TypeBinding;
 /**
  * Contains the workaround for {@link Types#asMemberOf(DeclaredType, Element)} using Eclipse implementation types.
  * <p>
- * <strong>This class may only be loaded when running within Eclipse</strong>
+ * <strong>This class may only be accessed through {@link EclipseClassLoaderBridge} when running within Eclipse</strong>
  *
  * @author Andreas Gudian
  */

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/workarounds/EclipseClassLoaderBridge.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/workarounds/EclipseClassLoaderBridge.java
@@ -1,0 +1,88 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.util.workarounds;
+
+import java.lang.reflect.Method;
+import java.net.URLClassLoader;
+
+import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.element.Element;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * In Eclipse 4.6, the ClassLoader of the annotation processor does not provide access to the implementation types of
+ * the APT-API anymore, so we need to create a new ClassLoader containing the processor class path URLs and having the
+ * ClassLoader of the APT-API implementations as parent. The method invocation then consequently needs to be done via
+ * reflection.
+ *
+ * @author Andreas Gudian
+ */
+class EclipseClassLoaderBridge {
+    private static final String ECLIPSE_AS_MEMBER_OF_WORKAROUND =
+        "org.mapstruct.ap.internal.util.workarounds.EclipseAsMemberOfWorkaround";
+
+    private static ClassLoader classLoader;
+    private static Method asMemberOf;
+
+    private EclipseClassLoaderBridge() {
+    }
+
+    /**
+     * Invokes {@link EclipseAsMemberOfWorkaround#asMemberOf(ProcessingEnvironment, DeclaredType, Element)} via
+     * reflection using a special ClassLoader.
+     */
+    static TypeMirror invokeAsMemberOfWorkaround(ProcessingEnvironment env, DeclaredType containing, Element element)
+        throws Exception {
+        return (TypeMirror) getAsMemberOf( element.getClass().getClassLoader() ).invoke(
+            null,
+            env,
+            containing,
+            element );
+    }
+
+    private static ClassLoader getOrCreateClassLoader(ClassLoader parent) {
+        if ( classLoader == null ) {
+            classLoader = new URLClassLoader(
+                ( (URLClassLoader) EclipseClassLoaderBridge.class.getClassLoader() ).getURLs(),
+                parent );
+        }
+
+        return classLoader;
+    }
+
+    private static Method getAsMemberOf(ClassLoader platformClassLoader) throws Exception {
+        if ( asMemberOf == null ) {
+            Class<?> workaroundClass =
+                getOrCreateClassLoader( platformClassLoader ).loadClass( ECLIPSE_AS_MEMBER_OF_WORKAROUND );
+
+            Method found = workaroundClass.getDeclaredMethod(
+                "asMemberOf",
+                ProcessingEnvironment.class,
+                DeclaredType.class,
+                Element.class );
+
+            found.setAccessible( true );
+
+            asMemberOf = found;
+        }
+
+        return asMemberOf;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/workarounds/SpecificCompilerWorkarounds.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/workarounds/SpecificCompilerWorkarounds.java
@@ -36,7 +36,8 @@ import org.mapstruct.ap.internal.version.VersionInformation;
  * @author Andreas Gudian
  */
 public class SpecificCompilerWorkarounds {
-    private SpecificCompilerWorkarounds() { }
+    private SpecificCompilerWorkarounds() {
+    }
 
     /**
      * Tests whether one type is assignable to another, checking for VOID first.
@@ -120,7 +121,7 @@ public class SpecificCompilerWorkarounds {
     /**
      * Workaround for Bugs in the Eclipse implementation of {@link Types#asMemberOf(DeclaredType, Element)}.
      *
-     * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=382590">Eclipse Bug 382590</a>
+     * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=382590">Eclipse Bug 382590 (fixed in Eclipse 4.6)</a>
      * @see <a href="https://bugs.eclipse.org/bugs/show_bug.cgi?id=481555">Eclipse Bug 481555</a>
      */
     static TypeMirror asMemberOf(Types typeUtils, ProcessingEnvironment env, VersionInformation versionInformation,
@@ -134,7 +135,7 @@ public class SpecificCompilerWorkarounds {
             catch ( IllegalArgumentException e ) {
                 lastException = e;
                 if ( versionInformation.isEclipseJDTCompiler() ) {
-                    result = EclipseAsMemberOfWorkaround.asMemberOf( env, containing, element );
+                    result = EclipseClassLoaderBridge.invokeAsMemberOfWorkaround( env, containing, element );
                 }
             }
         }


### PR DESCRIPTION
I wasn't able to add a test for it, as there are no bundles of the new compiler version on Maven central, yet.
But I did test it locally with a fresh Eclipse Neon package and in Eclipse Mars (4.5.2).