### PR TITLE
#981 moving SourceReference out of PropertyMapping

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -105,12 +105,11 @@ public class IterableMappingMethod extends MappingMethod {
 
             Assignment assignment = ctx.getMappingResolver().getTargetAssignment(
                 method,
-                "collection element",
                 targetElementType,
                 null, // there is no targetPropertyName
                 formattingParameters,
                 selectionParameters,
-                new SourceRHS( loopVariableName, sourceElementType, new HashSet<String>() ),
+                new SourceRHS( loopVariableName, sourceElementType, new HashSet<String>(), "collection element" ),
                 false
             );
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -108,12 +108,11 @@ public class MapMappingMethod extends MappingMethod {
 
             Assignment keyAssignment = ctx.getMappingResolver().getTargetAssignment(
                 method,
-                "map key",
                 keyTargetType,
                 null, // there is no targetPropertyName
                 keyFormattingParameters,
                 keySelectionParameters,
-                new SourceRHS( "entry.getKey()", keySourceType, new HashSet<String>() ),
+                new SourceRHS( "entry.getKey()", keySourceType, new HashSet<String>(), "map key" ),
                 false
             );
 
@@ -134,12 +133,11 @@ public class MapMappingMethod extends MappingMethod {
 
             Assignment valueAssignment = ctx.getMappingResolver().getTargetAssignment(
                 method,
-                "map value",
                 valueTargetType,
                 null, // there is no targetPropertyName
                 valueFormattingParameters,
                 valueSelectionParameters,
-                new SourceRHS( "entry.getValue()", valueSourceType, new HashSet<String>() ),
+                new SourceRHS( "entry.getValue()", valueSourceType, new HashSet<String>(), "map value" ),
                 false
             );
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
@@ -75,7 +75,6 @@ public class MappingBuilderContext {
          * returns a parameter assignment
          *
          * @param mappingMethod target mapping method
-         * @param mappedElement used for error messages
          * @param targetType return type to match
          * @param targetPropertyName name of the target property
          * @param formattingParameters used for formatting dates and numbers
@@ -91,9 +90,8 @@ public class MappingBuilderContext {
          * <li>null, no assignment found</li>
          * </ol>
          */
-        @SuppressWarnings("checkstyle:parameternumber")
-        Assignment getTargetAssignment(Method mappingMethod, String mappedElement, Type targetType,
-                                       String targetPropertyName, FormattingParameters formattingParameters,
+        Assignment getTargetAssignment(Method mappingMethod, Type targetType, String targetPropertyName,
+                                       FormattingParameters formattingParameters,
                                        SelectionParameters selectionParameters, SourceRHS sourceRHS,
                                        boolean preferUpdateMethods);
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MethodReference.java
@@ -128,6 +128,11 @@ public class MethodReference extends MappingMethod implements Assignment {
     }
 
     @Override
+    public String getSourcePresenceCheckerReference() {
+        return assignment.getSourcePresenceCheckerReference();
+    }
+
+    @Override
     public Type getSourceType() {
         return assignment.getSourceType();
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/SourceRHS.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/SourceRHS.java
@@ -30,6 +30,8 @@ import org.mapstruct.ap.internal.util.Strings;
 /**
  * SourceRHS Assignment. Right Hand Side (RHS), source part of the assignment.
  *
+ * This class contains all information on the source side of an assignment needed for common use in the mapping.
+ *
  * @author Sjaak Derksen
  */
 public class SourceRHS extends ModelElement implements Assignment {
@@ -38,16 +40,34 @@ public class SourceRHS extends ModelElement implements Assignment {
     private final Type sourceType;
     private String sourceLocalVarName;
     private final Set<String> existingVariableNames;
+    private final String sourceErrorMessagePart;
+    private final String sourcePresenceCheckerReference;
+    private boolean useElementAsSourceTypeForMatching = false;
+    private final String sourceParameterName;
 
-    public SourceRHS(String sourceReference, Type sourceType, Set<String> existingVariableNames ) {
+    public SourceRHS(String sourceReference, Type sourceType, Set<String> existingVariableNames,
+        String sourceErrorMessagePart ) {
+        this( null, sourceReference, null, sourceType, existingVariableNames, sourceErrorMessagePart );
+    }
+
+    public SourceRHS(String sourceParameterName, String sourceReference, String sourcePresenceCheckerReference,
+        Type sourceType, Set<String> existingVariableNames,  String sourceErrorMessagePart ) {
         this.sourceReference = sourceReference;
         this.sourceType = sourceType;
         this.existingVariableNames = existingVariableNames;
+        this.sourceErrorMessagePart = sourceErrorMessagePart;
+        this.sourcePresenceCheckerReference = sourcePresenceCheckerReference;
+        this.sourceParameterName = sourceParameterName;
     }
 
     @Override
     public String getSourceReference() {
         return sourceReference;
+    }
+
+    @Override
+    public String getSourcePresenceCheckerReference() {
+        return sourcePresenceCheckerReference;
     }
 
     @Override
@@ -99,4 +119,32 @@ public class SourceRHS extends ModelElement implements Assignment {
     public String toString() {
         return sourceReference;
     }
+
+    public String getSourceErrorMessagePart() {
+        return sourceErrorMessagePart;
+    }
+
+    /**
+     * The source type that is to be used when resolving the mapping from source to target.
+     *
+     * @return the source type to be used in the matching process.
+     */
+    public Type getSourceTypeForMatching() {
+        return useElementAsSourceTypeForMatching && sourceType.isCollectionType() ?
+            sourceType.getTypeParameters().get( 0 ) : sourceType;
+    }
+
+    /**
+     * For collection type, use element as source type to find a suitable mapping method.
+     *
+     * @param useElementAsSourceTypeForMatching
+     */
+    public void setUseElementAsSourceTypeForMatching(boolean useElementAsSourceTypeForMatching) {
+        this.useElementAsSourceTypeForMatching = useElementAsSourceTypeForMatching;
+    }
+
+    public String getSourceParameterName() {
+        return sourceParameterName;
+    }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/TypeConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/TypeConversion.java
@@ -87,6 +87,11 @@ public class TypeConversion extends ModelElement implements Assignment {
     }
 
     @Override
+    public String getSourcePresenceCheckerReference() {
+        return assignment.getSourcePresenceCheckerReference();
+    }
+
+    @Override
     public Type getSourceType() {
         return assignment.getSourceType();
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AdderWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AdderWrapper.java
@@ -38,8 +38,8 @@ public class AdderWrapper extends AssignmentWrapper {
     public AdderWrapper( Assignment decoratedAssignment, List<Type> thrownTypesToExclude, boolean fieldAssignment ) {
         super( decoratedAssignment, fieldAssignment );
         this.thrownTypesToExclude = thrownTypesToExclude;
-        this.sourceIteratorName =
-            decoratedAssignment.createLocalVarName( decoratedAssignment.getSourceType().getName() );
+        String desiredName = decoratedAssignment.getSourceType().getTypeParameters().get( 0 ).getName();
+        this.sourceIteratorName = decoratedAssignment.createLocalVarName( desiredName );
         decoratedAssignment.setSourceLocalVarName( sourceIteratorName );
     }
 
@@ -61,7 +61,7 @@ public class AdderWrapper extends AssignmentWrapper {
     public Set<Type> getImportTypes() {
         Set<Type> imported = new HashSet<Type>();
         imported.addAll( super.getImportTypes() );
-        imported.add( getSourceType() );
+        imported.add( getSourceType().getTypeParameters().get( 0 ) );
         return imported;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Assignment.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Assignment.java
@@ -78,6 +78,13 @@ public interface Assignment {
     String getSourceReference();
 
     /**
+     * the source presence checker reference
+     *
+     * @return source reference
+     */
+    String getSourcePresenceCheckerReference();
+
+    /**
      * the source type used in the matching process
      *
      * @return source type (can be null)

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AssignmentWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AssignmentWrapper.java
@@ -64,6 +64,11 @@ public abstract class AssignmentWrapper extends ModelElement implements Assignme
     }
 
     @Override
+    public String getSourcePresenceCheckerReference() {
+        return decoratedAssignment.getSourcePresenceCheckerReference();
+    }
+
+    @Override
     public Type getSourceType() {
         return decoratedAssignment.getSourceType();
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.java
@@ -39,17 +39,14 @@ import org.mapstruct.ap.internal.model.common.Type;
 public class GetterWrapperForCollectionsAndMaps extends WrapperForCollectionsAndMaps {
 
     /**
-     * constructor for property mapping
-     *
      * @param decoratedAssignment
      * @param thrownTypesToExclude
-     * @param sourcePresenceChecker
      * @param existingVariableNames
      * @param targetType
+     * @param fieldAssignment
      */
     public GetterWrapperForCollectionsAndMaps(Assignment decoratedAssignment,
                                               List<Type> thrownTypesToExclude,
-                                              String sourcePresenceChecker,
                                               Set<String> existingVariableNames,
                                               Type targetType,
                                               boolean fieldAssignment) {
@@ -57,28 +54,10 @@ public class GetterWrapperForCollectionsAndMaps extends WrapperForCollectionsAnd
         super(
             decoratedAssignment,
             thrownTypesToExclude,
-            sourcePresenceChecker,
             existingVariableNames,
             targetType,
             fieldAssignment
         );
-    }
-
-    /**
-     * constructor for e.g. constants and expressions
-     *
-     * @param decoratedAssignment
-     * @param thrownTypesToExclude
-     * @param existingVariableNames
-     * @param targetType
-     */
-    public GetterWrapperForCollectionsAndMaps(Assignment decoratedAssignment,
-                                              List<Type> thrownTypesToExclude,
-                                              Set<String> existingVariableNames,
-                                              Type targetType,
-                                              boolean fieldAssignment) {
-
-        super( decoratedAssignment, thrownTypesToExclude, null, existingVariableNames, targetType, fieldAssignment );
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/NullCheckWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/NullCheckWrapper.java
@@ -25,14 +25,8 @@ package org.mapstruct.ap.internal.model.assignment;
  */
 public class NullCheckWrapper extends AssignmentWrapper {
 
-    private final String sourcePresenceChecker;
-
-    public NullCheckWrapper( Assignment decoratedAssignment, String sourcePresenceChecker ) {
+    public NullCheckWrapper( Assignment decoratedAssignment ) {
         super( decoratedAssignment, false );
-        this.sourcePresenceChecker = sourcePresenceChecker;
     }
 
-    public String getSourcePresenceChecker() {
-        return sourcePresenceChecker;
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.java
@@ -47,7 +47,6 @@ public class SetterWrapperForCollectionsAndMaps extends WrapperForCollectionsAnd
 
     public SetterWrapperForCollectionsAndMaps(Assignment decoratedAssignment,
                                               List<Type> thrownTypesToExclude,
-                                              String sourcePresenceChecker,
                                               Set<String> existingVariableNames,
                                               Type targetType,
                                               boolean allwaysIncludeNullCheck,
@@ -57,7 +56,6 @@ public class SetterWrapperForCollectionsAndMaps extends WrapperForCollectionsAnd
         super(
             decoratedAssignment,
             thrownTypesToExclude,
-            sourcePresenceChecker,
             existingVariableNames,
             targetType,
             fieldAssignment
@@ -95,10 +93,6 @@ public class SetterWrapperForCollectionsAndMaps extends WrapperForCollectionsAnd
 
     public boolean isEnumSet() {
         return "java.util.EnumSet".equals( targetType.getFullyQualifiedName() );
-    }
-
-    public boolean isFieldAssignment() {
-        return fieldAssignment;
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/UpdateNullCheckWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/UpdateNullCheckWrapper.java
@@ -26,16 +26,8 @@ package org.mapstruct.ap.internal.model.assignment;
  */
 public class UpdateNullCheckWrapper extends AssignmentWrapper {
 
-    private final String sourcePresenceChecker;
-
-    public UpdateNullCheckWrapper(Assignment decoratedAssignment, String sourcePresenceChecker,
-                                  boolean fieldAssignment) {
+    public UpdateNullCheckWrapper(Assignment decoratedAssignment, boolean fieldAssignment) {
         super( decoratedAssignment, fieldAssignment );
-        this.sourcePresenceChecker = sourcePresenceChecker;
-    }
-
-    public String getSourcePresenceChecker() {
-        return sourcePresenceChecker;
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/WrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/WrapperForCollectionsAndMaps.java
@@ -35,13 +35,11 @@ import org.mapstruct.ap.internal.util.Strings;
 public class WrapperForCollectionsAndMaps extends AssignmentWrapper {
 
     private final List<Type> thrownTypesToExclude;
-    private final String sourcePresenceChecker;
     private final String localVarName;
     private final Type localVarType;
 
     public WrapperForCollectionsAndMaps(Assignment decoratedAssignment,
                                         List<Type> thrownTypesToExclude,
-                                        String sourcePresenceChecker,
                                         Set<String> existingVariableNames,
                                         Type targetType,
                                         boolean fieldAssignment) {
@@ -49,7 +47,6 @@ public class WrapperForCollectionsAndMaps extends AssignmentWrapper {
         super( decoratedAssignment, fieldAssignment );
 
         this.thrownTypesToExclude = thrownTypesToExclude;
-        this.sourcePresenceChecker = sourcePresenceChecker;
         if ( getType() == AssignmentType.DIRECT && getSourceType() != null ) {
             this.localVarType = getSourceType();
         }
@@ -81,10 +78,6 @@ public class WrapperForCollectionsAndMaps extends AssignmentWrapper {
         imported.add( localVarType );
         imported.addAll( localVarType.getTypeParameters() );
         return imported;
-    }
-
-    public String getSourcePresenceChecker() {
-        return sourcePresenceChecker;
     }
 
     public String getLocalVarName() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
@@ -296,4 +296,25 @@ public class SourceReference {
 
         return new SourceReference( replacement, propertyEntries, isValid );
     }
+
+    @Override
+    public String toString() {
+
+        if ( propertyEntries.isEmpty() ) {
+            return String.format( "parameter \"%s %s\"", getParameter().getType(), getParameter().getName() );
+        }
+        else if ( propertyEntries.size() == 1 ) {
+            PropertyEntry propertyEntry = propertyEntries.get( 0 );
+            return String.format( "property \"%s %s\"", propertyEntry.getType(), propertyEntry.getName() );
+        }
+        else {
+            PropertyEntry lastPropertyEntry = propertyEntries.get( propertyEntries.size() - 1 );
+            return String.format(
+                "property \"%s %s\"",
+                lastPropertyEntry.getType(),
+                Strings.join( getElementNames(), "." )
+            );
+        }
+    }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
@@ -104,10 +104,9 @@ public class MappingResolverImpl implements MappingResolver {
     }
 
     @Override
-    @SuppressWarnings("checkstyle:parameternumber")
-    public Assignment getTargetAssignment(Method mappingMethod, String mappedElement,
-        Type targetType, String targetPropertyName, FormattingParameters formattingParameters,
-        SelectionParameters selectionParameters, SourceRHS sourceRHS, boolean preferUpdateMapping) {
+    public Assignment getTargetAssignment(Method mappingMethod, Type targetType, String targetPropertyName,
+        FormattingParameters formattingParameters, SelectionParameters selectionParameters, SourceRHS sourceRHS,
+        boolean preferUpdateMapping) {
 
         SelectionCriteria criteria =
             new SelectionCriteria( selectionParameters, targetPropertyName, preferUpdateMapping, false );
@@ -122,14 +121,13 @@ public class MappingResolverImpl implements MappingResolver {
         ResolvingAttempt attempt = new ResolvingAttempt(
             sourceModel,
             mappingMethod,
-            mappedElement,
             dateFormat,
             numberFormat,
             sourceRHS,
             criteria
         );
 
-        return attempt.getTargetAssignment( sourceRHS.getSourceType(), targetType );
+        return attempt.getTargetAssignment( sourceRHS.getSourceTypeForMatching(), targetType );
     }
 
     @Override
@@ -143,7 +141,7 @@ public class MappingResolverImpl implements MappingResolver {
 
         SelectionCriteria criteria = new SelectionCriteria( selectionParameters, null, false, true );
 
-        ResolvingAttempt attempt = new ResolvingAttempt( sourceModel, mappingMethod, null, null, null, null, criteria );
+        ResolvingAttempt attempt = new ResolvingAttempt( sourceModel, mappingMethod, null, null, null, criteria );
 
         List<SourceMethod> matchingSourceMethods = attempt.getMatches( sourceModel, null, targetType );
 
@@ -199,7 +197,6 @@ public class MappingResolverImpl implements MappingResolver {
     private class ResolvingAttempt {
 
         private final Method mappingMethod;
-        private final String mappedElement;
         private final List<SourceMethod> methods;
         private final String dateFormat;
         private final String numberFormat;
@@ -212,12 +209,10 @@ public class MappingResolverImpl implements MappingResolver {
         // so this set must be cleared.
         private final Set<VirtualMappingMethod> virtualMethodCandidates;
 
-        private ResolvingAttempt(List<SourceMethod> sourceModel, Method mappingMethod, String mappedElement,
-                String dateFormat, String numberFormat, SourceRHS sourceRHS, SelectionCriteria criteria) {
-
+        private ResolvingAttempt(List<SourceMethod> sourceModel, Method mappingMethod, String dateFormat,
+                                 String numberFormat, SourceRHS sourceRHS, SelectionCriteria criteria) {
 
             this.mappingMethod = mappingMethod;
-            this.mappedElement = mappedElement;
             this.methods = filterPossibleCandidateMethods( sourceModel );
             this.dateFormat = dateFormat;
             this.numberFormat = numberFormat;
@@ -520,10 +515,10 @@ public class MappingResolverImpl implements MappingResolver {
             // into the target type
             if ( candidates.size() > 1 ) {
 
-                if ( mappedElement != null ) {
+                if ( sourceRHS.getSourceErrorMessagePart() != null ) {
                     messager.printMessage( mappingMethod.getExecutable(),
                         Message.GENERAL_AMBIGIOUS_MAPPING_METHOD,
-                        mappedElement,
+                        sourceRHS.getSourceErrorMessagePart(),
                         returnType,
                         Strings.join( candidates, ", " )
                     );

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/AdderWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/AdderWrapper.ftl
@@ -21,7 +21,7 @@
 <#import "../macro/CommonMacros.ftl" as lib>
 <@lib.handleExceptions>
   if ( ${sourceReference} != null ) {
-      for ( <@includeModel object=sourceType/> ${sourceIteratorName} : ${sourceReference} ) {
+      for ( <@includeModel object=sourceType.typeParameters[0]/> ${sourceIteratorName} : ${sourceReference} ) {
           ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite><@lib.handleAssignment/></@lib.handleWrite>;
       }
   }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/NullCheckWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/NullCheckWrapper.ftl
@@ -25,7 +25,7 @@ if ( ${sourceLocalVarName} != null ) {
     <@_assignment object=assignment defaultValue=ext.defaultValueAssignment/>
 }
 <#else>
-if ( <#if sourcePresenceChecker?? >${sourcePresenceChecker}<#else>${sourceReference} != null</#if> ) {
+if ( <#if sourcePresenceCheckerReference?? >${sourcePresenceCheckerReference}<#else>${sourceReference} != null</#if> ) {
     <@_assignment object=assignment defaultValue=ext.defaultValueAssignment/>
 }
 </#if>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.ftl
@@ -26,7 +26,7 @@
             ${ext.targetBeanName}.${ext.targetReadAccessorName}.clear();
             ${ext.targetBeanName}.${ext.targetReadAccessorName}.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( ${localVarName} );
         </@lib.handleNullCheck>
-        <#if !ext.defaultValueAssignment?? && !sourcePresenceChecker?? && !allwaysIncludeNullCheck>else {<#-- the opposite (defaultValueAssignment) case is handeld inside lib.handleNullCheck -->
+        <#if !ext.defaultValueAssignment?? && !sourcePresenceCheckerReference?? && !allwaysIncludeNullCheck>else {<#-- the opposite (defaultValueAssignment) case is handeld inside lib.handleNullCheck -->
           ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite>null</@lib.handleWrite>;
         }
         </#if>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/UpdateNullCheckWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/UpdateNullCheckWrapper.ftl
@@ -19,7 +19,7 @@
 
 -->
 <#import '../macro/CommonMacros.ftl' as lib>
-if ( <#if sourcePresenceChecker?? >${sourcePresenceChecker}<#else>${sourceReference} != null</#if> ) {
+if ( <#if sourcePresenceCheckerReference?? >${sourcePresenceCheckerReference}<#else>${sourceReference} != null</#if> ) {
     <@includeModel object=assignment
                 targetBeanName=ext.targetBeanName
                 existingInstanceMapping=ext.existingInstanceMapping

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
@@ -28,8 +28,8 @@
            present.
 -->
 <#macro handleNullCheck>
-  <#if sourcePresenceChecker??>
-    if ( ${sourcePresenceChecker} ) {
+  <#if sourcePresenceCheckerReference??>
+    if ( ${sourcePresenceCheckerReference} ) {
       <@includeModel object=localVarType/> ${localVarName} = <@lib.handleAssignment/>;
       <#nested>
     }


### PR DESCRIPTION
Following PR is general refactoring. I want to have this in place before I refactor the standard property mapping (see #973 ). 

Actually I wanted to move the `SourceReference` in outside of `PropertyMapping` to `BeanMappng` and use `SourceRHS` to construct `PropertyMapping`. Note `TargetReference` is also not used inside `PropertyMapping`. But I'm not there yet, so I can't close #981. I also don't want to make this PR too big. So lets take it step by step. This means that `getSourceRHS` and referred methods also moves to `BeanMapping`. 

