### PR TITLE
Enable support for Iterable classes which are not generic

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -91,10 +91,12 @@ public class IterableMappingMethod extends MappingMethod {
             Type sourceParameterType = first( method.getSourceParameters() ).getType();
             Type resultType = method.getResultType();
 
-            Type sourceElementType  = sourceParameterType.isArrayType() ? sourceParameterType.getComponentType()
-                : first( sourceParameterType.getTypeParameters() ).getTypeBound();
-            Type targetElementType = resultType.isArrayType() ? resultType.getComponentType()
-                : first( resultType.getTypeParameters() ).getTypeBound();
+            Type sourceElementType =
+                sourceParameterType.isArrayType() ? sourceParameterType.getComponentType() : first(
+                    sourceParameterType.determineTypeArguments( Iterable.class ) ).getTypeBound();
+            Type targetElementType =
+                resultType.isArrayType() ? resultType.getComponentType() : first(
+                    resultType.determineTypeArguments( Iterable.class ) ).getTypeBound();
 
             String loopVariableName =
                 Strings.getSaveVariableName( sourceElementType.getName(), method.getParameterNames() );
@@ -246,7 +248,7 @@ public class IterableMappingMethod extends MappingMethod {
             return sourceParameterType.getComponentType();
         }
         else {
-            return sourceParameterType.getTypeParameters().get( 0 ).getTypeBound();
+            return sourceParameterType.determineTypeArguments( Iterable.class ).get( 0 ).getTypeBound();
         }
     }
 
