### PR TITLE
#962 Java 8 Stream conversions to Collections

### DIFF
--- a/core-common/src/main/java/org/mapstruct/IterableMapping.java
+++ b/core-common/src/main/java/org/mapstruct/IterableMapping.java
@@ -28,10 +28,21 @@ import java.text.DecimalFormat;
 import java.util.Date;
 
 /**
- * Configures the mapping between two iterable types, e.g. {@code List<String>} and {@code List<Date>}.
+ * Configures the mapping between two iterable like types, e.g. {@code List<String>} and {@code List<Date>}.
+ *
  *
  * <p>Note: either  @IterableMapping#dateFormat, @IterableMapping#resultType or @IterableMapping#qualifiedBy
  * must be specified</p>
+ *
+ * Supported mappings are:
+ * <ul>
+ *     <li>{@code Iterable<A>} to/from {@code Iterable<B>}/{@code Iterable<A>}</li>
+ *     <li>{@code Iterable<A>} to/from {@code B[]}/{@code A[]}</li>
+ *     <li>{@code Iterable<A>} to/from {@code Stream<B>}/{@code Stream<A>}</li>
+ *     <li>{@code A[]} to/from {@code Stream<B>}/{@code Stream<A>}</li>
+ *     <li>{@code A[]} to/from {@code B[]}</li>
+ *     <li>{@code Stream<A>} to/from {@code Stream<B>}</li>
+ * </ul>
  *
  * @author Gunnar Morling
  */

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -66,6 +66,7 @@
               </dependencies>
               <configuration>
                     <sourceHighlighter>coderay</sourceHighlighter>
+                    <sourceDocumentName>mapstruct-reference-guide.asciidoc</sourceDocumentName>
                     <attributes>
                         <mapstructVersion>${project.version}</mapstructVersion>
                         <icons>font</icons>

--- a/documentation/src/main/asciidoc/mapping-streams.asciidoc
+++ b/documentation/src/main/asciidoc/mapping-streams.asciidoc
@@ -1,0 +1,67 @@
+[[mapping-streams]]
+== Mapping Streams
+
+The mapping of `java.util.Stream` is done in a similar way as the mapping of collection types, i.e. by defining mapping
+methods with the required source and target types in a mapper interface.
+
+The generated code will contain the creation of a `Stream` from the provided `Iterable`/`Array` or will collect the
+provided `Stream` into an `Iterable`/`Array`. If a mapping method or an implicit conversion for the source and target
+element types exists, then this conversion will be done in `Stream.map`. The following shows an example:
+
+.Mapper with stream mapping methods
+====
+[source, java, linenums]
+[subs="verbatim,attributes"]
+----
+@Mapper
+public interface CarMapper {
+
+    Set<String> integerStreamToStringSet(Stream<Integer> integers);
+
+    List<CarDto> carsToCarDtos(Stream<Car> cars);
+
+    CarDto carToCarDto(Car car);
+}
+----
+====
+
+The generated implementation of the `integerStreamToStringSet` performs the conversion from `Integer` to `String` for
+each element, while the generated `carsToCarDtos()` method invokes the `carToCarDto()` method for each contained
+element as shown in the following:
+
+.Generated stream mapping methods
+====
+[source, java, linenums]
+[subs="verbatim,attributes"]
+----
+//GENERATED CODE
+@Override
+public Set<String> integerStreamToStringSet(Stream<Integer> integers) {
+    if ( integers == null ) {
+        return null;
+    }
+
+    return integers.stream().map( integer -> String.valueOf( integer ) )
+        .collect( Collectors.toCollection( HashSet<String>::new ) );
+}
+
+@Override
+public List<CarDto> carsToCarDtos(Stream<Car> cars) {
+    if ( cars == null ) {
+        return null;
+    }
+
+    return integers.stream().map( car -> carToCarDto( car ) )
+        .collect( Collectors.toCollection( ArrayList<CarDto>::new ) );
+}
+----
+====
+
+[WARNING]
+====
+If a mapping from a `Stream` to an `Iterable` or an `Array` is performed, then the passed `Stream` will be consumed
+and will no longer be possible to consume it.
+====
+
+The same implementation types as in <<implementation-types-for-collection-mappings>>, are used for the creation of the
+collection when doing `Stream` to `Iterable` mapping.

--- a/documentation/src/main/asciidoc/mapping-streams.asciidoc
+++ b/documentation/src/main/asciidoc/mapping-streams.asciidoc
@@ -4,9 +4,9 @@
 The mapping of `java.util.Stream` is done in a similar way as the mapping of collection types, i.e. by defining mapping
 methods with the required source and target types in a mapper interface.
 
-The generated code will contain the creation of a `Stream` from the provided `Iterable`/`Array` or will collect the
-provided `Stream` into an `Iterable`/`Array`. If a mapping method or an implicit conversion for the source and target
-element types exists, then this conversion will be done in `Stream.map`. The following shows an example:
+The generated code will contain the creation of a `Stream` from the provided `Iterable`/array or will collect the
+provided `Stream` into an `Iterable`/array. If a mapping method or an implicit conversion for the source and target
+element types exists, then this conversion will be done in `Stream#map()`. The following shows an example:
 
 .Mapper with stream mapping methods
 ====
