### PR TITLE
#971 Make sure that an Iterable or Map MapingMethod are equal if their source parameters are from the same type

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -304,6 +304,9 @@ public class IterableMappingMethod extends MappingMethod {
         }
 
         for ( int i = 0; i < getSourceParameters().size(); i++ ) {
+            if ( !getSourceParameters().get( i ).getType().equals( other.getSourceParameters().get( i ).getType() ) ) {
+                return false;
+            }
             List<Type> thisTypeParameters = getSourceParameters().get( i ).getType().getTypeParameters();
             List<Type> otherTypeParameters = other.getSourceParameters().get( i ).getType().getTypeParameters();
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -319,8 +319,14 @@ public class MapMappingMethod extends MappingMethod {
         }
 
         for ( int i = 0; i < getSourceParameters().size(); i++ ) {
-            if ( !getSourceParameters().get( i ).getType().getTypeParameters().get( 0 )
-                .equals( other.getSourceParameters().get( i ).getType().getTypeParameters().get( 0 ) ) ) {
+            if ( !getSourceParameters().get( i ).getType().equals( other.getSourceParameters().get( i ).getType() ) ) {
+                return false;
+            }
+
+            List<Type> thisTypeParameters = getSourceParameters().get( i ).getType().getTypeParameters();
+            List<Type> otherTypeParameters = other.getSourceParameters().get( i ).getType().getTypeParameters();
+
+            if ( !thisTypeParameters.equals( otherTypeParameters ) ) {
                 return false;
             }
         }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/CollectionSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/CollectionSource.java
@@ -1,0 +1,48 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._971;
+
+import java.util.List;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+public class CollectionSource {
+
+    private List<Integer> integers;
+    private List<Integer> integersCollection;
+
+
+    public List<Integer> getIntegers() {
+        return integers;
+    }
+
+    public void setIntegers(List<Integer> integers) {
+        this.integers = integers;
+    }
+
+    public List<Integer> getIntegersCollection() {
+        return integersCollection;
+    }
+
+    public void setIntegersCollection(List<Integer> integersCollection) {
+        this.integersCollection = integersCollection;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/CollectionTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/CollectionTarget.java
@@ -1,0 +1,48 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._971;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+public class CollectionTarget {
+
+    private List<String> integers;
+    private Collection<String> integersCollection;
+
+    public List<String> getIntegers() {
+        return integers;
+    }
+
+    public void setIntegers(List<String> integers) {
+        this.integers = integers;
+    }
+
+    public Collection<String> getIntegersCollection() {
+        return integersCollection;
+    }
+
+    public void setIntegersCollection(Collection<String> integersCollection) {
+        this.integersCollection = integersCollection;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/Issue971CollectionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/Issue971CollectionMapper.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._971;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue971CollectionMapper {
+
+    Issue971CollectionMapper INSTANCE = Mappers.getMapper( Issue971CollectionMapper.class );
+
+    CollectionSource mapTargetToSource(CollectionTarget source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/Issue971MapMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/Issue971MapMapper.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._971;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue971MapMapper {
+
+    Issue971MapMapper INSTANCE = Mappers.getMapper( Issue971MapMapper.class );
+
+    MapSource mapTargetToSource(MapTarget source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/Issue971Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/Issue971Test.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._971;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ *
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("971")
+public class Issue971Test {
+
+    @Test
+    @WithClasses({ CollectionSource.class, CollectionTarget.class, Issue971CollectionMapper.class })
+    public void shouldCompileForCollections() {   }
+
+    @Test
+    @WithClasses({ MapSource.class, MapTarget.class, Issue971MapMapper.class })
+    public void shouldCompileForMaps() {   }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/MapSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/MapSource.java
@@ -1,0 +1,48 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._971;
+
+import java.util.Map;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+public class MapSource {
+
+    private Map<Integer, String> integersSortedMap;
+    private Map<Integer, String> integersBaseMap;
+
+
+    public Map<Integer, String> getIntegersSortedMap() {
+        return integersSortedMap;
+    }
+
+    public void setIntegersSortedMap(Map<Integer, String> integersSortedMap) {
+        this.integersSortedMap = integersSortedMap;
+    }
+
+    public Map<Integer, String> getIntegersBaseMap() {
+        return integersBaseMap;
+    }
+
+    public void setIntegersBaseMap(Map<Integer, String> integersBaseMap) {
+        this.integersBaseMap = integersBaseMap;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/MapTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_971/MapTarget.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._971;
+
+import java.util.Map;
+import java.util.SortedMap;
+
+/**
+ *
+ * @author Filip Hrisafov
+ */
+public class MapTarget {
+
+    private SortedMap<String, Integer> integersSortedMap;
+    private Map<String, Integer> integersBaseMap;
+
+
+    public SortedMap<String, Integer> getIntegersSortedMap() {
+        return integersSortedMap;
+    }
+
+    public void setIntegersSortedMap(SortedMap<String, Integer> integersSortedMap) {
+        this.integersSortedMap = integersSortedMap;
+    }
+
+    public Map<String, Integer> getIntegersBaseMap() {
+        return integersBaseMap;
+    }
+
+    public void setIntegersBaseMap(Map<String, Integer> integersBaseMap) {
+        this.integersBaseMap = integersBaseMap;
+    }
+}


### PR DESCRIPTION
This one fixes #971. However, now we will generate a Mapping method for each of the types that we are converting for example there will be one method for each of: `Iterable`, `Collection`, `List` to a `List`. Where we could only use one method with a source parameter an `Iterable` that will do the mapping for the `Collection` and the `List` to a `List`.

Maybe we need to do some refactoring and for the `IterableMappingMethod` always use the most generic possible method.

Mapping any `Iterable`, `Collection` and/or `List` to a list in our case is exactly the same no matter what the parameter is.