### PR TITLE
Updates mapstruct-reference-guide: Revives caption

### DIFF
--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -580,6 +580,7 @@ public interface CarMapper {
 * Between `enum` types and `String`.
 
 * Between big number types (`java.math.BigInteger`, `java.math.BigDecimal`) and Java primitive types (including their wrappers) as well as String. A format string as understood by `java.text.DecimalFormat` can be specified.
+
 .Conversion from BigDecimal to String
 ====
 [source, java, linenums]


### PR DESCRIPTION
Caption to example 17 got lost (due to a missing line). Adds the missing line in front of
    .Conversion from BigDecimal to String
so that this caption is printed as caption again.