### PR TITLE
#1014 do not generate FQN for extends/super bound Types

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/common/Type.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/common/Type.ftl
@@ -1,3 +1,4 @@
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.common.Type" -->
 <#--
 
      Copyright 2012-2016 Gunnar Morling (http://www.gunnarmorling.de/)
@@ -18,4 +19,19 @@
      limitations under the License.
 
 -->
-<#if imported>${name}<#else>${fullyQualifiedName}</#if><#if (!ext.raw?? && typeParameters?size > 0) ><<#list typeParameters as typeParameter><@includeModel object=typeParameter /><#if typeParameter_has_next>, </#if></#list>></#if>
+<@compress single_line=true>
+    <#if wildCardExtendsBound>
+        ? extends <@includeModel object=typeBound />
+    <#elseif wildCardSuperBound>
+        ? super <@includeModel object=typeBound />
+    <#else>
+        <#if imported>
+            ${name}
+        <#else>
+            ${fullyQualifiedName}
+        </#if>
+    </#if>
+    <#if (!ext.raw?? && typeParameters?size > 0) >
+        <<#list typeParameters as typeParameter><@includeModel object=typeParameter /><#if typeParameter_has_next>, </#if></#list>>
+    </#if>
+</@compress>

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/wildcard/WildCardTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/wildcard/WildCardTest.java
@@ -25,6 +25,7 @@ import java.math.BigDecimal;
 import javax.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
@@ -33,6 +34,7 @@ import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
 /**
  * Reproducer for https://github.com/mapstruct/mapstruct/issues/527.
@@ -42,6 +44,9 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 @IssueKey("527")
 @RunWith(AnnotationProcessorTestRunner.class)
 public class WildCardTest {
+
+    @Rule
+    public final GeneratedSource generatedSource = new GeneratedSource();
 
     @Test
     @WithClasses({
@@ -59,7 +64,10 @@ public class WildCardTest {
 
         assertThat( target ).isNotNull();
         assertThat( target.getElements() ).isNull();
-
+        generatedSource.forMapper( ExtendsBoundSourceTargetMapper.class )
+            .content()
+            .as( "Should not contain FQN after extends" )
+            .doesNotContain( "? extends org.mapstruct.ap.test.collection.wildcard.Idea" );
     }
 
     @Test
@@ -78,7 +86,10 @@ public class WildCardTest {
 
         assertThat( target ).isNotNull();
         assertThat( target.getElements() ).isNull();
-
+        generatedSource.forMapper( SourceSuperBoundTargetMapper.class )
+            .content()
+            .as( "Should not contain FQN after super" )
+            .doesNotContain( "? super org.mapstruct.ap.test.collection.wildcard.Idea" );
     }
 
     @Test


### PR DESCRIPTION
The problem was that for extends/super bound `Type`(s) the name is `? extends/super java.lang.Integer`.

Do we need some more complex tests? 