### PR TITLE
#909 Avoid using 'values' as parameter name to work around a supsected issue in Freemarker

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
@@ -30,12 +30,14 @@ import org.mapstruct.ap.internal.util.Collections;
 public class Parameter extends ModelElement {
 
     private final String name;
+    private final String originalName;
     private final Type type;
     private final boolean mappingTarget;
     private final boolean targetType;
 
     public Parameter(String name, Type type, boolean mappingTarget, boolean targetType) {
-        this.name = name;
+        this.name = "values".equals( name ) ? "values_" : name;
+        this.originalName = name;
         this.type = type;
         this.mappingTarget = mappingTarget;
         this.targetType = targetType;
@@ -47,6 +49,10 @@ public class Parameter extends ModelElement {
 
     public String getName() {
         return name;
+    }
+
+    public String getOriginalName() {
+        return originalName;
     }
 
     public Type getType() {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_909/Issue909Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_909/Issue909Test.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._909;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.bugs._909.ValuesMapper.ValuesHolder;
+import org.mapstruct.ap.test.bugs._909.ValuesMapper.ValuesHolderDto;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Verifies that forged iterable mapping methods for multi-dimensional arrays are generated properly.
+ *
+ * @author Andreas Gudian
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses(ValuesMapper.class)
+public class Issue909Test {
+    @Test
+    public void properlyCreatesMapperWithValuesAsParameterName() {
+        ValuesHolder valuesHolder = new ValuesHolder();
+        valuesHolder.setValues( "values" );
+
+        ValuesHolderDto dto = Mappers.getMapper( ValuesMapper.class ).convert( valuesHolder );
+        assertThat( dto.getValues() ).isEqualTo( "values" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_909/ValuesMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_909/ValuesMapper.java
@@ -1,0 +1,53 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._909;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Andreas Gudian
+ */
+@Mapper
+public interface ValuesMapper {
+    ValuesHolderDto convert(ValuesHolder values);
+
+    class ValuesHolder {
+        private String values;
+
+        public String getValues() {
+            return values;
+        }
+
+        public void setValues(String values) {
+            this.values = values;
+        }
+    }
+
+    class ValuesHolderDto {
+        private String values;
+
+        public String getValues() {
+            return values;
+        }
+
+        public void setValues(String values) {
+            this.values = values;
+        }
+    }
+}


### PR DESCRIPTION
Not really a fix, but a workaround for #909. I guess it might hit us at some other places as well.

I'll create an issue in the Freemarker issue tracker tomorrow or so.