### PR TITLE
#657 Using bean mapping result types works when the map return type is not an interface

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -365,7 +365,10 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
                     .build();
 
                 if ( beanMappingMethod != null ) {
-                    hasFactoryMethod = beanMappingMethod.getFactoryMethod() != null;
+                    // We can consider that the mapping method has a factory method if it has one,
+                    // or if the result type of the methods is not an interface
+                    hasFactoryMethod = beanMappingMethod.getFactoryMethod() != null ||
+                        !beanMappingMethod.getResultType().isInterface();
                     mappingMethods.add( beanMappingMethod );
                 }
             }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
@@ -42,6 +42,7 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
  */
 @IssueKey("385")
 @WithClasses({
+    IsFruit.class,
     Fruit.class,
     FruitDto.class,
     Apple.class,
@@ -86,6 +87,33 @@ public class InheritanceSelectionTest {
         Fruit fruit = ResultTypeConstructingFruitMapper.INSTANCE.map( fruitDto );
         assertThat( fruit ).isNotNull();
         assertThat( fruit.getType() ).isEqualTo( "constructed-by-constructor" );
+    }
+
+    @Test
+    @IssueKey("657")
+    @WithClasses( { ResultTypeConstructingFruitInterfaceMapper.class } )
+    public void testResultTypeBasedConstructionOfResultForInterface() {
+
+        FruitDto fruitDto = new FruitDto( null );
+        IsFruit fruit = ResultTypeConstructingFruitInterfaceMapper.INSTANCE.map( fruitDto );
+        assertThat( fruit ).isNotNull();
+        assertThat( fruit.getType() ).isEqualTo( "constructed-by-constructor" );
+    }
+
+    @Test
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ResultTypeConstructingFruitInterfaceErroneousMapper.class,
+                kind = Kind.ERROR,
+                line = 36,
+                messageRegExp = "No implementation type is registered for return type .*\\.IsFruit."
+            )
+        }
+    )
+    @IssueKey("657")
+    @WithClasses({ ResultTypeConstructingFruitInterfaceErroneousMapper.class })
+    public void testResultTypeBasedConstructionOfResultForInterfaceErroneous() {
     }
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/IsFruit.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/IsFruit.java
@@ -20,15 +20,11 @@ package org.mapstruct.ap.test.selection.resulttype;
 
 /**
  *
- * @author Sjaak Derksen
+ * @author Filip Hrisafov
  */
-public class Apple extends Fruit implements IsFruit {
+public interface IsFruit {
 
-    public Apple() {
-        super( "constructed-by-constructor" );
-    }
+    String getType();
 
-    public Apple(String type) {
-        super( type );
-    }
+    void setType(String type);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/ResultTypeConstructingFruitInterfaceErroneousMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/ResultTypeConstructingFruitInterfaceErroneousMapper.java
@@ -18,17 +18,20 @@
  */
 package org.mapstruct.ap.test.selection.resulttype;
 
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
 /**
  *
- * @author Sjaak Derksen
+ * @author Filip Hrisafov
  */
-public class Apple extends Fruit implements IsFruit {
+@Mapper
+public interface ResultTypeConstructingFruitInterfaceErroneousMapper {
 
-    public Apple() {
-        super( "constructed-by-constructor" );
-    }
+    ResultTypeConstructingFruitInterfaceErroneousMapper INSTANCE = Mappers.getMapper(
+        ResultTypeConstructingFruitInterfaceErroneousMapper.class );
 
-    public Apple(String type) {
-        super( type );
-    }
+    @Mapping(target = "type", ignore = true)
+    IsFruit map(FruitDto source);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/ResultTypeConstructingFruitInterfaceMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/ResultTypeConstructingFruitInterfaceMapper.java
@@ -18,17 +18,22 @@
  */
 package org.mapstruct.ap.test.selection.resulttype;
 
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
 /**
  *
- * @author Sjaak Derksen
+ * @author Filip Hrisafov
  */
-public class Apple extends Fruit implements IsFruit {
+@Mapper
+public interface ResultTypeConstructingFruitInterfaceMapper {
 
-    public Apple() {
-        super( "constructed-by-constructor" );
-    }
+    ResultTypeConstructingFruitInterfaceMapper INSTANCE = Mappers.getMapper(
+        ResultTypeConstructingFruitInterfaceMapper.class );
 
-    public Apple(String type) {
-        super( type );
-    }
+    @BeanMapping(resultType = Apple.class)
+    @Mapping(target = "type", ignore = true)
+    IsFruit map(FruitDto source);
 }


### PR DESCRIPTION
This PR basically makes sure that if the result type of the `BeanMappingMethod` is not an interface it can be considered that the methods has a "factory" method and therefore we do not need to report an error.