### PR TITLE
Fixed ordering of beanProperties

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -22,7 +22,6 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -216,23 +215,24 @@ public class BeanMappingMethod extends MappingMethod {
                 );
             }
             else {
-                Collections.sort(
-                    propertyMappings, new Comparator<PropertyMapping>() {
+                List<PropertyMapping> sortedPropertyMappings = new ArrayList<PropertyMapping>( );
+                Set<String> fullfilledDependencies = new HashSet<String>();
 
-                        @Override
-                        public int compare(PropertyMapping o1, PropertyMapping o2) {
-                            if ( graphAnalyzer.getAllDescendants( o1.getName() ).contains( o2.getName() ) ) {
-                                return 1;
-                            }
-                            else if ( graphAnalyzer.getAllDescendants( o2.getName() ).contains( o1.getName() ) ) {
-                                return -1;
-                            }
-                            else {
-                                return 0;
-                            }
+                while ( !propertyMappings.isEmpty() ) {
+                    //find the first property mapping that has all dependencies filled
+                    for ( PropertyMapping propertyMapping: new ArrayList<PropertyMapping>( propertyMappings )) {
+                        if ( fullfilledDependencies.containsAll(
+                                graphAnalyzer.getAllDescendants( propertyMapping.getName() ) )) {
+                            sortedPropertyMappings.add( propertyMapping );
+                            fullfilledDependencies.add( propertyMapping.getName() );
+                            propertyMappings.remove( propertyMapping );
+                            //we need to break out, so that we continue with the outer loop, to keep the correct order
+                            break;
                         }
                     }
-                );
+                }
+
+                propertyMappings.addAll( sortedPropertyMappings );
             }
         }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/AddressMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/AddressMapper.java
@@ -39,4 +39,10 @@ public interface AddressMapper {
         @Mapping(target = "lastName", dependsOn = { "firstName", "middleName" })
     })
     PersonDto personToDto(Person person);
+
+    @Mappings({
+            @Mapping(target = "field0", dependsOn = "field2"),
+            @Mapping(target = "order", ignore = true)
+    })
+    DemoDTO demoToDemoDto(Demo demo);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/Demo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/Demo.java
@@ -1,0 +1,67 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.dependency;
+
+public class Demo {
+    private String field0;
+    private String field1;
+    private String field2;
+    private String field3;
+    private String field4;
+
+    public String getField0() {
+        return field0;
+    }
+
+    public void setField0(String field0) {
+        this.field0 = field0;
+    }
+
+    public String getField1() {
+        return field1;
+    }
+
+    public void setField1(String field1) {
+        this.field1 = field1;
+    }
+
+    public String getField2() {
+        return field2;
+    }
+
+    public void setField2(String field2) {
+        this.field2 = field2;
+    }
+
+    public String getField3() {
+        return field3;
+    }
+
+    public void setField3(String field3) {
+        this.field3 = field3;
+    }
+
+    public String getField4() {
+        return field4;
+    }
+
+    public void setField4(String field4) {
+        this.field4 = field4;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/DemoDTO.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/DemoDTO.java
@@ -1,0 +1,52 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.dependency;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class DemoDTO {
+    private List<String> order = new LinkedList<String>();
+
+    public void setField0(String field0) {
+        order.add( "field0" );
+    }
+
+    public void setField1(String field1) {
+        order.add( "field1" );
+    }
+
+    public void setField2(String field2) {
+        order.add( "field2" );
+    }
+
+
+    public void setField3(String field3) {
+        order.add( "field3" );
+    }
+
+
+    public void setField4(String field4) {
+        order.add( "field4" );
+    }
+
+    public List<String> getOrder() {
+        return order;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/OrderingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/OrderingTest.java
@@ -18,8 +18,6 @@
  */
 package org.mapstruct.ap.test.dependency;
 
-import static org.fest.assertions.Assertions.assertThat;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.Mapping;
@@ -30,14 +28,26 @@ import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
+import static org.fest.assertions.Assertions.assertThat;
+
 /**
  * Test for ordering mapped attributes by means of {@link Mapping#dependsOn()}.
  *
  * @author Gunnar Morling
  */
-@WithClasses({ Person.class, PersonDto.class, Address.class, AddressDto.class, AddressMapper.class })
+@WithClasses({ Person.class, PersonDto.class, Address.class, AddressDto.class, AddressMapper.class,
+        Demo.class, DemoDTO.class })
 @RunWith(AnnotationProcessorTestRunner.class)
 public class OrderingTest {
+
+    @Test
+    public void shouldApplyCorrectOrdering() {
+        Demo source = new Demo();
+
+        DemoDTO target = AddressMapper.INSTANCE.demoToDemoDto( source );
+
+        assertThat( target.getOrder() ).containsExactly( "field1", "field2", "field0", "field3", "field4" );
+    }
 
     @Test
     @IssueKey("304")


### PR DESCRIPTION
The sorting of properties returned sometimes the wrong order, when there are several properties, that have no descendants and are considered equal in the comparator. I changed the GraphAnalyzer to create a node path, that contains a valid order and use that to sort the properties.

I wasn't able to extract a standalone test case that displays the old wrong behavior from our code base. But without this change we get wrongly sorted dependencies in our application.