### PR TITLE
#941 fixing too many suffixes, naming strategy and logical variable names

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
@@ -90,23 +90,25 @@ public abstract class MappingMethod extends ModelElement {
     }
 
     protected MappingMethod(Method method, List<Parameter> parameters) {
-        this( method, parameters, method.getParameterNames(), null, null, Collections.<ForgedMethod>emptyList() );
+        this( method, parameters, new ArrayList<String>( method.getParameterNames() ), null, null,
+            Collections.<ForgedMethod>emptyList() );
     }
 
     protected MappingMethod(Method method) {
-        this( method, method.getParameterNames(), null, null );
+        this( method, new ArrayList<String>( method.getParameterNames() ), null, null );
     }
 
     protected MappingMethod(Method method, List<LifecycleCallbackMethodReference> beforeMappingReferences,
                             List<LifecycleCallbackMethodReference> afterMappingReferences) {
-        this( method, method.getParameterNames(), beforeMappingReferences, afterMappingReferences );
+        this( method, new ArrayList<String>( method.getParameterNames() ), beforeMappingReferences,
+            afterMappingReferences );
     }
 
     protected MappingMethod(Method method, List<LifecycleCallbackMethodReference> beforeMappingReferences,
                             List<LifecycleCallbackMethodReference> afterMappingReferences,
                             List<ForgedMethod> forgedMethods) {
-        this( method, method.getParameters(), method.getParameterNames(), beforeMappingReferences,
-                afterMappingReferences, forgedMethods );
+        this( method, method.getParameters(), new ArrayList<String>( method.getParameterNames() ),
+            beforeMappingReferences, afterMappingReferences, forgedMethods );
     }
 
     public MappingMethod(Method method, Collection<String> existingVariableNames,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -366,7 +366,7 @@ public class PropertyMapping extends ModelElement {
             Assignment result = rightHandSide;
 
             if ( result.getSourceType().isCollectionType() ) {
-                result = new AdderWrapper( result, method.getThrownTypes(), isFieldAssignment() );
+                result = new AdderWrapper( result, method.getThrownTypes(), isFieldAssignment(), targetPropertyName );
             }
             else {
                 // Possibly adding null to a target collection. So should be surrounded by an null check.
@@ -508,7 +508,7 @@ public class PropertyMapping extends ModelElement {
                 );
 
                 // create a local variable to which forged method can be assigned.
-                String desiredName = first( sourceReference.getPropertyEntries() ).getName();
+                String desiredName = last( sourceReference.getPropertyEntries() ).getName();
                 sourceRhs.setSourceLocalVarName( sourceRhs.createLocalVarName( desiredName ) );
 
                 return sourceRhs;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AdderWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AdderWrapper.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.util.Nouns;
 
 /**
  * Wraps the assignment in a target setter.
@@ -34,10 +35,13 @@ public class AdderWrapper extends AssignmentWrapper {
 
     private final List<Type> thrownTypesToExclude;
 
-    public AdderWrapper( Assignment rhs, List<Type> thrownTypesToExclude, boolean fieldAssignment ) {
+    public AdderWrapper( Assignment rhs,
+                         List<Type> thrownTypesToExclude,
+                         boolean fieldAssignment,
+                         String targetPropertyName ) {
         super( rhs, fieldAssignment );
         this.thrownTypesToExclude = thrownTypesToExclude;
-        String desiredName = rhs.getSourceType().getTypeParameters().get( 0 ).getName();
+        String desiredName = Nouns.singularize( targetPropertyName );
         rhs.setSourceLocalVarName( rhs.createLocalVarName( desiredName ) );
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -314,11 +314,13 @@ public class SourceMethod implements Method {
     @Override
     public List<String> getParameterNames() {
         if ( parameterNames == null ) {
-            parameterNames = new ArrayList<String>( parameters.size() );
+            List<String> names = new ArrayList<String>( parameters.size() );
 
             for ( Parameter parameter : parameters ) {
-                parameterNames.add( parameter.getName() );
+                names.add( parameter.getName() );
             }
+
+            parameterNames = Collections.unmodifiableList( names );
         }
 
         return parameterNames;

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Strings.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Strings.java
@@ -156,11 +156,17 @@ public class Strings {
         Set<String> conflictingNames = new HashSet<String>( KEYWORDS );
         conflictingNames.addAll( existingVariableNames );
 
-        while ( conflictingNames.contains( name ) ) {
-            name = name + "_";
+        if ( !conflictingNames.contains( name ) ) {
+            return name;
         }
 
-        return name;
+        int c = 1;
+        String seperator = Character.isDigit( name.charAt( name.length() - 1 ) ) ? "_" : "";
+        while ( conflictingNames.contains( name + seperator + c ) ) {
+            c++;
+        }
+
+        return name + seperator + c;
     }
 
     /**

--- a/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
@@ -73,21 +73,27 @@ public class StringsTest {
     @Test
     public void testGetSaveVariableNameWithArrayExistingVariables() throws Exception {
         assertThat( Strings.getSaveVariableName( "int[]" ) ).isEqualTo( "intArray" );
-        assertThat( Strings.getSaveVariableName( "Extends" ) ).isEqualTo( "extends_" );
-        assertThat( Strings.getSaveVariableName( "class" ) ).isEqualTo( "class_" );
-        assertThat( Strings.getSaveVariableName( "Class" ) ).isEqualTo( "class_" );
-        assertThat( Strings.getSaveVariableName( "Case" ) ).isEqualTo( "case_" );
-        assertThat( Strings.getSaveVariableName( "Synchronized" ) ).isEqualTo( "synchronized_" );
-        assertThat( Strings.getSaveVariableName( "prop", "prop", "prop_" ) ).isEqualTo( "prop__" );
+        assertThat( Strings.getSaveVariableName( "Extends" ) ).isEqualTo( "extends1" );
+        assertThat( Strings.getSaveVariableName( "class" ) ).isEqualTo( "class1" );
+        assertThat( Strings.getSaveVariableName( "Class" ) ).isEqualTo( "class1" );
+        assertThat( Strings.getSaveVariableName( "Case" ) ).isEqualTo( "case1" );
+        assertThat( Strings.getSaveVariableName( "Synchronized" ) ).isEqualTo( "synchronized1" );
+        assertThat( Strings.getSaveVariableName( "prop", "prop", "prop_" ) ).isEqualTo( "prop1" );
+    }
+
+    @Test
+    public void testGetSaveVariableNameVariablesEndingOnNumberVariables() throws Exception {
+        assertThat( Strings.getSaveVariableName( "prop1", "prop1" ) ).isEqualTo( "prop1_1" );
+        assertThat( Strings.getSaveVariableName( "prop1", "prop1", "prop1_1" ) ).isEqualTo( "prop1_2" );
     }
 
     @Test
     public void testGetSaveVariableNameWithCollection() throws Exception {
         assertThat( Strings.getSaveVariableName( "int[]", new ArrayList<String>() ) ).isEqualTo( "intArray" );
-        assertThat( Strings.getSaveVariableName( "Extends", new ArrayList<String>() ) ).isEqualTo( "extends_" );
-        assertThat( Strings.getSaveVariableName( "prop", Arrays.asList( "prop", "prop_" ) ) ).isEqualTo( "prop__" );
+        assertThat( Strings.getSaveVariableName( "Extends", new ArrayList<String>() ) ).isEqualTo( "extends1" );
+        assertThat( Strings.getSaveVariableName( "prop", Arrays.asList( "prop", "prop1" ) ) ).isEqualTo( "prop2" );
         assertThat( Strings.getSaveVariableName( "prop.font", Arrays.asList( "propFont", "propFont_" ) ) )
-            .isEqualTo( "propFont__" );
+            .isEqualTo( "propFont1" );
     }
 
     @Test


### PR DESCRIPTION
The following commits are in:

1. Fix. The problem was related to adding the parameter (argument) names too the set of existing variables. However, constructing of a MappingMethod was done on a clone but on the set of parameter names.

2. Next, as discussed in #941, the local variable naming strategy is adapted. 

3. Finally more logical names are sported for nested source properties and in the adder implementation. Have a look at the generated sources.