@@ -25,7 +25,7 @@ public interface CarMapper {
 ----
 ====
 
-The generated implementation of the `integerStreamToStringSet` performs the conversion from `Integer` to `String` for
+The generated implementation of the `integerStreamToStringSet()` performs the conversion from `Integer` to `String` for
 each element, while the generated `carsToCarDtos()` method invokes the `carToCarDto()` method for each contained
 element as shown in the following:
 
@@ -59,9 +59,9 @@ public List<CarDto> carsToCarDtos(Stream<Car> cars) {
 
 [WARNING]
 ====
-If a mapping from a `Stream` to an `Iterable` or an `Array` is performed, then the passed `Stream` will be consumed
-and will no longer be possible to consume it.
+If a mapping from a `Stream` to an `Iterable` or an array is performed, then the passed `Stream` will be consumed
+and it will no longer be possible to consume it.
 ====
 
-The same implementation types as in <<implementation-types-for-collection-mappings>>, are used for the creation of the
+The same implementation types as in <<implementation-types-for-collection-mappings>> are used for the creation of the
 collection when doing `Stream` to `Iterable` mapping.

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -1338,6 +1338,8 @@ When an iterable or map mapping method declares an interface type as return type
 |`ConcurrentNavigableMap`|`ConcurrentSkipListMap`
 |===
 
+include::mapping-streams.asciidoc[]
+
 [[mapping-enum-types]]
 == Mapping Values
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -18,17 +18,11 @@
  */
 package org.mapstruct.ap.internal.model;
 
-import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType.DIRECT;
-import static org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism.ALWAYS;
-import static org.mapstruct.ap.internal.util.Collections.first;
-import static org.mapstruct.ap.internal.util.Collections.last;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.DeclaredType;
 
@@ -58,6 +52,11 @@ import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.ValueProvider;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+
+import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType.DIRECT;
+import static org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism.ALWAYS;
+import static org.mapstruct.ap.internal.util.Collections.first;
+import static org.mapstruct.ap.internal.util.Collections.last;
 
 /**
  * Represents the mapping between a source and target property, e.g. from {@code String Source#foo} to
@@ -261,6 +260,11 @@ public class PropertyMapping extends ModelElement {
                 }
                 else if ( sourceType.isMapType() && targetType.isMapType() ) {
                     assignment = forgeMapMapping( sourceType, targetType, rightHandSide, method.getExecutable() );
+                }
+                else if ( ( sourceType.isIterableType() && targetType.isStreamType() ) ||
+                    ( sourceType.isStreamType() && targetType.isStreamType() ) ||
+                    ( sourceType.isStreamType() && targetType.isIterableType() ) ) {
+                    assignment = forgeStreamMapping( sourceType, targetType, rightHandSide, method.getExecutable() );
                 }
                 else {
                     assignment = forgeMapping( rightHandSide );
@@ -533,16 +537,69 @@ public class PropertyMapping extends ModelElement {
             return sourcePresenceChecker;
         }
 
+        private Assignment forgeStreamMapping(Type sourceType, Type targetType, SourceRHS source,
+                                              ExecutableElement element) {
+
+            ForgedMethod methodRef = prepareForgedMethod( sourceType, targetType, source, element );
+
+            StreamMappingMethod.Builder builder = new StreamMappingMethod.Builder();
+            StreamMappingMethod streamMappingMethod = builder
+                .mappingContext( ctx )
+                .method( methodRef )
+                .selectionParameters( selectionParameters )
+                .build();
+
+            return getForgedAssignment( source, methodRef, streamMappingMethod );
+        }
+
         private Assignment forgeIterableMapping(Type sourceType, Type targetType, SourceRHS source,
                                                 ExecutableElement element) {
 
+            ForgedMethod methodRef = prepareForgedMethod( sourceType, targetType, source, element );
+            IterableMappingMethod.Builder builder = new IterableMappingMethod.Builder();
+
+            IterableMappingMethod iterableMappingMethod = builder
+                .mappingContext( ctx )
+                .method( methodRef )
+                .selectionParameters( selectionParameters )
+                .callingContextTargetPropertyName( targetPropertyName )
+                .build();
+
+            return getForgedAssignment( source, methodRef, iterableMappingMethod );
+        }
+
+        private Assignment getForgedAssignment(SourceRHS source, ForgedMethod methodRef,
+                                               MappingMethod mappingMethod) {
             Assignment assignment = null;
+            if ( mappingMethod != null ) {
+                if ( !ctx.getMappingsToGenerate().contains( mappingMethod ) ) {
+                    ctx.getMappingsToGenerate().add( mappingMethod );
+                }
+                else {
+                    String existingName = ctx.getExistingMappingMethod( mappingMethod ).getName();
+                    methodRef = new ForgedMethod( existingName, methodRef );
+                }
+
+                assignment = new MethodReference(
+                    methodRef,
+                    null,
+                    ParameterBinding.fromParameters( methodRef.getParameters() )
+                );
+                assignment.setAssignment( source );
+                forgedMethods.addAll( mappingMethod.getForgedMethods() );
+            }
+
+            return assignment;
+        }
+
+        private ForgedMethod prepareForgedMethod(Type sourceType, Type targetType, SourceRHS source,
+                                                 ExecutableElement element) {
             String name = getName( sourceType, targetType );
             name = Strings.getSaveVariableName( name, ctx.getNamesOfMappingsToGenerate() );
 
             // copy mapper configuration from the source method, its the same mapper
             MapperConfiguration config = method.getMapperConfiguration();
-            ForgedMethod methodRef = new ForgedMethod(
+            return new ForgedMethod(
                 name,
                 sourceType,
                 targetType,
@@ -556,62 +613,12 @@ public class PropertyMapping extends ModelElement {
                     targetType
                 )
             );
-            IterableMappingMethod.Builder builder = new IterableMappingMethod.Builder();
-
-            IterableMappingMethod iterableMappingMethod = builder
-                .mappingContext( ctx )
-                .method( methodRef )
-                .selectionParameters( selectionParameters )
-                .callingContextTargetPropertyName( targetPropertyName )
-                .build();
-
-            if ( iterableMappingMethod != null ) {
-                if ( !ctx.getMappingsToGenerate().contains( iterableMappingMethod ) ) {
-                    ctx.getMappingsToGenerate().add( iterableMappingMethod );
-                }
-                else {
-                    String existingName = ctx.getExistingMappingMethod( iterableMappingMethod ).getName();
-                    methodRef = new ForgedMethod( existingName, methodRef );
-                }
-
-                assignment = new MethodReference(
-                    methodRef,
-                    null,
-                    ParameterBinding.fromParameters( methodRef.getParameters() ) );
-
-                assignment.setAssignment( source );
-
-                forgedMethods.addAll( iterableMappingMethod.getForgedMethods() );
-            }
-
-            return assignment;
         }
 
         private Assignment forgeMapMapping(Type sourceType, Type targetType, SourceRHS source,
                                            ExecutableElement element) {
 
-            Assignment assignment = null;
-
-            String name = getName( sourceType, targetType );
-            name = Strings.getSaveVariableName( name, ctx.getNamesOfMappingsToGenerate() );
-
-            // copy mapper configuration from the source method, its the same mapper
-            MapperConfiguration config = method.getMapperConfiguration();
-            ForgedMethod methodRef =
-                new ForgedMethod(
-                    name,
-                    sourceType,
-                    targetType,
-                    config,
-                    element,
-                    method.getContextParameters(),
-                new ForgedMethodHistory( getForgedMethodHistory( source ),
-                    source.getSourceErrorMessagePart(),
-                    targetPropertyName,
-                    source.getSourceType(),
-                    targetType
-                )
-            );
+            ForgedMethod methodRef = prepareForgedMethod( sourceType, targetType, source, element );
 
             MapMappingMethod.Builder builder = new MapMappingMethod.Builder();
             MapMappingMethod mapMappingMethod = builder
@@ -619,24 +626,7 @@ public class PropertyMapping extends ModelElement {
                 .method( methodRef )
                 .build();
 
-            if ( mapMappingMethod != null ) {
-                if ( !ctx.getMappingsToGenerate().contains( mapMappingMethod ) ) {
-                    ctx.getMappingsToGenerate().add( mapMappingMethod );
-                }
-                else {
-                    String existingName = ctx.getExistingMappingMethod( mapMappingMethod ).getName();
-                    methodRef = new ForgedMethod( existingName, methodRef );
-                }
-                assignment = new MethodReference(
-                    methodRef,
-                    null,
-                    ParameterBinding.fromParameters( methodRef.getParameters() ) );
-                assignment.setAssignment( source );
-
-                forgedMethods.addAll( mapMappingMethod.getForgedMethods() );
-            }
-
-            return assignment;
+            return getForgedAssignment( source, methodRef, mapMappingMethod );
         }
 
         private Assignment forgeMapping(SourceRHS sourceRHS) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -547,6 +547,7 @@ public class PropertyMapping extends ModelElement {
                 .mappingContext( ctx )
                 .method( methodRef )
                 .selectionParameters( selectionParameters )
+                .callingContextTargetPropertyName( targetPropertyName )
                 .build();
 
             return getForgedAssignment( source, methodRef, streamMappingMethod );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
@@ -1,0 +1,349 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model;
+
+import static org.mapstruct.ap.internal.util.Collections.first;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import javax.lang.model.type.TypeKind;
+
+import org.mapstruct.ap.internal.model.assignment.Assignment;
+import org.mapstruct.ap.internal.model.assignment.Java8FunctionWrapper;
+import org.mapstruct.ap.internal.model.common.Parameter;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.source.ForgedMethod;
+import org.mapstruct.ap.internal.model.source.FormattingParameters;
+import org.mapstruct.ap.internal.model.source.Method;
+import org.mapstruct.ap.internal.model.source.SelectionParameters;
+import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
+import org.mapstruct.ap.internal.util.JavaStreamConstants;
+import org.mapstruct.ap.internal.util.Message;
+import org.mapstruct.ap.internal.util.Strings;
+
+/**
+ * A {@link MappingMethod} implemented by a {@link Mapper} class which maps one iterable or array type to Stream.
+ * The collection elements are mapped either by a {@link TypeConversion} or another mapping method.
+ *
+ * @author Filip Hrisafov
+ */
+public class StreamMappingMethod extends MappingMethod {
+
+    private final Assignment elementAssignment;
+    private final MethodReference factoryMethod;
+    private final boolean overridden;
+    private final boolean mapNullToDefault;
+    private final String loopVariableName;
+    private final SelectionParameters selectionParameters;
+    private final Set<Type> helperImports;
+
+    public static class Builder {
+
+        private Method method;
+        private MappingBuilderContext ctx;
+        private SelectionParameters selectionParameters;
+        private FormattingParameters formattingParameters;
+        private NullValueMappingStrategyPrism nullValueMappingStrategy;
+
+        public Builder mappingContext(MappingBuilderContext mappingContext) {
+            this.ctx = mappingContext;
+            return this;
+        }
+
+        public Builder method(Method sourceMethod) {
+            this.method = sourceMethod;
+            return this;
+        }
+
+        public Builder formattingParameters(FormattingParameters formattingParameters) {
+            this.formattingParameters = formattingParameters;
+            return this;
+        }
+
+        public Builder selectionParameters(SelectionParameters selectionParameters) {
+            this.selectionParameters = selectionParameters;
+            return this;
+        }
+
+        public Builder nullValueMappingStrategy(NullValueMappingStrategyPrism nullValueMappingStrategy) {
+            this.nullValueMappingStrategy = nullValueMappingStrategy;
+            return this;
+        }
+
+        public StreamMappingMethod build() {
+            //TODO the building of the methods is the same as the IterableMappingMethod, the only difference being
+            // the static extracted getElementType and the wrapper of the assignment using Java8FunctionWrapper
+
+            Type sourceParameterType = first( method.getSourceParameters() ).getType();
+            Type resultType = method.getResultType();
+
+            Type sourceElementType = getElementType( sourceParameterType );
+            Type targetElementType = getElementType( resultType );
+
+            String loopVariableName =
+                Strings.getSaveVariableName( sourceElementType.getName(), method.getParameterNames() );
+
+            Assignment assignment = ctx.getMappingResolver().getTargetAssignment(
+                method,
+                "stream element",
+                sourceElementType,
+                targetElementType,
+                null, // there is no targetPropertyName
+                formattingParameters,
+                selectionParameters,
+                new SourceRHS( loopVariableName, sourceElementType ),
+                false
+            );
+
+            if ( assignment == null ) {
+                if ( method instanceof ForgedMethod ) {
+                    // leave messaging to calling property mapping
+                    return null;
+                }
+                else {
+                    ctx.getMessager().printMessage( method.getExecutable(), Message.ITERABLEMAPPING_MAPPING_NOT_FOUND );
+                }
+            }
+            else {
+                if ( method instanceof ForgedMethod ) {
+                    ForgedMethod forgedMethod = (ForgedMethod) method;
+                    forgedMethod.addThrownTypes( assignment.getThrownTypes() );
+
+                }
+            }
+
+            assignment = new Java8FunctionWrapper(
+                assignment,
+                new ArrayList<Type>(),
+                ctx.getTypeFactory().getType( JavaStreamConstants.FUNCTION_FQN )
+            );
+
+            // mapNullToDefault
+            boolean mapNullToDefault = false;
+            if ( method.getMapperConfiguration() != null ) {
+                mapNullToDefault = method.getMapperConfiguration().isMapToDefault( nullValueMappingStrategy );
+            }
+
+            MethodReference factoryMethod = null;
+            if ( !method.isUpdateMethod() ) {
+                factoryMethod = ctx.getMappingResolver().getFactoryMethod( method, method.getResultType(), null );
+            }
+
+            List<LifecycleCallbackMethodReference> beforeMappingMethods =
+                LifecycleCallbackFactory.beforeMappingMethods( method, selectionParameters, ctx );
+            List<LifecycleCallbackMethodReference> afterMappingMethods =
+                LifecycleCallbackFactory.afterMappingMethods( method, selectionParameters, ctx );
+
+            Set<Type> helperImports = new HashSet<Type>();
+            if ( resultType.isIterableType() ) {
+                helperImports.add( ctx.getTypeFactory().getType( JavaStreamConstants.COLLECTORS_FQN ) );
+            }
+
+            if ( !sourceParameterType.isCollectionType() && !sourceParameterType.isArrayType() &&
+                sourceParameterType.isIterableType() ) {
+                helperImports.add( ctx.getTypeFactory().getType( JavaStreamConstants.STREAM_SUPPORT_FQN ) );
+            }
+
+            return new StreamMappingMethod(
+                method,
+                assignment,
+                factoryMethod,
+                mapNullToDefault,
+                loopVariableName,
+                beforeMappingMethods,
+                afterMappingMethods,
+                selectionParameters,
+                helperImports
+            );
+        }
+    }
+
+
+    private StreamMappingMethod(Method method, Assignment parameterAssignment, MethodReference factoryMethod,
+                                boolean mapNullToDefault, String loopVariableName,
+                                List<LifecycleCallbackMethodReference> beforeMappingReferences,
+                                List<LifecycleCallbackMethodReference> afterMappingReferences,
+                                SelectionParameters selectionParameters, Set<Type> helperImports) {
+        super( method, beforeMappingReferences, afterMappingReferences );
+        this.elementAssignment = parameterAssignment;
+        this.factoryMethod = factoryMethod;
+        this.overridden = method.overridesMethod();
+        this.mapNullToDefault = mapNullToDefault;
+        this.loopVariableName = loopVariableName;
+        this.selectionParameters = selectionParameters;
+        this.helperImports = helperImports;
+    }
+
+    public Parameter getSourceParameter() {
+        for ( Parameter parameter : getParameters() ) {
+            if ( !parameter.isMappingTarget() ) {
+                return parameter;
+            }
+        }
+
+        throw new IllegalStateException( "Method " + this + " has no source parameter." );
+    }
+
+    public Assignment getElementAssignment() {
+        return elementAssignment;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        Set<Type> types = super.getImportTypes();
+        if ( elementAssignment != null ) {
+            types.addAll( elementAssignment.getImportTypes() );
+        }
+        if ( ( factoryMethod == null ) && ( !isExistingInstanceMapping() ) ) {
+            if ( getReturnType().getImplementationType() != null ) {
+                types.addAll( getReturnType().getImplementationType().getImportTypes() );
+            }
+        }
+
+        types.addAll( helperImports );
+
+        return types;
+    }
+
+    public boolean isMapNullToDefault() {
+        return mapNullToDefault;
+    }
+
+    public boolean isOverridden() {
+        return overridden;
+    }
+
+    public String getLoopVariableName() {
+        return loopVariableName;
+    }
+
+    public String getDefaultValue() {
+        TypeKind kind = getResultElementType().getTypeMirror().getKind();
+        switch ( kind ) {
+            case BOOLEAN:
+                return "false";
+            case BYTE:
+            case SHORT:
+            case INT:
+            case CHAR:  /*"'\u0000'" would have been better, but depends on platformencoding */
+                return "0";
+            case LONG:
+                return "0L";
+            case FLOAT:
+                return "0.0f";
+            case DOUBLE:
+                return "0.0d";
+            default:
+                return "null";
+        }
+    }
+
+    public MethodReference getFactoryMethod() {
+        return this.factoryMethod;
+    }
+
+    public Type getSourceElementType() {
+        return getElementType( getSourceParameter().getType() );
+    }
+
+    public Type getResultElementType() {
+        return getElementType( getResultType() );
+    }
+
+    public String getIndex1Name() {
+        return Strings.getSaveVariableName( "i", loopVariableName, getSourceParameter().getName(), getResultName() );
+    }
+
+    public String getIndex2Name() {
+        return Strings.getSaveVariableName( "j", loopVariableName, getSourceParameter().getName(), getResultName() );
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( getResultType() == null ) ? 0 : getResultType().hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        StreamMappingMethod other = (StreamMappingMethod) obj;
+
+        if ( !getResultType().equals( other.getResultType() ) ) {
+            return false;
+        }
+
+        if ( getSourceParameters().size() != other.getSourceParameters().size() ) {
+            return false;
+        }
+
+        for ( int i = 0; i < getSourceParameters().size(); i++ ) {
+            if ( !getSourceParameters().get( i ).getType().equals( other.getSourceParameters().get( i ).getType() ) ) {
+                return false;
+            }
+
+            List<Type> thisTypeParameters = getSourceParameters().get( i ).getType().getTypeParameters();
+            List<Type> otherTypeParameters = other.getSourceParameters().get( i ).getType().getTypeParameters();
+
+            if ( !thisTypeParameters.equals( otherTypeParameters ) ) {
+                return false;
+            }
+        }
+
+        if ( this.selectionParameters != null ) {
+            if ( !this.selectionParameters.equals( other.selectionParameters ) ) {
+                return false;
+            }
+        }
+        else if ( other.selectionParameters != null ) {
+            return false;
+        }
+
+        return isMapNullToDefault() == other.isMapNullToDefault();
+    }
+
+    private static Type getElementType(Type parameterType) {
+        if ( parameterType.isArrayType() ) {
+            return parameterType.getComponentType();
+        }
+        else if ( parameterType.isIterableType() ) {
+            return first( parameterType.determineTypeArguments( Iterable.class ) ).getTypeBound();
+        }
+        else if ( parameterType.isStreamType() ) {
+            return first( parameterType.determineTypeArguments( JavaStreamConstants.STREAM_FQN ) ).getTypeBound();
+        }
+
+        throw new IllegalArgumentException( "Could not get the element type" );
+
+    }
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
@@ -130,11 +129,7 @@ public class StreamMappingMethod extends MappingMethod {
                 }
             }
 
-            assignment = new Java8FunctionWrapper(
-                assignment,
-                new ArrayList<Type>(),
-                ctx.getTypeFactory().getType( Function.class )
-            );
+            assignment = new Java8FunctionWrapper( assignment );
 
             // mapNullToDefault
             boolean mapNullToDefault = false;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
@@ -194,6 +194,7 @@ public class StreamMappingMethod extends MappingMethod {
                 targetType,
                 method.getMapperConfiguration(),
                 method.getExecutable(),
+                method.getContextParameters(),
                 forgedMethodHistory
             );
 
@@ -244,7 +245,7 @@ public class StreamMappingMethod extends MappingMethod {
 
     public Parameter getSourceParameter() {
         for ( Parameter parameter : getParameters() ) {
-            if ( !parameter.isMappingTarget() ) {
+            if ( !parameter.isMappingTarget() && !parameter.isMappingContext() ) {
                 return parameter;
             }
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
@@ -23,6 +23,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 import javax.lang.model.type.TypeKind;
 
 import org.mapstruct.ap.internal.model.assignment.Assignment;
@@ -36,7 +40,6 @@ import org.mapstruct.ap.internal.model.source.FormattingParameters;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
-import org.mapstruct.ap.internal.util.JavaStreamConstants;
 import org.mapstruct.ap.internal.util.Strings;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
@@ -118,22 +121,19 @@ public class StreamMappingMethod extends MappingMethod {
             );
 
             if ( assignment == null ) {
-
                 assignment = forgeMapping( sourceRHS, sourceElementType, targetElementType );
-
             }
             else {
                 if ( method instanceof ForgedMethod ) {
                     ForgedMethod forgedMethod = (ForgedMethod) method;
                     forgedMethod.addThrownTypes( assignment.getThrownTypes() );
-
                 }
             }
 
             assignment = new Java8FunctionWrapper(
                 assignment,
                 new ArrayList<Type>(),
-                ctx.getTypeFactory().getType( JavaStreamConstants.FUNCTION_FQN )
+                ctx.getTypeFactory().getType( Function.class )
             );
 
             // mapNullToDefault
@@ -165,12 +165,12 @@ public class StreamMappingMethod extends MappingMethod {
 
             Set<Type> helperImports = new HashSet<Type>();
             if ( resultType.isIterableType() ) {
-                helperImports.add( ctx.getTypeFactory().getType( JavaStreamConstants.COLLECTORS_FQN ) );
+                helperImports.add( ctx.getTypeFactory().getType( Collectors.class ) );
             }
 
             if ( !sourceParameterType.isCollectionType() && !sourceParameterType.isArrayType() &&
                 sourceParameterType.isIterableType() ) {
-                helperImports.add( ctx.getTypeFactory().getType( JavaStreamConstants.STREAM_SUPPORT_FQN ) );
+                helperImports.add( ctx.getTypeFactory().getType( StreamSupport.class ) );
             }
 
             return new StreamMappingMethod(
@@ -188,7 +188,6 @@ public class StreamMappingMethod extends MappingMethod {
         }
 
         private Assignment forgeMapping(SourceRHS sourceRHS, Type sourceType, Type targetType) {
-
             ForgedMethodHistory forgedMethodHistory = null;
             if ( method instanceof ForgedMethod ) {
                 forgedMethodHistory = ( (ForgedMethod) method ).getHistory();
@@ -394,11 +393,9 @@ public class StreamMappingMethod extends MappingMethod {
             return first( parameterType.determineTypeArguments( Iterable.class ) ).getTypeBound();
         }
         else if ( parameterType.isStreamType() ) {
-            return first( parameterType.determineTypeArguments( JavaStreamConstants.STREAM_FQN ) ).getTypeBound();
+            return first( parameterType.determineTypeArguments( Stream.class ) ).getTypeBound();
         }
 
         throw new IllegalArgumentException( "Could not get the element type" );
-
     }
-
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
@@ -67,6 +67,7 @@ public class StreamMappingMethod extends MappingMethod {
         private FormattingParameters formattingParameters;
         private NullValueMappingStrategyPrism nullValueMappingStrategy;
         private ForgedMethod forgedMethod;
+        private String callingContextTargetPropertyName;
 
         public Builder mappingContext(MappingBuilderContext mappingContext) {
             this.ctx = mappingContext;
@@ -93,6 +94,11 @@ public class StreamMappingMethod extends MappingMethod {
             return this;
         }
 
+        public Builder callingContextTargetPropertyName(String callingContextTargetPropertyName) {
+            this.callingContextTargetPropertyName = callingContextTargetPropertyName;
+            return this;
+        }
+
         public StreamMappingMethod build() {
             //TODO the building of the methods is the same as the IterableMappingMethod, the only difference being
             // the static extracted getElementType and the wrapper of the assignment using Java8FunctionWrapper
@@ -112,7 +118,7 @@ public class StreamMappingMethod extends MappingMethod {
             Assignment assignment = ctx.getMappingResolver().getTargetAssignment(
                 method,
                 targetElementType,
-                null, // there is no targetPropertyName
+                callingContextTargetPropertyName,
                 formattingParameters,
                 selectionParameters,
                 sourceRHS,
@@ -375,6 +381,15 @@ public class StreamMappingMethod extends MappingMethod {
             }
         }
         else if ( other.selectionParameters != null ) {
+            return false;
+        }
+
+        if ( this.factoryMethod != null ) {
+            if ( !this.factoryMethod.equals( other.factoryMethod ) ) {
+                return false;
+            }
+        }
+        else if ( other.factoryMethod != null ) {
             return false;
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.java
@@ -18,9 +18,7 @@
  */
 package org.mapstruct.ap.internal.model.assignment;
 
-import java.util.ArrayList;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.Type;
@@ -32,33 +30,21 @@ import org.mapstruct.ap.internal.model.common.Type;
  */
 public class Java8FunctionWrapper extends AssignmentWrapper {
 
-    private final List<Type> thrownTypesToExclude;
     private final Type functionType;
 
-    public Java8FunctionWrapper(Assignment decoratedAssignment, List<Type> thrownTypesToExclude, Type functionType) {
-        super( decoratedAssignment, false );
-        this.thrownTypesToExclude = thrownTypesToExclude;
-        this.functionType = functionType;
+    public Java8FunctionWrapper(Assignment decoratedAssignment) {
+        this( decoratedAssignment, null );
     }
 
-    @Override
-    public List<Type> getThrownTypes() {
-        List<Type> parentThrownTypes = super.getThrownTypes();
-        List<Type> result = new ArrayList<Type>( parentThrownTypes );
-        for ( Type thrownTypeToExclude : thrownTypesToExclude ) {
-            for ( Type parentThrownType : parentThrownTypes ) {
-                if ( parentThrownType.isAssignableTo( thrownTypeToExclude ) ) {
-                    result.remove( parentThrownType );
-                }
-            }
-        }
-        return result;
+    public Java8FunctionWrapper(Assignment decoratedAssignment, Type functionType) {
+        super( decoratedAssignment, false );
+        this.functionType = functionType;
     }
 
     @Override
     public Set<Type> getImportTypes() {
         Set<Type> imported = new HashSet<Type>( super.getImportTypes() );
-        if ( isDirectAssignment() ) {
+        if ( isDirectAssignment() && functionType != null ) {
             imported.add( functionType );
         }
         return imported;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.java
@@ -1,0 +1,76 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model.assignment;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.Type;
+
+/**
+ * Wraps the assignment in a Function to be used in Java 8 map methods
+ *
+ * @author Filip Hrisafov
+ */
+public class Java8FunctionWrapper extends AssignmentWrapper {
+
+    private final List<Type> thrownTypesToExclude;
+    private final Type functionType;
+
+    public Java8FunctionWrapper(Assignment decoratedAssignment, List<Type> thrownTypesToExclude, Type functionType) {
+        super( decoratedAssignment );
+        this.thrownTypesToExclude = thrownTypesToExclude;
+        this.functionType = functionType;
+    }
+
+    @Override
+    public List<Type> getThrownTypes() {
+        List<Type> parentThrownTypes = super.getThrownTypes();
+        List<Type> result = new ArrayList<Type>( parentThrownTypes );
+        for ( Type thrownTypeToExclude : thrownTypesToExclude ) {
+            for ( Type parentThrownType : parentThrownTypes ) {
+                if ( parentThrownType.isAssignableTo( thrownTypeToExclude ) ) {
+                    result.remove( parentThrownType );
+                }
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        Set<Type> imported = new HashSet<Type>( super.getImportTypes() );
+        if ( isDirectAssignment() ) {
+            imported.add( functionType );
+        }
+        return imported;
+    }
+
+    /**
+     *
+     * @return {@code true} if the wrapped assignment is
+     * {@link org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType#DIRECT}, {@code false} otherwise
+     */
+    public boolean isDirectAssignment() {
+        return getAssignment().getType() == AssignmentType.DIRECT;
+    }
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.java
@@ -36,7 +36,7 @@ public class Java8FunctionWrapper extends AssignmentWrapper {
     private final Type functionType;
 
     public Java8FunctionWrapper(Assignment decoratedAssignment, List<Type> thrownTypesToExclude, Type functionType) {
-        super( decoratedAssignment );
+        super( decoratedAssignment, false );
         this.thrownTypesToExclude = thrownTypesToExclude;
         this.functionType = functionType;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -226,6 +226,7 @@ public class Type extends ModelElement implements Comparable<Type> {
     public boolean isIterableOrStreamType() {
         return isIterableType() || isStreamType();
     }
+
     public boolean isCollectionType() {
         return isCollectionType;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -84,6 +84,7 @@ public class Type extends ModelElement implements Comparable<Type> {
     private final boolean isMapType;
     private final boolean isImported;
     private final boolean isVoid;
+    private final boolean isStream;
 
     private final List<String> enumConstants;
 
@@ -105,7 +106,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                 List<Type> typeParameters, Type implementationType, Type componentType,
                 String packageName, String name, String qualifiedName,
                 boolean isInterface, boolean isEnumType, boolean isIterableType,
-                boolean isCollectionType, boolean isMapType, boolean isImported) {
+                boolean isCollectionType, boolean isMapType, boolean isStreamType, boolean isImported) {
 
         this.typeUtils = typeUtils;
         this.elementUtils = elementUtils;
@@ -126,6 +127,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         this.isIterableType = isIterableType;
         this.isCollectionType = isCollectionType;
         this.isMapType = isMapType;
+        this.isStream = isStreamType;
         this.isImported = isImported;
         this.isVoid = typeMirror.getKind() == TypeKind.VOID;
 
@@ -215,6 +217,15 @@ public class Type extends ModelElement implements Comparable<Type> {
         return isIterableType || isArrayType();
     }
 
+    /**
+     * Whether this type is a sub-type of{@link Iterable}, {@link java.util.stream.Stream} or an array type
+     *
+     * @return {@code true} if this type is a sub-type of{@link Iterable}, {@link java.util.stream.Stream} or
+     * an array type, {@code false} otherwise
+     */
+    public boolean isIterableOrStreamType() {
+        return isIterableType() || isStreamType();
+    }
     public boolean isCollectionType() {
         return isCollectionType;
     }
@@ -233,6 +244,15 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     public boolean isTypeVar() {
         return (typeMirror.getKind() == TypeKind.TYPEVAR);
+    }
+
+    /**
+     * Whether this type is a sub-type of {@link java.util.stream.Stream}.
+     *
+     * @return {@code true} it this type is a sub-type of {@link java.util.stream.Stream}, {@code false otherwise}
+     */
+    public boolean isStreamType() {
+        return isStream;
     }
 
     public boolean isWildCardSuperBound() {
@@ -334,6 +354,7 @@ public class Type extends ModelElement implements Comparable<Type> {
             isIterableType,
             isCollectionType,
             isMapType,
+            isStream,
             isImported
         );
     }
@@ -840,14 +861,27 @@ public class Type extends ModelElement implements Comparable<Type> {
      * @return a list of type arguments or null, if superclass was not found
      */
     public List<Type> determineTypeArguments(Class<?> superclass) {
-        if ( qualifiedName.equals( superclass.getName() ) ) {
+        return determineTypeArguments( superclass.getName() );
+    }
+
+    /**
+     * Searches for the given superclass and collects all type arguments for the given className.
+     * This is used for support with Java 8 streams, as must use the FQN in order to be able to compile
+     * with Java 6.
+     *
+     * @param superClassName the superclass or interface the generic type arguments are searched for
+     * @return a list of type arguments or null, if superclass was not found
+     */
+
+    public List<Type> determineTypeArguments(String superClassName) {
+        if ( qualifiedName.equals( superClassName ) ) {
             return getTypeParameters();
         }
 
         List<? extends TypeMirror> directSupertypes = typeUtils.directSupertypes( typeMirror );
         for ( TypeMirror supertypemirror : directSupertypes ) {
             Type supertype = typeFactory.getType( supertypemirror );
-            List<Type> supertypeTypeArguments = supertype.determineTypeArguments( superclass );
+            List<Type> supertypeTypeArguments = supertype.determineTypeArguments( superClassName );
             if ( supertypeTypeArguments != null ) {
                 return supertypeTypeArguments;
             }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -862,27 +862,14 @@ public class Type extends ModelElement implements Comparable<Type> {
      * @return a list of type arguments or null, if superclass was not found
      */
     public List<Type> determineTypeArguments(Class<?> superclass) {
-        return determineTypeArguments( superclass.getName() );
-    }
-
-    /**
-     * Searches for the given superclass and collects all type arguments for the given className.
-     * This is used for support with Java 8 streams, as must use the FQN in order to be able to compile
-     * with Java 6.
-     *
-     * @param superClassName the superclass or interface the generic type arguments are searched for
-     * @return a list of type arguments or null, if superclass was not found
-     */
-
-    public List<Type> determineTypeArguments(String superClassName) {
-        if ( qualifiedName.equals( superClassName ) ) {
+        if ( qualifiedName.equals( superclass.getName() ) ) {
             return getTypeParameters();
         }
 
         List<? extends TypeMirror> directSupertypes = typeUtils.directSupertypes( typeMirror );
         for ( TypeMirror supertypemirror : directSupertypes ) {
             Type supertype = typeFactory.getType( supertypemirror );
-            List<Type> supertypeTypeArguments = supertype.determineTypeArguments( superClassName );
+            List<Type> supertypeTypeArguments = supertype.determineTypeArguments( superclass );
             if ( supertypeTypeArguments != null ) {
                 return supertypeTypeArguments;
             }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -54,8 +54,9 @@ import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 import org.mapstruct.ap.internal.util.AnnotationProcessingException;
-import org.mapstruct.ap.internal.util.Collections;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.Collections;
+import org.mapstruct.ap.internal.util.JavaStreamConstants;
 
 /**
  * Factory creating {@link Type} instances.
@@ -70,6 +71,7 @@ public class TypeFactory {
     private final TypeMirror iterableType;
     private final TypeMirror collectionType;
     private final TypeMirror mapType;
+    private final TypeMirror streamType;
 
     private final Map<String, Type> implementationTypes = new HashMap<String, Type>();
     private final Map<String, String> importedQualifiedTypesBySimpleName = new HashMap<String, String>();
@@ -82,6 +84,8 @@ public class TypeFactory {
         collectionType =
             typeUtils.erasure( elementUtils.getTypeElement( Collection.class.getCanonicalName() ).asType() );
         mapType = typeUtils.erasure( elementUtils.getTypeElement( Map.class.getCanonicalName() ).asType() );
+        TypeElement streamTypeElement = elementUtils.getTypeElement( JavaStreamConstants.STREAM_FQN );
+        streamType = streamTypeElement == null ? null : typeUtils.erasure( streamTypeElement.asType() );
 
         implementationTypes.put( Iterable.class.getName(), getType( ArrayList.class ) );
         implementationTypes.put( Collection.class.getName(), getType( ArrayList.class ) );
@@ -147,6 +151,7 @@ public class TypeFactory {
         boolean isIterableType = typeUtils.isSubtype( mirror, iterableType );
         boolean isCollectionType = typeUtils.isSubtype( mirror, collectionType );
         boolean isMapType = typeUtils.isSubtype( mirror, mapType );
+        boolean isStreamType = streamType != null && typeUtils.isSubtype( mirror, streamType );
 
         boolean isEnumType;
         boolean isInterface;
@@ -224,6 +229,7 @@ public class TypeFactory {
             isIterableType,
             isCollectionType,
             isMapType,
+            isStreamType,
             isImported( name, qualifiedName )
         );
     }
@@ -420,6 +426,7 @@ public class TypeFactory {
                 implementationType.isIterableType(),
                 implementationType.isCollectionType(),
                 implementationType.isMapType(),
+                implementationType.isStreamType(),
                 isImported( implementationType.getName(), implementationType.getFullyQualifiedName() )
             );
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -81,6 +81,7 @@ public class SourceMethod implements Method {
     private Boolean isValueMapping;
     private Boolean isIterableMapping;
     private Boolean isMapMapping;
+    private Boolean isStreamMapping;
 
     public static class Builder {
 
@@ -376,6 +377,16 @@ public class SourceMethod implements Method {
         return isIterableMapping;
     }
 
+    public boolean isStreamMapping() {
+        if ( isStreamMapping == null ) {
+            isStreamMapping = getSourceParameters().size() == 1
+                && ( first( getSourceParameters() ).getType().isIterableType() && getResultType().isStreamType()
+                    || first( getSourceParameters() ).getType().isStreamType() && getResultType().isIterableType()
+                    || first( getSourceParameters() ).getType().isStreamType() && getResultType().isStreamType() );
+        }
+        return isStreamMapping;
+    }
+
     public boolean isMapMapping() {
         if ( isMapMapping == null ) {
             isMapMapping = getSourceParameters().size() == 1
@@ -399,7 +410,8 @@ public class SourceMethod implements Method {
             isBeanMapping = !isIterableMapping()
                 && !isMapMapping()
                 && !isEnumMapping()
-                && !isValueMapping();
+                && !isValueMapping()
+                && !isStreamMapping();
         }
         return isBeanMapping;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -400,7 +400,7 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
 
         Type parameterType = sourceParameters.get( 0 ).getType();
 
-        if ( parameterType.isIterableType() && !resultType.isIterableType() ) {
+        if ( parameterType.isIterableOrStreamType() && !resultType.isIterableOrStreamType() ) {
             messager.printMessage( method, Message.RETRIEVAL_ITERABLE_TO_NON_ITERABLE );
             return false;
         }
@@ -410,7 +410,7 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
             return false;
         }
 
-        if ( !parameterType.isIterableType() && resultType.isIterableType() ) {
+        if ( !parameterType.isIterableOrStreamType() && resultType.isIterableOrStreamType() ) {
             messager.printMessage( method, Message.RETRIEVAL_NON_ITERABLE_TO_ITERABLE );
             return false;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/JavaStreamConstants.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/JavaStreamConstants.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.util;
+
+/**
+ * Helper holding Java Stream full qualified class names for conversion registration
+ *
+ * @author Filip Hrisafov
+ */
+public final class JavaStreamConstants {
+
+    public static final String STREAM_FQN = "java.util.stream.Stream";
+    public static final String COLLECTORS_FQN = "java.util.stream.Collectors";
+    public static final String STREAM_SUPPORT_FQN = "java.util.stream.StreamSupport";
+    public static final String OPTIONAL_FQN = "java.util.Optional";
+    public static final String FUNCTION_FQN = "java.util.function.Function";
+
+
+    private JavaStreamConstants() {
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/JavaStreamConstants.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/JavaStreamConstants.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
@@ -116,10 +116,10 @@
                                     .collect( Collectors.toCollection( <@iterableCollectionSupplier /> ) )
                                 );
         <#else>
-            <@returnLocalVerDefOrUpdate>
+            <@returnLocalVarDefOrUpdate>
                 <#lt>${sourceParameter.name}<@streamMapSupplier />
                     .collect( Collectors.toCollection( <@iterableCollectionSupplier /> ) );
-            </@returnLocalVerDefOrUpdate>
+            </@returnLocalVarDefOrUpdate>
 
         </#if>
     <#else>
@@ -128,13 +128,13 @@
             <#--TODO fhr: after the the result is no longer the same instance, how does it affect the
                 Before mapping methods. Does it even make sense to have before mapping on a stream? -->
             <#if sourceParameter.type.arrayType>
-                <@returnLocalVerDefOrUpdate>Stream.of( ${sourceParameter.name} )<@streamMapSupplier />;</@returnLocalVerDefOrUpdate>
+                <@returnLocalVarDefOrUpdate>Stream.of( ${sourceParameter.name} )<@streamMapSupplier />;</@returnLocalVarDefOrUpdate>
             <#elseif sourceParameter.type.collectionType>
-                <@returnLocalVerDefOrUpdate>${sourceParameter.name}.stream()<@streamMapSupplier />;</@returnLocalVerDefOrUpdate>
+                <@returnLocalVarDefOrUpdate>${sourceParameter.name}.stream()<@streamMapSupplier />;</@returnLocalVarDefOrUpdate>
             <#elseif sourceParameter.type.iterableType>
-                <@returnLocalVerDefOrUpdate>StreamSupport.stream( ${sourceParameter.name}.spliterator(), false )<@streamMapSupplier />;</@returnLocalVerDefOrUpdate>
+                <@returnLocalVarDefOrUpdate>StreamSupport.stream( ${sourceParameter.name}.spliterator(), false )<@streamMapSupplier />;</@returnLocalVarDefOrUpdate>
             <#else>
-                <@returnLocalVerDefOrUpdate>${sourceParameter.name}<@streamMapSupplier />;</@returnLocalVerDefOrUpdate>
+                <@returnLocalVarDefOrUpdate>${sourceParameter.name}<@streamMapSupplier />;</@returnLocalVarDefOrUpdate>
             </#if>
         </#if>
 
@@ -205,6 +205,6 @@
         </#if>
     </@compress>
 </#macro>
-<#macro returnLocalVerDefOrUpdate>
+<#macro returnLocalVarDefOrUpdate>
     <#if canReturnImmediatelly><#if returnType.name != "void">return </#if><#elseif !needVarDefine><@iterableLocalVarDef/> ${resultName} = <#else>${resultName} = </#if><#nested />
 </#macro>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
@@ -1,0 +1,186 @@
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.StreamMappingMethod" -->
+<#--
+
+     Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+     and/or other contributors as indicated by the @authors tag. See the
+     copyright.txt file in the distribution for a full listing of all
+     contributors.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<#if overridden>@Override</#if>
+<#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
+    <#--TODO does it even make sense to do a callback if the result is a Stream, as they are immutable-->
+    <#list beforeMappingReferencesWithoutMappingTarget as callback>
+    	<@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+    	<#if !callback_has_next>
+
+    	</#if>
+    </#list>
+    if ( ${sourceParameter.name} == null ) {
+        <#if !mapNullToDefault>
+            <#-- returned target type starts to miss-align here with target handed via param, TODO is this right? -->
+            return<#if returnType.name != "void"> null</#if>;
+        <#else>
+            <#if resultType.arrayType>
+                <#if existingInstanceMapping>
+                    <#-- we can't clear an existing array, so we've got to clear by setting values to default -->
+                    for (int ${index2Name} = 0; ${index2Name} < ${resultName}.length; ${index2Name}++ ) {
+                        ${resultName}[${index2Name}] = ${defaultValue};
+                    }
+                    return<#if returnType.name != "void"> ${resultName}</#if>;
+                <#else>
+                    return new <@includeModel object=resultElementType/>[0];
+                </#if>
+            <#elseif resultType.iterableType>
+                <#if existingInstanceMapping>
+                    ${resultName}.clear();
+                    return<#if returnType.name != "void"> ${resultName}</#if>;
+                <#else>
+                    return <@iterableCreation/>;
+                </#if>
+            <#else>
+                <#if existingInstanceMapping>
+                    <#-- We cannot update an existing stream so we just return the old one -->
+                    return<#if returnType.name != "void"> ${resultName}</#if>;
+                <#else>
+                    return Stream.empty();
+                </#if>
+            </#if>
+        </#if>
+    }
+
+    <#if resultType.arrayType>
+        <#if !existingInstanceMapping>
+            <#-- We create a null array which later will be directly assigned from the stream-->
+            ${resultElementType}[] ${resultName} = null;
+        </#if>
+    <#elseif resultType.iterableType>
+        <#if existingInstanceMapping>
+            ${resultName}.clear();
+        <#else>
+            <#-- Use the interface type on the left side, except it is java.lang.Iterable; use the implementation type - if present - on the right side -->
+            <@iterableLocalVarDef/> ${resultName} = <@iterableCreation/>;
+        </#if>
+    <#else>
+        <#-- Streams are immutable so we can't update them -->
+        <#if !existingInstanceMapping>
+            <@iterableLocalVarDef/> ${resultName} = Stream.empty();
+        </#if>
+    </#if>
+
+    <#list beforeMappingReferencesWithMappingTarget as callback>
+        <@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+        <#if !callback_has_next>
+
+        </#if>
+    </#list>
+
+    <#if resultType.arrayType>
+        <#if existingInstanceMapping>
+        int ${index1Name} = 0;
+        for ( <@includeModel object=resultElementType/> ${loopVariableName} : ${sourceParameter.name}.limit( ${resultName}.length ).map( <@includeModel object=elementAssignment targetBeanName=resultName targetType=resultElementType/> ).toArray( ${resultElementType}[]::new ) ) {
+            if ( ( ${index1Name} >= ${resultName}.length ) ) {
+                break;
+            }
+            ${resultName}[${index1Name}++] = ${loopVariableName};
+        }
+        <#else>
+        ${resultName} = ${sourceParameter.name}.map( <@includeModel object=elementAssignment targetBeanName=resultName targetType=resultElementType/> )
+                        .toArray( <@includeModel object=resultElementType/>[]::new );
+        </#if>
+    <#elseif resultType.iterableType>
+        ${resultName}.addAll( ${sourceParameter.name}.map( <@includeModel object=elementAssignment targetBeanName=resultName targetType=resultElementType/> )
+                                .collect( Collectors.toCollection( <@iterableCollectionSupplier /> ) )
+                            );
+    <#else>
+        <#-- Streams are immutable so we can't update them -->
+        <#if !existingInstanceMapping>
+            <#--TODO fhr: after the the result is no longer the same instance, how does it affect the
+                Before mapping methods. Does it even make sense to have before mapping on a stream? -->
+            <#if sourceParameter.type.arrayType>
+                ${resultName} = Stream.of( ${sourceParameter.name} )
+                                    .map( <@includeModel object=elementAssignment targetBeanName=resultName targetType=resultElementType/> );
+            <#elseif sourceParameter.type.collectionType>
+                ${resultName} = ${sourceParameter.name}.stream()
+                                    .map( <@includeModel object=elementAssignment targetBeanName=resultName targetType=resultElementType/> );
+            <#elseif sourceParameter.type.iterableType>
+                ${resultName} = StreamSupport.stream( ${sourceParameter.name}.spliterator(), false )
+                                    .map( <@includeModel object=elementAssignment targetBeanName=resultName targetType=resultElementType/> );
+            <#else>
+                ${resultName} = ${sourceParameter.name}.map( <@includeModel object=elementAssignment targetBeanName=resultName targetType=resultElementType/> );
+            </#if>
+        </#if>
+
+    </#if>
+
+    <#--TODO does it even make sense to do a callback if the result is a Stream, as they are immutable-->
+    <#list afterMappingReferences as callback>
+    	<#if callback_index = 0>
+
+    	</#if>
+    	<@includeModel object=callback targetBeanName=resultName targetType=resultType/>
+    </#list>
+
+    <#if returnType.name != "void">
+        return ${resultName};
+    </#if>
+}
+<#macro throws>
+    <#if (thrownTypes?size > 0)><#lt> throws </#if><@compress single_line=true>
+        <#list thrownTypes as exceptionType>
+            <@includeModel object=exceptionType/>
+            <#if exceptionType_has_next>, </#if><#t>
+        </#list>
+    </@compress>
+</#macro>
+<#macro iterableSize>
+    <@compress single_line=true>
+        <#if sourceParameter.type.arrayType>
+           ${sourceParameter.name}.length
+        <#else>
+           ${sourceParameter.name}.size()
+        </#if>
+    </@compress>
+</#macro>
+<#macro iterableLocalVarDef>
+    <@compress single_line=true>
+        <#if resultType.fullyQualifiedName == "java.lang.Iterable">
+            <@includeModel object=resultType.implementationType/>
+        <#else>
+            <@includeModel object=resultType/>
+        </#if>
+    </@compress>
+</#macro>
+<#macro iterableCreation>
+    <@compress single_line=true>
+        <#if factoryMethod??>
+            <@includeModel object=factoryMethod targetType=resultType/>
+        <#else>
+            new
+            <#if resultType.implementationType??>
+                <@includeModel object=resultType.implementationType/>
+            <#else>
+                <@includeModel object=resultType/></#if>()
+        </#if>
+    </@compress>
+</#macro>
+<#macro iterableCollectionSupplier>
+    <@compress single_line=true>
+        <#if resultType.implementationType??>
+            <@includeModel object=resultType.implementationType/>
+        <#else>
+            <@includeModel object=resultType/></#if>::new
+    </@compress>
+</#macro>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
@@ -1,7 +1,7 @@
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.StreamMappingMethod" -->
 <#--
 
-     Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+     Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
      and/or other contributors as indicated by the @authors tag. See the
      copyright.txt file in the distribution for a full listing of all
      contributors.

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.ftl
@@ -1,0 +1,51 @@
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.Java8FunctionWrapper" -->
+<#--
+
+     Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+     and/or other contributors as indicated by the @authors tag. See the
+     copyright.txt file in the distribution for a full listing of all
+     contributors.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<#assign sourceVarName><#if assignment.sourceLocalVarName?? >${assignment.sourceLocalVarName}<#else>${assignment.sourceReference}</#if></#assign>
+<#if (thrownTypes?size == 0) >
+    <#compress>
+        <#if directAssignment>
+        Function.identity()
+        <#else>
+        ${sourceVarName} -> <@_assignment/></#if>
+    </#compress>
+<#else>
+    <#compress>
+        ${sourceVarName} -> {
+            try {
+                return <@_assignment/>;
+            }
+            <#list thrownTypes as exceptionType>
+            catch ( <@includeModel object=exceptionType/> e ) {
+                throw new RuntimeException( e );
+            }
+            </#list>
+        }
+    </#compress>
+</#if>
+<#macro _assignment>
+    <@includeModel object=assignment
+    targetBeanName=ext.targetBeanName
+    existingInstanceMapping=ext.existingInstanceMapping
+    targetReadAccessorName=ext.targetReadAccessorName
+    targetWriteAccessorName=ext.targetWriteAccessorName
+    targetType=ext.targetType/>
+</#macro>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.ftl
@@ -1,7 +1,7 @@
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.Java8FunctionWrapper" -->
 <#--
 
-     Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+     Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
      and/or other contributors as indicated by the @authors tag. See the
      copyright.txt file in the distribution for a full listing of all
      contributors.

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/DateFormatValidatorFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/DateFormatValidatorFactoryTest.java
@@ -181,6 +181,7 @@ public class DateFormatValidatorFactoryTest {
                         false,
                         false,
                         false,
+                        false,
                         false );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
@@ -118,6 +118,7 @@ public class DefaultConversionContextTest {
                         false,
                         false,
                         false,
+                        false,
                         false );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/Colour.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/Colour.java
@@ -1,0 +1,23 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream;
+
+public enum Colour {
+    RED, GREEN, BLUE;
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/Colour.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/Colour.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/Source.java
@@ -22,59 +22,59 @@ import java.util.stream.Stream;
 
 public class Source {
 
-    private Stream<String> stringList;
-    private Stream<String> stringArrayList;
+    private Stream<String> stringStream;
+    private Stream<String> stringArrayStream;
 
-    private Stream<String> stringSet;
+    private Stream<String> stringStreamToSet;
 
-    private Stream<Integer> integerList;
+    private Stream<Integer> integerStream;
 
-    private Stream<Integer> anotherIntegerSet;
+    private Stream<Integer> anotherIntegerStream;
 
     private Stream<Colour> colours;
 
-    private Stream<String> stringList2;
+    private Stream<String> stringStream2;
 
-    private Stream<String> stringList3;
+    private Stream<String> stringStream3;
 
-    public Stream<String> getStringList() {
-        return stringList;
+    public Stream<String> getStringStream() {
+        return stringStream;
     }
 
-    public void setStringList(Stream<String> stringList) {
-        this.stringList = stringList;
+    public void setStringStream(Stream<String> stringStream) {
+        this.stringStream = stringStream;
     }
 
-    public Stream<String> getStringArrayList() {
-        return stringArrayList;
+    public Stream<String> getStringArrayStream() {
+        return stringArrayStream;
     }
 
-    public void setStringArrayList(Stream<String> stringArrayList) {
-        this.stringArrayList = stringArrayList;
+    public void setStringArrayStream(Stream<String> stringArrayStream) {
+        this.stringArrayStream = stringArrayStream;
     }
 
-    public Stream<String> getStringSet() {
-        return stringSet;
+    public Stream<String> getStringStreamToSet() {
+        return stringStreamToSet;
     }
 
-    public void setStringSet(Stream<String> stringSet) {
-        this.stringSet = stringSet;
+    public void setStringStreamToSet(Stream<String> stringStreamToSet) {
+        this.stringStreamToSet = stringStreamToSet;
     }
 
-    public Stream<Integer> getIntegerList() {
-        return integerList;
+    public Stream<Integer> getIntegerStream() {
+        return integerStream;
     }
 
-    public void setIntegerList(Stream<Integer> integerList) {
-        this.integerList = integerList;
+    public void setIntegerStream(Stream<Integer> integerStream) {
+        this.integerStream = integerStream;
     }
 
-    public Stream<Integer> getAnotherIntegerSet() {
-        return anotherIntegerSet;
+    public Stream<Integer> getAnotherIntegerStream() {
+        return anotherIntegerStream;
     }
 
-    public void setAnotherIntegerSet(Stream<Integer> anotherIntegerSet) {
-        this.anotherIntegerSet = anotherIntegerSet;
+    public void setAnotherIntegerStream(Stream<Integer> anotherIntegerStream) {
+        this.anotherIntegerStream = anotherIntegerStream;
     }
 
     public Stream<Colour> getColours() {
@@ -85,19 +85,19 @@ public class Source {
         this.colours = colours;
     }
 
-    public Stream<String> getStringList2() {
-        return stringList2;
+    public Stream<String> getStringStream2() {
+        return stringStream2;
     }
 
-    public void setStringList2(Stream<String> stringList2) {
-        this.stringList2 = stringList2;
+    public void setStringStream2(Stream<String> stringStream2) {
+        this.stringStream2 = stringStream2;
     }
 
-    public Stream<String> getStringList3() {
-        return stringList3;
+    public Stream<String> getStringStream3() {
+        return stringStream3;
     }
 
-    public void setStringList3(Stream<String> stringList3) {
-        this.stringList3 = stringList3;
+    public void setStringStream3(Stream<String> stringStream3) {
+        this.stringStream3 = stringStream3;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/Source.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/Source.java
@@ -1,0 +1,103 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream;
+
+import java.util.stream.Stream;
+
+public class Source {
+
+    private Stream<String> stringList;
+    private Stream<String> stringArrayList;
+
+    private Stream<String> stringSet;
+
+    private Stream<Integer> integerList;
+
+    private Stream<Integer> anotherIntegerSet;
+
+    private Stream<Colour> colours;
+
+    private Stream<String> stringList2;
+
+    private Stream<String> stringList3;
+
+    public Stream<String> getStringList() {
+        return stringList;
+    }
+
+    public void setStringList(Stream<String> stringList) {
+        this.stringList = stringList;
+    }
+
+    public Stream<String> getStringArrayList() {
+        return stringArrayList;
+    }
+
+    public void setStringArrayList(Stream<String> stringArrayList) {
+        this.stringArrayList = stringArrayList;
+    }
+
+    public Stream<String> getStringSet() {
+        return stringSet;
+    }
+
+    public void setStringSet(Stream<String> stringSet) {
+        this.stringSet = stringSet;
+    }
+
+    public Stream<Integer> getIntegerList() {
+        return integerList;
+    }
+
+    public void setIntegerList(Stream<Integer> integerList) {
+        this.integerList = integerList;
+    }
+
+    public Stream<Integer> getAnotherIntegerSet() {
+        return anotherIntegerSet;
+    }
+
+    public void setAnotherIntegerSet(Stream<Integer> anotherIntegerSet) {
+        this.anotherIntegerSet = anotherIntegerSet;
+    }
+
+    public Stream<Colour> getColours() {
+        return colours;
+    }
+
+    public void setColours(Stream<Colour> colours) {
+        this.colours = colours;
+    }
+
+    public Stream<String> getStringList2() {
+        return stringList2;
+    }
+
+    public void setStringList2(Stream<String> stringList2) {
+        this.stringList2 = stringList2;
+    }
+
+    public Stream<String> getStringList3() {
+        return stringList3;
+    }
+
+    public void setStringList3(Stream<String> stringList3) {
+        this.stringList3 = stringList3;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/SourceTargetMapper.java
@@ -35,10 +35,13 @@ public abstract class SourceTargetMapper {
     static final SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
 
     @Mappings({
-        @Mapping(source = "integerList", target = "integerCollection"),
-        @Mapping(source = "anotherIntegerSet", target = "anotherStringSet"),
-        @Mapping(source = "stringList2", target = "stringListNoSetter"),
-        @Mapping(source = "stringList3", target = "nonGenericStringList")
+        @Mapping(source = "stringStream", target = "stringList"),
+        @Mapping(source = "stringArrayStream", target = "stringArrayList"),
+        @Mapping(source = "stringStreamToSet", target = "stringSet"),
+        @Mapping(source = "integerStream", target = "integerCollection"),
+        @Mapping(source = "anotherIntegerStream", target = "anotherStringSet"),
+        @Mapping(source = "stringStream2", target = "stringListNoSetter"),
+        @Mapping(source = "stringStream3", target = "nonGenericStringList")
     })
     public abstract Target sourceToTarget(Source source);
 

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/SourceTargetMapper.java
@@ -1,0 +1,70 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class SourceTargetMapper {
+
+    static final SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    @Mappings({
+        @Mapping(source = "integerList", target = "integerCollection"),
+        @Mapping(source = "anotherIntegerSet", target = "anotherStringSet"),
+        @Mapping(source = "stringList2", target = "stringListNoSetter"),
+        @Mapping(source = "stringList3", target = "nonGenericStringList")
+    })
+    public abstract Target sourceToTarget(Source source);
+
+    @InheritInverseConfiguration( name = "sourceToTarget" )
+    public abstract Source targetToSource(Target target);
+
+    @InheritConfiguration
+    public abstract Target sourceToTargetTwoArg(Source source, @MappingTarget Target target);
+
+    public abstract Set<String> integerSetToStringSet(Set<Integer> integers);
+
+    @InheritInverseConfiguration
+    public abstract Set<Integer> stringSetToIntegerSet(Set<String> strings);
+
+    public abstract Set<String> colourSetToStringSet(Set<Colour> colours);
+
+    @InheritInverseConfiguration
+    public abstract Set<Colour> stringSetToColourSet(Set<String> colours);
+
+    public abstract Set<Number> integerSetToNumberSet(Stream<Integer> integers);
+
+    protected StringHolder toStringHolder(String string) {
+        return new StringHolder( string );
+    }
+
+    protected String toString(StringHolder string) {
+        return string.getString();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/SourceTargetMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/StreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/StreamMappingTest.java
@@ -62,13 +62,13 @@ public class StreamMappingTest {
         Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
 
         assertThat( source ).isNotNull();
-        assertThat( source.getStringList() ).isNull();
+        assertThat( source.getStringStream() ).isNull();
     }
 
     @Test
     public void shouldMapList() {
         Source source = new Source();
-        source.setStringList( Arrays.asList( "Bob", "Alice" ).stream() );
+        source.setStringStream( Arrays.asList( "Bob", "Alice" ).stream() );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -79,7 +79,7 @@ public class StreamMappingTest {
     @Test
     public void shouldMapListWithoutSetter() {
         Source source = new Source();
-        source.setStringList2( Arrays.asList( "Bob", "Alice" ).stream() );
+        source.setStringStream2( Arrays.asList( "Bob", "Alice" ).stream() );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -95,13 +95,13 @@ public class StreamMappingTest {
         Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
 
         assertThat( source ).isNotNull();
-        assertThat( source.getStringList() ).containsExactly( "Bob", "Alice" );
+        assertThat( source.getStringStream() ).containsExactly( "Bob", "Alice" );
     }
 
     @Test
     public void shouldMapArrayList() {
         Source source = new Source();
-        source.setStringArrayList( new ArrayList<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
+        source.setStringArrayStream( new ArrayList<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -117,13 +117,13 @@ public class StreamMappingTest {
         Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
 
         assertThat( source ).isNotNull();
-        assertThat( source.getStringArrayList() ).containsExactly( "Bob", "Alice" );
+        assertThat( source.getStringArrayStream() ).containsExactly( "Bob", "Alice" );
     }
 
     @Test
     public void shouldMapSet() {
         Source source = new Source();
-        source.setStringSet( new HashSet<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
+        source.setStringStreamToSet( new HashSet<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -139,13 +139,13 @@ public class StreamMappingTest {
         Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
 
         assertThat( source ).isNotNull();
-        assertThat( source.getStringSet() ).contains( "Bob", "Alice" );
+        assertThat( source.getStringStreamToSet() ).contains( "Bob", "Alice" );
     }
 
     @Test
     public void shouldMapListToCollection() {
         Source source = new Source();
-        source.setIntegerList( Arrays.asList( 1, 2 ).stream() );
+        source.setIntegerStream( Arrays.asList( 1, 2 ).stream() );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -161,13 +161,13 @@ public class StreamMappingTest {
         Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
 
         assertThat( source ).isNotNull();
-        assertThat( source.getIntegerList() ).containsOnly( 1, 2 );
+        assertThat( source.getIntegerStream() ).containsOnly( 1, 2 );
     }
 
     @Test
     public void shouldMapIntegerSetToStringSet() {
         Source source = new Source();
-        source.setAnotherIntegerSet( new HashSet<Integer>( Arrays.asList( 1, 2 ) ).stream() );
+        source.setAnotherIntegerStream( new HashSet<Integer>( Arrays.asList( 1, 2 ) ).stream() );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -183,7 +183,7 @@ public class StreamMappingTest {
         Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
 
         assertThat( source ).isNotNull();
-        assertThat( source.getAnotherIntegerSet() ).containsOnly( 1, 2 );
+        assertThat( source.getAnotherIntegerStream() ).containsOnly( 1, 2 );
     }
 
     @Test
@@ -220,7 +220,7 @@ public class StreamMappingTest {
     @Test
     public void shouldMapNonGenericList() {
         Source source = new Source();
-        source.setStringList3( new ArrayList<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
+        source.setStringStream3( new ArrayList<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -239,6 +239,6 @@ public class StreamMappingTest {
         Source mappedSource = SourceTargetMapper.INSTANCE.targetToSource( newTarget );
 
         assertThat( mappedSource ).isNotNull();
-        assertThat( mappedSource.getStringList3() ).containsExactly( "Bill", "Bob" );
+        assertThat( mappedSource.getStringStream3() ).containsExactly( "Bill", "Bob" );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/StreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/StreamMappingTest.java
@@ -1,0 +1,244 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+@WithClasses({
+    Source.class,
+    Target.class,
+    Colour.class,
+    SourceTargetMapper.class,
+    TestList.class,
+    StringHolderArrayList.class,
+    StringHolder.class
+})
+@IssueKey( "962" )
+@RunWith(AnnotationProcessorTestRunner.class)
+public class StreamMappingTest {
+
+    @Test
+    public void shouldMapNullList() {
+        Source source = new Source();
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getStringList() ).isNull();
+    }
+
+    @Test
+    public void shouldReverseMapNullList() {
+        Target target = new Target();
+
+        Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getStringList() ).isNull();
+    }
+
+    @Test
+    public void shouldMapList() {
+        Source source = new Source();
+        source.setStringList( Arrays.asList( "Bob", "Alice" ).stream() );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getStringList() ).containsExactly( "Bob", "Alice" );
+    }
+
+    @Test
+    public void shouldMapListWithoutSetter() {
+        Source source = new Source();
+        source.setStringList2( Arrays.asList( "Bob", "Alice" ).stream() );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getStringListNoSetter() ).containsExactly( "Bob", "Alice" );
+    }
+
+    @Test
+    public void shouldReverseMapList() {
+        Target target = new Target();
+        target.setStringList( Arrays.asList( "Bob", "Alice" ) );
+
+        Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getStringList() ).containsExactly( "Bob", "Alice" );
+    }
+
+    @Test
+    public void shouldMapArrayList() {
+        Source source = new Source();
+        source.setStringArrayList( new ArrayList<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getStringArrayList() ).containsExactly( "Bob", "Alice" );
+    }
+
+    @Test
+    public void shouldReverseMapArrayList() {
+        Target target = new Target();
+        target.setStringArrayList( new ArrayList<String>( Arrays.asList( "Bob", "Alice" ) ) );
+
+        Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getStringArrayList() ).containsExactly( "Bob", "Alice" );
+    }
+
+    @Test
+    public void shouldMapSet() {
+        Source source = new Source();
+        source.setStringSet( new HashSet<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getStringSet() ).contains( "Bob", "Alice" );
+    }
+
+    @Test
+    public void shouldReverseMapSet() {
+        Target target = new Target();
+        target.setStringSet( new HashSet<String>( Arrays.asList( "Bob", "Alice" ) ) );
+
+        Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getStringSet() ).contains( "Bob", "Alice" );
+    }
+
+    @Test
+    public void shouldMapListToCollection() {
+        Source source = new Source();
+        source.setIntegerList( Arrays.asList( 1, 2 ).stream() );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getIntegerCollection() ).containsOnly( 1, 2 );
+    }
+
+    @Test
+    public void shouldReverseMapListToCollection() {
+        Target target = new Target();
+        target.setIntegerCollection( Arrays.asList( 1, 2 ) );
+
+        Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getIntegerList() ).containsOnly( 1, 2 );
+    }
+
+    @Test
+    public void shouldMapIntegerSetToStringSet() {
+        Source source = new Source();
+        source.setAnotherIntegerSet( new HashSet<Integer>( Arrays.asList( 1, 2 ) ).stream() );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getAnotherStringSet() ).containsOnly( "1", "2" );
+    }
+
+    @Test
+    public void shouldReverseMapIntegerSetToStringSet() {
+        Target target = new Target();
+        target.setAnotherStringSet( new HashSet<String>( Arrays.asList( "1", "2" ) ) );
+
+        Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getAnotherIntegerSet() ).containsOnly( 1, 2 );
+    }
+
+    @Test
+    public void shouldMapSetOfEnumToStringSet() {
+        Source source = new Source();
+        source.setColours( EnumSet.of( Colour.BLUE, Colour.GREEN ).stream() );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getColours() ).containsOnly( "BLUE", "GREEN" );
+    }
+
+    @Test
+    public void shouldReverseMapSetOfEnumToStringSet() {
+        Target target = new Target();
+        target.setColours( new HashSet<String>( Arrays.asList( "BLUE", "GREEN" ) ) );
+
+        Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getColours() ).containsOnly( Colour.GREEN, Colour.BLUE );
+    }
+
+    @Test
+    public void shouldMapIntegerSetToNumberSet() {
+        Set<Number> numbers = SourceTargetMapper.INSTANCE
+            .integerSetToNumberSet( new HashSet<Integer>( Arrays.asList( 123, 456 ) ).stream() );
+
+        assertThat( numbers ).isNotNull();
+        assertThat( numbers ).containsOnly( 123, 456 );
+    }
+
+    @Test
+    public void shouldMapNonGenericList() {
+        Source source = new Source();
+        source.setStringList3( new ArrayList<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getNonGenericStringList() ).containsExactly(
+            new StringHolder( "Bob" ),
+            new StringHolder( "Alice" )
+        );
+
+        // Inverse direction
+        Target newTarget = new Target();
+        StringHolderArrayList nonGenericStringList = new StringHolderArrayList();
+        nonGenericStringList.addAll( Arrays.asList( new StringHolder( "Bill" ), new StringHolder( "Bob" ) ) );
+        newTarget.setNonGenericStringList( nonGenericStringList );
+
+        Source mappedSource = SourceTargetMapper.INSTANCE.targetToSource( newTarget );
+
+        assertThat( mappedSource ).isNotNull();
+        assertThat( mappedSource.getStringList3() ).containsExactly( "Bill", "Bob" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/StreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/StreamMappingTest.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/StringHolder.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/StringHolder.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/StringHolder.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/StringHolder.java
@@ -1,0 +1,66 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream;
+
+/**
+ * @author Andreas Gudian
+ *
+ */
+public class StringHolder {
+    private final String string;
+
+    public StringHolder(String string) {
+        this.string = string;
+    }
+
+    public String getString() {
+        return string;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( string == null ) ? 0 : string.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        StringHolder other = (StringHolder) obj;
+        if ( string == null ) {
+            if ( other.string != null ) {
+                return false;
+            }
+        }
+        else if ( !string.equals( other.string ) ) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/StringHolderArrayList.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/StringHolderArrayList.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/StringHolderArrayList.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/StringHolderArrayList.java
@@ -1,0 +1,29 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream;
+
+import java.util.ArrayList;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class StringHolderArrayList extends ArrayList<StringHolder> {
+
+    private static final long serialVersionUID = 1L;
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/Target.java
@@ -1,0 +1,105 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+public class Target {
+
+    private List<String> stringList;
+    private ArrayList<String> stringArrayList;
+
+    private Set<String> stringSet;
+
+    private Collection<Integer> integerCollection;
+
+    private Set<String> anotherStringSet;
+
+    private Set<String> colours;
+
+    private List<String> stringListNoSetter;
+
+    private StringHolderArrayList nonGenericStringList;
+
+    public List<String> getStringList() {
+        return stringList;
+    }
+
+    public void setStringList(List<String> stringList) {
+        this.stringList = stringList;
+    }
+
+    public ArrayList<String> getStringArrayList() {
+        return stringArrayList;
+    }
+
+    public void setStringArrayList(ArrayList<String> stringArrayList) {
+        this.stringArrayList = stringArrayList;
+    }
+
+    public Set<String> getStringSet() {
+        return stringSet;
+    }
+
+    public void setStringSet(Set<String> stringSet) {
+        this.stringSet = stringSet;
+    }
+
+    public Collection<Integer> getIntegerCollection() {
+        return integerCollection;
+    }
+
+    public void setIntegerCollection(Collection<Integer> integerCollection) {
+        this.integerCollection = integerCollection;
+    }
+
+    public Set<String> getAnotherStringSet() {
+        return anotherStringSet;
+    }
+
+    public void setAnotherStringSet(Set<String> anotherStringSet) {
+        this.anotherStringSet = anotherStringSet;
+    }
+
+    public void setColours(Set<String> colours) {
+        this.colours = colours;
+    }
+
+    public Set<String> getColours() {
+        return colours;
+    }
+
+    public List<String> getStringListNoSetter() {
+        if ( stringListNoSetter == null ) {
+            stringListNoSetter = new ArrayList<String>();
+        }
+        return stringListNoSetter;
+    }
+
+    public StringHolderArrayList getNonGenericStringList() {
+        return nonGenericStringList;
+    }
+
+    public void setNonGenericStringList(StringHolderArrayList nonGenericStringList) {
+        this.nonGenericStringList = nonGenericStringList;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/Target.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/TestList.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/TestList.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * @author Sjaak Derksen
+ */
+public class TestList<E> extends ArrayList<E> {
+
+    private static final long serialVersionUID = 1L;
+
+    private static boolean addAllCalled = false;
+
+    public static boolean isAddAllCalled() {
+        return addAllCalled;
+    }
+
+    public static void setAddAllCalled(boolean addAllCalled) {
+        TestList.addAllCalled = addAllCalled;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends E> c) {
+        addAllCalled = true;
+        return super.addAll( c );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/TestList.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/TestList.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/MyCustomException.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/MyCustomException.java
@@ -1,0 +1,25 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.base;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class MyCustomException extends Exception {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/MyCustomException.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/MyCustomException.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/Source.java
@@ -26,7 +26,6 @@ import java.util.stream.Stream;
  */
 public class Source {
 
-
     private List<Integer> ints;
 
     private Stream<Integer> stream;
@@ -48,7 +47,6 @@ public class Source {
     private Stream<String> stringArrayStream;
 
     private Stream<SourceElement> sourceElements;
-
 
     public List<Integer> getInts() {
         return ints;

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/Source.java
@@ -1,0 +1,140 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.base;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Source {
+
+
+    private List<Integer> ints;
+
+    private Stream<Integer> stream;
+
+    private Stream<String> stringStream;
+
+    private Stream<String> stringCollection;
+
+    private Stream<Integer> integerSet;
+
+    private Stream<Integer> integerIterable;
+
+    private Stream<Integer> sortedSet;
+
+    private Stream<Integer> navigableSet;
+
+    private Stream<Integer> intToStringStream;
+
+    private Stream<String> stringArrayStream;
+
+    private Stream<SourceElement> sourceElements;
+
+
+    public List<Integer> getInts() {
+        return ints;
+    }
+
+    public void setInts(List<Integer> ints) {
+        this.ints = ints;
+    }
+
+    public Stream<Integer> getStream() {
+        return stream;
+    }
+
+    public void setStream(Stream<Integer> stream) {
+        this.stream = stream;
+    }
+
+    public Stream<String> getStringStream() {
+        return stringStream;
+    }
+
+    public void setStringStream(Stream<String> stringStream) {
+        this.stringStream = stringStream;
+    }
+
+    public Stream<String> getStringCollection() {
+        return stringCollection;
+    }
+
+    public void setStringCollection(Stream<String> stringCollection) {
+        this.stringCollection = stringCollection;
+    }
+
+    public Stream<Integer> getIntegerSet() {
+        return integerSet;
+    }
+
+    public void setIntegerSet(Stream<Integer> integerSet) {
+        this.integerSet = integerSet;
+    }
+
+    public Stream<Integer> getIntegerIterable() {
+        return integerIterable;
+    }
+
+    public void setIntegerIterable(Stream<Integer> integerIterable) {
+        this.integerIterable = integerIterable;
+    }
+
+    public Stream<Integer> getSortedSet() {
+        return sortedSet;
+    }
+
+    public void setSortedSet(Stream<Integer> sortedSet) {
+        this.sortedSet = sortedSet;
+    }
+
+    public Stream<Integer> getNavigableSet() {
+        return navigableSet;
+    }
+
+    public void setNavigableSet(Stream<Integer> navigableSet) {
+        this.navigableSet = navigableSet;
+    }
+
+    public Stream<Integer> getIntToStringStream() {
+        return intToStringStream;
+    }
+
+    public void setIntToStringStream(Stream<Integer> intToStringStream) {
+        this.intToStringStream = intToStringStream;
+    }
+
+    public Stream<String> getStringArrayStream() {
+        return stringArrayStream;
+    }
+
+    public void setStringArrayStream(Stream<String> stringArrayStream) {
+        this.stringArrayStream = stringArrayStream;
+    }
+
+    public Stream<SourceElement> getSourceElements() {
+        return sourceElements;
+    }
+
+    public void setSourceElements(Stream<SourceElement> sourceElements) {
+        this.sourceElements = sourceElements;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/Source.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/SourceElement.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/SourceElement.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/SourceElement.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/SourceElement.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.base;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class SourceElement {
+
+    private String source;
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/StreamMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/StreamMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/StreamMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/StreamMapper.java
@@ -1,0 +1,52 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.base;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface StreamMapper {
+
+    StreamMapper INSTANCE = Mappers.getMapper( StreamMapper.class );
+
+    @Mappings( {
+        @Mapping( source = "stream", target = "targetStream"),
+        @Mapping( source = "sourceElements", target = "targetElements")
+    } )
+    Target map(Source source);
+
+    @InheritInverseConfiguration
+    Source map(Target target);
+
+    SourceElement mapElement(TargetElement targetElement) throws MyCustomException;
+
+    @InheritInverseConfiguration
+    TargetElement mapElement(SourceElement sourceElement);
+
+    @InheritInverseConfiguration
+    Source updateSource(Target target, @MappingTarget Source source) throws MyCustomException;
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/StreamsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/StreamsTest.java
@@ -1,0 +1,118 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.base;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.internal.util.Collections;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("962")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    Source.class,
+    Target.class,
+    StreamMapper.class,
+    MyCustomException.class,
+    TargetElement.class,
+    SourceElement.class
+})
+public class StreamsTest {
+
+    @Test
+    public void shouldMapSourceStream() throws Exception {
+        List<Integer> someInts = Arrays.asList( 1, 2, 3 );
+        Stream<Integer> stream = someInts.stream();
+        Source source = new Source();
+        source.setStream( stream );
+        source.setStringStream( Arrays.asList( "4", "5", "6", "7" ).stream() );
+        source.setInts( Arrays.asList( 1, 2, 3 ) );
+        source.setIntegerSet( Arrays.asList( 1, 1, 2, 2, 4, 4 ).stream() );
+        source.setStringCollection( Arrays.asList( "1", "1", "2", "3" ).stream().distinct() );
+        source.setIntegerIterable( Arrays.asList( 10, 11, 12 ).stream() );
+        source.setSortedSet( Arrays.asList( 12, 11, 10 ).stream() );
+        source.setNavigableSet( Arrays.asList( 12, 11, 10 ).stream() );
+        source.setIntToStringStream( Arrays.asList( 10, 11, 12 ).stream() );
+        source.setStringArrayStream( Arrays.asList( "4", "5", "6", "6" ).stream().limit( 2 ) );
+
+        SourceElement element = new SourceElement();
+        element.setSource( "source1" );
+        source.setSourceElements( Arrays.asList( element ).stream() );
+
+
+        Target target = StreamMapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getTargetStream() ).isSameAs( stream );
+        assertThat( target.getStringStream() ).containsExactly( "4", "5", "6", "7" );
+        assertThat( target.getInts() ).containsExactly( 1, 2, 3 );
+        assertThat( target.getIntegerSet() ).containsOnly( 1, 2, 4 );
+        assertThat( target.getStringCollection() ).containsExactly( "1", "2", "3" ).isInstanceOf( List.class );
+        assertThat( target.getIntegerIterable() ).containsExactly( 10, 11, 12 ).isInstanceOf( List.class );
+        assertThat( target.getSortedSet() ).containsExactly( 10, 11, 12 ).isInstanceOf( TreeSet.class );
+        assertThat( target.getNavigableSet() ).containsExactly( 10, 11, 12 ).isInstanceOf( TreeSet.class );
+        assertThat( target.getIntToStringStream() ).containsExactly( "10", "11", "12" );
+        assertThat( target.getStringArrayStream() ).containsExactly( 4, 5 );
+        assertThat( target.getTargetElements().get( 0 ).getSource() ).isEqualTo( "source1" );
+    }
+
+    @Test
+    public void shouldMapTargetStream() throws Exception {
+        List<Integer> someInts = Arrays.asList( 1, 2, 3 );
+        Stream<Integer> stream = someInts.stream();
+        Target target = new Target();
+        target.setTargetStream( stream );
+        target.setStringStream( Arrays.asList( "4", "5", "6", "7" ) );
+        target.setInts( Arrays.asList( 1, 2, 3 ).stream() );
+        target.setIntegerSet( Collections.asSet( 1, 1, 2, 2, 4, 4 ) );
+        target.setStringCollection( Collections.asSet( "1", "1", "2", "3" ) );
+        target.setIntegerIterable( Arrays.asList( 10, 11, 12 ) );
+        target.setSortedSet( new TreeSet<Integer>( Arrays.asList( 12, 11, 10 ) ) );
+        target.setNavigableSet( new TreeSet<Integer>( Arrays.asList( 12, 11, 10 ) ) );
+        target.setIntToStringStream( Arrays.asList( "4", "5", "6" ) );
+        target.setStringArrayStream( new Integer[] { 10, 11, 12 } );
+
+
+        Source source = StreamMapper.INSTANCE.map( target );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getStream() ).isSameAs( stream );
+        assertThat( source.getStringStream() ).containsExactly( "4", "5", "6", "7" );
+        assertThat( source.getInts() ).containsExactly( 1, 2, 3 );
+        assertThat( source.getIntegerSet() ).containsOnly( 1, 2, 4 );
+        assertThat( source.getStringCollection() ).containsExactly( "1", "2", "3" );
+        assertThat( source.getIntegerIterable() ).containsExactly( 10, 11, 12 );
+        assertThat( source.getSortedSet() ).containsExactly( 10, 11, 12 );
+        assertThat( source.getNavigableSet() ).containsExactly( 10, 11, 12 );
+        assertThat( source.getIntToStringStream() ).containsExactly( 4, 5, 6 );
+        assertThat( source.getStringArrayStream() ).containsExactly( "10", "11", "12" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/StreamsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/StreamsTest.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/StreamsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/StreamsTest.java
@@ -18,19 +18,21 @@
  */
 package org.mapstruct.ap.test.java8stream.base;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.util.Arrays;
 import java.util.List;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.internal.util.Collections;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Filip Hrisafov
@@ -46,6 +48,17 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
     SourceElement.class
 })
 public class StreamsTest {
+
+    @Rule
+    public final GeneratedSource generatedSource = new GeneratedSource();
+
+    @Test
+    public void shouldNotContainFunctionIdentity() throws Exception {
+        generatedSource.forMapper( StreamMapper.class )
+            .content()
+            .as( "The Mapper implementation should not use Function.identity()" )
+            .doesNotContain( "Function.identity()" );
+    }
 
     @Test
     public void shouldMapSourceStream() throws Exception {

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/Target.java
@@ -1,0 +1,142 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.base;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.stream.Stream;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Target {
+
+    private Stream<Integer> ints;
+
+    private Stream<Integer> targetStream;
+
+    private List<String> stringStream;
+
+    private Collection<String> stringCollection;
+
+    private Set<Integer> integerSet;
+
+    private Iterable<Integer> integerIterable;
+
+    private SortedSet<Integer> sortedSet;
+
+    private NavigableSet<Integer> navigableSet;
+
+    private List<String> intToStringStream;
+
+    private Integer[] stringArrayStream;
+
+    private List<TargetElement> targetElements;
+
+    public Stream<Integer> getInts() {
+        return ints;
+    }
+
+    public void setInts(Stream<Integer> ints) {
+        this.ints = ints;
+    }
+
+    public Stream<Integer> getTargetStream() {
+        return targetStream;
+    }
+
+    public void setTargetStream(Stream<Integer> targetStream) {
+        this.targetStream = targetStream;
+    }
+
+    public List<String> getStringStream() {
+        return stringStream;
+    }
+
+    public void setStringStream(List<String> stringStream) {
+        this.stringStream = stringStream;
+    }
+
+    public Collection<String> getStringCollection() {
+        return stringCollection;
+    }
+
+    public void setStringCollection(Collection<String> stringCollection) {
+        this.stringCollection = stringCollection;
+    }
+
+    public Set<Integer> getIntegerSet() {
+        return integerSet;
+    }
+
+    public void setIntegerSet(Set<Integer> integerSet) {
+        this.integerSet = integerSet;
+    }
+
+    public Iterable<Integer> getIntegerIterable() {
+        return integerIterable;
+    }
+
+    public void setIntegerIterable(Iterable<Integer> integerIterable) {
+        this.integerIterable = integerIterable;
+    }
+
+    public SortedSet<Integer> getSortedSet() {
+        return sortedSet;
+    }
+
+    public void setSortedSet(SortedSet<Integer> sortedSet) {
+        this.sortedSet = sortedSet;
+    }
+
+    public NavigableSet<Integer> getNavigableSet() {
+        return navigableSet;
+    }
+
+    public void setNavigableSet(NavigableSet<Integer> navigableSet) {
+        this.navigableSet = navigableSet;
+    }
+
+    public List<String> getIntToStringStream() {
+        return intToStringStream;
+    }
+
+    public void setIntToStringStream(List<String> intToStringStream) {
+        this.intToStringStream = intToStringStream;
+    }
+
+    public Integer[] getStringArrayStream() {
+        return stringArrayStream;
+    }
+
+    public void setStringArrayStream(Integer[] stringArrayStream) {
+        this.stringArrayStream = stringArrayStream;
+    }
+
+    public List<TargetElement> getTargetElements() {
+        return targetElements;
+    }
+
+    public void setTargetElements(List<TargetElement> targetElements) {
+        this.targetElements = targetElements;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/Target.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/TargetElement.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/TargetElement.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.base;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class TargetElement {
+
+    private String source;
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/TargetElement.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/base/TargetElement.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamContext.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamContext.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamContext.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamContext.java
@@ -1,0 +1,59 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.context;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.BeforeMapping;
+import org.mapstruct.MappingTarget;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class StreamContext {
+
+    @BeforeMapping
+    public void beforeArrayMapping(Integer[] strings) {
+        if ( strings != null && strings.length > 0 ) {
+            strings[0] = 30;
+        }
+    }
+
+    @BeforeMapping
+    public void beforeMapping(@MappingTarget Stream<Integer> stream) {
+
+    }
+
+    @BeforeMapping
+    public void beforeMapping(@MappingTarget Collection<String> collection) {
+        collection.add( "23" );
+    }
+
+    @AfterMapping
+    public void afterMapping(@MappingTarget Collection<String> collection) {
+        collection.add( "230" );
+    }
+
+    @AfterMapping
+    public Stream<String> afterMapping(@MappingTarget Stream<String> stringStream) {
+        return stringStream.limit( 2 );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextMapper.java
@@ -33,13 +33,14 @@ public interface StreamWithContextMapper {
     StreamWithContextMapper INSTANCE = Mappers.getMapper( StreamWithContextMapper.class );
 
     Collection<String> streamToCollection(Stream<Integer> integerStream);
+
     Stream<Long> collectionToStream(Collection<Integer> integerCollection);
 
     String[] streamToArray(Stream<Integer> integerStream);
+
     Stream<Integer> arrayToStream(Integer[] integers);
 
     Stream<Integer> streamToStream(Stream<String> stringStream);
+
     Stream<String> intStreamToStringStream(Stream<Integer> integerStream);
-
-
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextMapper.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.context;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(uses = StreamContext.class)
+public interface StreamWithContextMapper {
+
+    StreamWithContextMapper INSTANCE = Mappers.getMapper( StreamWithContextMapper.class );
+
+    Collection<String> streamToCollection(Stream<Integer> integerStream);
+    Stream<Long> collectionToStream(Collection<Integer> integerCollection);
+
+    String[] streamToArray(Stream<Integer> integerStream);
+    Stream<Integer> arrayToStream(Integer[] integers);
+
+    Stream<Integer> streamToStream(Stream<String> stringStream);
+    Stream<String> intStreamToStringStream(Stream<Integer> integerStream);
+
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextTest.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextTest.java
@@ -59,6 +59,6 @@ public class StreamWithContextTest {
         Collection<String> stringsStream = StreamWithContextMapper.INSTANCE.streamToCollection(
             Arrays.asList( 10, 20, 40 ).stream() );
 
-        assertThat( stringsStream ).containsOnly( "23", "10", "20", "40", "230");
+        assertThat( stringsStream ).containsOnly( "23", "10", "20", "40", "230" );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextTest.java
@@ -1,0 +1,64 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.context;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses({ StreamContext.class, StreamWithContextMapper.class })
+@IssueKey("962")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class StreamWithContextTest {
+
+    @Test
+    public void shouldApplyAfterMapping() throws Exception {
+        Stream<String> stringStream = StreamWithContextMapper.INSTANCE.intStreamToStringStream(
+            Arrays.asList( 1, 2, 3, 5 ).stream() );
+
+        assertThat( stringStream ).containsOnly( "1", "2" );
+    }
+
+    @Test
+    public void shouldApplyBeforeMappingOnArray() throws Exception {
+        Integer[] integers = new Integer[] { 1, 3 };
+        Stream<Integer> stringStream = StreamWithContextMapper.INSTANCE.arrayToStream( integers );
+
+        assertThat( stringStream ).containsOnly( 30, 3 );
+    }
+
+    @Test
+    public void shouldApplyBeforeAndAfterMappingOnCollection() throws Exception {
+        Collection<String> stringsStream = StreamWithContextMapper.INSTANCE.streamToCollection(
+            Arrays.asList( 10, 20, 40 ).stream() );
+
+        assertThat( stringsStream ).containsOnly( "23", "10", "20", "40", "230");
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/DefaultStreamImplementationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/DefaultStreamImplementationTest.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/DefaultStreamImplementationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/DefaultStreamImplementationTest.java
@@ -1,0 +1,190 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.defaultimplementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+@WithClasses({
+    Source.class,
+    Target.class,
+    SourceFoo.class,
+    TargetFoo.class,
+    SourceTargetMapper.class
+})
+@IssueKey("962")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class DefaultStreamImplementationTest {
+
+    @Test
+    public void shouldUseDefaultImplementationForNavigableSet() {
+        NavigableSet<TargetFoo> target =
+            SourceTargetMapper.INSTANCE.streamToNavigableSet( createSourceFooStream() );
+
+        assertResultList( target );
+        assertThat( target ).isInstanceOf( TreeSet.class );
+    }
+
+    @Test
+    public void shouldUseDefaultImplementationForCollection() {
+        Collection<TargetFoo> target =
+            SourceTargetMapper.INSTANCE.streamToCollection( createSourceFooStream() );
+
+        assertResultList( target );
+        assertThat( target ).isInstanceOf( ArrayList.class );
+    }
+
+    @Test
+    public void shouldUseDefaultImplementationForIterable() {
+        Iterable<TargetFoo> target =
+            SourceTargetMapper.INSTANCE.streamToIterable( createSourceFooStream() );
+
+        assertResultList( target );
+        assertThat( target ).isInstanceOf( ArrayList.class );
+    }
+
+    @Test
+    public void shouldUseDefaultImplementationForList() {
+        List<TargetFoo> target = SourceTargetMapper.INSTANCE.streamToList( createSourceFooStream() );
+
+        assertResultList( target );
+        assertThat( target ).isInstanceOf( ArrayList.class );
+    }
+
+    @Test
+    public void shouldUseDefaultImplementationForSet() {
+        Set<TargetFoo> target =
+            SourceTargetMapper.INSTANCE.streamToSet( createSourceFooStream() );
+
+        assertResultList( target );
+        assertThat( target ).isInstanceOf( HashSet.class );
+    }
+
+    @Test
+    public void shouldUseDefaultImplementationForSortedSet() {
+        SortedSet<TargetFoo> target =
+            SourceTargetMapper.INSTANCE.streamToSortedSet( createSourceFooStream() );
+
+        assertResultList( target );
+        assertThat( target ).isInstanceOf( TreeSet.class );
+    }
+
+    @Test
+    public void shouldUseTargetParameterForMapping() {
+        List<TargetFoo> target = new ArrayList<TargetFoo>();
+        SourceTargetMapper.INSTANCE.sourceFoosToTargetFoosUsingTargetParameter(
+            target,
+            createSourceFooStream()
+        );
+
+        assertResultList( target );
+    }
+
+    @Test
+    public void shouldUseTargetParameterForArrayMapping() {
+        TargetFoo[] target = new TargetFoo[3];
+        SourceTargetMapper.INSTANCE.streamToArrayUsingTargetParameter(
+            target,
+            createSourceFooStream()
+        );
+
+        assertThat( target ).isNotNull();
+        assertThat( target ).containsOnly( new TargetFoo( "Bob" ), new TargetFoo( "Alice" ), null );
+    }
+
+    @Test
+    public void shouldUseTargetParameterForArrayMappingAndSmallerArray() {
+        TargetFoo[] target = new TargetFoo[1];
+        SourceTargetMapper.INSTANCE.streamToArrayUsingTargetParameter(
+            target,
+            createSourceFooStream()
+        );
+
+        assertThat( target ).isNotNull();
+        assertThat( target ).containsOnly( new TargetFoo( "Bob" ) );
+    }
+
+    @Test
+    public void shouldUseAndReturnTargetParameterForArrayMapping() {
+        TargetFoo[] target = new TargetFoo[3];
+        TargetFoo[] result =
+            SourceTargetMapper.INSTANCE.streamToArrayUsingTargetParameterAndReturn( createSourceFooStream(), target );
+
+        assertThat( result ).isSameAs( target );
+        assertThat( target ).isNotNull();
+        assertThat( target ).containsOnly( new TargetFoo( "Bob" ), new TargetFoo( "Alice" ), null );
+    }
+
+    @Test
+    public void shouldUseAndReturnTargetParameterForArrayMappingAndSmallerArray() {
+        TargetFoo[] target = new TargetFoo[1];
+        TargetFoo[] result =
+            SourceTargetMapper.INSTANCE.streamToArrayUsingTargetParameterAndReturn( createSourceFooStream(), target );
+
+        assertThat( result ).isSameAs( target );
+        assertThat( target ).isNotNull();
+        assertThat( target ).containsOnly( new TargetFoo( "Bob" ) );
+    }
+
+    @Test
+    public void shouldUseAndReturnTargetParameterForMapping() {
+        List<TargetFoo> target = new ArrayList<TargetFoo>();
+        Iterable<TargetFoo> result =
+            SourceTargetMapper.INSTANCE
+                .sourceFoosToTargetFoosUsingTargetParameterAndReturn( createSourceFooStream(), target );
+
+        assertThat( result ).isSameAs( target );
+        assertResultList( target );
+    }
+
+    @Test
+    public void shouldUseDefaultImplementationForListWithoutSetter() {
+        Source source = new Source();
+        source.setFooStream( createSourceFooStream() );
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFooListNoSetter() ).containsExactly( new TargetFoo( "Bob" ), new TargetFoo( "Alice" ) );
+    }
+
+    private void assertResultList(Iterable<TargetFoo> fooIterable) {
+        assertThat( fooIterable ).isNotNull();
+        assertThat( fooIterable ).containsOnly( new TargetFoo( "Bob" ), new TargetFoo( "Alice" ) );
+    }
+
+    private Stream<SourceFoo> createSourceFooStream() {
+        return Arrays.asList( new SourceFoo( "Bob" ), new SourceFoo( "Alice" ) ).stream();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterMapper.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.defaultimplementation;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ *
+ */
+@Mapper
+public interface NoSetterMapper {
+
+    NoSetterMapper INSTANCE = Mappers.getMapper( NoSetterMapper.class );
+
+    NoSetterTarget toTarget(NoSetterSource source);
+
+    NoSetterTarget toTargetWithExistingTarget(NoSetterSource source, @MappingTarget NoSetterTarget preExistTarget);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterSource.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterSource.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.defaultimplementation;
+
+import java.util.stream.Stream;
+
+/**
+ * @author Filip Hrisafov
+ *
+ */
+public class NoSetterSource {
+    private Stream<String> listValues;
+
+    public Stream<String> getListValues() {
+        return listValues;
+    }
+
+    public void setListValues(Stream<String> listValues) {
+        this.listValues = listValues;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterStreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterStreamMappingTest.java
@@ -1,0 +1,61 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.defaultimplementation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisfaov
+ *
+ */
+@WithClasses({ NoSetterMapper.class, NoSetterSource.class, NoSetterTarget.class })
+@IssueKey("962")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class NoSetterStreamMappingTest {
+
+    @Test
+    public void compilesAndMapsCorrectly() {
+        NoSetterSource source = new NoSetterSource();
+        source.setListValues( Arrays.asList( "foo", "bar" ).stream() );
+
+        NoSetterTarget target = NoSetterMapper.INSTANCE.toTarget( source );
+
+        assertThat( target.getListValues() ).containsExactly( "foo", "bar" );
+
+        // now test existing instances
+
+        NoSetterSource source2 = new NoSetterSource();
+        source2.setListValues( Arrays.asList( "baz" ).stream() );
+        List<String> originalCollectionInstance = target.getListValues();
+
+        NoSetterTarget target2 = NoSetterMapper.INSTANCE.toTargetWithExistingTarget( source2, target );
+
+        assertThat( target2.getListValues() ).isSameAs( originalCollectionInstance );
+        assertThat( target2.getListValues() ).containsExactly( "baz" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterStreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterStreamMappingTest.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterTarget.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterTarget.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.defaultimplementation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Filip Hrisafov
+ *
+ */
+public class NoSetterTarget {
+    private List<String> listValues = new ArrayList<String>();
+
+    public List<String> getListValues() {
+        return listValues;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/Source.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/Source.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.defaultimplementation;
+
+import java.util.stream.Stream;
+
+public class Source {
+
+    private Stream<SourceFoo> fooStream;
+
+    public Stream<SourceFoo> getFooStream() {
+        return fooStream;
+    }
+
+    public void setFooStream(Stream<SourceFoo> fooStream) {
+        this.fooStream = fooStream;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/SourceFoo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/SourceFoo.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/SourceFoo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/SourceFoo.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.defaultimplementation;
+
+public class SourceFoo {
+
+    private String name;
+
+    public SourceFoo() {
+    }
+
+    public SourceFoo(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/SourceTargetMapper.java
@@ -1,0 +1,65 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.defaultimplementation;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface SourceTargetMapper {
+
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    @Mapping(source = "fooStream", target = "fooListNoSetter")
+    Target sourceToTarget(Source source);
+
+    TargetFoo sourceFooToTargetFoo(SourceFoo sourceFoo);
+
+    List<TargetFoo> streamToList(Stream<SourceFoo> foos);
+
+    Set<TargetFoo> streamToSet(Stream<SourceFoo> foos);
+
+    Collection<TargetFoo> streamToCollection(Stream<SourceFoo> foos);
+
+    Iterable<TargetFoo> streamToIterable(Stream<SourceFoo> foos);
+
+    void sourceFoosToTargetFoosUsingTargetParameter(@MappingTarget List<TargetFoo> targetFoos,
+                                                    Stream<SourceFoo> sourceFoos);
+
+    Iterable<TargetFoo> sourceFoosToTargetFoosUsingTargetParameterAndReturn(Stream<SourceFoo> sourceFoos,
+                                                                            @MappingTarget List<TargetFoo> targetFoos);
+
+    SortedSet<TargetFoo> streamToSortedSet(Stream<SourceFoo> foos);
+
+    NavigableSet<TargetFoo> streamToNavigableSet(Stream<SourceFoo> foos);
+
+    void streamToArrayUsingTargetParameter(@MappingTarget TargetFoo[] targetFoos, Stream<SourceFoo> sourceFoo);
+
+    TargetFoo[] streamToArrayUsingTargetParameterAndReturn(Stream<SourceFoo> sourceFoos,
+                                                           @MappingTarget TargetFoo[] targetFoos);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/SourceTargetMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/Target.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.defaultimplementation;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Target {
+
+    private List<TargetFoo> fooListNoSetter;
+
+    public List<TargetFoo> getFooListNoSetter() {
+        if ( fooListNoSetter == null ) {
+            fooListNoSetter = new ArrayList<TargetFoo>();
+        }
+        return fooListNoSetter;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/Target.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/TargetFoo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/TargetFoo.java
@@ -1,0 +1,75 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.defaultimplementation;
+
+public class TargetFoo implements Comparable<TargetFoo> {
+
+    private String name;
+
+    public TargetFoo() {
+    }
+
+    public TargetFoo(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        TargetFoo other = (TargetFoo) obj;
+        if ( name == null ) {
+            if ( other.name != null ) {
+                return false;
+            }
+        }
+        else if ( !name.equals( other.name ) ) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int compareTo(TargetFoo o) {
+        return getName().compareTo( o.getName() );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/TargetFoo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/TargetFoo.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/EmptyStreamMappingMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/EmptyStreamMappingMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/EmptyStreamMappingMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/EmptyStreamMappingMapper.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.mapstruct.IterableMapping;
+import org.mapstruct.Mapper;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface EmptyStreamMappingMapper {
+
+    @IterableMapping
+    Stream<String> dateStreamToStringStream(Stream<Date> dates);
+
+    @IterableMapping
+    Stream<String> dateListToStringStream(List<Date> dates);
+
+    @IterableMapping
+    List<String> dateListToStringStream(Stream<Date> dates);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousListToStreamNoElementMappingFound.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousListToStreamNoElementMappingFound.java
@@ -26,18 +26,13 @@ import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
 
 /**
- *
  * @author Filip Hrisafov
  */
 @Mapper
-public interface ErroneousStreamNoElementMappingFound {
+public interface ErroneousListToStreamNoElementMappingFound {
 
-    ErroneousStreamNoElementMappingFound INSTANCE =
-        Mappers.getMapper( ErroneousStreamNoElementMappingFound.class );
-
-    List<String> mapStreamToCollection(Stream<AttributedString> source);
+    ErroneousListToStreamNoElementMappingFound INSTANCE =
+        Mappers.getMapper( ErroneousListToStreamNoElementMappingFound.class );
 
     Stream<String> mapCollectionToStream(List<AttributedString> source);
-
-    Stream<String> mapStreamToStream(Stream<AttributedString> source);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousListToStreamNoElementMappingFound.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousListToStreamNoElementMappingFound.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamMappingTest.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamMappingTest.java
@@ -108,28 +108,47 @@ public class ErroneousStreamMappingTest {
     }
 
     @Test
-    @WithClasses({ ErroneousStreamNoElementMappingFound.class })
+    @WithClasses({ ErroneousStreamToStreamNoElementMappingFound.class })
     @ExpectedCompilationOutcome(
         value = CompilationResult.FAILED,
         diagnostics = {
-            @Diagnostic(type = ErroneousStreamNoElementMappingFound.class,
+            @Diagnostic(type = ErroneousStreamToStreamNoElementMappingFound.class,
                 kind = Kind.ERROR,
-                line = 38,
-                messageRegExp = "No implementation can be generated for this method. Found no method nor implicit "
-                    + "conversion for mapping source element type into target element type."),
-            @Diagnostic(type = ErroneousStreamNoElementMappingFound.class,
-                kind = Kind.ERROR,
-                line = 40,
-                messageRegExp = "No implementation can be generated for this method. Found no method nor implicit "
-                    + "conversion for mapping source element type into target element type."),
-            @Diagnostic(type = ErroneousStreamNoElementMappingFound.class,
-                kind = Kind.ERROR,
-                line = 42,
-                messageRegExp = "No implementation can be generated for this method. Found no method nor implicit "
-                    + "conversion for mapping source element type into target element type.")
-
+                line = 36,
+                messageRegExp = "Can't map .*AttributedString to .*String. " +
+                    "Consider to implement a mapping method: \".*String map(.*AttributedString value)")
         }
     )
-    public void shouldFailOnNoElementMappingFound() {
+    public void shouldFailOnNoElementMappingFoundForStreamToStream() {
+    }
+
+    @Test
+    @WithClasses({ ErroneousListToStreamNoElementMappingFound.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousListToStreamNoElementMappingFound.class,
+                kind = Kind.ERROR,
+                line = 37,
+                messageRegExp = "Can't map .*AttributedString to .*String. " +
+                    "Consider to implement a mapping method: \".*String map(.*AttributedString value)")
+        }
+    )
+    public void shouldFailOnNoElementMappingFoundForListToStream() {
+    }
+
+    @Test
+    @WithClasses({ ErroneousStreamToListNoElementMappingFound.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousStreamToListNoElementMappingFound.class,
+                kind = Kind.ERROR,
+                line = 37,
+                messageRegExp = "Can't map .*AttributedString to .*String. " +
+                    "Consider to implement a mapping method: \".*String map(.*AttributedString value)")
+        }
+    )
+    public void shouldFailOnNoElementMappingFoundForStreamToList() {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamMappingTest.java
@@ -1,0 +1,135 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+import javax.tools.Diagnostic.Kind;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Test for illegal mappings between collection/stream types, iterable and non-iterable types etc.
+ *
+ * Currently org.mapstruct.ap.test.stream.erroneous.ErroneousStreamMappingTest#shouldFailOnNoElementMappingFound
+ * and org.mapstruct.ap.test.stream.erroneous
+ * .ErroneousStreamMappingTest#shouldFailOnEmptyIterableAnnotationStreamMappings
+ * fail with the eclipse compiler, because when the result type is a Stream also the Message.GENERAL_NO_IMPLEMENTATION
+ * is reported, because Stream is an Interface. However, maybe if the resultType is stream when we
+ * do StreamMethodMapping in the MapperCreationProcessor we need to say that there is a factory method
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("962")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class ErroneousStreamMappingTest {
+
+    @Test
+    @WithClasses({ ErroneousStreamToNonStreamMapper.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousStreamToNonStreamMapper.class,
+                kind = Kind.ERROR,
+                line = 28,
+                messageRegExp = "Can't generate mapping method from iterable type to non-iterable type"),
+            @Diagnostic(type = ErroneousStreamToNonStreamMapper.class,
+                kind = Kind.ERROR,
+                line = 30,
+                messageRegExp = "Can't generate mapping method from non-iterable type to iterable type")
+        }
+    )
+    public void shouldFailToGenerateImplementationBetweenStreamAndNonStreamOrIterable() {
+    }
+
+    @Test
+    @WithClasses({ ErroneousStreamToPrimitivePropertyMapper.class, Source.class, Target.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousStreamToPrimitivePropertyMapper.class,
+                kind = Kind.ERROR,
+                line = 26,
+                messageRegExp =
+                    "Can't map property \"java.util.stream.Stream<java.lang.String> strings\" to \"int strings\". "
+                        +
+                        "Consider to declare/implement a mapping method: \"int map\\(java.util.stream.Stream<java" +
+                        ".lang.String>"
+                        + " value\\)\"")
+        }
+    )
+    public void shouldFailToGenerateImplementationBetweenCollectionAndPrimitive() {
+    }
+
+    @Test
+    @WithClasses({ EmptyStreamMappingMapper.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = EmptyStreamMappingMapper.class,
+                kind = Kind.ERROR,
+                line = 36,
+                messageRegExp = "'nullValueMappingStrategy','dateformat', 'qualifiedBy' and 'elementTargetType' are "
+                    + "undefined in @IterableMapping, define at least one of them."),
+            @Diagnostic(type = EmptyStreamMappingMapper.class,
+                kind = Kind.ERROR,
+                line = 39,
+                messageRegExp = "'nullValueMappingStrategy','dateformat', 'qualifiedBy' and 'elementTargetType' are "
+                    + "undefined in @IterableMapping, define at least one of them."),
+            @Diagnostic(type = EmptyStreamMappingMapper.class,
+                kind = Kind.ERROR,
+                line = 42,
+                messageRegExp = "'nullValueMappingStrategy','dateformat', 'qualifiedBy' and 'elementTargetType' are "
+                    + "undefined in @IterableMapping, define at least one of them.")
+        }
+    )
+    public void shouldFailOnEmptyIterableAnnotationStreamMappings() {
+    }
+
+    @Test
+    @WithClasses({ ErroneousStreamNoElementMappingFound.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousStreamNoElementMappingFound.class,
+                kind = Kind.ERROR,
+                line = 38,
+                messageRegExp = "No implementation can be generated for this method. Found no method nor implicit "
+                    + "conversion for mapping source element type into target element type."),
+            @Diagnostic(type = ErroneousStreamNoElementMappingFound.class,
+                kind = Kind.ERROR,
+                line = 40,
+                messageRegExp = "No implementation can be generated for this method. Found no method nor implicit "
+                    + "conversion for mapping source element type into target element type."),
+            @Diagnostic(type = ErroneousStreamNoElementMappingFound.class,
+                kind = Kind.ERROR,
+                line = 42,
+                messageRegExp = "No implementation can be generated for this method. Found no method nor implicit "
+                    + "conversion for mapping source element type into target element type.")
+
+        }
+    )
+    public void shouldFailOnNoElementMappingFound() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamNoElementMappingFound.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamNoElementMappingFound.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+import java.text.AttributedString;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface ErroneousStreamNoElementMappingFound {
+
+    ErroneousStreamNoElementMappingFound INSTANCE =
+        Mappers.getMapper( ErroneousStreamNoElementMappingFound.class );
+
+    List<String> mapStreamToCollection(Stream<AttributedString> source);
+
+    Stream<String> mapCollectionToStream(List<AttributedString> source);
+
+    Stream<String> mapStreamToStream(Stream<AttributedString> source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToListNoElementMappingFound.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToListNoElementMappingFound.java
@@ -16,21 +16,23 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.internal.util;
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+import java.text.AttributedString;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
 
 /**
- * Helper holding Java Stream full qualified class names for conversion registration
- *
  * @author Filip Hrisafov
  */
-public final class JavaStreamConstants {
+@Mapper
+public interface ErroneousStreamToListNoElementMappingFound {
 
-    public static final String STREAM_FQN = "java.util.stream.Stream";
-    public static final String COLLECTORS_FQN = "java.util.stream.Collectors";
-    public static final String STREAM_SUPPORT_FQN = "java.util.stream.StreamSupport";
-    public static final String OPTIONAL_FQN = "java.util.Optional";
-    public static final String FUNCTION_FQN = "java.util.function.Function";
+    ErroneousStreamToListNoElementMappingFound INSTANCE =
+        Mappers.getMapper( ErroneousStreamToListNoElementMappingFound.class );
 
-    private JavaStreamConstants() {
-    }
+    List<String> mapStreamToCollection(Stream<AttributedString> source);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToListNoElementMappingFound.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToListNoElementMappingFound.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToNonStreamMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToNonStreamMapper.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface ErroneousStreamToNonStreamMapper {
+
+    Integer stringStreamToInteger(Stream<String> strings);
+
+    Stream<String> integerToStringStream(Integer integer);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToNonStreamMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToNonStreamMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToPrimitivePropertyMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToPrimitivePropertyMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToPrimitivePropertyMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToPrimitivePropertyMapper.java
@@ -1,0 +1,27 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface ErroneousStreamToPrimitivePropertyMapper {
+
+    Target mapStreamToNonStreamAsProperty(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToStreamNoElementMappingFound.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToStreamNoElementMappingFound.java
@@ -16,21 +16,22 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.internal.util;
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+import java.text.AttributedString;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
 
 /**
- * Helper holding Java Stream full qualified class names for conversion registration
- *
  * @author Filip Hrisafov
  */
-public final class JavaStreamConstants {
+@Mapper
+public interface ErroneousStreamToStreamNoElementMappingFound {
 
-    public static final String STREAM_FQN = "java.util.stream.Stream";
-    public static final String COLLECTORS_FQN = "java.util.stream.Collectors";
-    public static final String STREAM_SUPPORT_FQN = "java.util.stream.StreamSupport";
-    public static final String OPTIONAL_FQN = "java.util.Optional";
-    public static final String FUNCTION_FQN = "java.util.function.Function";
+    ErroneousStreamToStreamNoElementMappingFound INSTANCE =
+        Mappers.getMapper( ErroneousStreamToStreamNoElementMappingFound.class );
 
-    private JavaStreamConstants() {
-    }
+    Stream<String> mapStreamToStream(Stream<AttributedString> source);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToStreamNoElementMappingFound.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToStreamNoElementMappingFound.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/Source.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/Source.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+import java.util.stream.Stream;
+
+public class Source {
+
+    private Stream<String> strings;
+
+    public Stream<String> getStrings() {
+        return strings;
+    }
+
+    public void setStrings(Stream<String> strings) {
+        this.strings = strings;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/Target.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/Target.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+public class Target {
+
+    private int strings;
+
+    public int getStrings() {
+        return strings;
+    }
+
+    public void setStrings(int strings) {
+        this.strings = strings;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Bar.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Bar.java
@@ -1,0 +1,27 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.forged;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+public class Bar {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Bar.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Bar.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousNonMappableStreamSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousNonMappableStreamSource.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousNonMappableStreamSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousNonMappableStreamSource.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.forged;
+
+import java.util.stream.Stream;
+
+public class ErroneousNonMappableStreamSource {
+
+    private Stream<Foo> nonMappableStream;
+
+    public Stream<Foo> getNonMappableStream() {
+        return nonMappableStream;
+    }
+
+    public void setNonMappableStream(Stream<Foo> nonMappableStream) {
+        this.nonMappableStream = nonMappableStream;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousNonMappableStreamTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousNonMappableStreamTarget.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousNonMappableStreamTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousNonMappableStreamTarget.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.forged;
+
+import java.util.stream.Stream;
+
+public class ErroneousNonMappableStreamTarget {
+
+    private Stream<Bar> nonMappableStream;
+
+    public Stream<Bar> getNonMappableStream() {
+        return nonMappableStream;
+    }
+
+    public void setNonMappableStream(Stream<Bar> nonMappableStream) {
+        this.nonMappableStream = nonMappableStream;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousStreamNonMappableStreamMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousStreamNonMappableStreamMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousStreamNonMappableStreamMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ErroneousStreamNonMappableStreamMapper.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.forged;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ErroneousStreamNonMappableStreamMapper {
+
+    ErroneousStreamNonMappableStreamMapper INSTANCE =
+        Mappers.getMapper( ErroneousStreamNonMappableStreamMapper.class );
+
+    ErroneousNonMappableStreamTarget sourceToTarget(ErroneousNonMappableStreamSource source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Foo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Foo.java
@@ -1,0 +1,27 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.forged;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Foo {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Foo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Foo.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ForgedStreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ForgedStreamMappingTest.java
@@ -39,7 +39,7 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
  */
 @IssueKey("962")
 @RunWith(AnnotationProcessorTestRunner.class)
-public class StreamMappingTest {
+public class ForgedStreamMappingTest {
 
     @Test
     @WithClasses({ StreamMapper.class, Source.class, Target.class })

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ForgedStreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ForgedStreamMappingTest.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ForgedStreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/ForgedStreamMappingTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.internal.util.Collections;
@@ -31,6 +32,7 @@ import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
 /**
  * Test for mappings between collection and stream types,
@@ -40,6 +42,9 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 @IssueKey("962")
 @RunWith(AnnotationProcessorTestRunner.class)
 public class ForgedStreamMappingTest {
+
+    @Rule
+    public final GeneratedSource generatedSource = new GeneratedSource();
 
     @Test
     @WithClasses({ StreamMapper.class, Source.class, Target.class })
@@ -55,6 +60,13 @@ public class ForgedStreamMappingTest {
         Source source2 = StreamMapper.INSTANCE.targetToSource( target );
         assertThat( source2 ).isNotNull();
         assertThat( source2.getFooStream() ).contains( "1", "2" );
+
+        generatedSource.forMapper( StreamMapper.class )
+            .content()
+            .as( "Mapper should not uas addAll" )
+            .doesNotContain( "addAll( " )
+            .as( "Mapper should not use Stream.empty()" )
+            .doesNotContain( "Stream.empty()" );
     }
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Source.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Source.java
@@ -1,0 +1,53 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.forged;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class Source {
+
+    private Stream<String> fooStream;
+    private Set<String> fooStream2;
+    private Stream<String> fooStream3;
+
+    public Stream<String> getFooStream() {
+        return fooStream;
+    }
+
+    public void setFooStream(Stream<String> fooStream) {
+        this.fooStream = fooStream;
+    }
+
+    public Set<String> getFooStream2() {
+        return fooStream2;
+    }
+
+    public void setFooStream2(Set<String> fooStream2) {
+        this.fooStream2 = fooStream2;
+    }
+
+    public Stream<String> getFooStream3() {
+        return fooStream3;
+    }
+
+    public void setFooStream3(Stream<String> fooStream3) {
+        this.fooStream3 = fooStream3;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/StreamMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/StreamMapper.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.forged;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface StreamMapper {
+
+    StreamMapper INSTANCE = Mappers.getMapper( StreamMapper.class );
+
+    Target sourceToTarget(Source source);
+
+    Source targetToSource(Target target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/StreamMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/StreamMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/StreamMapperNullValueMappingReturnDefault.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/StreamMapperNullValueMappingReturnDefault.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/StreamMapperNullValueMappingReturnDefault.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/StreamMapperNullValueMappingReturnDefault.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.forged;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValueMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+public interface StreamMapperNullValueMappingReturnDefault {
+
+    StreamMapperNullValueMappingReturnDefault INSTANCE =
+        Mappers.getMapper( StreamMapperNullValueMappingReturnDefault.class );
+
+    Target sourceToTarget(Source source);
+
+    Source targetToSource(Target target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/StreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/StreamMappingTest.java
@@ -1,0 +1,120 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.forged;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.tools.Diagnostic.Kind;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.internal.util.Collections;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Test for mappings between collection and stream types,
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("962")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class StreamMappingTest {
+
+    @Test
+    @WithClasses({ StreamMapper.class, Source.class, Target.class })
+    public void shouldForgeNewIterableMappingMethod() {
+
+        Source source = new Source();
+        source.setFooStream( Collections.asSet( "1", "2" ).stream() );
+
+        Target target = StreamMapper.INSTANCE.sourceToTarget( source );
+        assertThat( target ).isNotNull();
+        assertThat( target.getFooStream() ).contains( 1L, 2L );
+
+        Source source2 = StreamMapper.INSTANCE.targetToSource( target );
+        assertThat( source2 ).isNotNull();
+        assertThat( source2.getFooStream() ).contains( "1", "2" );
+    }
+
+    @Test
+    @WithClasses({
+        ErroneousStreamNonMappableStreamMapper.class,
+        ErroneousNonMappableStreamSource.class,
+        ErroneousNonMappableStreamTarget.class,
+        Foo.class,
+        Bar.class
+    })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousStreamNonMappableStreamMapper.class,
+                kind = Kind.ERROR,
+                line = 30,
+                messageRegExp = "Can't map property \".* nonMappableStream\" to \".* nonMappableStream\". "
+                    + "Consider to declare/implement a mapping method: .*."),
+        }
+    )
+    public void shouldGenerateNonMappableMethodForSetMapping() {
+    }
+
+    @Test
+    @WithClasses({ StreamMapper.class, Source.class, Target.class })
+    public void shouldForgeNewIterableMappingMethodReturnNullOnNullSource() {
+
+        Source source = new Source();
+        source.setFooStream( null );
+        source.setFooStream3( null );
+
+        Target target = StreamMapper.INSTANCE.sourceToTarget( source );
+        assertThat( target ).isNotNull();
+        assertThat( target.getFooStream() ).isNull();
+
+        Source source2 = StreamMapper.INSTANCE.targetToSource( target );
+        assertThat( source2 ).isNotNull();
+        assertThat( source2.getFooStream() ).isNull();
+        assertThat( source2.getFooStream3() ).isNull();
+    }
+
+    @Test
+    @WithClasses({ StreamMapperNullValueMappingReturnDefault.class, Source.class, Target.class })
+    public void shouldForgeNewIterableMappingMethodReturnEmptyOnNullSource() {
+
+        Source source = new Source();
+        source.setFooStream( null );
+        source.setFooStream3( null );
+
+        Target target = StreamMapperNullValueMappingReturnDefault.INSTANCE.sourceToTarget( source );
+        assertThat( target ).isNotNull();
+        assertThat( target.getFooStream() ).isEmpty();
+        assertThat( target.getFooStream3() ).isEmpty();
+
+        //The empty stream was already consumed so need to set a new one
+        target.setFooStream3( null );
+
+        Source source2 = StreamMapperNullValueMappingReturnDefault.INSTANCE.targetToSource( target );
+        assertThat( source2 ).isNotNull();
+        assertThat( source2.getFooStream() ).isEmpty();
+        assertThat( source2.getFooStream3() ).isEmpty();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Target.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/forged/Target.java
@@ -1,0 +1,53 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.forged;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+public class Target {
+
+    private Set<Long> fooStream;
+    private Stream<Long> fooStream2;
+    private Stream<Long> fooStream3;
+
+    public Set<Long> getFooStream() {
+        return fooStream;
+    }
+
+    public void setFooStream(Set<Long> fooStream) {
+        this.fooStream = fooStream;
+    }
+
+    public Stream<Long> getFooStream2() {
+        return fooStream2;
+    }
+
+    public void setFooStream2(Stream<Long> fooStream2) {
+        this.fooStream2 = fooStream2;
+    }
+
+    public Stream<Long> getFooStream3() {
+        return fooStream3;
+    }
+
+    public void setFooStream3(Stream<Long> fooStream3) {
+        this.fooStream3 = fooStream3;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/Source.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.streamtononiterable;
+
+import java.util.stream.Stream;
+
+public class Source {
+
+    private Stream<String> names;
+
+    public Stream<String> getNames() {
+        return names;
+    }
+
+    public void setNames(Stream<String> names) {
+        this.names = names;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/Source.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/SourceTargetMapper.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.streamtononiterable;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = StringListMapper.class)
+public interface SourceTargetMapper {
+
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    Target sourceToTarget(Source source);
+
+    Source targetToSource(Target target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/SourceTargetMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StreamToNonIterableMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StreamToNonIterableMappingTest.java
@@ -1,0 +1,56 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.streamtononiterable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+@WithClasses({ Source.class, Target.class, SourceTargetMapper.class, StringListMapper.class })
+@IssueKey("962")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class StreamToNonIterableMappingTest {
+
+    @Test
+    public void shouldMapStringStreamToStringUsingCustomMapper() {
+        Source source = new Source();
+        source.setNames( Arrays.asList( "Alice", "Bob", "Jim" ).stream() );
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getNames() ).isEqualTo( "Alice-Bob-Jim" );
+    }
+
+    @Test
+    public void shouldReverseMapStringStreamToStringUsingCustomMapper() {
+        Target target = new Target();
+        target.setNames( "Alice-Bob-Jim" );
+
+        Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getNames() ).containsExactly( "Alice", "Bob", "Jim" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StreamToNonIterableMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StreamToNonIterableMappingTest.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StringListMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StringListMapper.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.streamtononiterable;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class StringListMapper {
+
+    public String stringListToString(Stream<String> strings) {
+        return strings == null ? null : strings.collect( Collectors.joining( "-" ) );
+    }
+
+    public Stream<String> stringToStringList(String string) {
+        return string == null ? null : Arrays.asList( string.split( "-" ) ).stream();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StringListMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StringListMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/Target.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/Target.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.streamtononiterable;
+
+public class Target {
+
+    private String names;
+
+    public String getNames() {
+        return names;
+    }
+
+    public void setNames(String names) {
+        this.names = names;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableExtendsBoundTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableExtendsBoundTargetMapper.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface ErroneousIterableExtendsBoundTargetMapper {
+
+    List<? extends BigDecimal> map(Stream<BigDecimal> in);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableExtendsBoundTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableExtendsBoundTargetMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableSuperBoundSourceMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableSuperBoundSourceMapper.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper
+public interface ErroneousIterableSuperBoundSourceMapper {
+
+    List<BigDecimal> map(Stream<? super BigDecimal> in);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableSuperBoundSourceMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableSuperBoundSourceMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableTypeVarBoundMapperOnMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableTypeVarBoundMapperOnMapper.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface ErroneousIterableTypeVarBoundMapperOnMapper<T extends BigDecimal> {
+
+    List<BigDecimal> map(Stream<T> in);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableTypeVarBoundMapperOnMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableTypeVarBoundMapperOnMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableTypeVarBoundMapperOnMethod.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableTypeVarBoundMapperOnMethod.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableTypeVarBoundMapperOnMethod.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ErroneousIterableTypeVarBoundMapperOnMethod.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface ErroneousIterableTypeVarBoundMapperOnMethod {
+
+    <T extends BigDecimal> List<T> map(Stream<BigDecimal> in);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ExtendsBoundSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ExtendsBoundSource.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+public class ExtendsBoundSource {
+
+    private Stream<? extends Idea> elements;
+
+    private List<? extends Idea> listElements;
+
+    public Stream<? extends Idea> getElements() {
+        return elements;
+    }
+
+    public void setElements(Stream<? extends Idea> elements) {
+        this.elements = elements;
+    }
+
+    public List<? extends Idea> getListElements() {
+        return listElements;
+    }
+
+    public void setListElements(List<? extends Idea> listElements) {
+        this.listElements = listElements;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ExtendsBoundSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ExtendsBoundSource.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ExtendsBoundSourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ExtendsBoundSourceTargetMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ExtendsBoundSourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/ExtendsBoundSourceTargetMapper.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper
+public interface ExtendsBoundSourceTargetMapper {
+
+    ExtendsBoundSourceTargetMapper STM = Mappers.getMapper( ExtendsBoundSourceTargetMapper.class );
+
+    Target map(ExtendsBoundSource source);
+
+    Plan map(Idea in);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Idea.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Idea.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Idea.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Idea.java
@@ -1,0 +1,27 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Idea {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Plan.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Plan.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Plan.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Plan.java
@@ -1,0 +1,27 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Plan {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Source.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Source.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+public class Source {
+
+    private Stream<Idea> elements;
+
+    private List<Idea> listElements;
+
+    public Stream<Idea> getElements() {
+        return elements;
+    }
+
+    public void setElements(Stream<Idea> elements) {
+        this.elements = elements;
+    }
+
+    public List<Idea> getListElements() {
+        return listElements;
+    }
+
+    public void setListElements(List<Idea> listElements) {
+        this.listElements = listElements;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/SourceSuperBoundTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/SourceSuperBoundTargetMapper.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper
+public interface SourceSuperBoundTargetMapper {
+
+    SourceSuperBoundTargetMapper STM = Mappers.getMapper( SourceSuperBoundTargetMapper.class );
+
+    SuperBoundTarget map(Source source);
+
+    Plan map(Idea in);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/SourceSuperBoundTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/SourceSuperBoundTargetMapper.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/SuperBoundTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/SuperBoundTarget.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/SuperBoundTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/SuperBoundTarget.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+public class SuperBoundTarget {
+
+    private List<? super Plan> elements;
+
+    private Stream<? super Plan> listElements;
+
+    public List<? super Plan> getElements() {
+        return elements;
+    }
+
+    public void setElements(List<? super Plan> elements) {
+        this.elements = elements;
+    }
+
+    public Stream<? super Plan> getListElements() {
+        return listElements;
+    }
+
+    public void setListElements(Stream<? super Plan> listElements) {
+        this.listElements = listElements;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Target.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/Target.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+public class Target {
+
+    private List<Plan> elements;
+
+    private Stream<Plan> listElements;
+
+    public List<Plan> getElements() {
+        return elements;
+    }
+
+    public void setElements(List<Plan> elements) {
+        this.elements = elements;
+    }
+
+    public Stream<Plan> getListElements() {
+        return listElements;
+    }
+
+    public void setListElements(Stream<Plan> listElements) {
+        this.listElements = listElements;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/WildCardTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/WildCardTest.java
@@ -1,5 +1,5 @@
 /**
- *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
  *  and/or other contributors as indicated by the @authors tag. See the
  *  copyright.txt file in the distribution for a full listing of all
  *  contributors.

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/WildCardTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/wildcard/WildCardTest.java
@@ -1,0 +1,134 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.wildcard;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("962")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class WildCardTest {
+
+    @Test
+    @WithClasses({
+        ExtendsBoundSourceTargetMapper.class,
+        ExtendsBoundSource.class,
+        Target.class,
+        Plan.class,
+        Idea.class
+    })
+    public void shouldGenerateExtendsBoundSourceForgedStreamMethod() {
+
+        ExtendsBoundSource source = new ExtendsBoundSource();
+
+        Target target = ExtendsBoundSourceTargetMapper.STM.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getElements() ).isNull();
+        assertThat( target.getListElements() ).isNull();
+
+    }
+
+    @Test
+    @WithClasses({
+        SourceSuperBoundTargetMapper.class,
+        Source.class,
+        SuperBoundTarget.class,
+        Plan.class,
+        Idea.class
+    })
+    public void shouldGenerateSuperBoundTargetForgedIterableMethod() {
+
+        Source source = new Source();
+
+        SuperBoundTarget target = SourceSuperBoundTargetMapper.STM.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getElements() ).isNull();
+        assertThat( target.getListElements() ).isNull();
+
+    }
+
+    @Test
+    @WithClasses({ ErroneousIterableSuperBoundSourceMapper.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousIterableSuperBoundSourceMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 34,
+                messageRegExp = "Can't generate mapping method for a wildcard super bound source.")
+        }
+    )
+    public void shouldFailOnSuperBoundSource() {
+    }
+
+    @Test
+    @WithClasses({ ErroneousIterableExtendsBoundTargetMapper.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousIterableExtendsBoundTargetMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 34,
+                messageRegExp = "Can't generate mapping method for a wildcard extends bound result.")
+        }
+    )
+    public void shouldFailOnExtendsBoundTarget() {
+    }
+
+    @Test
+    @WithClasses({ ErroneousIterableTypeVarBoundMapperOnMethod.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousIterableTypeVarBoundMapperOnMethod.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 34,
+                messageRegExp = "Can't generate mapping method for a generic type variable target.")
+        }
+    )
+    public void shouldFailOnTypeVarSource() {
+    }
+
+    @Test
+    @WithClasses({ ErroneousIterableTypeVarBoundMapperOnMapper.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousIterableTypeVarBoundMapperOnMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 34,
+                messageRegExp = "Can't generate mapping method for a generic type variable source.")
+        }
+    )
+    public void shouldFailOnTypeVarTarget() {
+    }
+}


### PR DESCRIPTION
This PR covers the easier part of #962 (converting a `Stream` to some collection type).  The implementation type are same as for the [collection mappings](http://mapstruct.org/documentation/1.1/reference/html/index.html#implementation-types-for-collection-mappings) (without the `Map` implementations of course 😄)

Documentation is not updated, once this is resolved I will update the documentation.

Also I am not sure why, but in the generated mappers there are no null checks for the Stream conversions. What am I doing wrong?

