### PR TITLE
#824 Target Bean Factory

### DIFF
--- a/core-common/src/main/java/org/mapstruct/ObjectFactory.java
+++ b/core-common/src/main/java/org/mapstruct/ObjectFactory.java
@@ -1,0 +1,73 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * By default beans are created during the mapping process with the default constructor.
+ * This method allows to mark a method as a factory method to create beans.
+ * The type of the factory method is determined by its return type. A factory is used
+ * to create a bean if their types match.
+ * <p>
+ * The factory method can retrieve the mapping sources by specifying
+ * them as parameters, exactly like mapping and lifecycle methods do. This allows the factory
+ * method to create target beans based on source beans.
+ * The use of source parameters opens up a variety of possibilities. For example,
+ * a factory method for entities can look up an
+ * EntityManager to check whether the entity already exists and then return its
+ * managed instance.
+ *
+ * <pre>
+ * {@literal @}ApplicationScoped // CDI component model
+ * public class ReferenceMapper {
+ *
+ *     {@literal @}PersistenceContext
+ *     private EntityManager em;
+ *
+ *     {@literal @}ObjectFactory
+ *     public SomeEntity resolve(SomeDto dto) {
+ *         SomeEntity entity = em.find(SomeEntity.class, dto.getId());
+ *         return entity != null ? entity : new SomeEntity();
+ *     }
+ * }
+ * </pre>
+ *
+ * If no such parameters
+ * are provided, the use of this annotation is optional.
+ *
+ * <p>
+ * If there are two factory methods, both serving the same type, one with no parameters
+ * and one taking sources as input, then the one with the source parameters is favored.
+ * If multiple factory method take sources as input, them the one is chosen which allows a
+ * valid assignment from mapping source parameters to those factory parameters. If
+ * there are multiple such factories, an ambiguity exception is thrown.
+ * </p>
+ *
+ * @author Remo Meier
+ * @since 1.2
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target(ElementType.METHOD)
+public @interface ObjectFactory {
+
+}

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -1410,7 +1410,8 @@ By default, the generated code for mapping one bean type into another will call 
 
 Alternatively you can plug in custom object factories which will be invoked to obtain instances of the target type. One use case for this is JAXB which creates `ObjectFactory` classes for obtaining new instances of schema types.
 
-To make use of custom factories register them via `@Mapper#uses()` as described in <<invoking-other-mappers>>. When creating the target object of a bean mapping, MapStruct will look for a parameterless method, or a method with only one `@TargetType` parameter that returns the required target type and invoke this method instead of calling the default constructor:
+To make use of custom factories register them via `@Mapper#uses()` as described in <<invoking-other-mappers>>. When creating the target object of a bean mapping, MapStruct will look for a parameterless method, 
+a method annotated with `@ObjectFactory`, or a method with only one `@TargetType` parameter that returns the required target type and invoke this method instead of calling the default constructor:
 
 .Custom object factories
 ====
@@ -1485,6 +1486,27 @@ public class CarMapperImpl implements CarMapper {
 }
 ----
 ====
+
+In addition, annotating a factory with `@ObjectFactory` lets you gain access to the mapping sources. 
+Source objects can be added as parameters in the same way as for mapping method. The `@ObjectFactory`
+annotation is necessary to let MapStruct know that the given method is only a factory method. 
+
+.Custom object factories with `@ObjectFactory`
+
+====
+[source, java, linenums]
+[subs="verbatim,attributes"]
+----
+public class DtoFactory {
+
+     @ObjectFactory
+     public CarDto createCarDto(Car car) {
+         return // ... custom factory logic 
+     }
+}
+----
+====
+
 
 == Advanced mapping options
 This chapter describes several advanced options which allow to fine-tune the behavior of the generated mapping code as needed.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/HelperMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/HelperMethod.java
