### PR TITLE
Expanding converters to cover java 8 LocalDate to java.util.Date

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/Conversions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/Conversions.java
@@ -225,6 +225,7 @@ public class Conversions {
         // Java 8 to Date
         register( JavaTimeConstants.ZONED_DATE_TIME_FQN, Date.class, new JavaZonedDateTimeToDateConversion() );
         register( JavaTimeConstants.LOCAL_DATE_TIME_FQN, Date.class, new JavaLocalDateTimeToDateConversion() );
+        register( JavaTimeConstants.LOCAL_DATE_FQN, Date.class, new JavaLocalDateToDateConversion() );
 
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateToDateConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateToDateConversion.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.conversion;
+
+import org.mapstruct.ap.internal.model.common.ConversionContext;
+
+/**
+ * SimpleConversion for mapping {@link java.time.LocalDate} to
+ * {@link java.util.Date} and vice versa.
+ */
+public class JavaLocalDateToDateConversion extends SimpleConversion {
+
+    @Override
+    protected String getToExpression(ConversionContext conversionContext) {
+        return "java.util.Date.from( <SOURCE>.atStartOfDay( java.time.ZoneOffset.UTC ).toInstant() )";
+
+    }
+
+    @Override
+    protected String getFromExpression(ConversionContext conversionContext) {
+        return "java.time.LocalDateTime.ofInstant( <SOURCE>.toInstant(), java.time.ZoneOffset.UTC ).toLocalDate()";
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/java8time/Java8TimeConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/java8time/Java8TimeConversionTest.java
@@ -267,4 +267,28 @@ public class Java8TimeConversionTest {
 
         assertThat( source.getForDateConversionWithLocalDateTime() ).isEqualTo( dateTime );
     }
+
+    @Test
+    public void testLocalDateToDateMapping() {
+        TimeZone.setDefault( TimeZone.getTimeZone( "Australia/Melbourne" ) );
+
+        Source source = new Source();
+        LocalDate localDate = LocalDate.of( 2016, 3, 1 );
+        source.setForDateConversionWithLocalDate( localDate );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTargetDefaultMapping( source );
+
+        assertThat( target.getForDateConversionWithLocalDate() ).isNotNull();
+
+        Calendar instance = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) );
+        instance.setTimeInMillis( target.getForDateConversionWithLocalDate().getTime() );
+
+        assertThat( instance.get( Calendar.YEAR ) ).isEqualTo( localDate.getYear() );
+        assertThat( instance.get( Calendar.MONTH ) ).isEqualTo( localDate.getMonthValue() - 1 );
+        assertThat( instance.get( Calendar.DATE ) ).isEqualTo( localDate.getDayOfMonth() );
+
+        source = SourceTargetMapper.INSTANCE.targetToSource( target );
+
+        assertThat( source.getForDateConversionWithLocalDate() ).isEqualTo( localDate );
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/java8time/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/java8time/Source.java
@@ -42,6 +42,8 @@ public class Source {
 
     private LocalDateTime forDateConversionWithLocalDateTime;
 
+    private LocalDate forDateConversionWithLocalDate;
+
     public ZonedDateTime getZonedDateTime() {
         return zonedDateTime;
     }
@@ -96,5 +98,13 @@ public class Source {
 
     public void setForDateConversionWithLocalDateTime(LocalDateTime forDateConversionWithLocalDateTime) {
         this.forDateConversionWithLocalDateTime = forDateConversionWithLocalDateTime;
+    }
+
+    public LocalDate getForDateConversionWithLocalDate() {
+        return forDateConversionWithLocalDate;
+    }
+
+    public void setForDateConversionWithLocalDate(LocalDate forDateConversionWithLocalDate) {
+        this.forDateConversionWithLocalDate = forDateConversionWithLocalDate;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/java8time/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/java8time/Target.java
@@ -39,6 +39,8 @@ public class Target {
 
     private Date forDateConversionWithLocalDateTime;
 
+    private Date forDateConversionWithLocalDate;
+
     public String getZonedDateTime() {
         return zonedDateTime;
     }
@@ -95,4 +97,11 @@ public class Target {
         this.forDateConversionWithLocalDateTime = forDateConversionWithLocalDateTime;
     }
 
+    public Date getForDateConversionWithLocalDate() {
+        return forDateConversionWithLocalDate;
+    }
+
+    public void setForDateConversionWithLocalDate(Date forDateConversionWithLocalDate) {
+        this.forDateConversionWithLocalDate = forDateConversionWithLocalDate;
+    }
 }


### PR DESCRIPTION
Hi gents, sorry for the delay getting this to you. I have followed the pattern I could see in the code to add another converter for java.util.Date <-> java.time.LocalDate

All the tests pass except one is breaking related to an XML Gregorian Calendar converter. I don't know the project well enough to figure out what got broken. Seems like maybe it is using the new converter somewhere as an intermediate? Or perhaps I am not using the right methods for converting and it is leaving the extra time zone hanging on it.

For to issue #852 