### PR TITLE
#60 Automapping

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -46,7 +46,7 @@
         <org.apache.maven.plugins.surefire.version>2.19.1</org.apache.maven.plugins.surefire.version>
         <org.apache.maven.plugins.javadoc.version>2.10.3</org.apache.maven.plugins.javadoc.version>
         <org.springframework.version>4.0.3.RELEASE</org.springframework.version>
-        <org.eclipse.tycho.compiler-jdt.version>0.23.1</org.eclipse.tycho.compiler-jdt.version>
+        <org.eclipse.tycho.compiler-jdt.version>0.26.0</org.eclipse.tycho.compiler-jdt.version>
         <com.puppycrawl.tools.checkstyle.version>7.2</com.puppycrawl.tools.checkstyle.version>
         <add.release.arguments />
         <forkCount>1</forkCount>

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -875,6 +875,5 @@ public class BeanMappingMethod extends MappingMethod {
         }
     }
 
-
 }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -712,7 +712,6 @@ public class BeanMappingMethod extends MappingMethod {
         return this.factoryMethod;
     }
 
-
     private static class NestedTargetObjects {
 
         private final Set<LocalVariable> localVariables;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -20,6 +20,7 @@ package org.mapstruct.ap.internal.model;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -32,11 +33,11 @@ import org.mapstruct.ap.internal.model.assignment.SetterWrapper;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.ForgedMethod;
+import org.mapstruct.ap.internal.model.source.ForgedMethodHistory;
 import org.mapstruct.ap.internal.model.source.FormattingParameters;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
-import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 
 /**
@@ -61,6 +62,7 @@ public class IterableMappingMethod extends MappingMethod {
         private SelectionParameters selectionParameters;
         private FormattingParameters formattingParameters;
         private NullValueMappingStrategyPrism nullValueMappingStrategy;
+        private ForgedMethod forgedMethod;
 
         public Builder mappingContext(MappingBuilderContext mappingContext) {
             this.ctx = mappingContext;
@@ -103,24 +105,21 @@ public class IterableMappingMethod extends MappingMethod {
             String loopVariableName =
                 Strings.getSaveVariableName( sourceElementType.getName(), method.getParameterNames() );
 
+            SourceRHS sourceRHS = new SourceRHS( loopVariableName, sourceElementType, new HashSet<String>(), "collection element" );
             Assignment assignment = ctx.getMappingResolver().getTargetAssignment(
                 method,
                 targetElementType,
                 null, // there is no targetPropertyName
                 formattingParameters,
                 selectionParameters,
-                new SourceRHS( loopVariableName, sourceElementType, new HashSet<String>(), "collection element" ),
+                sourceRHS,
                 false
             );
 
             if ( assignment == null ) {
-                if ( method instanceof ForgedMethod ) {
-                    // leave messaging to calling property mapping
-                    return null;
-                }
-                else {
-                    ctx.getMessager().printMessage( method.getExecutable(), Message.ITERABLEMAPPING_MAPPING_NOT_FOUND );
-                }
+
+                assignment = forgeMapping( sourceRHS, sourceElementType, targetElementType );
+
             }
             else {
                 if ( method instanceof ForgedMethod ) {
@@ -140,7 +139,7 @@ public class IterableMappingMethod extends MappingMethod {
             // mapNullToDefault
             boolean mapNullToDefault = false;
             if ( method.getMapperConfiguration() != null ) {
-                 mapNullToDefault = method.getMapperConfiguration().isMapToDefault( nullValueMappingStrategy );
+                mapNullToDefault = method.getMapperConfiguration().isMapToDefault( nullValueMappingStrategy );
             }
 
             MethodReference factoryMethod = null;
@@ -163,23 +162,66 @@ public class IterableMappingMethod extends MappingMethod {
                 existingVariables );
 
             return new IterableMappingMethod(
-                    method,
-                    assignment,
-                    factoryMethod,
-                    mapNullToDefault,
-                    loopVariableName,
-                    beforeMappingMethods,
-                    afterMappingMethods,
-                    selectionParameters );
+                method,
+                assignment,
+                factoryMethod,
+                mapNullToDefault,
+                loopVariableName,
+                beforeMappingMethods,
+                afterMappingMethods,
+                selectionParameters,
+                forgedMethod
+            );
         }
+
+        private Assignment forgeMapping(SourceRHS sourceRHS, Type sourceType, Type targetType) {
+
+            ForgedMethodHistory forgedMethodHistory = null;
+            if ( method instanceof ForgedMethod ) {
+                forgedMethodHistory = ( (ForgedMethod) method ).getHistory();
+            }
+            String name = getName( sourceType, targetType );
+            forgedMethod = new ForgedMethod(
+                name,
+                sourceType,
+                targetType,
+                method.getMapperConfiguration(),
+                method.getExecutable(),
+                forgedMethodHistory
+            );
+
+            Assignment assignment = new MethodReference( forgedMethod, null, targetType );
+            assignment.setAssignment( sourceRHS );
+
+            return assignment;
+        }
+
+        private String getName(Type sourceType, Type targetType) {
+            String fromName = getName( sourceType );
+            String toName = getName( targetType );
+            return Strings.decapitalize( fromName + "To" + toName );
+        }
+
+        private String getName(Type type) {
+            StringBuilder builder = new StringBuilder();
+            for ( Type typeParam : type.getTypeParameters() ) {
+                builder.append( typeParam.getIdentification() );
+            }
+            builder.append( type.getIdentification() );
+            return builder.toString();
+        }
+
     }
 
     private IterableMappingMethod(Method method, Assignment parameterAssignment, MethodReference factoryMethod,
                                   boolean mapNullToDefault, String loopVariableName,
-                                 List<LifecycleCallbackMethodReference> beforeMappingReferences,
-                                 List<LifecycleCallbackMethodReference> afterMappingReferences,
-                                 SelectionParameters selectionParameters ) {
-        super( method, beforeMappingReferences, afterMappingReferences );
+                                  List<LifecycleCallbackMethodReference> beforeMappingReferences,
+                                  List<LifecycleCallbackMethodReference> afterMappingReferences,
+                                  SelectionParameters selectionParameters, ForgedMethod forgedMethod) {
+        super( method, beforeMappingReferences, afterMappingReferences,
+            forgedMethod == null ? Collections.<ForgedMethod>emptyList() :
+                java.util.Collections.singletonList( forgedMethod )
+        );
         this.elementAssignment = parameterAssignment;
         this.factoryMethod = factoryMethod;
         this.overridden = method.overridesMethod();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -105,7 +105,8 @@ public class IterableMappingMethod extends MappingMethod {
             String loopVariableName =
                 Strings.getSaveVariableName( sourceElementType.getName(), method.getParameterNames() );
 
-            SourceRHS sourceRHS = new SourceRHS( loopVariableName, sourceElementType, new HashSet<String>(), "collection element" );
+            SourceRHS sourceRHS = new SourceRHS( loopVariableName, sourceElementType, new HashSet<String>(),
+                "collection element" );
             Assignment assignment = ctx.getMappingResolver().getTargetAssignment(
                 method,
                 targetElementType,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -136,7 +136,8 @@ public class MapMappingMethod extends MappingMethod {
             Type valueSourceType = sourceTypeParams.get( 1 ).getTypeBound();
             Type valueTargetType = resultTypeParams.get( 1 ).getTypeBound();
 
-            SourceRHS valueSourceRHS = new SourceRHS( "entry.getValue()", valueSourceType, new HashSet<String>(), "map value" );
+            SourceRHS valueSourceRHS = new SourceRHS( "entry.getValue()", valueSourceType, new HashSet<String>(),
+                    "map value" );
             Assignment valueAssignment = ctx.getMappingResolver().getTargetAssignment(
                 method,
                 valueTargetType,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -203,7 +203,6 @@ public class MapMappingMethod extends MappingMethod {
             );
         }
 
-
         private Assignment forgeMapping(SourceRHS sourceRHS, Type sourceType, Type targetType) {
 
             String name = getName( sourceType, targetType );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
@@ -67,7 +67,8 @@ public abstract class MappingMethod extends ModelElement {
     protected MappingMethod(Method method, Collection<String> existingVariableNames,
                             List<LifecycleCallbackMethodReference> beforeMappingReferences,
                             List<LifecycleCallbackMethodReference> afterMappingReferences) {
-        this( method, method.getParameters(), existingVariableNames, beforeMappingReferences, afterMappingReferences, Collections.<ForgedMethod>emptyList() );
+        this( method, method.getParameters(), existingVariableNames, beforeMappingReferences, afterMappingReferences,
+                Collections.<ForgedMethod>emptyList() );
     }
 
     protected MappingMethod(Method method, List<Parameter> parameters, Collection<String> existingVariableNames,
@@ -104,14 +105,16 @@ public abstract class MappingMethod extends ModelElement {
     protected MappingMethod(Method method, List<LifecycleCallbackMethodReference> beforeMappingReferences,
                             List<LifecycleCallbackMethodReference> afterMappingReferences,
                             List<ForgedMethod> forgedMethods) {
-        this( method, method.getParameters(), method.getParameterNames(), beforeMappingReferences, afterMappingReferences, forgedMethods );
+        this( method, method.getParameters(), method.getParameterNames(), beforeMappingReferences,
+                afterMappingReferences, forgedMethods );
     }
 
     public MappingMethod(Method method, Collection<String> existingVariableNames,
                          List<LifecycleCallbackMethodReference> beforeMappingReferences,
                          List<LifecycleCallbackMethodReference> afterMappingReferences,
                          List<ForgedMethod> allForgedMethods) {
-        this(method, method.getParameters(), existingVariableNames, beforeMappingReferences, afterMappingReferences, allForgedMethods);
+        this( method, method.getParameters(), existingVariableNames, beforeMappingReferences, afterMappingReferences,
+                allForgedMethods );
     }
 
     private String initResultName(Collection<String> existingVarNames) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
@@ -23,6 +23,7 @@ import static org.mapstruct.ap.internal.util.Strings.join;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -31,6 +32,7 @@ import org.mapstruct.ap.internal.model.common.Accessibility;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.source.ForgedMethod;
 import org.mapstruct.ap.internal.model.source.Method;
 
 /**
@@ -51,6 +53,7 @@ public abstract class MappingMethod extends ModelElement {
     private final List<LifecycleCallbackMethodReference> beforeMappingReferencesWithMappingTarget;
     private final List<LifecycleCallbackMethodReference> beforeMappingReferencesWithoutMappingTarget;
     private final List<LifecycleCallbackMethodReference> afterMappingReferences;
+    private final List<ForgedMethod> forgedMethods;
 
     /**
      * constructor to be overloaded when local variable names are required prior to calling this constructor. (e.g. for
@@ -64,12 +67,13 @@ public abstract class MappingMethod extends ModelElement {
     protected MappingMethod(Method method, Collection<String> existingVariableNames,
                             List<LifecycleCallbackMethodReference> beforeMappingReferences,
                             List<LifecycleCallbackMethodReference> afterMappingReferences) {
-        this( method, method.getParameters(), existingVariableNames, beforeMappingReferences, afterMappingReferences );
+        this( method, method.getParameters(), existingVariableNames, beforeMappingReferences, afterMappingReferences, Collections.<ForgedMethod>emptyList() );
     }
 
     protected MappingMethod(Method method, List<Parameter> parameters, Collection<String> existingVariableNames,
                             List<LifecycleCallbackMethodReference> beforeMappingReferences,
-                            List<LifecycleCallbackMethodReference> afterMappingReferences) {
+                            List<LifecycleCallbackMethodReference> afterMappingReferences,
+                            List<ForgedMethod> forgedMethods) {
         this.name = method.getName();
         this.parameters = parameters;
         this.returnType = method.getReturnType();
@@ -81,10 +85,11 @@ public abstract class MappingMethod extends ModelElement {
         this.beforeMappingReferencesWithMappingTarget = filterMappingTarget( beforeMappingReferences, true );
         this.beforeMappingReferencesWithoutMappingTarget = filterMappingTarget( beforeMappingReferences, false );
         this.afterMappingReferences = afterMappingReferences;
+        this.forgedMethods = forgedMethods;
     }
 
     protected MappingMethod(Method method, List<Parameter> parameters) {
-        this( method, parameters, method.getParameterNames(), null, null );
+        this( method, parameters, method.getParameterNames(), null, null, Collections.<ForgedMethod>emptyList() );
     }
 
     protected MappingMethod(Method method) {
@@ -94,6 +99,19 @@ public abstract class MappingMethod extends ModelElement {
     protected MappingMethod(Method method, List<LifecycleCallbackMethodReference> beforeMappingReferences,
                             List<LifecycleCallbackMethodReference> afterMappingReferences) {
         this( method, method.getParameterNames(), beforeMappingReferences, afterMappingReferences );
+    }
+
+    protected MappingMethod(Method method, List<LifecycleCallbackMethodReference> beforeMappingReferences,
+                            List<LifecycleCallbackMethodReference> afterMappingReferences,
+                            List<ForgedMethod> forgedMethods) {
+        this( method, method.getParameters(), method.getParameterNames(), beforeMappingReferences, afterMappingReferences, forgedMethods );
+    }
+
+    public MappingMethod(Method method, Collection<String> existingVariableNames,
+                         List<LifecycleCallbackMethodReference> beforeMappingReferences,
+                         List<LifecycleCallbackMethodReference> afterMappingReferences,
+                         List<ForgedMethod> allForgedMethods) {
+        this(method, method.getParameters(), existingVariableNames, beforeMappingReferences, afterMappingReferences, allForgedMethods);
     }
 
     private String initResultName(Collection<String> existingVarNames) {
@@ -220,5 +238,9 @@ public abstract class MappingMethod extends ModelElement {
 
     public List<LifecycleCallbackMethodReference> getBeforeMappingReferencesWithoutMappingTarget() {
         return beforeMappingReferencesWithoutMappingTarget;
+    }
+
+    public List<ForgedMethod> getForgedMethods() {
+        return forgedMethods;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -594,7 +594,9 @@ public class PropertyMapping extends ModelElement {
             // copy mapper configuration from the source method, its the same mapper
             MapperConfiguration config = method.getMapperConfiguration();
             ForgedMethod methodRef = new ForgedMethod( name, sourceType, targetType, config, element,
-                new ForgedMethodHistory( getForgedMethodHistory(source), source.getSourceErrorMessagePart(), targetPropertyName,
+                new ForgedMethodHistory( getForgedMethodHistory( source ),
+                    source.getSourceErrorMessagePart(),
+                    targetPropertyName,
                     source.getSourceType(),
                     targetType
                 )
@@ -636,7 +638,9 @@ public class PropertyMapping extends ModelElement {
             // copy mapper configuration from the source method, its the same mapper
             MapperConfiguration config = method.getMapperConfiguration();
             ForgedMethod methodRef = new ForgedMethod( name, sourceType, targetType, config, element,
-                new ForgedMethodHistory( getForgedMethodHistory(source), source.getSourceErrorMessagePart(), targetPropertyName,
+                new ForgedMethodHistory( getForgedMethodHistory( source ),
+                    source.getSourceErrorMessagePart(),
+                    targetPropertyName,
                     source.getSourceType(),
                     targetType
                 )
@@ -680,7 +684,7 @@ public class PropertyMapping extends ModelElement {
                 targetType,
                 method.getMapperConfiguration(),
                 method.getExecutable(),
-                getForgedMethodHistory(sourceRHS)
+                getForgedMethodHistory( sourceRHS )
             );
 
             Assignment assignment = new MethodReference( forgedMethod, null, targetType );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
@@ -45,8 +45,9 @@ public class ForgedMethod implements Method {
     private final ExecutableElement positionHintElement;
     private final List<Type> thrownTypes;
     private final MapperConfiguration mapperConfiguration;
+    private ForgedMethodHistory history;
 
-     /**
+    /**
      * Creates a new forged method with the given name.
      *
      * @param name the (unique name) for this method
@@ -65,6 +66,29 @@ public class ForgedMethod implements Method {
         this.name = Strings.sanitizeIdentifierName( name );
         this.mapperConfiguration = mapperConfiguration;
         this.positionHintElement = positionHintElement;
+    }
+
+     /**
+     * Creates a new forged method with the given name.
+     *
+     * @param name the (unique name) for this method
+     * @param sourceType the source type
+     * @param targetType the target type.
+     * @param mapperConfiguration the mapper configuration
+     * @param positionHintElement element used to for reference to the position in the source file.
+     * @param history a parent forged method if this is a forged method within a forged method
+     */
+    public ForgedMethod(String name, Type sourceType, Type targetType, MapperConfiguration mapperConfiguration,
+        ExecutableElement positionHintElement, ForgedMethodHistory history) {
+        String sourceParamName = Strings.decapitalize( sourceType.getName() );
+        String sourceParamSafeName = Strings.getSaveVariableName( sourceParamName );
+        this.parameters = Arrays.asList( new Parameter( sourceParamSafeName, sourceType ) );
+        this.returnType = targetType;
+        this.thrownTypes = new ArrayList<Type>();
+        this.name = Strings.sanitizeIdentifierName( name );
+        this.mapperConfiguration = mapperConfiguration;
+        this.positionHintElement = positionHintElement;
+        this.history = history;
     }
 
     /**
@@ -142,6 +166,10 @@ public class ForgedMethod implements Method {
     @Override
     public List<Type> getThrownTypes() {
         return thrownTypes;
+    }
+
+    public ForgedMethodHistory getHistory() {
+        return history;
     }
 
     public void addThrownTypes(List<Type> thrownTypesToAdd) {
@@ -225,5 +253,34 @@ public class ForgedMethod implements Method {
     @Override
     public boolean isObjectFactory() {
         return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        ForgedMethod that = (ForgedMethod) o;
+
+        if ( parameters != null ? !parameters.equals( that.parameters ) : that.parameters != null ) {
+            return false;
+        }
+        if ( returnType != null ? !returnType.equals( that.returnType ) : that.returnType != null ) {
+            return false;
+        }
+        return name != null ? name.equals( that.name ) : that.name == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = parameters != null ? parameters.hashCode() : 0;
+        result = 31 * result + ( returnType != null ? returnType.hashCode() : 0 );
+        result = 31 * result + ( name != null ? name.hashCode() : 0 );
+        return result;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethodHistory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethodHistory.java
@@ -1,0 +1,60 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model.source;
+
+import org.mapstruct.ap.internal.model.common.Type;
+
+public class ForgedMethodHistory {
+
+    private final ForgedMethodHistory prevHistory;
+    private final String sourceElement;
+    private final String targetPropertyName;
+    private final Type targetType;
+    private final Type sourceType;
+
+    public ForgedMethodHistory(ForgedMethodHistory history, String sourceElement, String targetPropertyName,
+                               Type sourceType, Type targetType) {
+        prevHistory = history;
+        this.sourceElement = sourceElement;
+        this.targetPropertyName = targetPropertyName;
+        this.sourceType = sourceType;
+        this.targetType = targetType;
+    }
+
+    public String getSourceElement() {
+        return sourceElement;
+    }
+
+    public String getTargetPropertyName() {
+        return targetPropertyName;
+    }
+
+    public Type getTargetType() {
+        return targetType;
+    }
+
+    public Type getSourceType() {
+        return sourceType;
+    }
+
+    public ForgedMethodHistory getPrevHistory() {
+        return prevHistory;
+    }
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethodHistory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethodHistory.java
@@ -1,10 +1,10 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2016 Dmytro Polovinkin
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  Licensed under the Apache License, Version q2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethodHistory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethodHistory.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Dmytro Polovinkin (http://github.com/navpil)
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.
@@ -20,6 +20,11 @@ package org.mapstruct.ap.internal.model.source;
 
 import org.mapstruct.ap.internal.model.common.Type;
 
+/**
+ * Keeps the context where the ForgedMethod is generated, especially handy with nested forged methods
+ *
+ * @author Dmytro Polovinkin
+ */
 public class ForgedMethodHistory {
 
     private final ForgedMethodHistory prevHistory;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethodHistory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethodHistory.java
@@ -1,10 +1,10 @@
 /**
- *  Copyright 2012-2016 Dmytro Polovinkin
+ *  Copyright 2012-2016 Dmytro Polovinkin (http://github.com/navpil)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.
  *
- *  Licensed under the Apache License, Version q2.0 (the "License");
+ *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.
  *  You may obtain a copy of the License at
  *

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
@@ -75,7 +75,7 @@ public class MappingResolverImpl implements MappingResolver {
     private final Types typeUtils;
     private final TypeFactory typeFactory;
 
-    private final List<SourceMethod> sourceModel;
+    private final List<Method> sourceModel;
     private final List<MapperReference> mapperReferences;
 
     private final Conversions conversions;
@@ -89,7 +89,7 @@ public class MappingResolverImpl implements MappingResolver {
     private final Set<VirtualMappingMethod> usedVirtualMappings = new HashSet<VirtualMappingMethod>();
 
     public MappingResolverImpl(FormattingMessager messager, Elements elementUtils, Types typeUtils,
-                               TypeFactory typeFactory, List<SourceMethod> sourceModel,
+                               TypeFactory typeFactory, List<Method> sourceModel,
                                List<MapperReference> mapperReferences) {
         this.messager = messager;
         this.typeUtils = typeUtils;
@@ -143,12 +143,12 @@ public class MappingResolverImpl implements MappingResolver {
 
         ResolvingAttempt attempt = new ResolvingAttempt( sourceModel, mappingMethod, null, null, null, criteria );
 
-        List<SourceMethod> matchingSourceMethods = attempt.getMatches( sourceModel, null, targetType );
+        List<Method> matchingSourceMethods = attempt.getMatches( sourceModel, null, targetType );
 
         List<MethodReference> factoryRefsWithAssigments = new ArrayList<MethodReference>();
-        List<SourceMethod> factoryRefSources = new ArrayList<SourceMethod>();
+        List<Method> factoryRefSources = new ArrayList<Method>();
 
-        for ( SourceMethod matchingSourceMethod : matchingSourceMethods ) {
+        for ( Method matchingSourceMethod : matchingSourceMethods ) {
 
             if ( matchingSourceMethod != null ) {
                 MapperReference ref = attempt.findMapperReference( matchingSourceMethod );
@@ -197,7 +197,7 @@ public class MappingResolverImpl implements MappingResolver {
     private class ResolvingAttempt {
 
         private final Method mappingMethod;
-        private final List<SourceMethod> methods;
+        private final List<Method> methods;
         private final String dateFormat;
         private final String numberFormat;
         private final SelectionCriteria selectionCriteria;
@@ -209,7 +209,7 @@ public class MappingResolverImpl implements MappingResolver {
         // so this set must be cleared.
         private final Set<VirtualMappingMethod> virtualMethodCandidates;
 
-        private ResolvingAttempt(List<SourceMethod> sourceModel, Method mappingMethod, String dateFormat,
+        private ResolvingAttempt(List<Method> sourceModel, Method mappingMethod, String dateFormat,
                                  String numberFormat, SourceRHS sourceRHS, SelectionCriteria criteria) {
 
             this.mappingMethod = mappingMethod;
@@ -315,7 +315,7 @@ public class MappingResolverImpl implements MappingResolver {
         private Assignment resolveViaMethod(Type sourceType, Type targetType, boolean considerBuiltInMethods) {
 
             // first try to find a matching source method
-            SourceMethod matchingSourceMethod = getBestMatch( methods, sourceType, targetType );
+            Method matchingSourceMethod = getBestMatch( methods, sourceType, targetType );
 
             if ( matchingSourceMethod != null ) {
                 return getMappingMethodReference( matchingSourceMethod, targetType );
@@ -539,7 +539,7 @@ public class MappingResolverImpl implements MappingResolver {
             return null;
         }
 
-        private Assignment getMappingMethodReference(SourceMethod method,
+        private Assignment getMappingMethodReference(Method method,
                                                      Type targetType) {
             MapperReference mapperReference = findMapperReference( method );
 
@@ -549,7 +549,7 @@ public class MappingResolverImpl implements MappingResolver {
             );
         }
 
-        private MapperReference findMapperReference(SourceMethod method) {
+        private MapperReference findMapperReference(Method method) {
             for ( MapperReference ref : mapperReferences ) {
                 if ( ref.getType().equals( method.getDeclaringMapper() ) ) {
                     ref.setUsed( !method.isStatic() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -40,6 +40,7 @@ public enum Message {
     BEANMAPPING_UNKNOWN_PROPERTY_IN_DEPENDS_ON( "\"%s\" is no property of the method return type." ),
 
     PROPERTYMAPPING_MAPPING_NOT_FOUND( "Can't map %s to \"%s %s\". Consider to declare/implement a mapping method: \"%s map(%s value)\"." ),
+    PROPERTYMAPPING_FORGED_MAPPING_NOT_FOUND( "Can't map %s to %s. Consider to implement a mapping method: \"%s map(%s value)\"." ),
     PROPERTYMAPPING_DUPLICATE_TARGETS( "Target property \"%s\" must not be mapped more than once." ),
     PROPERTYMAPPING_EMPTY_TARGET( "Target must not be empty in @Mapping." ),
     PROPERTYMAPPING_SOURCE_AND_CONSTANT_BOTH_DEFINED( "Source and constant are both defined in @Mapping, either define a source or a constant." ),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -18,7 +18,7 @@
      limitations under the License.
 
 -->
-@Override
+<#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     <#list beforeMappingReferencesWithoutMappingTarget as callback>
     	<@includeModel object=callback targetBeanName=resultName targetType=resultType/>

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/ReferencedMapperDefaultSame.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/ReferencedMapperDefaultSame.java
@@ -26,7 +26,7 @@ public class ReferencedMapperDefaultSame {
 
     ReferencedTarget sourceToTarget( ReferencedSource source ) {
         ReferencedTarget target = new ReferencedTarget();
-        target.setFoo( source.getFoo() );
+        target.setBar( source.getFoo() );
         return target;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/ReferencedMapperPrivate.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/ReferencedMapperPrivate.java
@@ -26,7 +26,7 @@ public class ReferencedMapperPrivate {
     @SuppressWarnings("unused")
     private ReferencedTarget sourceToTarget(ReferencedSource source) {
         ReferencedTarget target = new ReferencedTarget();
-        target.setFoo( source.getFoo() );
+        target.setBar( source.getFoo() );
         return target;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/ReferencedMapperProtected.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/ReferencedMapperProtected.java
@@ -26,7 +26,7 @@ public class ReferencedMapperProtected {
 
     protected ReferencedTarget sourceToTarget( ReferencedSource source ) {
         ReferencedTarget target = new ReferencedTarget();
-        target.setFoo( source.getFoo() );
+        target.setBar( source.getFoo() );
         return target;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/ReferencedTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/ReferencedTarget.java
@@ -22,13 +22,13 @@ package org.mapstruct.ap.test.accessibility.referenced;
  * @author Sjaak Derksen
  */
 public class ReferencedTarget {
-    private String foo;
+    private String bar;
 
-    public String getFoo() {
-        return foo;
+    public String getBar() {
+        return bar;
     }
 
-    public void setFoo(String foo) {
-        this.foo = foo;
+    public void setBar(String bar) {
+        this.bar = bar;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/SourceTargetmapperProtectedBase.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/SourceTargetmapperProtectedBase.java
@@ -26,7 +26,7 @@ public class SourceTargetmapperProtectedBase {
 
     protected ReferencedTarget sourceToTarget( ReferencedSource source ) {
         ReferencedTarget target = new ReferencedTarget();
-        target.setFoo( source.getFoo() );
+        target.setBar( source.getFoo() );
         return target;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/a/ReferencedMapperDefaultOther.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/a/ReferencedMapperDefaultOther.java
@@ -30,7 +30,7 @@ public class ReferencedMapperDefaultOther {
 
      ReferencedTarget sourceToTarget( ReferencedSource source ) {
         ReferencedTarget target = new ReferencedTarget();
-        target.setFoo( source.getFoo() );
+        target.setBar( source.getFoo() );
         return target;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionMappingTest.java
@@ -115,8 +115,8 @@ public class ErroneousCollectionMappingTest {
             @Diagnostic(type = ErroneousCollectionNoElementMappingFound.class,
                 kind = Kind.ERROR,
                 line = 37,
-                messageRegExp = "No implementation can be generated for this method. Found no method nor implicit "
-                    + "conversion for mapping source element type into target element type.")
+                messageRegExp = "Can't map .*AttributedString to .*String. " +
+                    "Consider to implement a mapping method: \".*String map(.*AttributedString value)")
         }
     )
     public void shouldFailOnNoElementMappingFound() {
@@ -131,8 +131,8 @@ public class ErroneousCollectionMappingTest {
             @Diagnostic(type = ErroneousCollectionNoKeyMappingFound.class,
                 kind = Kind.ERROR,
                 line = 37,
-                messageRegExp = "No implementation can be generated for this method. Found no method nor implicit "
-                    + "conversion for mapping source key type to target key type.")
+                messageRegExp = "Can't map .*AttributedString to .*String. " +
+                    "Consider to implement a mapping method: \".*String map(.*AttributedString value)")
         }
     )
     public void shouldFailOnNoKeyMappingFound() {
@@ -147,8 +147,8 @@ public class ErroneousCollectionMappingTest {
             @Diagnostic(type = ErroneousCollectionNoValueMappingFound.class,
                 kind = Kind.ERROR,
                 line = 37,
-                messageRegExp = "No implementation can be generated for this method. Found no method nor implicit "
-                    + "conversion for mapping source value type to target value type.")
+                messageRegExp = "Can't map .*AttributedString to .*String. " +
+                    "Consider to implement a mapping method: \".*String map(.*AttributedString value)")
         }
     )
     public void shouldFailOnNoValueMappingFound() {

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/Car.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/Car.java
@@ -1,0 +1,100 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+import java.util.List;
+
+public class Car {
+
+    private String name;
+    private int year;
+    private List<Wheel> wheels;
+
+    public Car() {
+    }
+
+    public Car(String name, int year, List<Wheel> wheels) {
+        this.name = name;
+        this.year = year;
+        this.wheels = wheels;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public void setYear(int year) {
+        this.year = year;
+    }
+
+    public List<Wheel> getWheels() {
+        return wheels;
+    }
+
+    public void setWheels(List<Wheel> wheels) {
+        this.wheels = wheels;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        Car car = (Car) o;
+
+        if ( year != car.year ) {
+            return false;
+        }
+        if ( name != null ? !name.equals( car.name ) : car.name != null ) {
+            return false;
+        }
+        return wheels != null ? wheels.equals( car.wheels ) : car.wheels == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + year;
+        result = 31 * result + ( wheels != null ? wheels.hashCode() : 0 );
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Car{" +
+            "name='" + name + '\'' +
+            ", year=" + year +
+            ", wheels=" + wheels +
+            '}';
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/CarDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/CarDto.java
@@ -1,0 +1,100 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+import java.util.List;
+
+public class CarDto {
+
+    private String name;
+    private int year;
+    private List<WheelDto> wheels;
+
+    public CarDto() {
+    }
+
+    public CarDto(String name, int year, List<WheelDto> wheels) {
+        this.name = name;
+        this.year = year;
+        this.wheels = wheels;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public void setYear(int year) {
+        this.year = year;
+    }
+
+    public List<WheelDto> getWheels() {
+        return wheels;
+    }
+
+    public void setWheels(List<WheelDto> wheels) {
+        this.wheels = wheels;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        CarDto carDto = (CarDto) o;
+
+        if ( year != carDto.year ) {
+            return false;
+        }
+        if ( name != null ? !name.equals( carDto.name ) : carDto.name != null ) {
+            return false;
+        }
+        return wheels != null ? wheels.equals( carDto.wheels ) : carDto.wheels == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + year;
+        result = 31 * result + ( wheels != null ? wheels.hashCode() : 0 );
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "CarDto{" +
+            "name='" + name + '\'' +
+            ", year=" + year +
+            ", wheels=" + wheels +
+            '}';
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/House.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/House.java
@@ -1,0 +1,100 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+public class House {
+
+    private String name;
+    private int year;
+    private Roof roof;
+
+    public House() {
+    }
+
+    public House(String name, int year, Roof roof) {
+
+
+        this.name = name;
+        this.year = year;
+        this.roof = roof;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public void setYear(int year) {
+        this.year = year;
+    }
+
+    public Roof getRoof() {
+        return roof;
+    }
+
+    public void setRoof(Roof roof) {
+        this.roof = roof;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        House house = (House) o;
+
+        if ( year != house.year ) {
+            return false;
+        }
+        if ( name != null ? !name.equals( house.name ) : house.name != null ) {
+            return false;
+        }
+        return roof != null ? roof.equals( house.roof ) : house.roof == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + year;
+        result = 31 * result + ( roof != null ? roof.hashCode() : 0 );
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "House{" +
+            "name='" + name + '\'' +
+            ", year=" + year +
+            ", roof=" + roof +
+            '}';
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/HouseDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/HouseDto.java
@@ -1,0 +1,98 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+public class HouseDto {
+
+    private String name;
+    private int year;
+    private RoofDto roof;
+
+    public HouseDto() {
+    }
+
+    public HouseDto(String name, int year, RoofDto roof) {
+        this.name = name;
+        this.year = year;
+        this.roof = roof;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getYear() {
+        return year;
+    }
+
+    public void setYear(int year) {
+        this.year = year;
+    }
+
+    public RoofDto getRoof() {
+        return roof;
+    }
+
+    public void setRoof(RoofDto roof) {
+        this.roof = roof;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        HouseDto houseDto = (HouseDto) o;
+
+        if ( year != houseDto.year ) {
+            return false;
+        }
+        if ( name != null ? !name.equals( houseDto.name ) : houseDto.name != null ) {
+            return false;
+        }
+        return roof != null ? roof.equals( houseDto.roof ) : houseDto.roof == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + year;
+        result = 31 * result + ( roof != null ? roof.hashCode() : 0 );
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "HouseDto{" +
+            "name='" + name + '\'' +
+            ", year=" + year +
+            ", roof=" + roof +
+            '}';
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/NestedSimpleBeansMapping.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/NestedSimpleBeansMapping.java
@@ -1,0 +1,54 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses({
+    User.class, UserDto.class, Car.class, CarDto.class, House.class, HouseDto.class,
+    Wheel.class, WheelDto.class,
+    Roof.class, RoofDto.class,
+    UserDtoMapperClassic.class,
+    UserDtoMapperSmart.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class NestedSimpleBeansMapping {
+
+    @Test
+    public void shouldMapNestedBeans() {
+
+        User user = TestData.createUser();
+
+        UserDto classicMapping = UserDtoMapperClassic.INSTANCE.userToUserDto( user );
+        UserDto smartMapping = UserDtoMapperSmart.INSTANCE.userToUserDto( user );
+
+        System.out.println( smartMapping );
+        System.out.println( classicMapping );
+
+
+        assertThat( smartMapping ).isNotNull();
+        assertThat( smartMapping ).isEqualTo( classicMapping );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/NestedSimpleBeansMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/NestedSimpleBeansMappingTest.java
@@ -20,34 +20,35 @@ package org.mapstruct.ap.test.nestedbeans;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mapstruct.ap.test.nestedbeans.maps.AutoMapMapper;
-import org.mapstruct.ap.test.nestedbeans.maps.Bar;
-import org.mapstruct.ap.test.nestedbeans.maps.BarDto;
-import org.mapstruct.ap.test.nestedbeans.maps.Dto;
-import org.mapstruct.ap.test.nestedbeans.maps.Entity;
-import org.mapstruct.ap.test.nestedbeans.multiplecollections.Garage;
-import org.mapstruct.ap.test.nestedbeans.multiplecollections.GarageDto;
-import org.mapstruct.ap.test.nestedbeans.multiplecollections.MultipleListMapper;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses({
+    User.class, UserDto.class, Car.class, CarDto.class, House.class, HouseDto.class,
+    Wheel.class, WheelDto.class,
+    Roof.class, RoofDto.class,
+    UserDtoMapperClassic.class,
+    UserDtoMapperSmart.class
+})
 @RunWith(AnnotationProcessorTestRunner.class)
-public class TestMultipleForgedMethods {
+public class NestedSimpleBeansMappingTest {
 
-    @WithClasses({
-        Bar.class, BarDto.class, Dto.class, Entity.class, AutoMapMapper.class
-    })
     @Test
-    public void testNestedMapsAutoMap() {
-        AutoMapMapper.INSTANCE.entityToDto( new Dto() );
-    }
+    public void shouldMapNestedBeans() {
 
-    @WithClasses( {MultipleListMapper.class, Garage.class, GarageDto.class, Car.class, CarDto.class,
-    Wheel.class, WheelDto.class})
-    @Test
-    public void testMultipleCollections() {
-        MultipleListMapper.INSTANCE.convert( new Garage() );
-    }
+        User user = TestData.createUser();
 
+        UserDto classicMapping = UserDtoMapperClassic.INSTANCE.userToUserDto( user );
+        UserDto smartMapping = UserDtoMapperSmart.INSTANCE.userToUserDto( user );
+
+        System.out.println( smartMapping );
+        System.out.println( classicMapping );
+
+
+        assertThat( smartMapping ).isNotNull();
+        assertThat( smartMapping ).isEqualTo( classicMapping );
+    }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/Roof.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/Roof.java
@@ -16,17 +16,31 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
+public class Roof {
+    private int color;
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
+    public Roof() {
     }
+
+    public Roof(int color) {
+        this.color = color;
+    }
+
+    public int getColor() {
+        return color;
+    }
+
+    public void setColor(int color) {
+        this.color = color;
+    }
+
+    @Override
+    public String toString() {
+        return "Roof{" +
+            "color='" + color + '\'' +
+            '}';
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/RoofDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/RoofDto.java
@@ -1,0 +1,66 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+public class RoofDto {
+    private String color;
+
+    public RoofDto() {
+    }
+
+    public RoofDto(String color) {
+        this.color = color;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    public void setColor(String color) {
+        this.color = color;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        RoofDto roofDto = (RoofDto) o;
+
+        return color != null ? color.equals( roofDto.color ) : roofDto.color == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        return color != null ? color.hashCode() : 0;
+    }
+
+    @Override
+    public String toString() {
+        return "RoofDto{" +
+            "color='" + color + '\'' +
+            '}';
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestData.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestData.java
@@ -16,17 +16,26 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
+import java.util.Arrays;
+
+public class TestData {
+
+    private TestData() {
+
     }
+
+    public static User createUser() {
+        return new User( "John", new Car( "Chrysler", 1955, Arrays.asList(
+            new Wheel().front().left(),
+            new Wheel().front().right(),
+            new Wheel().rear().left(),
+            new Wheel().rear().right()
+        ) ),
+            new House( "Black", 1834, new Roof( 1 ) )
+        );
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestData.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestData.java
@@ -1,20 +1,20 @@
 /**
- * Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
- * and/or other contributors as indicated by the @authors tag. See the
- * copyright.txt file in the distribution for a full listing of all
- * contributors.
+ *  Copyright 2012-2016 Dmytro Polovinkin (http://github.com/navpil)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
  *
- * http://www.apache.org/licenses/LICENSE-2.0
+ *      http://www.apache.org/licenses/LICENSE-2.0
  *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
  */
 package org.mapstruct.ap.test.nestedbeans;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestData.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestData.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Dmytro Polovinkin (http://github.com/navpil)
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestData.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestData.java
@@ -1,23 +1,22 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
- *  and/or other contributors as indicated by the @authors tag. See the
- *  copyright.txt file in the distribution for a full listing of all
- *  contributors.
+ * Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ * and/or other contributors as indicated by the @authors tag. See the
+ * copyright.txt file in the distribution for a full listing of all
+ * contributors.
  *
- *  Licensed under the Apache License, Version 2.0 (the "License");
- *  you may not use this file except in compliance with the License.
- *  You may obtain a copy of the License at
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
- *  Unless required by applicable law or agreed to in writing, software
- *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *  See the License for the specific language governing permissions and
- *  limitations under the License.
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 package org.mapstruct.ap.test.nestedbeans;
-
 
 import java.util.Arrays;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestMultipleForgedMethods.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestMultipleForgedMethods.java
@@ -1,0 +1,53 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.nestedbeans.maps.AutoMapMapper;
+import org.mapstruct.ap.test.nestedbeans.maps.Bar;
+import org.mapstruct.ap.test.nestedbeans.maps.BarDto;
+import org.mapstruct.ap.test.nestedbeans.maps.Dto;
+import org.mapstruct.ap.test.nestedbeans.maps.Entity;
+import org.mapstruct.ap.test.nestedbeans.multiplecollections.Garage;
+import org.mapstruct.ap.test.nestedbeans.multiplecollections.GarageDto;
+import org.mapstruct.ap.test.nestedbeans.multiplecollections.MultipleListMapper;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+@RunWith(AnnotationProcessorTestRunner.class)
+public class TestMultipleForgedMethods {
+
+    @WithClasses({
+        Bar.class, BarDto.class, Dto.class, Entity.class, AutoMapMapper.class
+    })
+    @Test
+    public void testNestedMapsAutoMap() {
+        AutoMapMapper.INSTANCE.entityToDto( new Dto() );
+    }
+
+    @WithClasses( {MultipleListMapper.class, Garage.class, GarageDto.class, Car.class, CarDto.class,
+    Wheel.class, WheelDto.class})
+    @Test
+    public void testMultipleCollections() {
+        MultipleListMapper.INSTANCE.convert( new Garage() );
+    }
+
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestMultipleForgedMethodsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestMultipleForgedMethodsTest.java
@@ -49,5 +49,4 @@ public class TestMultipleForgedMethodsTest {
         MultipleListMapper.INSTANCE.convert( new Garage() );
     }
 
-
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestMultipleForgedMethodsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/TestMultipleForgedMethodsTest.java
@@ -20,35 +20,34 @@ package org.mapstruct.ap.test.nestedbeans;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.nestedbeans.maps.AutoMapMapper;
+import org.mapstruct.ap.test.nestedbeans.maps.Bar;
+import org.mapstruct.ap.test.nestedbeans.maps.BarDto;
+import org.mapstruct.ap.test.nestedbeans.maps.Dto;
+import org.mapstruct.ap.test.nestedbeans.maps.Entity;
+import org.mapstruct.ap.test.nestedbeans.multiplecollections.Garage;
+import org.mapstruct.ap.test.nestedbeans.multiplecollections.GarageDto;
+import org.mapstruct.ap.test.nestedbeans.multiplecollections.MultipleListMapper;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-@WithClasses({
-    User.class, UserDto.class, Car.class, CarDto.class, House.class, HouseDto.class,
-    Wheel.class, WheelDto.class,
-    Roof.class, RoofDto.class,
-    UserDtoMapperClassic.class,
-    UserDtoMapperSmart.class
-})
 @RunWith(AnnotationProcessorTestRunner.class)
-public class NestedSimpleBeansMapping {
+public class TestMultipleForgedMethodsTest {
 
+    @WithClasses({
+        Bar.class, BarDto.class, Dto.class, Entity.class, AutoMapMapper.class
+    })
     @Test
-    public void shouldMapNestedBeans() {
-
-        User user = TestData.createUser();
-
-        UserDto classicMapping = UserDtoMapperClassic.INSTANCE.userToUserDto( user );
-        UserDto smartMapping = UserDtoMapperSmart.INSTANCE.userToUserDto( user );
-
-        System.out.println( smartMapping );
-        System.out.println( classicMapping );
-
-
-        assertThat( smartMapping ).isNotNull();
-        assertThat( smartMapping ).isEqualTo( classicMapping );
+    public void testNestedMapsAutoMap() {
+        AutoMapMapper.INSTANCE.entityToDto( new Dto() );
     }
+
+    @WithClasses( {MultipleListMapper.class, Garage.class, GarageDto.class, Car.class, CarDto.class,
+    Wheel.class, WheelDto.class})
+    @Test
+    public void testMultipleCollections() {
+        MultipleListMapper.INSTANCE.convert( new Garage() );
+    }
+
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/User.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/User.java
@@ -1,0 +1,98 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+public class User {
+
+    private String name;
+    private Car car;
+    private House house;
+
+    public User() {
+    }
+
+    public User(String name, Car car, House house) {
+        this.name = name;
+        this.car = car;
+        this.house = house;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Car getCar() {
+        return car;
+    }
+
+    public void setCar(Car car) {
+        this.car = car;
+    }
+
+    public House getHouse() {
+        return house;
+    }
+
+    public void setHouse(House house) {
+        this.house = house;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        User user = (User) o;
+
+        if ( name != null ? !name.equals( user.name ) : user.name != null ) {
+            return false;
+        }
+        if ( car != null ? !car.equals( user.car ) : user.car != null ) {
+            return false;
+        }
+        return house != null ? house.equals( user.house ) : user.house == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + ( car != null ? car.hashCode() : 0 );
+        result = 31 * result + ( house != null ? house.hashCode() : 0 );
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "User{" +
+            "name='" + name + '\'' +
+            ", car=" + car +
+            ", house=" + house +
+            '}';
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/UserDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/UserDto.java
@@ -1,0 +1,98 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+public class UserDto {
+
+    private String name;
+    private CarDto car;
+    private HouseDto house;
+
+    public UserDto() {
+    }
+
+    public UserDto(String name, CarDto car, HouseDto house) {
+        this.name = name;
+        this.car = car;
+        this.house = house;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public CarDto getCar() {
+        return car;
+    }
+
+    public void setCar(CarDto car) {
+        this.car = car;
+    }
+
+    public HouseDto getHouse() {
+        return house;
+    }
+
+    public void setHouse(HouseDto house) {
+        this.house = house;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        UserDto userDto = (UserDto) o;
+
+        if ( name != null ? !name.equals( userDto.name ) : userDto.name != null ) {
+            return false;
+        }
+        if ( car != null ? !car.equals( userDto.car ) : userDto.car != null ) {
+            return false;
+        }
+        return house != null ? house.equals( userDto.house ) : userDto.house == null;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + ( car != null ? car.hashCode() : 0 );
+        result = 31 * result + ( house != null ? house.hashCode() : 0 );
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "UserDto{" +
+            "name='" + name + '\'' +
+            ", car=" + car +
+            ", house=" + house +
+            '}';
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/UserDtoMapperClassic.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/UserDtoMapperClassic.java
@@ -16,17 +16,28 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
-    }
+import java.util.List;
+
+@Mapper
+public interface UserDtoMapperClassic {
+
+    UserDtoMapperClassic INSTANCE = Mappers.getMapper( UserDtoMapperClassic.class );
+
+    UserDto userToUserDto(User user);
+
+    CarDto carToCarDto(Car car);
+
+    HouseDto houseToHouseDto(House house);
+
+    RoofDto roofToRoofDto(Roof roof);
+
+    List<WheelDto> mapWheels(List<Wheel> wheels);
+
+    WheelDto mapWheel(Wheel wheels);
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/UserDtoMapperSmart.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/UserDtoMapperSmart.java
@@ -16,17 +16,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
-    }
+@Mapper
+public interface UserDtoMapperSmart {
+
+    UserDtoMapperSmart INSTANCE = Mappers.getMapper( UserDtoMapperSmart.class );
+
+    UserDto userToUserDto(User user);
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/Wheel.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/Wheel.java
@@ -1,0 +1,99 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+public class Wheel {
+    private boolean front;
+    private boolean right;
+
+    public Wheel() {
+    }
+
+    public Wheel(boolean front, boolean right) {
+        this.front = front;
+        this.right = right;
+    }
+
+    public boolean isFront() {
+        return front;
+    }
+
+    public void setFront(boolean front) {
+        this.front = front;
+    }
+
+    public boolean isRight() {
+        return right;
+    }
+
+    public void setRight(boolean right) {
+        this.right = right;
+    }
+
+    public Wheel left() {
+        return new Wheel( this.front, false );
+    }
+
+    public Wheel right() {
+        return new Wheel( this.front, true );
+    }
+
+    public Wheel front() {
+        return new Wheel( true, this.right );
+    }
+
+    public Wheel rear() {
+        return new Wheel( false, this.right );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        Wheel wheel = (Wheel) o;
+
+        if ( front != wheel.front ) {
+            return false;
+        }
+        return right == wheel.right;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = ( front ? 1 : 0 );
+        result = 31 * result + ( right ? 1 : 0 );
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Wheel{" +
+            "front=" + front +
+            ", right=" + right +
+            '}';
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/WheelDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/WheelDto.java
@@ -1,0 +1,80 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+public class WheelDto {
+    private boolean front;
+    private boolean right;
+
+    public WheelDto() {
+    }
+
+    public WheelDto(boolean front, boolean right) {
+        this.front = front;
+        this.right = right;
+    }
+
+    public boolean isFront() {
+        return front;
+    }
+
+    public void setFront(boolean front) {
+        this.front = front;
+    }
+
+    public boolean isRight() {
+        return right;
+    }
+
+    public void setRight(boolean right) {
+        this.right = right;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
+            return false;
+        }
+
+        WheelDto wheel = (WheelDto) o;
+
+        if ( front != wheel.front ) {
+            return false;
+        }
+        return right == wheel.right;
+
+    }
+
+    @Override
+    public int hashCode() {
+        int result = ( front ? 1 : 0 );
+        result = 31 * result + ( right ? 1 : 0 );
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "Wheel{" + ( front ? "front" : "rear" ) + ";" + ( right ? "right" : "left" ) + '}';
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/AutoMapMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/AutoMapMapper.java
@@ -16,17 +16,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans.maps;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
-    }
+@Mapper
+public interface AutoMapMapper {
+
+    AutoMapMapper INSTANCE = Mappers.getMapper( AutoMapMapper.class );
+
+    Entity entityToDto(Dto dto);
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/Bar.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/Bar.java
@@ -16,17 +16,17 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans.maps;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
+public class Bar {
+    private String name;
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
+    public String getName() {
+        return name;
     }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/BarDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/BarDto.java
@@ -16,17 +16,17 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans.maps;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
+public class BarDto {
+    private String name;
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
+    public String getName() {
+        return name;
     }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/Dto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/Dto.java
@@ -16,17 +16,19 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans.maps;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
+import java.util.Map;
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
+public class Dto {
+    private Map<BarDto, BarDto> map;
+
+    public Map<BarDto, BarDto> getMap() {
+        return map;
     }
+
+    public void setMap( Map<BarDto, BarDto> map) {
+        this.map = map;
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/Entity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/Entity.java
@@ -16,17 +16,19 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans.maps;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
+import java.util.Map;
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
+public class Entity {
+    private Map<Bar, Bar> map;
+
+    public Map<Bar, Bar> getMap() {
+        return map;
     }
+
+    public void setMap(Map<Bar, Bar> map) {
+        this.map = map;
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/multiplecollections/Garage.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/multiplecollections/Garage.java
@@ -16,17 +16,30 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans.multiplecollections;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
+import java.util.List;
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
+import org.mapstruct.ap.test.nestedbeans.Car;
+
+public class Garage {
+    private List<Car> cars;
+    private List<Car> usedCars;
+
+    public List<Car> getCars() {
+        return cars;
     }
+
+    public void setCars(List<Car> cars) {
+        this.cars = cars;
+    }
+
+    public List<Car> getUsedCars() {
+        return usedCars;
+    }
+
+    public void setUsedCars(List<Car> usedCars) {
+        this.usedCars = usedCars;
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/multiplecollections/GarageDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/multiplecollections/GarageDto.java
@@ -16,17 +16,31 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans.multiplecollections;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
+import java.util.List;
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
+import org.mapstruct.ap.test.nestedbeans.CarDto;
+
+public class GarageDto {
+
+    private List<CarDto> cars;
+    private List<CarDto> usedCars;
+
+    public List<CarDto> getCars() {
+        return cars;
     }
+
+    public void setCars(List<CarDto> cars) {
+        this.cars = cars;
+    }
+
+    public List<CarDto> getUsedCars() {
+        return usedCars;
+    }
+
+    public void setUsedCars(List<CarDto> usedCars) {
+        this.usedCars = usedCars;
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/multiplecollections/MultipleListMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/multiplecollections/MultipleListMapper.java
@@ -16,17 +16,16 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.nestedbeans.multiplecollections;
 
-/**
- * @author Sjaak Derksen
- */
-public class SourceTargetmapperPrivateBase {
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
-    }
+@Mapper
+public interface MultipleListMapper {
+
+    MultipleListMapper INSTANCE = Mappers.getMapper( MultipleListMapper.class );
+
+    GarageDto convert(Garage garage);
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
@@ -170,7 +170,8 @@ public class ConversionTest {
                 line = 29,
                 messageRegExp = "Can't map property \"org.mapstruct.ap.test.selection.generics.WildCardSuperWrapper"
                     + "<java.lang.String> foo\" to"
-                    + " \"org.mapstruct.ap.test.selection.generics.WildCardSuperWrapper<java.lang.Integer> foo\"")
+                    + " \"org.mapstruct.ap.test.selection.generics.WildCardSuperWrapper" +
+                    "<org.mapstruct.ap.test.selection.generics.TypeA> foo\"")
         })
     public void shouldFailOnNonMatchingWildCards() {
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ErroneousTarget6.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ErroneousTarget6.java
@@ -20,13 +20,13 @@ package org.mapstruct.ap.test.selection.generics;
 
 public class ErroneousTarget6 {
 
-    private WildCardSuperWrapper<Integer> foo;
+    private WildCardSuperWrapper<TypeA> foo;
 
-    public WildCardSuperWrapper<Integer> getFoo() {
+    public WildCardSuperWrapper<TypeA> getFoo() {
         return foo;
     }
 
-    public void setFoo(WildCardSuperWrapper<Integer> foo) {
+    public void setFoo(WildCardSuperWrapper<TypeA> foo) {
         this.foo = foo;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UnmappableCompanyDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UnmappableCompanyDto.java
@@ -16,17 +16,31 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.accessibility.referenced;
+package org.mapstruct.ap.test.updatemethods;
 
 /**
- * @author Sjaak Derksen
+ *
+ * @author Dmytro Polovinkin
  */
-public class SourceTargetmapperPrivateBase {
+public class UnmappableCompanyDto {
 
-    @SuppressWarnings("unused")
-    private ReferencedTarget sourceToTarget(ReferencedSource source) {
-        ReferencedTarget target = new ReferencedTarget();
-        target.setBar( source.getFoo() );
-        return target;
+    private String name;
+    private UnmappableDepartmentDto department;
+
+    public String getName() {
+        return name;
     }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public UnmappableDepartmentDto getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(UnmappableDepartmentDto department) {
+        this.department = department;
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UnmappableDepartmentDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UnmappableDepartmentDto.java
@@ -18,28 +18,41 @@
  */
 package org.mapstruct.ap.test.updatemethods;
 
-import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
-import org.mapstruct.MappingTarget;
-import org.mapstruct.Mappings;
-import org.mapstruct.factory.Mappers;
+import java.util.List;
+import java.util.Map;
 
 /**
  *
- * @author Sjaak Derksen
+ * @author Dmytro Polovinkin
  */
-@Mapper( uses = DepartmentEntityFactory.class )
-public interface ErroneousCompanyMapper1 {
+public class UnmappableDepartmentDto {
 
-    ErroneousCompanyMapper1 INSTANCE = Mappers.getMapper( ErroneousCompanyMapper1.class );
+    private String name;
+    private List<EmployeeDto> workers;
+    private Map<SecretaryDto, EmployeeDto> secretaryToEmployee;
 
-    void toCompanyEntity(UnmappableCompanyDto dto, @MappingTarget CompanyEntity entity);
+    public String getName() {
+        return name;
+    }
 
-    void  toInBetween(UnmappableDepartmentDto dto, @MappingTarget DepartmentInBetween entity);
+    public void setName(String name) {
+        this.name = name;
+    }
 
-    @Mappings({
-        @Mapping( target = "employees", ignore = true ),
-        @Mapping( target = "secretaryToEmployee", ignore = true )
-    })
-    void toDepartmentEntity(DepartmentInBetween dto, @MappingTarget DepartmentEntity entity);
+    public List<EmployeeDto> getWorkers() {
+        return workers;
+    }
+
+    public void setWorkers(List<EmployeeDto> employees) {
+        this.workers = employees;
+    }
+
+    public Map<SecretaryDto, EmployeeDto> getSecretaryToEmployee() {
+        return secretaryToEmployee;
+    }
+
+    public void setSecretaryToEmployee(Map<SecretaryDto, EmployeeDto> secretaryToEmployee) {
+        this.secretaryToEmployee = secretaryToEmployee;
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
@@ -182,7 +182,9 @@ public class UpdateMethodsTest {
     @Test
     @WithClasses( {
         ErroneousCompanyMapper1.class,
-        DepartmentInBetween.class
+        DepartmentInBetween.class,
+        UnmappableCompanyDto.class,
+        UnmappableDepartmentDto.class
 
     } )
     @ExpectedCompilationOutcome(
@@ -191,7 +193,8 @@ public class UpdateMethodsTest {
             @Diagnostic(type = ErroneousCompanyMapper1.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 36,
-                messageRegExp = "Can't map property \".*DepartmentDto department\" to \".*DepartmentEntity department.")
+                messageRegExp = "Can't map property \".*UnmappableDepartmentDto department\" to \".*DepartmentEntity " +
+                    "department.")
         }
     )
     public void testShouldFailOnTwoNestedUpdateMethods() { }


### PR DESCRIPTION
Mapping methods are auto-generated for some obvious mappings between beans that have the same properties.
New tests were added. Several older were updated, because with new functionality mapping was generated when tests were expecting it to fail.
There is still one failing test: ConversionTest.shouldFailOnNonMatchingWildCards() for eclipse only.
Also for some reason integration tests fail on my new test classes with compilation errors.
