### PR TITLE
Documentation: fixes some typos

### DIFF
--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -1469,7 +1469,7 @@ public interface SourceTargetMapper {
 ----
 ====
 
-If `s.getStringProp() == null`, then the target property `stringProperty` will be set to `"undefined"` instead of applying the value from `s.getStringProp()`. If `s.getLongProp() == null`, then the target property `longProperty` will be set to `-1`.
+If `s.getStringProp() == null`, then the target property `stringProperty` will be set to `"undefined"` instead of applying the value from `s.getStringProp()`. If `s.getLongProperty() == null`, then the target property `longProperty` will be set to `-1`.
 The String `"Constant Value"` is set as is to the target property `stringConstant`. The value `"3001"` is type-converted to the `Long` (wrapper) class of target property `longWrapperConstant`. Date properties also require a date format. The constant `"jack-jill-tom"` demonstrates how the hand-written class `StringListMapper` is invoked to map the dash-separated list into a `List<String>`.
 
 [[expressions]]

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -1012,7 +1012,7 @@ public interface CarMapper {
 
 The generated implementation of the `integerSetToStringSet` performs the conversion from `Integer` to `String` for each element, while the generated `carsToCarDtos()` method invokes the `carToCarDto()` method for each contained element as shown in the following:
 
-. Generated collection mapping methods
+.Generated collection mapping methods
 ====
 [source, java, linenums]
 [subs="verbatim,attributes"]

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -1359,7 +1359,7 @@ By default, the generated code for mapping one bean type into another will call 
 
 Alternatively you can plug in custom object factories which will be invoked to obtain instances of the target type. One use case for this is JAXB which creates `ObjectFactory` classes for obtaining new instances of schema types.
 
-To do make use of custom factories register them via `@Mapper#uses()` as described in <<invoking-other-mappers>>. When creating the target object of a bean mapping, MapStruct will look for a parameterless method, or a method with only one `@TargetType` parameter that returns the required target type and invoke this method instead of calling the default constructor:
+To make use of custom factories register them via `@Mapper#uses()` as described in <<invoking-other-mappers>>. When creating the target object of a bean mapping, MapStruct will look for a parameterless method, or a method with only one `@TargetType` parameter that returns the required target type and invoke this method instead of calling the default constructor:
 
 .Custom object factories
 ====


### PR DESCRIPTION
fixes three typos:
1) converts an item to a caption (superflous blank)
2) fixes a typo
3) changes s.getLongProp() to s.getLongProperty() as no source name is specified in the mapping