### PR TITLE
#921 Avoid generation of duplicate local variable name

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -388,8 +388,9 @@ public class PropertyMapping extends ModelElement {
 
         private void useLocalVarWhenNested(Assignment rightHandSide) {
             if ( sourceReference.getPropertyEntries().size() > 1 ) {
-                String sourceTypeName = rightHandSide.getSourceType().getName();
-                String safeName = Strings.getSaveVariableName( sourceTypeName, existingVariableNames );
+                String name = first( sourceReference.getPropertyEntries() ).getName();
+                String safeName = Strings.getSaveVariableName( name, existingVariableNames );
+                existingVariableNames.add( safeName );
                 rightHandSide.setSourceLocalVarName( safeName );
             }
         }


### PR DESCRIPTION
Have a more meaningful name. And add it to the set of existing variables (forgotten initially).