@@ -123,6 +123,16 @@ public abstract class HelperMethod implements Method {
     }
 
     /**
+     * object factory mechanism not supported for built-in methods
+     *
+     * @return false
+     */
+    @Override
+    public boolean isObjectFactory() {
+        return false;
+    }
+
+    /**
      * the conversion context is used to format an auxiliary parameter in the method call with context specific
      * information such as a date format.
      *

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
@@ -41,7 +41,7 @@ import org.mapstruct.ap.internal.model.source.Method;
 public abstract class MappingMethod extends ModelElement {
 
     private final String name;
-    private final List<Parameter> parameters;
+    private List<Parameter> parameters;
     private final Type returnType;
     private final Parameter targetParameter;
     private final Accessibility accessibility;
@@ -64,8 +64,14 @@ public abstract class MappingMethod extends ModelElement {
     protected MappingMethod(Method method, Collection<String> existingVariableNames,
                             List<LifecycleCallbackMethodReference> beforeMappingReferences,
                             List<LifecycleCallbackMethodReference> afterMappingReferences) {
+        this( method, method.getParameters(), existingVariableNames, beforeMappingReferences, afterMappingReferences );
+    }
+
+    protected MappingMethod(Method method, List<Parameter> parameters, Collection<String> existingVariableNames,
+                            List<LifecycleCallbackMethodReference> beforeMappingReferences,
+                            List<LifecycleCallbackMethodReference> afterMappingReferences) {
         this.name = method.getName();
-        this.parameters = method.getParameters();
+        this.parameters = parameters;
         this.returnType = method.getReturnType();
         this.targetParameter = method.getMappingTargetParameter();
         this.accessibility = method.getAccessibility();
@@ -75,6 +81,10 @@ public abstract class MappingMethod extends ModelElement {
         this.beforeMappingReferencesWithMappingTarget = filterMappingTarget( beforeMappingReferences, true );
         this.beforeMappingReferencesWithoutMappingTarget = filterMappingTarget( beforeMappingReferences, false );
         this.afterMappingReferences = afterMappingReferences;
+    }
+
+    protected MappingMethod(Method method, List<Parameter> parameters) {
+        this( method, parameters, method.getParameterNames(), null, null );
     }
 
     protected MappingMethod(Method method) {
@@ -183,7 +193,7 @@ public abstract class MappingMethod extends ModelElement {
     }
 
     private List<LifecycleCallbackMethodReference> filterMappingTarget(List<LifecycleCallbackMethodReference> methods,
-                                                                         boolean mustHaveMappingTargetParameter) {
+                                                                       boolean mustHaveMappingTargetParameter) {
         if ( methods == null ) {
             return null;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ObjectFactoryMethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ObjectFactoryMethodReference.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.List;
+
+import org.mapstruct.ap.internal.model.common.Parameter;
+import org.mapstruct.ap.internal.model.source.Method;
+
+/**
+ * Represents a reference to a factory method.
+ *
+ * @author Remo Meier
+ */
+public class ObjectFactoryMethodReference extends MethodReference {
+
+    private final List<Parameter> parameterAssignments;
+
+    public ObjectFactoryMethodReference(Method method, MapperReference ref, List<Parameter> parameterAssignments) {
+        super( method, ref, null );
+        this.parameterAssignments = parameterAssignments;
+    }
+
+    public List<Parameter> getParameterAssignments() {
+        return parameterAssignments;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ParameterAssignmentUtil.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ParameterAssignmentUtil.java
@@ -1,0 +1,98 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.lang.model.type.TypeKind;
+
+import org.mapstruct.ap.internal.model.common.Parameter;
+
+public class ParameterAssignmentUtil {
+
+    private ParameterAssignmentUtil() {
+    }
+
+    public static List<Parameter> getParameterAssignments(List<Parameter> availableParams,
+                                                          List<Parameter> methodParameters) {
+        List<Parameter> result = new ArrayList<Parameter>( methodParameters.size() );
+
+        for ( Parameter methodParam : methodParameters ) {
+            List<Parameter> assignableParams = findCandidateParameters( availableParams, methodParam );
+
+            if ( assignableParams.isEmpty() ) {
+                return null;
+            }
+
+            if ( assignableParams.size() == 1 ) {
+                result.add( assignableParams.get( 0 ) );
+            }
+            else if ( assignableParams.size() > 1 ) {
+                Parameter paramWithMatchingName = findParameterWithName( assignableParams, methodParam.getName() );
+
+                if ( paramWithMatchingName != null ) {
+                    result.add( paramWithMatchingName );
+                }
+                else {
+                    return null;
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private static Parameter findParameterWithName(List<Parameter> parameters, String name) {
+        for ( Parameter param : parameters ) {
+            if ( name.equals( param.getName() ) ) {
+                return param;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param candidateParameters available for assignment.
+     * @param parameter that need assignment from one of the candidate parameters.
+     * @return list of matching candidate parameters that can be assigned.
+     */
+    private static List<Parameter> findCandidateParameters(List<Parameter> candidateParameters, Parameter parameter) {
+        List<Parameter> result = new ArrayList<Parameter>( candidateParameters.size() );
+
+        for ( Parameter candidate : candidateParameters ) {
+            if ( ( isTypeVarOrWildcard( parameter ) || candidate.getType().isAssignableTo( parameter.getType() ) )
+                && parameter.isMappingTarget() == candidate.isMappingTarget() && !parameter.isTargetType()
+                && !candidate.isTargetType() ) {
+                result.add( candidate );
+            }
+            else if ( parameter.isTargetType() && candidate.isTargetType() ) {
+                result.add( candidate );
+            }
+        }
+
+        return result;
+    }
+
+    private static boolean isTypeVarOrWildcard(Parameter parameter) {
+        TypeKind kind = parameter.getType().getTypeMirror().getKind();
+        return kind == TypeKind.TYPEVAR || kind == TypeKind.WILDCARD;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
@@ -34,18 +34,20 @@ public class Parameter extends ModelElement {
     private final Type type;
     private final boolean mappingTarget;
     private final boolean targetType;
+    private final boolean mappingSource;
 
-    public Parameter(String name, Type type, boolean mappingTarget, boolean targetType) {
+    public Parameter(String name, Type type, boolean mappingTarget, boolean targetType, boolean mappingSource) {
         // issue #909: FreeMarker doesn't like "values" as a parameter name
         this.name = "values".equals( name ) ? "values_" : name;
         this.originalName = name;
         this.type = type;
         this.mappingTarget = mappingTarget;
         this.targetType = targetType;
+        this.mappingSource = mappingSource;
     }
 
     public Parameter(String name, Type type) {
-        this( name, type, false, false );
+        this( name, type, false, false, false );
     }
 
     public String getName() {
@@ -58,6 +60,10 @@ public class Parameter extends ModelElement {
 
     public Type getType() {
         return type;
+    }
+
+    public boolean isMappingSource() {
+        return mappingSource;
     }
 
     public boolean isMappingTarget() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -299,7 +299,8 @@ public class TypeFactory {
                 parameter.getSimpleName().toString(),
                 getType( parameterType ),
                 MappingTargetPrism.getInstanceOn( parameter ) != null,
-                TargetTypePrism.getInstanceOn( parameter ) != null ) );
+                TargetTypePrism.getInstanceOn( parameter ) != null,
+                false) );
         }
 
         return result;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
@@ -216,4 +216,14 @@ public class ForgedMethod implements Method {
     public boolean isUpdateMethod() {
         return getMappingTargetParameter() != null;
     }
+
+    /**
+     * object factory mechanism not supported for forged methods
+     *
+     * @return false
+     */
+    @Override
+    public boolean isObjectFactory() {
+        return false;
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/Method.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/Method.java
@@ -85,6 +85,14 @@ public interface Method {
     Parameter getMappingTargetParameter();
 
     /**
+     * Returns whether the meethod is designated as bean factory for
+     * mapping target {@link  org.mapstruct.ObjectFactory }
+     *
+     * @return true if it is a target bean factory.
+     */
+    boolean isObjectFactory();
+
+    /**
      * Returns the parameter designated as target type (if present) {@link org.mapstruct.TargetType }
      *
      * @return target type parameter (when present) null otherwise.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MethodMatcher.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MethodMatcher.java
@@ -107,8 +107,8 @@ public class MethodMatcher {
             }
         }
         else {
-            // if the sourceTypes empty/contains only nulls then only methods with zero source parameters qualify
-            if ( !candidateMethod.getSourceParameters().isEmpty() ) {
+            // if the sourceTypes empty/contains only nulls then only factory and lifecycle methods qualify
+            if ( !candidateMethod.isObjectFactory() && !candidateMethod.isLifecycleCallbackMethod() ) {
                 return false;
             }
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInMethod.java
@@ -142,6 +142,16 @@ public abstract class BuiltInMethod implements Method {
     }
 
     /**
+     * object factory mechanism not supported for built-in methods
+     *
+     * @return false
+     */
+    @Override
+    public boolean isObjectFactory() {
+        return false;
+    }
+
+    /**
      * the conversion context is used to format an auxiliary parameter in the method call with context specific
      * information such as a date format.
      *
@@ -190,8 +200,6 @@ public abstract class BuiltInMethod implements Method {
         return true;
     }
 
-
-
     /**
      * There's currently only one parameter foreseen instead of a list of parameter
      *
@@ -226,7 +234,7 @@ public abstract class BuiltInMethod implements Method {
 
     @Override
     public boolean overridesMethod() {
-        return  false;
+        return false;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/MethodSelectors.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/MethodSelectors.java
@@ -41,6 +41,7 @@ public class MethodSelectors implements MethodSelector {
     public MethodSelectors(Types typeUtils, Elements elementUtils, TypeFactory typeFactory) {
         selectors =
             Arrays.<MethodSelector>asList(
+                new ObjectFactorySelector(),
                 new TypeSelector(),
                 new QualifierSelector( typeUtils, elementUtils ),
                 new TargetTypeSelector( typeUtils, elementUtils ),

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/ObjectFactorySelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/ObjectFactorySelector.java
@@ -1,0 +1,48 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model.source.selector;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.source.Method;
+import org.mapstruct.ap.internal.model.source.MethodMatcher;
+
+/**
+ * Selects those methods from the given input set which match whether a factory was requested ({@link MethodMatcher} and
+ * {@link org.mapstruct.ObjectFactory}).
+ *
+ * @author Remo Meier
+ */
+public class ObjectFactorySelector implements MethodSelector {
+
+    @Override
+    public <T extends Method> List<T> getMatchingMethods(Method mappingMethod, List<T> methods, Type sourceType,
+                                                         Type targetType, SelectionCriteria criteria) {
+
+        List<T> result = new ArrayList<T>();
+        for ( T method : methods ) {
+            if ( method.isObjectFactory() == criteria.isObjectFactoryRequired() ) {
+                result.add( method );
+            }
+        }
+        return result;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/SelectionCriteria.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/SelectionCriteria.java
@@ -36,9 +36,10 @@ public class SelectionCriteria {
     private final String targetPropertyName;
     private final TypeMirror qualifyingResultType;
     private boolean preferUpdateMapping;
+    private final boolean objectFactoryRequired;
 
-    public SelectionCriteria( SelectionParameters selectionParameters,  String targetPropertyName,
-        boolean preferUpdateMapping ) {
+    public SelectionCriteria(SelectionParameters selectionParameters, String targetPropertyName,
+                             boolean preferUpdateMapping, boolean objectFactoryRequired) {
         if ( selectionParameters != null ) {
             qualifiers.addAll( selectionParameters.getQualifiers() );
             qualifiedByNames.addAll( selectionParameters.getQualifyingNames() );
@@ -49,6 +50,14 @@ public class SelectionCriteria {
         }
         this.targetPropertyName = targetPropertyName;
         this.preferUpdateMapping = preferUpdateMapping;
+        this.objectFactoryRequired = objectFactoryRequired;
+    }
+
+    /**
+     * @return true if factory methods should be selected, false otherwise.
+     */
+    public boolean isObjectFactoryRequired() {
+        return objectFactoryRequired;
     }
 
     public List<TypeMirror> getQualifiers() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/prism/PrismGenerator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/prism/PrismGenerator.java
@@ -34,14 +34,15 @@ import org.mapstruct.MapperConfig;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.Mappings;
+import org.mapstruct.Named;
+import org.mapstruct.ObjectFactory;
 import org.mapstruct.Qualifier;
+import org.mapstruct.TargetType;
 import org.mapstruct.ValueMapping;
 import org.mapstruct.ValueMappings;
-import org.mapstruct.TargetType;
 
 import net.java.dev.hickory.prism.GeneratePrism;
 import net.java.dev.hickory.prism.GeneratePrisms;
-import org.mapstruct.Named;
 
 /**
  * Triggers the generation of prism types using <a href="https://java.net/projects/hickory">Hickory</a>.
@@ -63,6 +64,7 @@ import org.mapstruct.Named;
     @GeneratePrism(value = InheritInverseConfiguration.class, publicAccess = true),
     @GeneratePrism(value = Qualifier.class, publicAccess = true),
     @GeneratePrism(value = Named.class, publicAccess = true),
+    @GeneratePrism(value = ObjectFactory.class, publicAccess = true),
     @GeneratePrism(value = AfterMapping.class, publicAccess = true),
     @GeneratePrism(value = BeforeMapping.class, publicAccess = true),
     @GeneratePrism(value = ValueMapping.class, publicAccess = true),

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -49,6 +49,7 @@ import org.mapstruct.ap.internal.prism.IterableMappingPrism;
 import org.mapstruct.ap.internal.prism.MapMappingPrism;
 import org.mapstruct.ap.internal.prism.MappingPrism;
 import org.mapstruct.ap.internal.prism.MappingsPrism;
+import org.mapstruct.ap.internal.prism.ObjectFactoryPrism;
 import org.mapstruct.ap.internal.prism.ValueMappingPrism;
 import org.mapstruct.ap.internal.prism.ValueMappingsPrism;
 import org.mapstruct.ap.internal.util.AnnotationProcessingException;
@@ -197,8 +198,8 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
                 mapperConfig,
                 prototypeMethods );
         }
-        //otherwise add reference to existing mapper method
-        else if ( isValidReferencedMethod( parameters ) || isValidFactoryMethod( parameters, returnType )
+        // otherwise add reference to existing mapper method
+        else if ( isValidReferencedMethod( parameters ) || isValidFactoryMethod( method, parameters, returnType )
             || isValidLifecycleCallbackMethod( method, returnType ) ) {
             return getReferencedMethod( usedMapper, methodType, method, mapperToImplement, parameters );
         }
@@ -292,8 +293,13 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
         return isValidReferencedOrFactoryMethod( 1, 1, parameters );
     }
 
-    private boolean isValidFactoryMethod(List<Parameter> parameters, Type returnType) {
-        return !isVoid( returnType ) && isValidReferencedOrFactoryMethod( 0, 0, parameters );
+    private boolean isValidFactoryMethod(ExecutableElement method, List<Parameter> parameters, Type returnType) {
+        return !isVoid( returnType )
+            && ( isValidReferencedOrFactoryMethod( 0, 0, parameters ) || hasFactoryAnnotation( method ) );
+    }
+
+    private boolean hasFactoryAnnotation(ExecutableElement method) {
+        return ObjectFactoryPrism.getInstanceOn( method ) != null;
     }
 
     private boolean isVoid(Type returnType) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/writer/ModelWriter.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/writer/ModelWriter.java
@@ -103,7 +103,9 @@ public class ModelWriter {
         @Override
         public Reader getReader(Object name, String encoding) throws IOException {
             URL url = getClass().getClassLoader().getResource( String.valueOf( name ) );
-
+            if ( url == null ) {
+                throw new IllegalStateException( name + " not found on classpath" );
+            }
             URLConnection connection = url.openConnection();
 
             // don't use jar-file caching, as it caused occasionally closed input streams [at least under JDK 1.8.0_25]

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ObjectFactoryMethodReference.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ObjectFactoryMethodReference.ftl
@@ -1,0 +1,46 @@
+<#--
+
+     Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+     and/or other contributors as indicated by the @authors tag. See the
+     copyright.txt file in the distribution for a full listing of all
+     contributors.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<@compress single_line=true>
+    <#-- method is either internal to the mapper class, or external (via uses) declaringMapper!=null -->
+    <#if declaringMapper??><#if static><@includeModel object=declaringMapper.type/><#else>${mapperVariableName}</#if>.<@params/>
+    <#-- method is referenced java8 static method in the mapper to implement (interface)  -->
+    <#elseif static><@includeModel object=definingType/>.<@params/>
+    <#else>
+    <@params/>
+    </#if>
+    <#macro params>
+        <@compress>
+            ${name}<#if (parameterAssignments?size > 0)>( <@arguments/> )<#else>()</#if>
+        </@compress>
+    </#macro>
+    <#macro arguments>
+        <#list parameterAssignments as param>
+            <#if param.targetType>
+                <#-- a class is passed on for casting, see @TargetType -->
+                <@includeModel object=ext.targetType raw=true/>.class<#t>
+            <#elseif param.mappingTarget>
+                 ${ext.targetBeanName}.${ext.targetReadAccessorName}()
+            <#else>${param.name}</#if><#if param_has_next>, </#if><#t>
+        </#list>
+        <#-- context parameter, e.g. for builtin methods concerning date conversion -->
+        <#if contextParam??>, ${contextParam}</#if><#t>
+    </#macro>
+</@compress>

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/AmbiguousAnnotatedFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/AmbiguousAnnotatedFactoryTest.java
@@ -1,0 +1,59 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Remo Meier
+ */
+@WithClasses({
+    Bar.class, Foo.class, AmbiguousBarFactory.class, Source.class, SourceTargetMapperAndBarFactory.class,
+    Target.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class AmbiguousAnnotatedFactoryTest {
+
+    @Test
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = SourceTargetMapperAndBarFactory.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 35,
+                messageRegExp = "Ambiguous factory methods found for creating "
+                        + "org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod.Bar: "
+                        + "org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod.Bar "
+                        + "createBar\\(org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod.Foo foo\\), "
+                        + "org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod.Bar "
+                        + ".*AmbiguousBarFactory.createBar\\(org.mapstruct.ap.test.erroneous."
+                        + "ambiguousannotatedfactorymethod.Foo foo\\)." )
+        }
+    )
+    public void shouldUseTwoFactoryMethods() {
+    }
+}
+
+

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/AmbiguousBarFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/AmbiguousBarFactory.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod;
+
+import org.mapstruct.ObjectFactory;
+
+
+/**
+ * @author Remo Meier
+ */
+public class AmbiguousBarFactory {
+
+    @ObjectFactory
+    public Bar createBar( Foo foo ) {
+        return new Bar( "BAR" );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/Bar.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/Bar.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar {
+    private String prop;
+
+    private final String someTypeProp;
+
+    public Bar(String someTypeProp) {
+        this.someTypeProp = someTypeProp;
+    }
+
+    public String getProp() {
+        return prop;
+    }
+
+    public void setProp(String prop) {
+        this.prop = prop;
+    }
+
+    public String getSomeTypeProp() {
+        return someTypeProp;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/Foo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/Foo.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod;
+
+
+/**
+ * @author Remo Meier
+ */
+public class Foo {
+    private String prop;
+
+    public String getProp() {
+        return prop;
+    }
+
+    public void setProp(String prop) {
+        this.prop = prop;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/Source.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod;
+
+
+/**
+ * @author Remo Meier
+ */
+public class Source {
+
+    private Foo prop;
+
+    public Foo getProp() {
+        return prop;
+    }
+
+    public void setProp(Foo prop) {
+        this.prop = prop;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/SourceTargetMapperAndBarFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/SourceTargetMapperAndBarFactory.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ObjectFactory;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Remo Meier
+ */
+@Mapper(uses = AmbiguousBarFactory.class)
+public abstract class SourceTargetMapperAndBarFactory {
+    public static final SourceTargetMapperAndBarFactory INSTANCE =
+        Mappers.getMapper( SourceTargetMapperAndBarFactory.class );
+
+    public abstract Target sourceToTarget(Source source);
+
+    public abstract Bar fooToBar(Foo foo);
+
+    @ObjectFactory
+    public Bar createBar( Foo foo ) {
+        return new Bar( "BAR" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/Target.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod;
+
+
+/**
+ * @author Remo Meier
+ */
+public class Target {
+
+    private Bar prop;
+
+    public Bar getProp() {
+        return prop;
+    }
+
+    public void setProp(Bar prop) {
+        this.prop = prop;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/Bar4.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/Bar4.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar4 {
+    private String prop;
+
+    private final String someTypeProp;
+
+    public Bar4(String someTypeProp) {
+        this.someTypeProp = someTypeProp;
+    }
+
+    public String getProp() {
+        return prop;
+    }
+
+    public void setProp(String prop) {
+        this.prop = prop;
+    }
+
+    public String getSomeTypeProp() {
+        return someTypeProp;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/FactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/FactoryTest.java
@@ -28,6 +28,11 @@ import java.util.Map;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.test.factories.a.BarFactory;
+import org.mapstruct.ap.test.factories.targettype.Bar9Base;
+import org.mapstruct.ap.test.factories.targettype.Bar9Child;
+import org.mapstruct.ap.test.factories.targettype.Bar9Factory;
+import org.mapstruct.ap.test.factories.targettype.Foo9Base;
+import org.mapstruct.ap.test.factories.targettype.Foo9Child;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
@@ -35,16 +40,16 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 /**
  * @author Sjaak Derksen
  */
-@IssueKey("81")
-@WithClasses({
-    Bar1.class, Foo1.class, Bar2.class, Foo2.class, Bar3.class, Foo3.class, BarFactory.class,
-    org.mapstruct.ap.test.factories.b.BarFactory.class, Source.class, SourceTargetMapperAndBar2Factory.class,
-    Target.class, CustomList.class, CustomListImpl.class, CustomMap.class, CustomMapImpl.class, FactoryCreatable.class
-})
-@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey( "81" )
+@WithClasses( { Bar1.class, Foo1.class, Bar2.class, Foo2.class, Bar3.class, Foo3.class, Bar4.class, Foo4.class,
+    Foo9Base.class, Foo9Child.class, Bar9Base.class, Bar9Child.class, BarFactory.class,
+    org.mapstruct.ap.test.factories.b.BarFactory.class, org.mapstruct.ap.test.factories.c.BarFactory.class,
+    Bar9Factory.class, Source.class, SourceTargetMapperAndBar2Factory.class, Target.class, CustomList.class,
+    CustomListImpl.class, CustomMap.class, CustomMapImpl.class, FactoryCreatable.class } )
+@RunWith( AnnotationProcessorTestRunner.class )
 public class FactoryTest {
     @Test
-    public void shouldUseTwoFactoryMethods() {
+    public void shouldUseThreeFactoryMethods() {
         Target target = SourceTargetMapperAndBar2Factory.INSTANCE.sourceToTarget( createSource() );
 
         assertThat( target ).isNotNull();
@@ -57,6 +62,14 @@ public class FactoryTest {
         assertThat( target.getProp3() ).isNotNull();
         assertThat( target.getProp3().getProp() ).isEqualTo( "foo3" );
         assertThat( target.getProp3().getSomeTypeProp() ).isEqualTo( "BAR3" );
+        assertThat( target.getProp4() ).isNotNull();
+        assertThat( target.getProp4().getProp() ).isEqualTo( "foo4" );
+
+        // notice that bar4 factory gets someTypeProp from the source!
+        assertThat( target.getProp4() ).isNotNull();
+        assertThat( target.getProp4().getProp() ).isEqualTo( "foo4" );
+        assertThat( target.getProp4().getSomeTypeProp() ).isEqualTo( "FOO4" );
+
         assertThat( target.getPropList() ).isNotNull();
         assertThat( target.getPropList().get( 0 ) ).isEqualTo( "fooListEntry" );
         assertThat( target.getPropList().getTypeProp() ).isEqualTo( "CUSTOMLIST" );
@@ -79,6 +92,10 @@ public class FactoryTest {
         Foo3 foo3 = new Foo3();
         foo3.setProp( "foo3" );
         source.setProp3( foo3 );
+
+        Foo4 foo4 = new Foo4();
+        foo4.setProp( "foo4" );
+        source.setProp4( foo4 );
 
         List<String> fooList = new ArrayList<String>();
         fooList.add( "fooListEntry" );

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/Foo4.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/Foo4.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories;
+
+/**
+ * @author Remo Meier
+ */
+public class Foo4 {
+    private String prop;
+
+    public String getProp() {
+        return prop;
+    }
+
+    public void setProp(String prop) {
+        this.prop = prop;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/Source.java
@@ -29,6 +29,7 @@ public class Source {
     private Foo1 prop1;
     private Foo2 prop2;
     private Foo3 prop3;
+    private Foo4 prop4;
     private List<String> propList;
     private Map<String, String> propMap;
 
@@ -54,6 +55,14 @@ public class Source {
 
     public void setProp3(Foo3 prop3) {
         this.prop3 = prop3;
+    }
+
+    public Foo4 getProp4() {
+        return prop4;
+    }
+
+    public void setProp4(Foo4 prop4) {
+        this.prop4 = prop4;
     }
 
     public List<String> getPropList() {

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/SourceTargetMapperAndBar2Factory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/SourceTargetMapperAndBar2Factory.java
@@ -28,7 +28,8 @@ import org.mapstruct.factory.Mappers;
 /**
  * @author Sjaak Derksen
  */
-@Mapper(uses = { BarFactory.class, org.mapstruct.ap.test.factories.b.BarFactory.class })
+@Mapper( uses = { BarFactory.class, org.mapstruct.ap.test.factories.b.BarFactory.class,
+    org.mapstruct.ap.test.factories.c.BarFactory.class } )
 public abstract class SourceTargetMapperAndBar2Factory {
     public static final SourceTargetMapperAndBar2Factory INSTANCE =
         Mappers.getMapper( SourceTargetMapperAndBar2Factory.class );
@@ -40,6 +41,8 @@ public abstract class SourceTargetMapperAndBar2Factory {
     public abstract Bar2 foo2ToBar2(Foo2 foo2);
 
     public abstract Bar3 foo3ToBar3(Foo3 foo3);
+
+    public abstract Bar4 foo4ToBar4(Foo4 foo4);
 
     public abstract CustomList<String> customListToList(List<String> list);
 

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/Target.java
@@ -26,6 +26,7 @@ public class Target {
     private Bar1 prop1;
     private Bar2 prop2;
     private Bar3 prop3;
+    private Bar4 prop4;
     private CustomList<String> propList;
     private CustomMap<String, String> propMap;
 
@@ -51,6 +52,14 @@ public class Target {
 
     public void setProp3(Bar3 prop3) {
         this.prop3 = prop3;
+    }
+
+    public Bar4 getProp4() {
+        return prop4;
+    }
+
+    public void setProp4(Bar4 prop4) {
+        this.prop4 = prop4;
     }
 
     public CustomList<String> getPropList() {

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar5.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar5.java
@@ -1,0 +1,59 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar5 {
+    private String propA;
+    private String propB;
+
+    private final String someTypeProp0;
+    private final String someTypeProp1;
+
+    public Bar5(String someTypeProp0, String someTypeProp1) {
+        this.someTypeProp0 = someTypeProp0;
+        this.someTypeProp1 = someTypeProp1;
+    }
+
+    public String getPropA() {
+        return propA;
+    }
+
+    public void setPropA(String propA) {
+        this.propA = propA;
+    }
+
+    public String getPropB() {
+        return propB;
+    }
+
+    public void setPropB(String propB) {
+        this.propB = propB;
+    }
+
+    public String getSomeTypeProp0() {
+        return someTypeProp0;
+    }
+
+    public String getSomeTypeProp1() {
+        return someTypeProp1;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar5Factory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar5Factory.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+import org.mapstruct.ObjectFactory;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar5Factory {
+
+    @ObjectFactory
+    public Bar5 createBar5(Foo5A foo5A, Foo5B foo5B) {
+        return new Bar5( foo5A.getPropA().toUpperCase(), foo5B.getPropB() );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar6.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar6.java
@@ -1,0 +1,53 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar6 {
+    private String propA;
+    private String propB;
+
+    private final String someTypeProp0;
+
+    public Bar6(String someTypeProp0) {
+        this.someTypeProp0 = someTypeProp0;
+    }
+
+    public String getPropA() {
+        return propA;
+    }
+
+    public void setPropA(String propA) {
+        this.propA = propA;
+    }
+
+    public String getPropB() {
+        return propB;
+    }
+
+    public void setPropB(String propB) {
+        this.propB = propB;
+    }
+
+    public String getSomeTypeProp0() {
+        return someTypeProp0;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar6Factory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar6Factory.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+import org.mapstruct.ObjectFactory;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar6Factory {
+
+    @ObjectFactory
+    public Bar6 createBar6(Foo6A foo6A) {
+        return new Bar6( foo6A.getPropA().toUpperCase() );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar7.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar7.java
@@ -1,0 +1,53 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar7 {
+    private String propA;
+    private String propB;
+
+    private final String someTypeProp0;
+
+    public Bar7(String someTypeProp0) {
+        this.someTypeProp0 = someTypeProp0;
+    }
+
+    public String getPropA() {
+        return propA;
+    }
+
+    public void setPropA(String propA) {
+        this.propA = propA;
+    }
+
+    public String getPropB() {
+        return propB;
+    }
+
+    public void setPropB(String propB) {
+        this.propB = propB;
+    }
+
+    public String getSomeTypeProp0() {
+        return someTypeProp0;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar7Factory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Bar7Factory.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+import org.mapstruct.ObjectFactory;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar7Factory {
+
+    @ObjectFactory
+    public Bar7 createBar7(Foo7B foo7B) {
+        return new Bar7( foo7B.getPropB().toUpperCase() );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo5A.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo5A.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+/**
+ * @author Remo Meier
+ */
+public class Foo5A {
+    private String propA;
+
+    public String getPropA() {
+        return propA;
+    }
+
+    public void setPropB(String prop) {
+        this.propA = prop;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo5B.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo5B.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+/**
+ * @author Remo Meier
+ */
+public class Foo5B {
+    private String propB;
+
+    public String getPropB() {
+        return propB;
+    }
+
+    public void setPropB(String propB) {
+        this.propB = propB;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo6A.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo6A.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+/**
+ * @author Remo Meier
+ */
+public class Foo6A {
+    private String propA;
+
+    public String getPropA() {
+        return propA;
+    }
+
+    public void setPropB(String prop) {
+        this.propA = prop;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo6B.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo6B.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+/**
+ * @author Remo Meier
+ */
+public class Foo6B {
+    private String propB;
+
+    public String getPropB() {
+        return propB;
+    }
+
+    public void setPropB(String propB) {
+        this.propB = propB;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo7A.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo7A.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+/**
+ * @author Remo Meier
+ */
+public class Foo7A {
+    private String propA;
+
+    public String getPropA() {
+        return propA;
+    }
+
+    public void setPropB(String prop) {
+        this.propA = prop;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo7B.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/Foo7B.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+/**
+ * @author Remo Meier
+ */
+public class Foo7B {
+    private String propB;
+
+    public String getPropB() {
+        return propB;
+    }
+
+    public void setPropB(String prop) {
+        this.propB = prop;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/ParameterAssigmentFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/ParameterAssigmentFactoryTest.java
@@ -1,0 +1,85 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Remo Meier
+ */
+@WithClasses( { Bar5.class, Foo5A.class, Foo5B.class, Bar6.class, Foo6A.class, Foo6B.class, Bar7.class, Foo7A.class,
+    Foo7B.class, Bar5Factory.class, Bar6Factory.class, Bar7Factory.class, ParameterAssignmentFactoryTestMapper.class } )
+@RunWith( AnnotationProcessorTestRunner.class )
+public class ParameterAssigmentFactoryTest {
+
+    @Test
+    public void shouldUseFactoryMethodWithMultipleParams() {
+        Foo5A foo5a = new Foo5A();
+        foo5a.setPropB( "foo5a" );
+
+        Foo5B foo5b = new Foo5B();
+        foo5b.setPropB( "foo5b" );
+
+        Bar5 bar5 = ParameterAssignmentFactoryTestMapper.INSTANCE.foos5ToBar5( foo5a, foo5b );
+
+        // foo5a and foo5b get merged into bar5 by a custom factory
+        assertThat( bar5 ).isNotNull();
+        assertThat( bar5.getPropA() ).isEqualTo( "foo5a" );
+        assertThat( bar5.getPropB() ).isEqualTo( "foo5b" );
+        assertThat( bar5.getSomeTypeProp0() ).isEqualTo( "FOO5A" );
+        assertThat( bar5.getSomeTypeProp1() ).isEqualTo( "foo5b" );
+    }
+
+    @Test
+    public void shouldUseFactoryMethodWithFirstParamsOfMappingMethod() {
+        Foo6A foo6a = new Foo6A();
+        foo6a.setPropB( "foo6a" );
+
+        Foo6B foo6b = new Foo6B();
+        foo6b.setPropB( "foo6b" );
+
+        Bar6 bar6 = ParameterAssignmentFactoryTestMapper.INSTANCE.foos6ToBar6( foo6a, foo6b );
+
+        assertThat( bar6 ).isNotNull();
+        assertThat( bar6.getPropA() ).isEqualTo( "foo6a" );
+        assertThat( bar6.getPropB() ).isEqualTo( "foo6b" );
+        assertThat( bar6.getSomeTypeProp0() ).isEqualTo( "FOO6A" );
+    }
+
+    @Test
+    public void shouldUseFactoryMethodWithSecondParamsOfMappingMethod() {
+        Foo7A foo7a = new Foo7A();
+        foo7a.setPropB( "foo7a" );
+
+        Foo7B foo7b = new Foo7B();
+        foo7b.setPropB( "foo7b" );
+
+        Bar7 bar7 = ParameterAssignmentFactoryTestMapper.INSTANCE.foos7ToBar7( foo7a, foo7b );
+
+        assertThat( bar7 ).isNotNull();
+        assertThat( bar7.getPropA() ).isEqualTo( "foo7a" );
+        assertThat( bar7.getPropB() ).isEqualTo( "foo7b" );
+        assertThat( bar7.getSomeTypeProp0() ).isEqualTo( "FOO7B" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/ParameterAssignmentFactoryTestMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/assignment/ParameterAssignmentFactoryTestMapper.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.assignment;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Remo Meier
+ */
+@Mapper( uses = { Bar5Factory.class, Bar6Factory.class, Bar7Factory.class } )
+public abstract class ParameterAssignmentFactoryTestMapper {
+    public static final ParameterAssignmentFactoryTestMapper INSTANCE =
+        Mappers.getMapper( ParameterAssignmentFactoryTestMapper.class );
+
+    public abstract Bar5 foos5ToBar5(Foo5A foo5A, Foo5B foo5B);
+
+    public abstract Bar6 foos6ToBar6(Foo6A foo6A, Foo6B foo6B);
+
+    public abstract Bar7 foos7ToBar7(Foo7A foo7A, Foo7B foo7B);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/c/BarFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/c/BarFactory.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.c;
+
+import org.mapstruct.ObjectFactory;
+import org.mapstruct.ap.test.factories.Bar4;
+import org.mapstruct.ap.test.factories.Foo4;
+
+/**
+ * @author Remo Meier
+ */
+public class BarFactory {
+
+    @ObjectFactory
+    public Bar4 createBar4(Foo4 foo4) {
+        return new Bar4( foo4.getProp().toUpperCase() );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/Bar10.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/Bar10.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.qualified;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar10 {
+    private String prop;
+
+    private final String someTypeProp;
+
+    public Bar10(String someTypeProp) {
+        this.someTypeProp = someTypeProp;
+    }
+
+    public String getProp() {
+        return prop;
+    }
+
+    public void setProp(String prop) {
+        this.prop = prop;
+    }
+
+    public String getSomeTypeProp() {
+        return someTypeProp;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/Bar10Factory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/Bar10Factory.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.qualified;
+
+import org.mapstruct.Named;
+import org.mapstruct.ObjectFactory;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar10Factory {
+
+    @ObjectFactory
+    public Bar10 createBar10Lower(Foo10 foo10) {
+        return new Bar10( foo10.getProp().toLowerCase() );
+    }
+
+    @TestQualifier
+    @ObjectFactory
+    public Bar10 createBar10Upper(Foo10 foo10) {
+        return new Bar10( foo10.getProp().toUpperCase() );
+    }
+
+    @Named( "Bar10NamedQualifier" )
+    @ObjectFactory
+    public Bar10 createBar10Camel(Foo10 foo10) {
+        char firstLetter =  Character.toUpperCase( foo10.getProp().charAt( 0 ) );
+        return new Bar10( firstLetter + foo10.getProp().toLowerCase().substring( 1 ) );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/Foo10.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/Foo10.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.qualified;
+
+/**
+ * @author Remo Meier
+ */
+public class Foo10 {
+    private String prop;
+
+    public String getProp() {
+        return prop;
+    }
+
+    public void setProp(String prop) {
+        this.prop = prop;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/QualifiedFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/QualifiedFactoryTest.java
@@ -1,0 +1,70 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.qualified;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Remo Meier
+ */
+@WithClasses( { Foo10.class, Bar10.class, TestQualifier.class, Bar10Factory.class, QualifiedFactoryTestMapper.class } )
+@RunWith( AnnotationProcessorTestRunner.class )
+public class QualifiedFactoryTest {
+
+    @Test
+    public void shouldUseFactoryWithoutQualifier() {
+        Foo10 foo10 = new Foo10();
+        foo10.setProp( "foo10" );
+
+        Bar10 bar10 = QualifiedFactoryTestMapper.INSTANCE.foo10ToBar10Lower( foo10 );
+
+        assertThat( bar10 ).isNotNull();
+        assertThat( bar10.getProp() ).isEqualTo( "foo10" );
+        assertThat( bar10.getSomeTypeProp() ).isEqualTo( "foo10" );
+    }
+
+    @Test
+    public void shouldUseFactoryWithQualifier() {
+        Foo10 foo10 = new Foo10();
+        foo10.setProp( "foo10" );
+
+        Bar10 bar10 = QualifiedFactoryTestMapper.INSTANCE.foo10ToBar10Lower( foo10 );
+
+        assertThat( bar10 ).isNotNull();
+        assertThat( bar10.getProp() ).isEqualTo( "foo10" );
+        assertThat( bar10.getSomeTypeProp() ).isEqualTo( "foo10" );
+    }
+
+    @Test
+    public void shouldUseFactoryWithQualifierName() {
+        Foo10 foo10 = new Foo10();
+        foo10.setProp( "foo10" );
+
+        Bar10 bar10 = QualifiedFactoryTestMapper.INSTANCE.foo10ToBar10Camel( foo10 );
+
+        assertThat( bar10 ).isNotNull();
+        assertThat( bar10.getProp() ).isEqualTo( "foo10" );
+        assertThat( bar10.getSomeTypeProp() ).isEqualTo( "Foo10" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/QualifiedFactoryTestMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/QualifiedFactoryTestMapper.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.qualified;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Remo Meier
+ */
+@Mapper( uses = { Bar10Factory.class } )
+public abstract class QualifiedFactoryTestMapper {
+    public static final QualifiedFactoryTestMapper INSTANCE = Mappers.getMapper( QualifiedFactoryTestMapper.class );
+
+    public abstract Bar10 foo10ToBar10Lower(Foo10 foo10);
+
+    @BeanMapping( qualifiedBy = TestQualifier.class )
+    public abstract Bar10 foo10ToBar10Upper(Foo10 foo10);
+
+    @BeanMapping( qualifiedByName = "Bar10NamedQualifier" )
+    public abstract Bar10 foo10ToBar10Camel(Foo10 foo10);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/TestQualifier.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/qualified/TestQualifier.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.qualified;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.mapstruct.Qualifier;
+
+/**
+ * @author Remo Meier
+ */
+@Qualifier
+@Target( ElementType.METHOD )
+@Retention( RetentionPolicy.CLASS )
+public @interface TestQualifier {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/Bar9Base.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/Bar9Base.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.targettype;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar9Base {
+    private String prop;
+
+    private final String someTypeProp;
+
+    public Bar9Base(String someTypeProp) {
+        this.someTypeProp = someTypeProp;
+    }
+
+    public String getProp() {
+        return prop;
+    }
+
+    public void setProp(String prop) {
+        this.prop = prop;
+    }
+
+    public String getSomeTypeProp() {
+        return someTypeProp;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/Bar9Child.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/Bar9Child.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.targettype;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar9Child extends Bar9Base {
+
+    private String childProp;
+
+    public Bar9Child(String someTypeProp) {
+        super( someTypeProp );
+    }
+
+    public String getChildProp() {
+        return childProp;
+    }
+
+    public void setChildProp(String childProp) {
+        this.childProp = childProp;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/Bar9Factory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/Bar9Factory.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.targettype;
+
+import org.mapstruct.ObjectFactory;
+import org.mapstruct.TargetType;
+
+/**
+ * @author Remo Meier
+ */
+public class Bar9Factory {
+
+    @SuppressWarnings( "unchecked" )
+    @ObjectFactory
+    public <T extends Bar9Base> T createBar9(Foo9Base foo8, @TargetType Class<T> targetType) {
+        if ( targetType == Bar9Base.class ) {
+            return (T) new Bar9Base( foo8.getProp().toUpperCase() );
+        }
+        else {
+            return (T) new Bar9Child( foo8.getProp().toUpperCase() );
+        }
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/Foo9Base.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/Foo9Base.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.targettype;
+
+/**
+ * @author Remo Meier
+ */
+public class Foo9Base {
+    private String prop;
+
+    public String getProp() {
+        return prop;
+    }
+
+    public void setProp(String prop) {
+        this.prop = prop;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/Foo9Child.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/Foo9Child.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.targettype;
+
+/**
+ * @author Remo Meier
+ */
+public class Foo9Child extends Foo9Base {
+
+    private String childProp;
+
+    public String getChildProp() {
+        return childProp;
+    }
+
+    public void setChildProp(String childProp) {
+        this.childProp = childProp;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/TargetTypeFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/TargetTypeFactoryTest.java
@@ -1,0 +1,61 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.targettype;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Remo Meier
+ */
+@WithClasses( { Foo9Base.class, Foo9Child.class, Bar9Base.class, Bar9Child.class, Bar9Factory.class,
+    TargetTypeFactoryTestMapper.class } )
+@RunWith( AnnotationProcessorTestRunner.class )
+public class TargetTypeFactoryTest {
+
+    @Test
+    public void shouldUseFactoryTwoCreateBaseClassDueToTargetType() {
+        Foo9Base foo9 = new Foo9Base();
+        foo9.setProp( "foo9" );
+
+        Bar9Base bar9 = TargetTypeFactoryTestMapper.INSTANCE.foo9BaseToBar9Base( foo9 );
+
+        assertThat( bar9 ).isNotNull();
+        assertThat( bar9.getProp() ).isEqualTo( "foo9" );
+        assertThat( bar9.getSomeTypeProp() ).isEqualTo( "FOO9" );
+    }
+
+    @Test
+    public void shouldUseFactoryTwoCreateChildClassDueToTargetType() {
+        Foo9Child foo9 = new Foo9Child();
+        foo9.setProp( "foo9" );
+        foo9.setChildProp( "foo9Child" );
+
+        Bar9Child bar9 = TargetTypeFactoryTestMapper.INSTANCE.foo9ChildToBar9Child( foo9 );
+
+        assertThat( bar9 ).isNotNull();
+        assertThat( bar9.getProp() ).isEqualTo( "foo9" );
+        assertThat( bar9.getChildProp() ).isEqualTo( "foo9Child" );
+        assertThat( bar9.getSomeTypeProp() ).isEqualTo( "FOO9" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/TargetTypeFactoryTestMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/targettype/TargetTypeFactoryTestMapper.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.factories.targettype;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Remo Meier
+ */
+@Mapper( uses = { Bar9Factory.class } )
+public abstract class TargetTypeFactoryTestMapper {
+    public static final TargetTypeFactoryTestMapper INSTANCE = Mappers.getMapper( TargetTypeFactoryTestMapper.class );
+
+    public abstract Bar9Base foo9BaseToBar9Base(Foo9Base foo9);
+
+    public abstract Bar9Child foo9ChildToBar9Child(Foo9Child foo9);
+}


### PR DESCRIPTION
Introduced @ObjectFactory annotation to distinguish between factory and mapping methods. So far this was decided based on the lack of parameters. @ObjectFactory lets a factory method carry the same
signature as a mapping method, letting it have access to the source objects.