### PR TITLE
#860 switch to using assertj instead of FEST assertions

### DIFF
--- a/core-common/pom.xml
+++ b/core-common/pom.xml
@@ -44,8 +44,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core-common/src/test/java/org/mapstruct/factory/MappersTest.java
+++ b/core-common/src/test/java/org/mapstruct/factory/MappersTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.factory;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.mapstruct.test.model.Foo;

--- a/core-jdk8/pom.xml
+++ b/core-jdk8/pom.xml
@@ -50,8 +50,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,8 +49,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -45,8 +45,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrationtest/src/test/resources/cdiTest/src/test/java/org/mapstruct/itest/cdi/CdiBasedMapperTest.java
+++ b/integrationtest/src/test/resources/cdiTest/src/test/java/org/mapstruct/itest/cdi/CdiBasedMapperTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.itest.cdi;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.inject.Inject;
 

--- a/integrationtest/src/test/resources/fullFeatureTest/src/test/java/org/mapstruct/itest/simple/AnimalTest.java
+++ b/integrationtest/src/test/resources/fullFeatureTest/src/test/java/org/mapstruct/itest/simple/AnimalTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.ignore;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 

--- a/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_603/Issue603Test.java
+++ b/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_603/Issue603Test.java
@@ -21,7 +21,7 @@ package org.mapstruct.ap.test.bugs._603;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class Issue603Test {
 

--- a/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_636/Issue636Test.java
+++ b/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_636/Issue636Test.java
@@ -20,7 +20,7 @@ package org.mapstruct.ap.test.bugs._636;
 
 import org.junit.Test;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class Issue636Test {
 

--- a/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/itest/java8/Java8MapperTest.java
+++ b/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/itest/java8/Java8MapperTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.itest.java8;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 

--- a/integrationtest/src/test/resources/jaxbTest/src/test/java/org/mapstruct/itest/jaxb/JaxbBasedMapperTest.java
+++ b/integrationtest/src/test/resources/jaxbTest/src/test/java/org/mapstruct/itest/jaxb/JaxbBasedMapperTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.itest.jaxb;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.text.ParseException;

--- a/integrationtest/src/test/resources/jsr330Test/src/test/java/org/mapstruct/itest/jsr330/Jsr330BasedMapperTest.java
+++ b/integrationtest/src/test/resources/jsr330Test/src/test/java/org/mapstruct/itest/jsr330/Jsr330BasedMapperTest.java
@@ -29,7 +29,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for generation of JSR-330-based Mapper implementations

--- a/integrationtest/src/test/resources/namingStrategyTest/usage/src/test/java/org/mapstruct/itest/naming/NamingTest.java
+++ b/integrationtest/src/test/resources/namingStrategyTest/usage/src/test/java/org/mapstruct/itest/naming/NamingTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.itest.naming;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.mapstruct.itest.naming.GolfPlayer;

--- a/integrationtest/src/test/resources/pom.xml
+++ b/integrationtest/src/test/resources/pom.xml
@@ -160,8 +160,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrationtest/src/test/resources/pom.xml
+++ b/integrationtest/src/test/resources/pom.xml
@@ -42,6 +42,8 @@
         <toolchain-jdk-vendor></toolchain-jdk-vendor>
         <compiler-id></compiler-id>
         <compiler-source-target-version></compiler-source-target-version>
+        <!-- As Mapstruct has java 6 requirement we need to use AssertJ 1.x which is compatible with java 6 -->
+        <assertj.version>1.7.1</assertj.version>
     </properties>
 
     <profiles>

--- a/integrationtest/src/test/resources/simpleTest/src/test/java/org/mapstruct/itest/simple/ConversionTest.java
+++ b/integrationtest/src/test/resources/simpleTest/src/test/java/org/mapstruct/itest/simple/ConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.itest.simple;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.mapstruct.itest.simple.Source;

--- a/integrationtest/src/test/resources/springTest/src/test/java/org/mapstruct/itest/spring/SpringBasedMapperTest.java
+++ b/integrationtest/src/test/resources/springTest/src/test/java/org/mapstruct/itest/spring/SpringBasedMapperTest.java
@@ -27,7 +27,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Test for generation of Spring-based Mapper implementations

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -105,9 +105,9 @@
                 <version>2.3.21</version>
             </dependency>
             <dependency>
-                <groupId>org.easytesting</groupId>
-                <artifactId>fest-assert</artifactId>
-                <version>1.4</version>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.5.2</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -50,6 +50,7 @@
         <com.puppycrawl.tools.checkstyle.version>6.14.1</com.puppycrawl.tools.checkstyle.version>
         <add.release.arguments />
         <forkCount>1</forkCount>
+        <assertj.version>3.5.2</assertj.version>
     </properties>
 
     <licenses>
@@ -107,7 +108,7 @@
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-core</artifactId>
-                <version>3.5.2</version>
+                <version>${assertj.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -70,8 +70,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/DateFormatValidatorFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/DateFormatValidatorFactoryTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.internal.model.common;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.annotation.Annotation;
 import java.util.List;

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.internal.model.common;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.annotation.Annotation;
 import java.util.List;

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/TypeFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/TypeFactoryTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.internal.model.common;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/abstractclass/AbstractClassTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/abstractclass/AbstractClassTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.abstractclass;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/abstractclass/generics/GenericsHierarchyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/abstractclass/generics/GenericsHierarchyTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.abstractclass.generics;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/array/ArrayMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/array/ArrayMappingTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.array;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
@@ -68,7 +68,7 @@ public class ArrayMappingTest {
             .scientistsToDtos( new Scientist[]{ new Scientist( "Bob" ), new Scientist( "Larry" ) } );
 
         assertThat( dtos ).isNotNull();
-        assertThat( dtos ).onProperty( "name" ).containsOnly( "Bob", "Larry" );
+        assertThat( dtos ).extracting( "name" ).containsOnly( "Bob", "Larry" );
     }
 
     @Test
@@ -77,7 +77,7 @@ public class ArrayMappingTest {
             .scientistsToDtos( Arrays.asList( new Scientist( "Bob" ), new Scientist( "Larry" ) ) );
 
         assertThat( dtos ).isNotNull();
-        assertThat( dtos ).onProperty( "name" ).containsOnly( "Bob", "Larry" );
+        assertThat( dtos ).extracting( "name" ).containsOnly( "Bob", "Larry" );
     }
 
     @Test
@@ -86,7 +86,7 @@ public class ArrayMappingTest {
             .scientistsToDtosAsList( new Scientist[]{ new Scientist( "Bob" ), new Scientist( "Larry" ) } );
 
         assertThat( dtos ).isNotNull();
-        assertThat( dtos ).onProperty( "name" ).containsOnly( "Bob", "Larry" );
+        assertThat( dtos ).extracting( "name" ).containsOnly( "Bob", "Larry" );
     }
 
     @Test
@@ -99,7 +99,7 @@ public class ArrayMappingTest {
 
         assertThat( target ).isNotNull();
         assertThat( target ).isEqualTo( existingTarget );
-        assertThat( target ).onProperty( "name" ).containsOnly( "Bob" );
+        assertThat( target ).extracting( "name" ).containsOnly( "Bob" );
     }
 
     @Test
@@ -112,7 +112,7 @@ public class ArrayMappingTest {
 
         assertThat( target ).isNotNull();
         assertThat( target ).isEqualTo( existingTarget );
-        assertThat( target ).onProperty( "name" ).containsOnly( "Bob", "Larry"  );
+        assertThat( target ).extracting( "name" ).containsOnly( "Bob", "Larry"  );
     }
 
     @Test
@@ -126,7 +126,7 @@ public class ArrayMappingTest {
 
         assertThat( target ).isNotNull();
         assertThat( target ).isEqualTo( existingTarget );
-        assertThat( target ).onProperty( "name" ).containsOnly( "Bob", "Larry", "John"  );
+        assertThat( target ).extracting( "name" ).containsOnly( "Bob", "Larry", "John"  );
     }
 
     @Test
@@ -139,7 +139,7 @@ public class ArrayMappingTest {
         ScientistDto[] target = ScienceMapper.INSTANCE.scientistsToDtos( null, existingTarget );
 
         assertThat( target ).isNull();
-        assertThat( existingTarget ).onProperty( "name" ).containsOnly( "Jim" );
+        assertThat( existingTarget ).extracting( "name" ).containsOnly( "Jim" );
     }
 
     @IssueKey("534")

--- a/processor/src/test/java/org/mapstruct/ap/test/bool/BooleanMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bool/BooleanMappingTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bool;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_289/Issue289Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_289/Issue289Test.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._289;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_374/Issue374Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_374/Issue374Test.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._374;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_394/SameClassNameInDifferentPackageTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_394/SameClassNameInDifferentPackageTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._394;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/Issue516Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/Issue516Test.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._516;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_577/Issue577Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_577/Issue577Test.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._577;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_580/Issue580Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_580/Issue580Test.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._580;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_581/Issue581Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_581/Issue581Test.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._581;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_625/Issue625Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_625/Issue625Test.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._625;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_634/GenericContainerTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_634/GenericContainerTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._634;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.List;
@@ -50,6 +50,6 @@ public class GenericContainerTest {
 
         Target<Bar> target = SourceTargetMapper.INSTANCE.mapSourceToTarget( source );
 
-        assertThat( target.getContent() ).onProperty( "value" ).containsExactly( 42L, 84L );
+        assertThat( target.getContent() ).extracting( "value" ).containsExactly( 42L, 84L );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableWithBoundedElementTypeTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableWithBoundedElementTypeTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._775;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_855/OrderingBug855Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_855/OrderingBug855Test.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._855;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/BuiltInTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/BuiltInTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.builtin;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/CallbackMethodTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/CallbackMethodTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.callbacks;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/MappingResultPostprocessorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/ongeneratedmethods/MappingResultPostprocessorTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.callbacks.ongeneratedmethods;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/callbacks/typematching/CallbackMethodTypeMatchingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/callbacks/typematching/CallbackMethodTypeMatchingTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.callbacks.typematching;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/CollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/CollectionMappingTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.collection;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/adder/AdderTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/adder/AdderTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.collection.adder;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/defaultimplementation/DefaultCollectionImplementationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/defaultimplementation/DefaultCollectionImplementationTest.java
@@ -18,8 +18,8 @@
  */
 package org.mapstruct.ap.test.collection.defaultimplementation;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -192,7 +192,7 @@ public class DefaultCollectionImplementationTest {
     private void assertResultMap(Map<String, TargetFoo> result) {
         assertThat( result ).isNotNull();
         assertThat( result ).hasSize( 2 );
-        assertThat( result ).includes( entry( "1", new TargetFoo( "Bob" ) ), entry( "2", new TargetFoo( "Alice" ) ) );
+        assertThat( result ).contains( entry( "1", new TargetFoo( "Bob" ) ), entry( "2", new TargetFoo( "Alice" ) ) );
     }
 
     private Map<Long, SourceFoo> createSourceFooMap() {

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/defaultimplementation/NoSetterCollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/defaultimplementation/NoSetterCollectionMappingTest.java
@@ -18,8 +18,8 @@
  */
 package org.mapstruct.ap.test.collection.defaultimplementation;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -53,7 +53,7 @@ public class NoSetterCollectionMappingTest {
         NoSetterTarget target = NoSetterMapper.INSTANCE.toTarget( source );
 
         assertThat( target.getListValues() ).containsExactly( "foo", "bar" );
-        assertThat( target.getMapValues() ).includes( entry( "fooKey", "fooVal" ), entry( "barKey", "barVal" ) );
+        assertThat( target.getMapValues() ).contains( entry( "fooKey", "fooVal" ), entry( "barKey", "barVal" ) );
 
         // now test existing instances
 
@@ -68,7 +68,7 @@ public class NoSetterCollectionMappingTest {
         assertThat( target2.getListValues() ).containsExactly( "baz" );
         assertThat( target2.getMapValues() ).isSameAs( originalMapInstance );
         // source2 mapvalues is empty, so the map is not cleared
-        assertThat( target2.getMapValues() ).includes( entry( "fooKey", "fooVal" ), entry( "barKey", "barVal" ) );
+        assertThat( target2.getMapValues() ).contains( entry( "fooKey", "fooVal" ), entry( "barKey", "barVal" ) );
 
 
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/forged/CollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/forged/CollectionMappingTest.java
@@ -19,7 +19,7 @@
 package org.mapstruct.ap.test.collection.forged;
 
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Map;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/iterabletononiterable/IterableToNonIterableMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/iterabletononiterable/IterableToNonIterableMappingTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.collection.iterabletononiterable;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/map/MapMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/map/MapMappingTest.java
@@ -18,8 +18,8 @@
  */
 package org.mapstruct.ap.test.collection.map;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Date;
 import java.util.GregorianCalendar;
@@ -53,7 +53,7 @@ public class MapMappingTest {
 
         assertThat( target ).isNotNull();
         assertThat( target ).hasSize( 2 );
-        assertThat( target ).includes(
+        assertThat( target ).contains(
             entry( "42", "01.01.1980" ),
             entry( "121", "20.07.2013" )
         );
@@ -100,7 +100,7 @@ public class MapMappingTest {
     private void assertResult(Map<Long, Date> target) {
         assertThat( target ).isNotNull();
         assertThat( target ).hasSize( 2 );
-        assertThat( target ).includes(
+        assertThat( target ).contains(
             entry( 42L, new GregorianCalendar( 1980, 0, 1 ).getTime() ),
             entry( 121L, new GregorianCalendar( 2013, 6, 20 ).getTime() )
         );
@@ -127,7 +127,7 @@ public class MapMappingTest {
         assertThat( target ).isNotNull();
         assertThat( target.getValues() ).isNotNull();
         assertThat( target.getValues() ).hasSize( 2 );
-        assertThat( target.getValues() ).includes(
+        assertThat( target.getValues() ).contains(
             entry( "42", "01.01.1980" ),
             entry( "121", "20.07.2013" )
         );
@@ -145,7 +145,7 @@ public class MapMappingTest {
         assertThat( source ).isNotNull();
         assertThat( source.getValues() ).isNotNull();
         assertThat( source.getValues() ).hasSize( 2 );
-        assertThat( source.getValues() ).includes(
+        assertThat( source.getValues() ).contains(
             entry( 42L, new GregorianCalendar( 1980, 0, 1 ).getTime() ),
             entry( 121L, new GregorianCalendar( 2013, 6, 20 ).getTime() )
         );

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/wildcard/WildCardTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/wildcard/WildCardTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.collection.wildcard;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/complex/CarMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/complex/CarMapperTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.complex;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/ConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.conversion;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/bignumbers/BigNumbersConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/bignumbers/BigNumbersConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.conversion.bignumbers;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/date/DateConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/date/DateConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.conversion.date;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.Date;

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/java8time/Java8TimeConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/java8time/Java8TimeConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.conversion.java8time;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.conversion.jodatime;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 import java.util.Locale;

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/BooleanConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/BooleanConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.conversion.nativetypes;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/CharConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/CharConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.conversion.nativetypes;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/NumberConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/nativetypes/NumberConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.conversion.nativetypes;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/numbers/NumberFormatConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/numbers/NumberFormatConversionTest.java
@@ -32,8 +32,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 @WithClasses({
         Source.class,
@@ -151,11 +151,11 @@ public class NumberFormatConversionTest {
 
         Map<String, String> target = SourceTargetMapper.INSTANCE.sourceToTarget( source1 );
         assertThat( target  ).hasSize( 1 );
-        assertThat( target ).includes( entry( "1.00", "2" ) );
+        assertThat( target ).contains( entry( "1.00", "2" ) );
 
         Map<Float, Float> source2 = SourceTargetMapper.INSTANCE.targetToSource( target );
         assertThat( source2  ).hasSize( 1 );
-        assertThat( source2 ).includes( entry( 1.00f, 2f ) );
+        assertThat( source2 ).contains( entry( 1.00f, 2f ) );
 
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/precedence/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/precedence/ConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.conversion.precedence;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/string/StringConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/string/StringConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.conversion.string;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/DecoratorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/DecoratorTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.decorator;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/jsr330/Jsr330DecoratorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/jsr330/Jsr330DecoratorTest.java
@@ -19,7 +19,7 @@
 package org.mapstruct.ap.test.decorator.jsr330;
 
 import static java.lang.System.lineSeparator;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/spring/SpringDecoratorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/spring/SpringDecoratorTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.decorator.spring;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Calendar;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/DefaultValueTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/DefaultValueTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.defaultvalue;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.text.ParseException;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/GraphAnalyzerTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/GraphAnalyzerTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.dependency;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.HashSet;
 import java.util.List;

--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/OrderingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/OrderingTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.dependency;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.destination;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Assert;
 import org.junit.Test;

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.destination;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/enums/EnumMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/enums/EnumMappingTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.enums;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.tools.Diagnostic.Kind;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/FactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/FactoryTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.factories;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/GenericsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/GenericsTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.generics;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/genericsupertype/MapperWithGenericSuperClassTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/genericsupertype/MapperWithGenericSuperClassTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.generics.genericsupertype;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 
@@ -51,7 +51,7 @@ public class MapperWithGenericSuperClassTest {
 
         SearchResult<VesselDto> dtos = VesselSearchResultMapper.INSTANCE.vesselSearchResultToDto( vessels );
 
-        assertThat( dtos.getValues() ).onProperty( "name" ).containsExactly( "Pacific Queen" );
+        assertThat( dtos.getValues() ).extracting( "name" ).containsExactly( "Pacific Queen" );
         assertThat( dtos.getSize() ).isEqualTo( 1L );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/IgnorePropertyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/IgnorePropertyTest.java
@@ -19,7 +19,7 @@
 package org.mapstruct.ap.test.ignore;
 
 import javax.tools.Diagnostic.Kind;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/imports/ConflictingTypesNamesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/imports/ConflictingTypesNamesTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.imports;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/processor/src/test/java/org/mapstruct/ap/test/imports/InnerClassesImportsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/imports/InnerClassesImportsTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.imports;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/processor/src/test/java/org/mapstruct/ap/test/imports/decorator/DecoratorInAnotherPackageTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/imports/decorator/DecoratorInAnotherPackageTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.imports.decorator;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/imports/sourcewithextendsbound/SourceTypeContainsCollectionWithExtendsBoundTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/imports/sourcewithextendsbound/SourceTypeContainsCollectionWithExtendsBoundTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.imports.sourcewithextendsbound;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collections;
 
@@ -66,7 +66,7 @@ public class SourceTypeContainsCollectionWithExtendsBoundTest {
         SpaceshipDto spaceshipDto = SpaceshipMapper.INSTANCE.spaceshipToDto( spaceship );
 
         assertThat( spaceshipDto ).isNotNull();
-        assertThat( spaceshipDto.getAstronauts() ).onProperty( "name" ).containsOnly( "Bob" );
+        assertThat( spaceshipDto.getAstronauts() ).extracting( "name" ).containsOnly( "Bob" );
 
         generatedSource.forMapper( SpaceshipMapper.class ).containsImportFor( Astronaut.class );
         generatedSource.forMapper( SpaceshipMapper.class ).containsImportFor( Spaceship.class );

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritance/InheritanceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritance/InheritanceTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.inheritance;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritance/attribute/AttributeInheritanceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritance/attribute/AttributeInheritanceTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.inheritance.attribute;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.tools.Diagnostic.Kind;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritance/complex/ComplexInheritanceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritance/complex/ComplexInheritanceTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.inheritance.complex;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritedmappingmethod/InheritedMappingMethodTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritedmappingmethod/InheritedMappingMethodTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.inheritedmappingmethod;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/InheritFromConfigTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/InheritFromConfigTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.inheritfromconfig;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.tools.Diagnostic.Kind;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/ConfigTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/ConfigTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.mapperconfig;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/VariableNamingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/VariableNamingTest.java
@@ -18,8 +18,8 @@
  */
 package org.mapstruct.ap.test.naming;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Arrays;
 import java.util.Date;
@@ -62,7 +62,7 @@ public class VariableNamingTest {
         assertThat( target.getValues() ).containsOnly( "42", "121" );
         assertThat( target.getSomeNumber() ).isEqualTo( "42" );
         assertThat( target.getMap() ).hasSize( 2 );
-        assertThat( target.getMap() ).includes(
+        assertThat( target.getMap() ).contains(
             entry( "42", "01.01.1980" ),
             entry( "121", "20.07.2013" )
         );

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomNamingStrategyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomNamingStrategyTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.naming.spi;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/NestedMappingMethodInvocationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/NestedMappingMethodInvocationTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.nestedmethodcall;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.GregorianCalendar;

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsource/parameter/NormalizingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsource/parameter/NormalizingTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.nestedsource.parameter;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/NestedSourcePropertiesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/NestedSourcePropertiesTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.nestedsourceproperties;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/ReversingNestedSourcePropertiesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/ReversingNestedSourcePropertiesTest.java
@@ -31,7 +31,7 @@ import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.mapstruct.ap.test.nestedsourceproperties._target.BaseChartEntry;
 import org.mapstruct.ap.test.nestedsourceproperties._target.ChartEntryComposed;
 import org.mapstruct.ap.test.nestedsourceproperties._target.ChartEntryLabel;

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedtargetproperties/NestedTargetPropertiesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedtargetproperties/NestedTargetPropertiesTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.nestedtargetproperties;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.test.nestedsourceproperties._target.ChartEntry;

--- a/processor/src/test/java/org/mapstruct/ap/test/nonvoidsetter/NonVoidSettersTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nonvoidsetter/NonVoidSettersTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.nonvoidsetter;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/NullCheckTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/NullCheckTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.nullcheck;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/NullValueMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/NullValueMappingTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.nullvaluemapping;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/processor/src/test/java/org/mapstruct/ap/test/oneway/OnewayTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/oneway/OnewayTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.oneway;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/prism/ConstantTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/prism/ConstantTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.prism;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 import org.junit.Test;

--- a/processor/src/test/java/org/mapstruct/ap/test/prism/EnumPrismsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/prism/EnumPrismsTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.prism;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/processor/src/test/java/org/mapstruct/ap/test/references/ReferencedMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/references/ReferencedMapperTest.java
@@ -18,8 +18,8 @@
  */
 package org.mapstruct.ap.test.references;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -73,7 +73,7 @@ public class ReferencedMapperTest {
     public void shouldUseGenericFactoryForIterable() {
         List<SomeType> result = SourceTargetMapper.INSTANCE.fromStringList( Arrays.asList( "foo1", "foo2" ) );
 
-        assertThat( result ).onProperty( "value" ).containsExactly( "foo1", "foo2" );
+        assertThat( result ).extracting( "value" ).containsExactly( "foo1", "foo2" );
     }
 
     @Test
@@ -85,7 +85,7 @@ public class ReferencedMapperTest {
         Map<SomeType, SomeOtherType> result = SourceTargetMapper.INSTANCE.fromStringMap( source );
 
         assertThat( result ).hasSize( 2 );
-        assertThat( result ).includes(
+        assertThat( result ).contains(
             entry( new SomeType( "foo1" ), new SomeOtherType( "bar1" ) ),
             entry( new SomeType( "foo2" ), new SomeOtherType( "bar2" ) ) );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/references/samename/SeveralReferencedMappersWithSameSimpleNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/references/samename/SeveralReferencedMappersWithSameSimpleNameTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.references.samename;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/references/statics/StaticsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/references/statics/StaticsTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.references.statics;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/processor/src/test/java/org/mapstruct/ap/test/reverse/InheritInverseConfigurationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/reverse/InheritInverseConfigurationTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.reverse;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.tools.Diagnostic.Kind;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.selection.generics;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/JaxbFactoryMethodSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/JaxbFactoryMethodSelectionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.selection.jaxb;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.xml.bind.annotation.XmlElementDecl;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/UnderscoreSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/UnderscoreSelectionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.selection.jaxb;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/primitives/PrimitiveVsWrappedSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/primitives/PrimitiveVsWrappedSelectionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.selection.primitives;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/QualifierTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/QualifierTest.java
@@ -18,8 +18,8 @@
  */
 package org.mapstruct.ap.test.selection.qualifier;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -97,7 +97,7 @@ public class QualifierTest {
 
         assertThat( germanMovies.getFacts() ).isNotNull();
         assertThat( germanMovies.getFacts() ).hasSize( 3 );
-        assertThat( germanMovies.getFacts() ).includes(
+        assertThat( germanMovies.getFacts() ).contains(
                 entry( "Regisseur", Arrays.asList( "M. Night Shyamalan" ) ),
                 entry( "Besetzung", Arrays.asList( "Bruce Willis", "Haley Joel Osment", "Toni Collette" ) ),
             entry( "Handlungstichwörter", Arrays.asList( "Jungen", "Kinderpsychologe", "Ich sehe tote Menschen" ) )
@@ -171,7 +171,7 @@ public class QualifierTest {
 
         assertThat( abstractEntry.getFacts() ).isNotNull();
         assertThat( abstractEntry.getFacts() ).hasSize( 3 );
-        assertThat( abstractEntry.getFacts() ).includes(
+        assertThat( abstractEntry.getFacts() ).contains(
                 entry( "director", Arrays.asList( "M. Night Shyamalan" ) ),
                 entry( "cast", Arrays.asList( "Bruce Willis", "Haley Joel Osment", "Toni Collette" ) ),
                 entry( "plot keywords", Arrays.asList( "boy", "child psychologist", "I see dead people" ) )

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/hybrid/HybridTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/hybrid/HybridTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.selection.qualifier.hybrid;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/named/NamedTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/named/NamedTest.java
@@ -18,8 +18,8 @@
  */
 package org.mapstruct.ap.test.selection.qualifier.named;
 
-import static org.fest.assertions.Assertions.assertThat;
-import static org.fest.assertions.MapAssert.entry;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -90,7 +90,7 @@ public class NamedTest {
 
         assertThat( germanMovies.getFacts() ).isNotNull();
         assertThat( germanMovies.getFacts() ).hasSize( 3 );
-        assertThat( germanMovies.getFacts() ).includes(
+        assertThat( germanMovies.getFacts() ).contains(
             entry( "Regisseur", Arrays.asList( "M. Night Shyamalan" ) ),
             entry( "Besetzung", Arrays.asList( "Bruce Willis", "Haley Joel Osment", "Toni Collette" ) ),
             entry( "Handlungstichwörter", Arrays.asList( "Jungen", "Kinderpsychologe", "Ich sehe tote Menschen" ) )
@@ -125,7 +125,7 @@ public class NamedTest {
 
         assertThat( abstractEntry.getFacts() ).isNotNull();
         assertThat( abstractEntry.getFacts() ).hasSize( 3 );
-        assertThat( abstractEntry.getFacts() ).includes(
+        assertThat( abstractEntry.getFacts() ).contains(
                 entry( "director", Arrays.asList( "M. Night Shyamalan" ) ),
                 entry( "cast", Arrays.asList( "Bruce Willis", "Haley Joel Osment", "Toni Collette" ) ),
                 entry( "plot keywords", Arrays.asList( "boy", "child psychologist", "I see dead people" ) )

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.selection.resulttype;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/processor/src/test/java/org/mapstruct/ap/test/severalsources/SeveralSourceParametersTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/severalsources/SeveralSourceParametersTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.severalsources;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.tools.Diagnostic.Kind;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/severaltargets/SourcePropertyMapSeveralTimesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/severaltargets/SourcePropertyMapSeveralTimesTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.severaltargets;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceConstantsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceConstantsTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.source.constants;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/JavaExpressionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/JavaExpressionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.source.expressions.java;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;

--- a/processor/src/test/java/org/mapstruct/ap/test/source/nullvaluecheckstrategy/PresenceCheckTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/nullvaluecheckstrategy/PresenceCheckTest.java
@@ -19,7 +19,7 @@
 package org.mapstruct.ap.test.source.nullvaluecheckstrategy;
 
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.WithClasses;

--- a/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/PresenceCheckTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/PresenceCheckTest.java
@@ -19,7 +19,7 @@
 package org.mapstruct.ap.test.source.presencecheck.spi;
 
 import java.util.Arrays;
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/template/InheritConfigurationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/template/InheritConfigurationTest.java
@@ -19,7 +19,7 @@
 package org.mapstruct.ap.test.template;
 
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.tools.Diagnostic.Kind;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/UnmappedTargetTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/UnmappedTargetTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.unmappedtarget;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.tools.Diagnostic.Kind;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.updatemethods;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/processor/src/test/java/org/mapstruct/ap/test/updatemethods/selection/ExternalSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/updatemethods/selection/ExternalSelectionTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.updatemethods.selection;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/processor/src/test/java/org/mapstruct/ap/test/value/EnumToEnumMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/EnumToEnumMappingTest.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.test.value;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.tools.Diagnostic.Kind;
 

--- a/processor/src/test/java/org/mapstruct/ap/testutil/assertions/JavaFileAssert.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/assertions/JavaFileAssert.java
@@ -21,9 +21,9 @@ package org.mapstruct.ap.testutil.assertions;
 import java.io.File;
 import java.io.IOException;
 
-import org.fest.assertions.Assertions;
-import org.fest.assertions.FileAssert;
-import org.fest.assertions.StringAssert;
+import org.assertj.core.api.AbstractCharSequenceAssert;
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.FileAssert;
 
 import com.google.common.base.Charsets;
 import com.google.common.io.Files;
@@ -44,7 +44,7 @@ public class JavaFileAssert extends FileAssert {
     /**
      * @return assertion on the file content
      */
-    public StringAssert content() {
+    public AbstractCharSequenceAssert<?, String> content() {
         exists();
         isFile();
 
@@ -52,7 +52,7 @@ public class JavaFileAssert extends FileAssert {
             return Assertions.assertThat( Files.toString( actual, Charsets.UTF_8 ) );
         }
         catch ( IOException e ) {
-            failIfCustomMessageIsSet( e );
+            failWithMessage( "Unable to read" + actual.toString() + ". Exception: " + e.getMessage() );
         }
         return null;
     }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingStatement.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingStatement.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.testutil.runner;
 
-import static org.fest.assertions.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;


### PR DESCRIPTION
This is a pull request for (#860) switching the assertions framework to the maintained assertj instead of FEST.