@@ -255,7 +257,7 @@ public class IterableMappingMethod extends MappingMethod {
             return getResultType().getComponentType();
         }
         else {
-            return getResultType().getTypeParameters().get( 0 );
+            return getResultType().determineTypeArguments( Iterable.class ).get( 0 );
         }
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -39,7 +39,7 @@ import org.mapstruct.ap.internal.util.Strings;
 /**
  * A {@link MappingMethod} implemented by a {@link Mapper} class which maps one {@code Map} type to another. Keys and
  * values are mapped either by a {@link TypeConversion} or another mapping method if required.
- * 
+ *
  * @author Gunnar Morling
  */
 public class MapMappingMethod extends MappingMethod {
@@ -105,15 +105,17 @@ public class MapMappingMethod extends MappingMethod {
             Type keySourceType = sourceTypeParams.get( 0 ).getTypeBound();
             Type keyTargetType = resultTypeParams.get( 0 ).getTypeBound();
 
-            Assignment keyAssignment =
-                ctx.getMappingResolver().getTargetAssignment( method, "map key", keySourceType, keyTargetType, null, // there
-                                                                                                                     // is
-                                                                                                                     // no
-                                                                                                                     // targetPropertyName
-                    keyFormattingParameters,
-                    keySelectionParameters,
-                    "entry.getKey()",
-                    false );
+            Assignment keyAssignment = ctx.getMappingResolver().getTargetAssignment(
+                method,
+                "map key",
+                keySourceType,
+                keyTargetType,
+                null, // there is no targetPropertyName
+                keyFormattingParameters,
+                keySelectionParameters,
+                "entry.getKey()",
+                false
+            );
 
             if ( keyAssignment == null ) {
                 if ( method instanceof ForgedMethod ) {
@@ -121,7 +123,8 @@ public class MapMappingMethod extends MappingMethod {
                     return null;
                 }
                 else {
-                    ctx.getMessager().printMessage( method.getExecutable(), Message.MAPMAPPING_KEY_MAPPING_NOT_FOUND );
+                    ctx.getMessager().printMessage( method.getExecutable(),
+                        Message.MAPMAPPING_KEY_MAPPING_NOT_FOUND );
                 }
             }
 
@@ -129,17 +132,17 @@ public class MapMappingMethod extends MappingMethod {
             Type valueSourceType = sourceTypeParams.get( 1 ).getTypeBound();
             Type valueTargetType = resultTypeParams.get( 1 ).getTypeBound();
 
-            Assignment valueAssignment =
-                ctx.getMappingResolver().getTargetAssignment(
-                    method,
-                    "map value",
-                    valueSourceType,
-                    valueTargetType,
-                    null, // there is no targetPropertyName
-                    valueFormattingParameters,
-                    valueSelectionParameters,
-                    "entry.getValue()",
-                    false );
+            Assignment valueAssignment = ctx.getMappingResolver().getTargetAssignment(
+                method,
+                "map value",
+                valueSourceType,
+                valueTargetType,
+                null, // there is no targetPropertyName
+                valueFormattingParameters,
+                valueSelectionParameters,
+                "entry.getValue()",
+                false
+            );
 
             if ( method instanceof ForgedMethod ) {
                 ForgedMethod forgedMethod = (ForgedMethod) method;
@@ -157,14 +160,15 @@ public class MapMappingMethod extends MappingMethod {
                     return null;
                 }
                 else {
-                    ctx.getMessager().printMessage( method.getExecutable(), Message.MAPMAPPING_VALUE_MAPPING_NOT_FOUND );
+                    ctx.getMessager().printMessage( method.getExecutable(),
+                        Message.MAPMAPPING_VALUE_MAPPING_NOT_FOUND );
                 }
             }
 
             // mapNullToDefault
             boolean mapNullToDefault = false;
             if ( method.getMapperConfiguration() != null ) {
-                mapNullToDefault = method.getMapperConfiguration().isMapToDefault( nullValueMappingStrategy );
+                 mapNullToDefault = method.getMapperConfiguration().isMapToDefault( nullValueMappingStrategy );
             }
 
             MethodReference factoryMethod = null;
@@ -187,7 +191,8 @@ public class MapMappingMethod extends MappingMethod {
                 factoryMethod,
                 mapNullToDefault,
                 beforeMappingMethods,
-                afterMappingMethods );
+                afterMappingMethods
+            );
         }
     }
 
@@ -252,15 +257,24 @@ public class MapMappingMethod extends MappingMethod {
     }
 
     public String getKeyVariableName() {
-        return Strings.getSaveVariableName( "key", getParameterNames() );
+        return Strings.getSaveVariableName(
+            "key",
+            getParameterNames()
+        );
     }
 
     public String getValueVariableName() {
-        return Strings.getSaveVariableName( "value", getParameterNames() );
+        return Strings.getSaveVariableName(
+            "value",
+            getParameterNames()
+        );
     }
 
     public String getEntryVariableName() {
-        return Strings.getSaveVariableName( "entry", getParameterNames() );
+        return Strings.getSaveVariableName(
+            "entry",
+            getParameterNames()
+        );
     }
 
     public MethodReference getFactoryMethod() {
@@ -305,13 +319,8 @@ public class MapMappingMethod extends MappingMethod {
         }
 
         for ( int i = 0; i < getSourceParameters().size(); i++ ) {
-            if ( !getSourceParameters()
-                                       .get( i )
-                                       .getType()
-                                       .getTypeParameters()
-                                       .get( 0 )
-                                       .equals(
-                                           other.getSourceParameters().get( i ).getType().getTypeParameters().get( 0 ) ) ) {
+            if ( !getSourceParameters().get( i ).getType().getTypeParameters().get( 0 )
+                .equals( other.getSourceParameters().get( i ).getType().getTypeParameters().get( 0 ) ) ) {
                 return false;
             }
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -793,7 +793,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     /**
      * Searches for the given superclass and collects all type arguments for the given class
-     * 
+     *
      * @param superclass the superclass or interface the generic type arguments are searched for
      * @return a list of type arguments or null, if superclass was not found
      */

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -790,4 +790,30 @@ public class Type extends ModelElement implements Comparable<Type> {
         }
         return hasEmptyAccessibleContructor;
     }
+
+    /**
+     * Searches for the given superclass and collects all type arguments for the given class
+     * 
+     * @param superclass the superclass or interface the generic type arguments are searched for
+     * @return a list of type arguments or null, if superclass was not found
+     */
+    public List<Type> determineTypeArguments(Class<?> superclass) {
+        TypeMirror superclassMirror =
+            typeUtils.erasure( elementUtils.getTypeElement( superclass.getCanonicalName() ).asType() );
+        if ( typeUtils.isAssignable( superclassMirror, typeMirror )
+            && typeUtils.isAssignable( typeMirror, superclassMirror ) ) {
+            return getTypeParameters();
+        }
+
+        List<? extends TypeMirror> directSupertypes = typeUtils.directSupertypes( typeMirror );
+        for ( TypeMirror supertypemirror : directSupertypes ) {
+            Type supertype = typeFactory.getType( supertypemirror );
+            List<Type> supertypeTypeArguments = supertype.determineTypeArguments( superclass );
+            if ( supertypeTypeArguments != null ) {
+                return supertypeTypeArguments;
+            }
+        }
+
+        return null;
+    }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
@@ -132,8 +132,7 @@
             <#if resultType.implementationType??>
                 <@includeModel object=resultType.implementationType/>
             <#else>
-                <@includeModel object=resultType/>
-            </#if>()
+                <@includeModel object=resultType/></#if>()
         </#if>
     </@compress>
 </#macro>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
@@ -56,11 +56,11 @@
     <#-- key -->
         <@includeModel object=keyAssignment
                    targetWriteAccessorName=keyVariableName
-                   targetType=resultType.typeParameters[0].typeBound/>
+                   targetType=resultElementTypes[0].typeBound/>
     <#-- value -->
         <@includeModel object=valueAssignment
                    targetWriteAccessorName=valueVariableName
-                   targetType=resultType.typeParameters[1].typeBound/>
+                   targetType=resultElementTypes[1].typeBound/>
         ${resultName}.put( ${keyVariableName}, ${valueVariableName} );
     }
     <#list afterMappingReferences as callback>
@@ -91,8 +91,7 @@
              <#if resultType.implementationType??>
                   <@includeModel object=resultType.implementationType />
              <#else>
-                  <@includeModel object=resultType />
-             </#if>()
+                  <@includeModel object=resultType /></#if>()
         </#if>
     </@compress>
 </#macro>

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/CollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/CollectionMappingTest.java
@@ -22,7 +22,6 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,7 +36,8 @@ import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
-@WithClasses({ Source.class, Target.class, Colour.class, SourceTargetMapper.class, TestList.class, TestMap.class, TestNonGenericList.class, StringToLongMap.class })
+@WithClasses({ Source.class, Target.class, Colour.class, SourceTargetMapper.class, TestList.class, TestMap.class,
+    TestNonGenericList.class, StringToLongMap.class })
 @RunWith(AnnotationProcessorTestRunner.class)
 public class CollectionMappingTest {
 
@@ -402,19 +402,19 @@ public class CollectionMappingTest {
 
         assertThat( target ).isNotNull();
         assertThat( target.getNonGenericStringList() ).containsExactly( "Bob", "Alice" );
-        
+
         // Inverse direction
         Target newTarget = new Target();
         TestNonGenericList nonGenericStringList = new TestNonGenericList();
         nonGenericStringList.addAll( Arrays.asList( "Bill", "Bob" ) );
         newTarget.setNonGenericStringList( nonGenericStringList );
-        
+
         Source mappedSource = SourceTargetMapper.INSTANCE.targetToSource( newTarget );
-        
+
         assertThat( mappedSource ).isNotNull();
         assertThat( mappedSource.getStringList3() ).containsExactly( "Bill", "Bob" );
     }
-    
+
     @Test
     @IssueKey("TODO")
     public void shouldMapNonGenericMap() {
@@ -423,22 +423,24 @@ public class CollectionMappingTest {
         map.put( "Bob", 123L );
         map.put( "Alice", 456L );
         source.setStringLongMapForNonGeneric( map );
-        
+
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
         assertThat( target ).isNotNull();
-        assertThat( target.getNonGenericMapStringtoLong() ).includes( MapAssert.entry("Bob", 123L), MapAssert.entry("Alice", 456L) );
-        
+        assertThat( target.getNonGenericMapStringtoLong() ).includes( MapAssert.entry( "Bob", 123L ),
+            MapAssert.entry( "Alice", 456L ) );
+
         // Inverse direction
         Target newTarget = new Target();
         StringToLongMap stringToLongMap = new StringToLongMap();
-        stringToLongMap.put("Blue", 321L);
+        stringToLongMap.put( "Blue", 321L );
         stringToLongMap.put( "Green", 654L );
         newTarget.setNonGenericMapStringtoLong( stringToLongMap );
-        
+
         Source mappedSource = SourceTargetMapper.INSTANCE.targetToSource( newTarget );
-        
+
         assertThat( mappedSource ).isNotNull();
-        assertThat( mappedSource.getStringLongMapForNonGeneric() ).includes( MapAssert.entry("Blue", 321L), MapAssert.entry("Green", 654L) );
+        assertThat( mappedSource.getStringLongMapForNonGeneric() ).includes( MapAssert.entry( "Blue", 321L ),
+            MapAssert.entry( "Green", 654L ) );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/CollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/CollectionMappingTest.java
@@ -22,6 +22,7 @@ import static org.fest.assertions.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,13 +30,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.fest.assertions.MapAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
-@WithClasses({ Source.class, Target.class, Colour.class, SourceTargetMapper.class, TestList.class, TestMap.class, TestNonGenericList.class })
+@WithClasses({ Source.class, Target.class, Colour.class, SourceTargetMapper.class, TestList.class, TestMap.class, TestNonGenericList.class, StringToLongMap.class })
 @RunWith(AnnotationProcessorTestRunner.class)
 public class CollectionMappingTest {
 
@@ -411,5 +413,32 @@ public class CollectionMappingTest {
         
         assertThat( mappedSource ).isNotNull();
         assertThat( mappedSource.getStringList3() ).containsExactly( "Bill", "Bob" );
+    }
+    
+    @Test
+    @IssueKey("TODO")
+    public void shouldMapNonGenericMap() {
+        Source source = new Source();
+        Map<String, Long> map = new HashMap<String, Long>();
+        map.put( "Bob", 123L );
+        map.put( "Alice", 456L );
+        source.setStringLongMapForNonGeneric( map );
+        
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getNonGenericMapStringtoLong() ).includes( MapAssert.entry("Bob", 123L), MapAssert.entry("Alice", 456L) );
+        
+        // Inverse direction
+        Target newTarget = new Target();
+        StringToLongMap stringToLongMap = new StringToLongMap();
+        stringToLongMap.put("Blue", 321L);
+        stringToLongMap.put( "Green", 654L );
+        newTarget.setNonGenericMapStringtoLong( stringToLongMap );
+        
+        Source mappedSource = SourceTargetMapper.INSTANCE.targetToSource( newTarget );
+        
+        assertThat( mappedSource ).isNotNull();
+        assertThat( mappedSource.getStringLongMapForNonGeneric() ).includes( MapAssert.entry("Blue", 321L), MapAssert.entry("Green", 654L) );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/CollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/CollectionMappingTest.java
@@ -35,7 +35,7 @@ import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
-@WithClasses({ Source.class, Target.class, Colour.class, SourceTargetMapper.class, TestList.class, TestMap.class })
+@WithClasses({ Source.class, Target.class, Colour.class, SourceTargetMapper.class, TestList.class, TestMap.class, TestNonGenericList.class })
 @RunWith(AnnotationProcessorTestRunner.class)
 public class CollectionMappingTest {
 
@@ -388,5 +388,28 @@ public class CollectionMappingTest {
 
         assertThat( source.getEnumSet() ).containsOnly( Colour.BLUE, Colour.GREEN, Colour.RED );
         assertThat( target.getEnumSet() ).containsOnly( Colour.BLUE, Colour.GREEN );
+    }
+
+    @Test
+    @IssueKey("TODO")
+    public void shouldMapNonGenericList() {
+        Source source = new Source();
+        source.setStringList3( new ArrayList<String>( Arrays.asList( "Bob", "Alice" ) ) );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getNonGenericStringList() ).containsExactly( "Bob", "Alice" );
+        
+        // Inverse direction
+        Target newTarget = new Target();
+        TestNonGenericList nonGenericStringList = new TestNonGenericList();
+        nonGenericStringList.addAll( Arrays.asList( "Bill", "Bob" ) );
+        newTarget.setNonGenericStringList( nonGenericStringList );
+        
+        Source mappedSource = SourceTargetMapper.INSTANCE.targetToSource( newTarget );
+        
+        assertThat( mappedSource ).isNotNull();
+        assertThat( mappedSource.getStringList3() ).containsExactly( "Bill", "Bob" );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/Source.java
@@ -55,6 +55,8 @@ public class Source {
 
     private EnumSet<Colour> enumSet;
 
+    private List<String> stringList3;
+
     public List<String> getStringList() {
         return stringList;
     }
@@ -173,5 +175,13 @@ public class Source {
 
     public void setEnumSet(EnumSet<Colour> enumSet) {
         this.enumSet = enumSet;
+    }
+
+    public List<String> getStringList3() {
+        return stringList3;
+    }
+
+    public void setStringList3(List<String> stringList3) {
+        this.stringList3 = stringList3;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/Source.java
@@ -49,6 +49,8 @@ public class Source {
 
     private Map<String, Long> otherStringLongMap;
 
+    private Map<String, Long> stringLongMapForNonGeneric;
+
     private List<String> stringList2;
 
     private Set<String> stringSet2;
@@ -183,5 +185,13 @@ public class Source {
 
     public void setStringList3(List<String> stringList3) {
         this.stringList3 = stringList3;
+    }
+    
+    public Map<String, Long> getStringLongMapForNonGeneric() {
+        return stringLongMapForNonGeneric;
+    }
+    
+    public void setStringLongMapForNonGeneric(Map<String, Long> stringLongMapForNonGeneric) {
+        this.stringLongMapForNonGeneric = stringLongMapForNonGeneric;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/Source.java
@@ -186,11 +186,11 @@ public class Source {
     public void setStringList3(List<String> stringList3) {
         this.stringList3 = stringList3;
     }
-    
+
     public Map<String, Long> getStringLongMapForNonGeneric() {
         return stringLongMapForNonGeneric;
     }
-    
+
     public void setStringLongMapForNonGeneric(Map<String, Long> stringLongMapForNonGeneric) {
         this.stringLongMapForNonGeneric = stringLongMapForNonGeneric;
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/SourceTargetMapper.java
@@ -38,7 +38,8 @@ public interface SourceTargetMapper {
         @Mapping(source = "integerSet", target = "set"),
         @Mapping(source = "anotherIntegerSet", target = "anotherStringSet"),
         @Mapping(source = "stringList2", target = "stringListNoSetter"),
-        @Mapping(source = "stringSet2", target = "stringListNoSetter2")
+        @Mapping(source = "stringSet2", target = "stringListNoSetter2"),
+        @Mapping(source = "stringList3", target = "nonGenericStringList")
     })
     Target sourceToTarget(Source source);
 

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/SourceTargetMapper.java
@@ -39,7 +39,8 @@ public interface SourceTargetMapper {
         @Mapping(source = "anotherIntegerSet", target = "anotherStringSet"),
         @Mapping(source = "stringList2", target = "stringListNoSetter"),
         @Mapping(source = "stringSet2", target = "stringListNoSetter2"),
-        @Mapping(source = "stringList3", target = "nonGenericStringList")
+        @Mapping(source = "stringList3", target = "nonGenericStringList"),
+        @Mapping(source = "stringLongMapForNonGeneric", target = "nonGenericMapStringtoLong")
     })
     Target sourceToTarget(Source source);
 

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/StringToLongMap.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/StringToLongMap.java
@@ -18,12 +18,13 @@
  */
 package org.mapstruct.ap.test.collection;
 
-import java.util.ArrayList;
+import java.util.HashMap;
 
 /**
  * @author Stefan May
  */
-public class TestNonGenericList extends ArrayList<String> {
+public class StringToLongMap extends HashMap<String, Long> {
 
     private static final long serialVersionUID = 1L;
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/Target.java
@@ -53,10 +53,12 @@ public class Target {
 
     private List<String> stringListNoSetter2;
 
-    @SuppressWarnings("rawtypes")
+    @SuppressWarnings( "rawtypes" )
     private Set set;
 
     private EnumSet<Colour> enumSet;
+
+    private TestNonGenericList nonGenericStringList;
 
     public Target() {
         otherStringLongMap = Maps.newHashMap();
@@ -183,5 +185,13 @@ public class Target {
 
     public void setEnumSet(EnumSet<Colour> enumSet) {
         this.enumSet = enumSet;
+    }
+
+    public TestNonGenericList getNonGenericStringList() {
+        return nonGenericStringList;
+    }
+
+    public void setNonGenericStringList(TestNonGenericList nonGenericStringList) {
+        this.nonGenericStringList = nonGenericStringList;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/Target.java
@@ -59,7 +59,7 @@ public class Target {
     private EnumSet<Colour> enumSet;
 
     private TestNonGenericList nonGenericStringList;
-    
+
     private StringToLongMap nonGenericMapStringtoLong;
 
     public Target() {
@@ -196,11 +196,11 @@ public class Target {
     public void setNonGenericStringList(TestNonGenericList nonGenericStringList) {
         this.nonGenericStringList = nonGenericStringList;
     }
-    
+
     public StringToLongMap getNonGenericMapStringtoLong() {
         return nonGenericMapStringtoLong;
     }
-    
+
     public void setNonGenericMapStringtoLong(StringToLongMap nonGenericMapStringtoLong) {
         this.nonGenericMapStringtoLong = nonGenericMapStringtoLong;
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/Target.java
@@ -59,6 +59,8 @@ public class Target {
     private EnumSet<Colour> enumSet;
 
     private TestNonGenericList nonGenericStringList;
+    
+    private StringToLongMap nonGenericMapStringtoLong;
 
     public Target() {
         otherStringLongMap = Maps.newHashMap();
@@ -193,5 +195,13 @@ public class Target {
 
     public void setNonGenericStringList(TestNonGenericList nonGenericStringList) {
         this.nonGenericStringList = nonGenericStringList;
+    }
+    
+    public StringToLongMap getNonGenericMapStringtoLong() {
+        return nonGenericMapStringtoLong;
+    }
+    
+    public void setNonGenericMapStringtoLong(StringToLongMap nonGenericMapStringtoLong) {
+        this.nonGenericMapStringtoLong = nonGenericMapStringtoLong;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/TestNonGenericList.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/TestNonGenericList.java
@@ -1,0 +1,29 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection;
+
+import java.util.ArrayList;
+
+/**
+ * @author Stefan may
+ */
+public class TestNonGenericList extends ArrayList<String> {
+
+    private static final long serialVersionUID = 1L;
+}


### PR DESCRIPTION
(e.g. public class StringList extends List<String>)

In one scenario I have an auto generated class, which just extends List<String> or (List<Object> ...) and we want to map it. Currently I get the following error:
"error: Internal error in the mapping processor: java.util.NoSuchElementException          at java.util.ArrayList$Itr.next(ArrayList.java:854)     at org.mapstruct.ap.internal.util.Collections.first(Collections.java:77)      at org.mapstruct.ap.internal.model.IterableMappingMethod$Builder.build(IterableMappingMethod.java:102)"

Attached you find a possible solution with an additional testcase.