### PR TITLE
#878 remove AcessorNamingStrategy#getCollectionGetterName from SPI

### DIFF
--- a/integrationtest/src/test/resources/namingStrategyTest/strategy/src/main/java/org/mapstruct/itest/naming/CustomAccessorNamingStrategy.java
+++ b/integrationtest/src/test/resources/namingStrategyTest/strategy/src/main/java/org/mapstruct/itest/naming/CustomAccessorNamingStrategy.java
@@ -24,7 +24,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeKind;
 
 import org.mapstruct.ap.spi.AccessorNamingStrategy;
-import org.mapstruct.ap.spi.MethodType;
+import org.mapstruct.ap.spi.DefaultAccessorNamingStrategy;
 
 /**
  * A custom {@link AccessorNamingStrategy} recognizing getters in the form of {@code property()} and setters in the
@@ -32,34 +32,21 @@ import org.mapstruct.ap.spi.MethodType;
  *
  * @author Gunnar Morling
  */
-public class CustomAccessorNamingStrategy implements AccessorNamingStrategy {
+public class CustomAccessorNamingStrategy  extends DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
 
     @Override
-    public MethodType getMethodType(ExecutableElement method) {
-        if ( isGetterMethod( method ) ) {
-            return MethodType.GETTER;
-        }
-        else if ( isSetterMethod( method ) ) {
-            return MethodType.SETTER;
-        }
-        else if ( isAdderMethod( method ) ) {
-            return MethodType.ADDER;
-        }
-        else {
-            return MethodType.OTHER;
-        }
-    }
-
-    private boolean isGetterMethod(ExecutableElement method) {
+    public boolean isGetterMethod(ExecutableElement method) {
         return method.getReturnType().getKind() != TypeKind.VOID;
     }
 
+    @Override
     public boolean isSetterMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
         return methodName.startsWith( "with" ) && methodName.length() > 4;
     }
 
+    @Override
     public boolean isAdderMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
         return methodName.startsWith( "add" ) && methodName.length() > 3;
@@ -77,8 +64,4 @@ public class CustomAccessorNamingStrategy implements AccessorNamingStrategy {
         return Introspector.decapitalize( methodName.substring( 3 ) );
     }
 
-    @Override
-    public String getCollectionGetterName(String property) {
-        return property.substring( 0, 1 ).toUpperCase() + property.substring( 1 );
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -462,7 +462,7 @@ public class PropertyMapping extends ModelElement {
                     // target accessor is setter, so wrap the setter in setter map/ collection handling
                     result = new SetterWrapperForCollectionsAndMaps(
                         result,
-                        Executables.getCollectionGetterName( targetWriteAccessor ),
+                        targetReadAccessor.getSimpleName().toString(),
                         newCollectionOrMap,
                         targetType,
                         existingVariableNames

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
@@ -125,11 +125,6 @@ public class Executables {
         return ACCESSOR_NAMING_STRATEGY.getElementName( adderMethod );
     }
 
-    public static String getCollectionGetterName(ExecutableElement targetSetter) {
-        String propertyName = ACCESSOR_NAMING_STRATEGY.getPropertyName( targetSetter );
-        return ACCESSOR_NAMING_STRATEGY.getCollectionGetterName( propertyName );
-    }
-
     /**
      * @param mirror the type mirror
      *

--- a/processor/src/main/java/org/mapstruct/ap/spi/AccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/AccessorNamingStrategy.java
@@ -60,6 +60,7 @@ public interface AccessorNamingStrategy {
      */
     String getElementName(ExecutableElement adderMethod);
 
+
     /**
      * Returns the getter name of the given collection property.
      * <p>
@@ -68,6 +69,11 @@ public interface AccessorNamingStrategy {
      * @param property to be getterOrSetterMethod.
      *
      * @return getter name for collection properties
+     *
+     * @deprecated MapStuct will not call this method anymore. Use {@link #getMethodType(ExecutableElement)} to
+     * determine the {@link MethodType}. When collections somehow need to be treated special, it should be done in
+     * {@link #getMethodType(ExecutableElement) } as well. In the future, this method will be removed.
      */
+    @Deprecated
     String getCollectionGetterName(String property);
 }

--- a/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
@@ -164,19 +164,6 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
     }
 
    /**
-     * Returns the getter name of a collection given the property name. This will start with 'get' and the
-     * first character of the remainder will be placed in upper case.
-     *
-     * @param property the property
-     *
-     * @return getter name for collections.
-     */
-    @Override
-    public String getCollectionGetterName(String property) {
-        return "get" + property.substring( 0, 1 ).toUpperCase() + property.substring( 1 );
-    }
-
-   /**
      * Helper method, to obtain the fully qualified name of a type.
      *
      * @param type input type
@@ -209,6 +196,12 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
         );
 
         return typeElement != null ? typeElement.getQualifiedName().toString() : null;
+    }
+
+    @Override
+    public String getCollectionGetterName(String property) {
+        throw new IllegalStateException( "This method is not intended to be called anymore and will be removed in "
+            + "future versions." );
     }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomAccessorNamingStrategy.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomAccessorNamingStrategy.java
@@ -24,7 +24,7 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeKind;
 
 import org.mapstruct.ap.spi.AccessorNamingStrategy;
-import org.mapstruct.ap.spi.MethodType;
+import org.mapstruct.ap.spi.DefaultAccessorNamingStrategy;
 
 /**
  * A custom {@link AccessorNamingStrategy} recognizing getters in the form of {@code property()} and setters in the
@@ -32,34 +32,21 @@ import org.mapstruct.ap.spi.MethodType;
  *
  * @author Gunnar Morling
  */
-public class CustomAccessorNamingStrategy implements AccessorNamingStrategy {
+public class CustomAccessorNamingStrategy extends DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
 
     @Override
-    public MethodType getMethodType(ExecutableElement method) {
-        if ( isGetterMethod( method ) ) {
-            return MethodType.GETTER;
-        }
-        else if ( isSetterMethod( method ) ) {
-            return MethodType.SETTER;
-        }
-        else if ( isAdderMethod( method ) ) {
-            return MethodType.ADDER;
-        }
-        else {
-            return MethodType.OTHER;
-        }
-    }
-
-    private boolean isGetterMethod(ExecutableElement method) {
+    public boolean isGetterMethod(ExecutableElement method) {
         return method.getReturnType().getKind() != TypeKind.VOID;
     }
 
+    @Override
     public boolean isSetterMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
         return methodName.startsWith( "with" ) && methodName.length() > 4;
     }
 
+    @Override
     public boolean isAdderMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
         return methodName.startsWith( "add" ) && methodName.length() > 3;
@@ -77,8 +64,4 @@ public class CustomAccessorNamingStrategy implements AccessorNamingStrategy {
         return Introspector.decapitalize( methodName.substring( 3 ) );
     }
 
-    @Override
-    public String getCollectionGetterName(String property) {
-        return property.substring( 0, 1 ).toUpperCase() + property.substring( 1 );
-    }
 }


### PR DESCRIPTION
Seems not to be needed.. Why was it there in the first place?