### PR TITLE
#975 Part 2: Context params used as source for factory and lifecycle methods

### DIFF
--- a/core-common/src/main/java/org/mapstruct/AfterMapping.java
+++ b/core-common/src/main/java/org/mapstruct/AfterMapping.java
@@ -23,36 +23,40 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.mapstruct.util.Experimental;
-
 /**
  * Marks a method to be invoked at the end of a generated mapping method, right before the last {@code return} statement
- * of the mapping method. The method can be implemented in an abstract mapper class or be declared in a type (class or
- * interface) referenced in {@link Mapper#uses()} in order to be used in a mapping method.
+ * of the mapping method. The method can be implemented in an abstract mapper class, be declared in a type (class or
+ * interface) referenced in {@link Mapper#uses()}, or in a type used as {@code @}{@link Context} parameter in order to
+ * be used in a mapping method.
  * <p>
- * Only methods with return type {@code void} may be annotated with this annotation.
- * <p>
- * If the method has parameters, the method invocation is only generated if all parameters can be <em>assigned</em> by
- * the source or target parameters of the mapping method:
+ * The method invocation is only generated if the return type of the method (if non-{@code void}) is assignable to the
+ * return type of the mapping method and all parameters can be <em>assigned</em> by the available source, target or
+ * context parameters of the mapping method:
  * <ul>
  * <li>A parameter annotated with {@code @}{@link MappingTarget} is populated with the target instance of the mapping.
  * </li>
  * <li>A parameter annotated with {@code @}{@link TargetType} is populated with the target type of the mapping.</li>
- * <li>Any other parameter is populated with a source parameter of the mapping, whereas each source parameter is used
- * once at most.</li>
+ * <li>Parameters annotated with {@code @}{@link Context} are populated with the context parameters of the mapping
+ * method.</li>
+ * <li>Any other parameter is populated with a source parameter of the mapping.</li>
  * </ul>
  * <p>
- * All <em>after-mapping</em> methods that can be applied to a mapping method will be used. Their order is determined by
- * their location of definition:
- * <ul>
- * <li>The order of methods within one type can not be guaranteed, as it depends on the compiler and the processing
- * environment implementation.</li>
- * <li>Methods declared in one type are used after methods declared in their super-type.</li>
- * <li>Methods implemented in the mapper itself are used before methods from types referenced in {@link Mapper#uses()}.
+ * For non-{@code void} methods, the return value of the method invocation is returned as the result of the mapping
+ * method if it is not {@code null}.
+ * <p>
+ * All <em>after-mapping</em> methods that can be applied to a mapping method will be used. {@code @}{@link Qualifier} /
+ * {@code @}{@link Named} can be used to filter the methods to use.
+ * <p>
+ * The order of the method invocation is determined by their location of definition:
+ * <ol>
+ * <li>Methods declared on {@code @}{@link Context} parameters, ordered by the parameter order.</li>
+ * <li>Methods implemented in the mapper itself.</li>
+ * <li>Methods from types referenced in {@link Mapper#uses()}, in the order of the type declaration in the annotation.
  * </li>
- * <li>Types referenced in {@link Mapper#uses()} are searched for <em>after-mapping</em> methods in the order specified
- * in the annotation.</li>
- * </ul>
+ * <li>Methods declared in one type are used after methods declared in their super-type</li>
+ * </ol>
+ * <em>Important:</em> the order of methods declared within one type can not be guaranteed, as it depends on the
+ * compiler and the processing environment implementation.
  * <p>
  * Example:
  *
@@ -97,8 +101,8 @@ import org.mapstruct.util.Experimental;
  *
  * @author Andreas Gudian
  * @see BeforeMapping
+ * @see Context
  */
-@Experimental
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.CLASS)
 public @interface AfterMapping {

--- a/core-common/src/main/java/org/mapstruct/BeanMapping.java
+++ b/core-common/src/main/java/org/mapstruct/BeanMapping.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
 /**
  * Configures the mapping between two bean types.
  * <p>
- * Either {@link #resultType()} , {@link #qualifiedBy()} or {@link #nullValueMappingStrategy()} must be specified.
+ * Either {@link #resultType()}, {@link #qualifiedBy()} or {@link #nullValueMappingStrategy()} must be specified.
  * </p>
  *
  * @author Sjaak Derksen
@@ -44,21 +44,23 @@ public @interface BeanMapping {
     Class<?> resultType() default void.class;
 
     /**
-     * A qualifier can be specified to aid the selection process of a suitable factory method. This is useful in case
-     * multiple factory method (hand written of internal) qualify and result in an 'Ambiguous factory methods' error.
-     *
+     * A qualifier can be specified to aid the selection process of a suitable factory method or filtering applicable
+     * {@code @}{@link BeforeMapping} / {@code @}{@link AfterMapping} methods. This is useful in case multiple factory
+     * method (hand written of internal) qualify and result in an 'Ambiguous factory methods' error.
+     * <p>
      * A qualifier is a custom annotation and can be placed on either a hand written mapper class or a method.
      *
      * @return the qualifiers
+     * @see BeanMapping#qualifiedByName()
      */
     Class<? extends Annotation>[] qualifiedBy() default { };
 
     /**
-     * See: { @link #qualifiedBy() }. String form of a predefined { @link @Qualifier }. The { @link @Qualifier }
-     * is more verbose, but offers more flexibility in terms of for instance refactoring. At the other hand, there
-     * is no need to define own annotations.
+     * Similar to {@link #qualifiedBy()}, but used in combination with {@code @}{@link Named} in case no custom
+     * qualifier annotation is defined.
      *
      * @return the qualifiers
+     * @see Named
      */
     String[] qualifiedByName() default { };
 

--- a/core-common/src/main/java/org/mapstruct/BeforeMapping.java
+++ b/core-common/src/main/java/org/mapstruct/BeforeMapping.java
@@ -23,39 +23,42 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.mapstruct.util.Experimental;
-
 /**
  * Marks a method to be invoked at the beginning of a generated mapping method. The method can be implemented in an
- * abstract mapper class or be declared in a type (class or interface) referenced in {@link Mapper#uses()} in order to
- * be used in a mapping method.
+ * abstract mapper class, be declared in a type (class or interface) referenced in {@link Mapper#uses()}, or in a type
+ * used as {@code @}{@link Context} parameter in order to be used in a mapping method.
  * <p>
- * Only methods with return type {@code void} may be annotated with this annotation.
- * <p>
- * If the method has parameters, the method invocation is only generated if all parameters can be <em>assigned</em> by
- * the source or target parameters of the mapping method:
+ * The method invocation is only generated if the return type of the method (if non-{@code void}) is assignable to the
+ * return type of the mapping method and all parameters can be <em>assigned</em> by the available source, target or
+ * context parameters of the mapping method:
  * <ul>
  * <li>A parameter annotated with {@code @}{@link MappingTarget} is populated with the target instance of the mapping.
  * </li>
  * <li>A parameter annotated with {@code @}{@link TargetType} is populated with the target type of the mapping.</li>
- * <li>Any other parameter is populated with a source parameter of the mapping, whereas each source parameter is used
- * once at most.</li>
+ * <li>Parameters annotated with {@code @}{@link Context} are populated with the context parameters of the mapping
+ * method.</li>
+ * <li>Any other parameter is populated with a source parameter of the mapping.</li>
  * </ul>
- * If a <em>before-mapping</em> method does not contain a {@code @}{@link MappingTarget} parameter, it is invoked
- * directly at the beginning of the applicable mapping method. If it contains a {@code @}{@link MappingTarget}
- * parameter, the method is invoked after the target parameter has been initialized in the mapping method.
  * <p>
- * All <em>before-mapping</em> methods that can be applied to a mapping method will be used. Their order is determined
- * by their location of definition:
- * <ul>
- * <li>The order of methods within one type can not be guaranteed, as it depends on the compiler and the processing
- * environment implementation.</li>
- * <li>Methods declared in one type are used after methods declared in their super-type.</li>
- * <li>Methods implemented in the mapper itself are used before methods from types referenced in {@link Mapper#uses()}.
+ * For non-{@code void} methods, the return value of the method invocation is returned as the result of the mapping
+ * method if it is not {@code null}.
+ * <p>
+ * All <em>before-mapping</em> methods that can be applied to a mapping method will be used. {@code @}{@link Qualifier}
+ * / {@code @}{@link Named} can be used to filter the methods to use.
+ * <p>
+ * The order of the method invocation is determined by their their variant and their location of definition:
+ * <ol>
+ * <li>Methods without an {@code @}{@link MappingTarget} parameter are called before any null-checks on source
+ * parameters and constructing a new target bean.</li>
+ * <li>Methods with an {@code @}{@link MappingTarget} parameter are called after constructing a new target bean.</li>
+ * <li>Methods declared on {@code @}{@link Context} parameters, ordered by the parameter order.</li>
+ * <li>Methods implemented in the mapper itself.</li>
+ * <li>Methods from types referenced in {@link Mapper#uses()}, in the order of the type declaration in the annotation.
  * </li>
- * <li>Types referenced in {@link Mapper#uses()} are searched for <em>after-mapping</em> methods in the order specified
- * in the annotation.</li>
- * </ul>
+ * <li>Methods declared in one type are used after methods declared in their super-type</li>
+ * </ol>
+ * <em>Important:</em> the order of methods declared within one type can not be guaranteed, as it depends on the
+ * compiler and the processing environment implementation.
  * <p>
  * Example:
  *
@@ -101,8 +104,8 @@ import org.mapstruct.util.Experimental;
  *
  * @author Andreas Gudian
  * @see AfterMapping
+ * @see Context
  */
-@Experimental
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.CLASS)
 public @interface BeforeMapping {

--- a/core-common/src/main/java/org/mapstruct/ObjectFactory.java
+++ b/core-common/src/main/java/org/mapstruct/ObjectFactory.java
@@ -24,44 +24,43 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * By default beans are created during the mapping process with the default constructor.
- * This method allows to mark a method as a factory method to create beans.
- * The type of the factory method is determined by its return type. A factory is used
- * to create a bean if their types match.
+ * This annotation marks a method as a <em>factory method</em> to create beans.
  * <p>
- * The factory method can retrieve the mapping sources by specifying
- * them as parameters, exactly like mapping and lifecycle methods do. This allows the factory
- * method to create target beans based on source beans.
- * The use of source parameters opens up a variety of possibilities. For example,
- * a factory method for entities can look up an
- * EntityManager to check whether the entity already exists and then return its
- * managed instance.
+ * By default beans are created during the mapping process with the default constructor. If a factory method with a
+ * return type that is assignable to the required object type is present, then the factory method is used instead.
+ * <p>
+ * Factory methods can be defined without parameters, with an {@code @}{@link TargetType} parameter, a {@code @}
+ * {@link Context} parameter, or with a mapping methods source parameter. If any of those parameters are defined, then
+ * the mapping method that is supposed to use the factory method needs to be declared with an assignable result type,
+ * assignable context parameter, and/or assignable source types.
+ * <p>
+ * <strong>Note:</strong> the usage of this annotation is <em>optional</em> if no source parameters are part of the
+ * signature, i.e. it is declared without parameters or only with {@code @}{@link TargetType} and/or {@code @}
+ * {@link Context}.
+ * <p>
+ * <strong>Example:</strong> Using a factory method for entities to check whether the entity already exists in the
+ * EntityManager and then returns the managed instance:
  *
  * <pre>
- * {@literal @}ApplicationScoped // CDI component model
+ * <code>
+ * &#64;ApplicationScoped // CDI component model
  * public class ReferenceMapper {
  *
- *     {@literal @}PersistenceContext
+ *     &#64;PersistenceContext
  *     private EntityManager em;
  *
- *     {@literal @}ObjectFactory
- *     public SomeEntity resolve(SomeDto dto) {
- *         SomeEntity entity = em.find(SomeEntity.class, dto.getId());
- *         return entity != null ? entity : new SomeEntity();
+ *     &#64;ObjectFactory
+ *     public &lt;T extends AbstractEntity&gt; T resolve(AbstractDto sourceDto, &#64;TargetType Class&lt;T&gt; type) {
+ *         T entity = em.find( type, sourceDto.getId() );
+ *         return entity != null ? entity : type.newInstance();
  *     }
  * }
+ * </code>
  * </pre>
- *
- * If no such parameters
- * are provided, the use of this annotation is optional.
- *
  * <p>
- * If there are two factory methods, both serving the same type, one with no parameters
- * and one taking sources as input, then the one with the source parameters is favored.
- * If multiple factory method take sources as input, them the one is chosen which allows a
- * valid assignment from mapping source parameters to those factory parameters. If
- * there are multiple such factories, an ambiguity exception is thrown.
- * </p>
+ * If there are two factory methods, both serving the same type, one with no parameters and one taking sources as input,
+ * then the one with the source parameters is favored. If there are multiple such factories, an ambiguity error is
+ * shown.
  *
  * @author Remo Meier
  * @since 1.2

--- a/core-common/src/main/java/org/mapstruct/Qualifier.java
+++ b/core-common/src/main/java/org/mapstruct/Qualifier.java
@@ -30,6 +30,7 @@ import java.lang.annotation.Target;
  * For more info see:
  * <ul>
  * <li>{@link Mapping#qualifiedBy() }</li>
+ * <li>{@link BeanMapping#qualifiedBy() }</li>
  * <li>{@link IterableMapping#qualifiedBy() }</li>
  * <li>{@link MapMapping#keyQualifiedBy() }</li>
  * <li>{@link MapMapping#valueQualifiedBy() }</li>
@@ -44,9 +45,10 @@ import java.lang.annotation.Target;
  * }
  * </pre>
  *
- * <b>NOTE: </b>Qualifiers should have {@link RetentionPolicy#CLASS}.
+ * <b>NOTE:</b> Qualifiers should have {@link RetentionPolicy#CLASS}.
  *
  * @author Sjaak Derksen
+ * @see Named
  */
 @Target(ElementType.ANNOTATION_TYPE)
 @Retention(RetentionPolicy.CLASS)

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -924,6 +924,54 @@ public class CarMapperImpl implements CarMapper {
 ----
 ====
 
+[[passing-context]]
+=== Passing context or state objects to custom methods
+
+Additional _context_ or _state_ information can be passed through generated mapping methods to custom methods with `@Context` parameters. Such parameters are passed to other mapping methods, `@ObjectFactory` methods (see <<object-factories>>) or `@BeforeMapping` / `@AfterMapping` methods (see <<customizing-mappings-with-before-and-after>>) when applicable and can thus be used in custom code.
+
+`@Context` parameters are also searched for `@BeforeMapping` / `@AfterMapping` methods, which are called on the provided context parameter value if applicable.
+
+*Note:* no `null` checks are performed before calling before/after mapping methods on context parameters. The caller needs to make sure that `null` is not passed in that case.
+
+For generated code to call a method that is declared with `@Context` parameters, the declaration of the mapping method being generated needs to contain at least those (or assignable) `@Context` parameters as well. The generated code will not create new instances of missing `@Context` parameters nor will it pass a literal `null` instead.
+
+.Using `@Context` parameters for passing data down to hand-written property mapping methods
+====
+[source, java, linenums]
+[subs="verbatim,attributes"]
+----
+public abstract CarDto toCar(Car car, @Context Locale translationLocale);
+
+protected OwnerManualDto translateOwnerManual(OwnerManual ownerManual, @Context Locale locale) {
+    // manually implemented logic to translate the OwnerManual with the given Locale
+}
+----
+====
+
+MapStruct will then generate something like this:
+
+.Generated code
+====
+[source, java, linenums]
+[subs="verbatim,attributes"]
+----
+//GENERATED CODE
+public CarDto toCar(Car car, Locale translationLocale) {
+    if ( car == null ) {
+        return null;
+    }
+
+    CarDto carDto = new CarDto();
+
+    carDto.setOwnerManual( translateOwnerManual( car.getOwnerManual(), translationLocale );
+    // more generated mapping code
+
+    return carDto;
+}
+----
+====
+
+
 [[mapping-method-resolution]]
 === Mapping method resolution
 
@@ -1492,8 +1540,7 @@ By default, the generated code for mapping one bean type into another will call 
 
 Alternatively you can plug in custom object factories which will be invoked to obtain instances of the target type. One use case for this is JAXB which creates `ObjectFactory` classes for obtaining new instances of schema types.
 
-To make use of custom factories register them via `@Mapper#uses()` as described in <<invoking-other-mappers>>. When creating the target object of a bean mapping, MapStruct will look for a parameterless method, 
-a method annotated with `@ObjectFactory`, or a method with only one `@TargetType` parameter that returns the required target type and invoke this method instead of calling the default constructor:
+To make use of custom factories register them via `@Mapper#uses()` as described in <<invoking-other-mappers>>, or implement them directly in your mapper. When creating the target object of a bean mapping, MapStruct will look for a parameterless method, a method annotated with `@ObjectFactory`, or a method with only one `@TargetType` parameter that returns the required target type and invoke this method instead of calling the default constructor:
 
 .Custom object factories
 ====
@@ -1569,9 +1616,9 @@ public class CarMapperImpl implements CarMapper {
 ----
 ====
 
-In addition, annotating a factory with `@ObjectFactory` lets you gain access to the mapping sources. 
+In addition, annotating a factory method with `@ObjectFactory` lets you gain access to the mapping sources.
 Source objects can be added as parameters in the same way as for mapping method. The `@ObjectFactory`
-annotation is necessary to let MapStruct know that the given method is only a factory method. 
+annotation is necessary to let MapStruct know that the given method is only a factory method.
 
 .Custom object factories with `@ObjectFactory`
 
@@ -1583,7 +1630,7 @@ public class DtoFactory {
 
      @ObjectFactory
      public CarDto createCarDto(Car car) {
-         return // ... custom factory logic 
+         return // ... custom factory logic
      }
 }
 ----
@@ -1908,7 +1955,7 @@ Methods that are considered for inverse inheritance need to be defined in the cu
 
 If multiple methods qualify, the method from which to inherit the configuration needs to be specified using the `name` property like this: `@InheritInverseConfiguration(name = "carToDto")`.
 
-Expressions and constants are excluded (silently ignored). Reverse mapping of nested source properties is experimental as of the 1.1.0.Beta2. Reverse mapping will take place automatically when the source property name and target property name are identical. Otherwise, `@Mapping` should specify both the target name and source name. In all cases, a suitable mapping method needs to be in place for the reverse mapping.
+Expressions and constants are excluded (silently ignored). Reverse mapping of nested source properties is experimental as of the 1.1.0.Beta2 release. Reverse mapping will take place automatically when the source property name and target property name are identical. Otherwise, `@Mapping` should specify both the target name and source name. In all cases, a suitable mapping method needs to be in place for the reverse mapping.
 
 [NOTE]
 ====
@@ -2142,7 +2189,7 @@ private PersonMapper personMapper; // injects the decorator, with the injected o
 
 Decorators may not always fit the needs when it comes to customizing mappers. For example, if you need to perform the customization not only for a few selected methods, but for all methods that map specific super-types: in that case, you can use *callback methods* that are invoked before the mapping starts or after the mapping finished.
 
-Callback methods can be implemented in the abstract mapper itself or in a type reference in `Mapper#uses`.
+Callback methods can be implemented in the abstract mapper itself, in a type reference in `Mapper#uses`, or in a type used as `@Context` parameter.
 
 .Mapper with @BeforeMapping and @AfterMapping hooks
 ====
@@ -2187,16 +2234,14 @@ public class VehicleMapperImpl extends VehicleMapper {
 ----
 ====
 
-If the `@BeforeMapping` / `@AfterMapping` method has parameters, the method invocation is only generated if all parameters can be *assigned* by the source or target parameters of the mapping method:
+If the `@BeforeMapping` / `@AfterMapping` method has parameters, the method invocation is only generated if the return type of the method (if non-`void`) is assignable to the return type of the mapping method and all parameters can be *assigned* by the source or target parameters of the mapping method:
 
 * A parameter annotated with `@MappingTarget` is populated with the target instance of the mapping.
 * A parameter annotated with `@TargetType` is populated with the target type of the mapping.
-* Any other parameter is populated with a source parameter of the mapping, whereas each source parameter is used once at most.
+* Parameters annotated with `@Context` are populated with the context parameters of the mapping method.
+* Any other parameter is populated with a source parameter of the mapping.
 
-If the before/after-mapping method has a return type other than `void`, it will be checked to match the target type of the mapping methods.
-Only the callback methods with a matching return type (or `void`) will be called in that mapping method. 
-
-If a callback method returns a non-null value, this value will be returned from the mapping method.
+For non-`void` methods, the return value of the method invocation is returned as the result of the mapping method if it is not `null`.
 
 As with mapping methods, it is possible to specify type parameters for before/after-mapping methods.
 
@@ -2243,17 +2288,23 @@ public class VehicleMapperImpl extends VehicleMapper {
 
 All before/after-mapping methods that *can* be applied to a mapping method *will* be used. <<selection-based-on-qualifiers>> can be used to further control which methods may be chosen and which not. For that, the qualifier annotation needs to be applied to the before/after-method and referenced in `BeanMapping#qualifiedBy` or `IterableMapping#qualifiedBy`.
 
-The order in which the selected methods are applied is roughly determined by their location of definition (although you should consider it a *code smell* if you need to rely on their order):
+The order of the method invocation is determined primarily by their variant:
 
-* The order of methods within one type can not be guaranteed, as it depends on the compiler and the processing environment implementation.
-* Methods declared in one type are used after methods declared in their super-type.
-* Methods implemented in the mapper itself are used before methods from types referenced in `Mapper#uses`.
-* Types referenced in `Mapper#uses` are searched for before/after-mapping methods in the order specified in the annotation.
+1. `@BeforeMapping` methods without an `@MappingTarget` parameter are called before any null-checks on source
+ parameters and constructing a new target bean.
+2. `@BeforeMapping` methods with an `@MappingTarget` parameter are called after constructing a new target bean.
+3. `@AfterMapping` methods are called at the end of the mapping method before the last `return` statement.
 
-[WARNING]
-====
-`@BeforeMapping` and `@AfterMapping` are considered experimental as of the 1.0.0.CR1 release. Details in the selection of before/after mapping methods that are applicable for a mapping method or the order in which they are called might still be changed.
-====
+Within those groups, the method invocations are ordered by their location of definition:
+
+1. Methods declared on `@Context` parameters, ordered by the parameter order.
+2. Methods implemented in the mapper itself.
+3. Methods from types referenced in `Mapper#uses()`, in the order of the type declaration in the annotation.
+4. Methods declared in one type are used after methods declared in their super-type.
+
+*Important:* the order of methods declared within one type can not be guaranteed, as it depends on the compiler and the processing environment implementation.
+
+
 [[using-spi]]
 == Using the MapStruct SPI
 === Custom Accessor Naming Strategy

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractBaseBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractBaseBuilder.java
@@ -76,11 +76,9 @@ class AbstractBaseBuilder<B extends AbstractBaseBuilder<B>> {
             methodRef = new ForgedMethod( existingName, methodRef );
         }
 
-        Assignment assignment = new MethodReference(
+        Assignment assignment = MethodReference.forForgedMethod(
             methodRef,
-            null,
-            ParameterBinding.fromParameters( methodRef.getParameters() )
-        );
+            ParameterBinding.fromParameters( methodRef.getParameters() ) );
         assignment.setAssignment( source );
 
         return assignment;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
@@ -59,6 +59,7 @@ public abstract class AbstractMappingMethodBuilder<B extends AbstractMappingMeth
             method.getMapperConfiguration(),
             method.getExecutable(),
             method.getContextParameters(),
+            method.getContextProvidedMethods(),
             new ForgedMethodHistory(
                 history,
                 Strings.stubPropertyName( sourceRHS.getSourceType().getName() ),

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
@@ -18,6 +18,8 @@
  */
 package org.mapstruct.ap.internal.model;
 
+import static org.mapstruct.ap.internal.util.Collections.first;
+
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -30,8 +32,6 @@ import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
 import org.mapstruct.ap.internal.util.Strings;
-
-import static org.mapstruct.ap.internal.util.Collections.first;
 
 /**
  * Builder that can be used to build {@link ContainerMappingMethod}(s).
@@ -75,6 +75,7 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
         return myself;
     }
 
+    @Override
     public final M build() {
         Type sourceParameterType = first( method.getSourceParameters() ).getType();
         Type resultType = method.getResultType();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/HelperMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/HelperMethod.java
@@ -31,6 +31,7 @@ import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
+import org.mapstruct.ap.internal.model.source.ParameterProvidedMethods;
 import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Strings;
 
@@ -87,6 +88,11 @@ public abstract class HelperMethod implements Method {
     @Override
     public List<Parameter> getContextParameters() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public ParameterProvidedMethods getContextProvidedMethods() {
+        return ParameterProvidedMethods.empty();
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -107,6 +107,7 @@ public class IterableMappingMethod extends ContainerMappingMethod {
         }
     }
 
+    @Override
     public Type getResultElementType() {
         if ( getResultType().isArrayType() ) {
             return getResultType().getComponentType();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleCallbackMethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleCallbackMethodReference.java
@@ -18,13 +18,14 @@
  */
 package org.mapstruct.ap.internal.model;
 
-import java.util.List;
 import java.util.Set;
 
+import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.ParameterBinding;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SourceMethod;
+import org.mapstruct.ap.internal.model.source.selector.SelectedMethod;
 import org.mapstruct.ap.internal.util.Collections;
 import org.mapstruct.ap.internal.util.Strings;
 
@@ -40,14 +41,18 @@ public class LifecycleCallbackMethodReference extends MethodReference {
     private final Type methodResultType;
     private final String targetVariableName;
 
-    public LifecycleCallbackMethodReference(SourceMethod method, MapperReference mapperReference,
-                                            List<ParameterBinding> parameterBindings,
-                                            Type methodReturnType, Type methodResultType,
-                                            Set<String> existingVariableNames) {
-        super( method, mapperReference, parameterBindings );
-        this.declaringType = method.getDeclaringMapper();
-        this.methodReturnType = methodReturnType;
-        this.methodResultType = methodResultType;
+    private LifecycleCallbackMethodReference(SelectedMethod<SourceMethod> lifecycleMethod,
+                                             MapperReference mapperReference, Parameter providingParameter,
+                                             Method containingMethod, Set<String> existingVariableNames) {
+        super(
+            lifecycleMethod.getMethod(),
+            mapperReference,
+            providingParameter,
+            lifecycleMethod.getParameterBindings() );
+
+        this.declaringType = lifecycleMethod.getMethod().getDeclaringMapper();
+        this.methodReturnType = containingMethod.getReturnType();
+        this.methodResultType = containingMethod.getResultType();
 
         if ( hasReturnType() ) {
             this.targetVariableName = Strings.getSaveVariableName( "target", existingVariableNames );
@@ -106,5 +111,30 @@ public class LifecycleCallbackMethodReference extends MethodReference {
      */
     public boolean hasReturnType() {
         return !getReturnType().isVoid();
+    }
+
+    public static LifecycleCallbackMethodReference forParameterProvidedMethod(
+            SelectedMethod<SourceMethod> lifecycleMethod,
+            Parameter providingParameter, Method containingMethod,
+            Set<String> existingVariableNames) {
+
+        return new LifecycleCallbackMethodReference(
+            lifecycleMethod,
+            null,
+            providingParameter,
+            containingMethod,
+            existingVariableNames );
+    }
+
+    public static LifecycleCallbackMethodReference forMethodReference(SelectedMethod<SourceMethod> lifecycleMethod,
+            MapperReference mapperReference, Method containingMethod,
+            Set<String> existingVariableNames) {
+
+        return new LifecycleCallbackMethodReference(
+            lifecycleMethod,
+            mapperReference,
+            null,
+            containingMethod,
+            existingVariableNames );
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
@@ -49,7 +49,8 @@ public class ForgedMethod implements Method {
     private final List<Parameter> contextParameters;
     private final Parameter mappingTargetParameter;
     private final MappingOptions mappingOptions;
-    private boolean autoMapping;
+    private final boolean autoMapping;
+    private final ParameterProvidedMethods contextProvidedMethods;
 
     /**
      * Creates a new forged method with the given name.
@@ -60,11 +61,23 @@ public class ForgedMethod implements Method {
      * @param mapperConfiguration the mapper configuration
      * @param positionHintElement element used to for reference to the position in the source file.
      * @param additionalParameters additional parameters to add to the forged method
+     * @param parameterProvidedMethods additional factory/lifecycle methods to consider that are provided by context
+     *            parameters
      */
     public ForgedMethod(String name, Type sourceType, Type returnType, MapperConfiguration mapperConfiguration,
-                        ExecutableElement positionHintElement, List<Parameter> additionalParameters) {
-        this( name, sourceType, returnType, mapperConfiguration, positionHintElement, additionalParameters, null,
-            false, MappingOptions.empty() );
+                        ExecutableElement positionHintElement, List<Parameter> additionalParameters,
+                        ParameterProvidedMethods parameterProvidedMethods) {
+        this(
+            name,
+            sourceType,
+            returnType,
+            mapperConfiguration,
+            positionHintElement,
+            additionalParameters,
+            parameterProvidedMethods,
+            null,
+            false,
+            MappingOptions.empty() );
     }
 
    /**
@@ -76,12 +89,24 @@ public class ForgedMethod implements Method {
      * @param mapperConfiguration the mapper configuration
      * @param positionHintElement element used to for reference to the position in the source file.
      * @param additionalParameters additional parameters to add to the forged method
+     * @param parameterProvidedMethods additional factory/lifecycle methods to consider that are provided by context
+     *            parameters
      * @param history a parent forged method if this is a forged method within a forged method
      */
     public ForgedMethod(String name, Type sourceType, Type returnType, MapperConfiguration mapperConfiguration,
-        ExecutableElement positionHintElement, List<Parameter> additionalParameters, ForgedMethodHistory history) {
-        this( name, sourceType, returnType, mapperConfiguration, positionHintElement, additionalParameters, history,
-            true, MappingOptions.empty() );
+                        ExecutableElement positionHintElement, List<Parameter> additionalParameters,
+                        ParameterProvidedMethods parameterProvidedMethods, ForgedMethodHistory history) {
+        this(
+            name,
+            sourceType,
+            returnType,
+            mapperConfiguration,
+            positionHintElement,
+            additionalParameters,
+            parameterProvidedMethods,
+            history,
+            true,
+            MappingOptions.empty() );
     }
 
    /**
@@ -93,13 +118,24 @@ public class ForgedMethod implements Method {
      * @param mapperConfiguration the mapper configuration
      * @param positionHintElement element used to for reference to the position in the source file.
      * @param additionalParameters additional parameters to add to the forged method
+     * @param parameterProvidedMethods additional factory/lifecycle methods to consider that are provided by context
+     *            parameters
      * @param mappingOptions with mapping options
      */
     public ForgedMethod(String name, Type sourceType, Type returnType, MapperConfiguration mapperConfiguration,
-        ExecutableElement positionHintElement, List<Parameter> additionalParameters,
-        MappingOptions mappingOptions) {
-        this( name, sourceType, returnType, mapperConfiguration, positionHintElement, additionalParameters, null,
-            false, mappingOptions );
+                        ExecutableElement positionHintElement, List<Parameter> additionalParameters,
+                        ParameterProvidedMethods parameterProvidedMethods, MappingOptions mappingOptions) {
+        this(
+            name,
+            sourceType,
+            returnType,
+            mapperConfiguration,
+            positionHintElement,
+            additionalParameters,
+            parameterProvidedMethods,
+            null,
+            false,
+            mappingOptions );
     }
 
      /**
@@ -111,12 +147,15 @@ public class ForgedMethod implements Method {
      * @param mapperConfiguration the mapper configuration
      * @param positionHintElement element used to for reference to the position in the source file.
      * @param additionalParameters additional parameters to add to the forged method
+     * @param parameterProvidedMethods additional factory/lifecycle methods to consider that are provided by context
+     *            parameters
      * @param history a parent forged method if this is a forged method within a forged method
      * @param mappingOptions the mapping options for this method
      */
     private ForgedMethod(String name, Type sourceType, Type returnType, MapperConfiguration mapperConfiguration,
                         ExecutableElement positionHintElement, List<Parameter> additionalParameters,
-                        ForgedMethodHistory history, boolean autoMapping, MappingOptions mappingOptions) {
+                        ParameterProvidedMethods parameterProvidedMethods, ForgedMethodHistory history,
+                        boolean autoMapping, MappingOptions mappingOptions) {
         String sourceParamName = Strings.decapitalize( sourceType.getName() );
         String sourceParamSafeName = Strings.getSaveVariableName( sourceParamName );
 
@@ -127,6 +166,7 @@ public class ForgedMethod implements Method {
         this.sourceParameters = Parameter.getSourceParameters( parameters );
         this.contextParameters = Parameter.getContextParameters( parameters );
         this.mappingTargetParameter = Parameter.getMappingTargetParameter( parameters );
+        this.contextProvidedMethods = parameterProvidedMethods;
 
         this.returnType = returnType;
         this.thrownTypes = new ArrayList<Type>();
@@ -157,6 +197,7 @@ public class ForgedMethod implements Method {
         this.contextParameters = Parameter.getContextParameters( parameters );
         this.mappingTargetParameter = Parameter.getMappingTargetParameter( parameters );
         this.mappingOptions = forgedMethod.mappingOptions;
+        this.contextProvidedMethods = forgedMethod.contextProvidedMethods;
 
         this.name = name;
     }
@@ -209,6 +250,11 @@ public class ForgedMethod implements Method {
     @Override
     public List<Parameter> getContextParameters() {
         return contextParameters;
+    }
+
+    @Override
+    public ParameterProvidedMethods getContextProvidedMethods() {
+        return contextProvidedMethods;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/Method.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/Method.java
@@ -86,6 +86,11 @@ public interface Method {
     List<Parameter> getContextParameters();
 
     /**
+     * @return a mapping between {@link #getContextParameters()} to factory and lifecycle methods provided by them.
+     */
+    ParameterProvidedMethods getContextProvidedMethods();
+
+    /**
      * Returns the parameter designated as mapping target (if present) {@link org.mapstruct.MappingTarget}
      *
      * @return mapping target parameter (when present) null otherwise.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ParameterProvidedMethods.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ParameterProvidedMethods.java
@@ -1,0 +1,111 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model.source;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.mapstruct.ap.internal.model.common.Parameter;
+
+/**
+ * Provides access to the {@link SourceMethod}s that are provided by {@link org.mapstruct.Context} parameters of a
+ * {@link Method} and maintains the relationship between those methods and their originating parameter.
+ *
+ * @author Andreas Gudian
+ */
+public class ParameterProvidedMethods {
+    private static final ParameterProvidedMethods EMPTY =
+        new ParameterProvidedMethods( Collections.<Parameter, List<SourceMethod>> emptyMap() );
+
+    private final Map<Parameter, List<SourceMethod>> parameterToProvidedMethods;
+    private final Map<SourceMethod, Parameter> methodToProvidingParameter;
+
+    private ParameterProvidedMethods(Map<Parameter, List<SourceMethod>> parameterToProvidedMethods) {
+        this.parameterToProvidedMethods = parameterToProvidedMethods;
+        this.methodToProvidingParameter = new IdentityHashMap<SourceMethod, Parameter>();
+        for ( Entry<Parameter, List<SourceMethod>> entry : parameterToProvidedMethods.entrySet() ) {
+            for ( SourceMethod method : entry.getValue() ) {
+                methodToProvidingParameter.put( method, entry.getKey() );
+            }
+        }
+    }
+
+    /**
+     * @param orderedParameters The parameters of which the provided methods are to be returned.
+     * @return The methods provided by the given parameters in the order as defined by the parameter list, with the
+     *         methods of each parameter ordered based on their definition in that parameter's type.
+     */
+    public List<SourceMethod> getAllProvidedMethodsInParameterOrder(List<Parameter> orderedParameters) {
+        List<SourceMethod> result = new ArrayList<SourceMethod>();
+
+        for ( Parameter parameter : orderedParameters ) {
+            List<SourceMethod> methods = parameterToProvidedMethods.get( parameter );
+            if ( methods != null ) {
+                result.addAll( methods );
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * @param method The method for which the defining parameter is to be returned.
+     * @return The Parameter on which's type the provided method is defined, or {@code null} if the method was not
+     *         defined on one of the tracked parameters.
+     */
+    public Parameter getParameterForProvidedMethod(Method method) {
+        return methodToProvidingParameter.get( method );
+    }
+
+    /**
+     * @return {@code true}, if no methods are provided by the tracked parameters or no parameters are tracked at all.
+     */
+    public boolean isEmpty() {
+        return methodToProvidingParameter.isEmpty();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static ParameterProvidedMethods empty() {
+        return EMPTY;
+    }
+
+    public static class Builder {
+        private Map<Parameter, List<SourceMethod>> contextProvidedMethods =
+            new HashMap<Parameter, List<SourceMethod>>();
+
+        private Builder() {
+        }
+
+        public void addMethodsForParameter(Parameter param, List<SourceMethod> methods) {
+            contextProvidedMethods.put( param, methods );
+        }
+
+        public ParameterProvidedMethods build() {
+            return new ParameterProvidedMethods( contextProvidedMethods );
+        }
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInMethod.java
@@ -35,6 +35,7 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.MappingOptions;
 import org.mapstruct.ap.internal.model.source.Method;
+import org.mapstruct.ap.internal.model.source.ParameterProvidedMethods;
 import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Strings;
 
@@ -107,6 +108,11 @@ public abstract class BuiltInMethod implements Method {
     @Override
     public List<Parameter> getContextParameters() {
         return Collections.emptyList();
+    }
+
+    @Override
+    public ParameterProvidedMethods getContextProvidedMethods() {
+        return ParameterProvidedMethods.empty();
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
@@ -165,7 +165,7 @@ public class MappingResolverImpl implements MappingResolver {
 
         MapperReference ref = findMapperReference( matchingFactoryMethod.getMethod() );
 
-        return new MethodReference(
+        return MethodReference.forMapperReference(
             matchingFactoryMethod.getMethod(),
             ref,
             matchingFactoryMethod.getParameterBindings() );
@@ -325,7 +325,7 @@ public class MappingResolverImpl implements MappingResolver {
                 ConversionContext ctx = new DefaultConversionContext( typeFactory, messager,
                                                                       sourceType,
                                                                       targetType, dateFormat, numberFormat);
-                Assignment methodReference = new MethodReference( matchingBuiltInMethod.getMethod(), ctx );
+                Assignment methodReference = MethodReference.forBuiltInMethod( matchingBuiltInMethod.getMethod(), ctx );
                 methodReference.setAssignment( sourceRHS );
                 return methodReference;
             }
@@ -521,11 +521,10 @@ public class MappingResolverImpl implements MappingResolver {
                                                      Type targetType) {
             MapperReference mapperReference = findMapperReference( method.getMethod() );
 
-            return new MethodReference(
+            return MethodReference.forMapperReference(
                 method.getMethod(),
                 mapperReference,
-                method.getParameterBindings()
-            );
+                method.getParameterBindings() );
         }
 
         /**

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MethodReference.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MethodReference.ftl
@@ -20,13 +20,15 @@
 -->
 <@compress single_line=true>
     <#-- method is either internal to the mapper class, or external (via uses) declaringMapper!=null -->
-    <#if declaringMapper??><#if static><@includeModel object=declaringMapper.type/><#else>${mapperVariableName}</#if>.<@params/>
+    <#if declaringMapper??><#if static><@includeModel object=declaringMapper.type/><#else>${mapperVariableName}</#if>.<@methodCall/>
+    <#-- method is provided by a context parameter  -->
+    <#elseif providingParameter??><#if static><@includeModel object=providingParameter.type/><#else>${providingParameter.name}</#if>.<@methodCall/>
     <#-- method is referenced java8 static method in the mapper to implement (interface)  -->
-    <#elseif static><@includeModel object=definingType/>.<@params/>
+    <#elseif static><@includeModel object=definingType/>.<@methodCall/>
     <#else>
-    <@params/>
+    <@methodCall/>
     </#if>
-    <#macro params>
+    <#macro methodCall>
         <@compress>
             ${name}<#if (parameterBindings?size > 0)>( <@arguments/> )<#else>()</#if>
         </@compress>

--- a/processor/src/test/java/org/mapstruct/ap/test/context/AutomappingNodeMapperWithSelfContainingContext.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/context/AutomappingNodeMapperWithSelfContainingContext.java
@@ -21,25 +21,20 @@ package org.mapstruct.ap.test.context;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.ap.test.context.Node.Attribute;
-import org.mapstruct.ap.test.context.NodeDto.AttributeDto;
 import org.mapstruct.factory.Mappers;
 
 /**
  * @author Andreas Gudian
  */
-@Mapper(uses = { CycleContextLifecycleMethods.class, FactoryContextMethods.class })
-public interface NodeMapperWithContext {
-    NodeMapperWithContext INSTANCE = Mappers.getMapper( NodeMapperWithContext.class );
+@Mapper(uses = FactoryContextMethods.class)
+public interface AutomappingNodeMapperWithSelfContainingContext {
 
-    NodeDto nodeToNodeDto(@Context FactoryContext factoryContext, Node node, @Context CycleContext cycleContext);
+    AutomappingNodeMapperWithSelfContainingContext INSTANCE =
+        Mappers.getMapper( AutomappingNodeMapperWithSelfContainingContext.class );
 
-    void nodeToNodeDto(@Context FactoryContext factoryContext, Node node, @MappingTarget NodeDto nodeDto,
-            @Context CycleContext cycleContext);
-
-    AttributeDto attributeToAttributeDto(Attribute attribute, @Context CycleContext cycleContext,
+    NodeDto nodeToNodeDto(Node node, @Context SelfContainingCycleContext cycleContext,
             @Context FactoryContext factoryContext);
 
-    void attributeToAttributeDto(Attribute attribute, @MappingTarget AttributeDto nodeDto,
-            @Context CycleContext cycleContext, @Context FactoryContext factoryContext);
+    void nodeToNodeDto(Node node, @MappingTarget NodeDto nodeDto, @Context SelfContainingCycleContext cycleContext,
+            @Context FactoryContext factoryContext);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/context/ContextParameterTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/context/ContextParameterTest.java
@@ -40,6 +40,7 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
  * <li>passing the parameter to factory methods (with and without {@link ObjectFactory})
  * <li>passing the parameter to lifecycle methods (in this case, {@link BeforeMapping}
  * <li>passing multiple parameters, with varied order of context params and mapping source params
+ * <li>calling lifecycle methods on context params
  * </ul>
  *
  * @author Andreas Gudian
@@ -50,9 +51,12 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
     NodeDto.class,
     NodeMapperWithContext.class,
     AutomappingNodeMapperWithContext.class,
+    AutomappingNodeMapperWithSelfContainingContext.class,
     CycleContext.class,
     FactoryContext.class,
-    CycleContextLifecycleMethods.class })
+    CycleContextLifecycleMethods.class,
+    FactoryContextMethods.class,
+    SelfContainingCycleContext.class })
 @RunWith(AnnotationProcessorTestRunner.class)
 public class ContextParameterTest {
 
@@ -80,6 +84,26 @@ public class ContextParameterTest {
         NodeDto updated = new NodeDto( 0 );
         AutomappingNodeMapperWithContext.INSTANCE
             .nodeToNodeDto( root, updated, new CycleContext(), new FactoryContext( 1, 10 ) );
+        assertResult( updated );
+    }
+
+    @Test
+    public void automappingWithSelfContainingContextCorrectlyResolvesCycles() {
+        Node root = buildNodes();
+        NodeDto rootDto = AutomappingNodeMapperWithSelfContainingContext.INSTANCE
+            .nodeToNodeDto(
+                root,
+                new SelfContainingCycleContext(),
+                new FactoryContext( 0, MAGIC_NUMBER_OFFSET ) );
+        assertResult( rootDto );
+
+        NodeDto updated = new NodeDto( 0 );
+        AutomappingNodeMapperWithSelfContainingContext.INSTANCE
+            .nodeToNodeDto(
+                root,
+                updated,
+                new SelfContainingCycleContext(),
+                new FactoryContext( 1, 10 ) );
         assertResult( updated );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/context/CycleContextLifecycleMethods.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/context/CycleContextLifecycleMethods.java
@@ -21,24 +21,12 @@ package org.mapstruct.ap.test.context;
 import org.mapstruct.BeforeMapping;
 import org.mapstruct.Context;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.ObjectFactory;
 import org.mapstruct.TargetType;
-import org.mapstruct.ap.test.context.Node.Attribute;
-import org.mapstruct.ap.test.context.NodeDto.AttributeDto;
 
 /**
  * @author Andreas Gudian
  */
 public class CycleContextLifecycleMethods {
-
-    public NodeDto createNodeDto(@Context FactoryContext context) {
-        return context.createNode();
-    }
-
-    @ObjectFactory
-    public AttributeDto createAttributeDto(Attribute source, @Context FactoryContext context) {
-        return context.createAttributeDto( source );
-    }
 
     @BeforeMapping
     public <T> T getInstance(Object source, @TargetType Class<T> type, @Context CycleContext cycleContext) {

--- a/processor/src/test/java/org/mapstruct/ap/test/context/FactoryContext.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/context/FactoryContext.java
@@ -31,9 +31,9 @@ public class FactoryContext {
     private int nodeCounter;
     private int attributeMagicNumberOffset;
 
-    public FactoryContext(int initialCounter, int attributeMaticNumberOffset) {
+    public FactoryContext(int initialCounter, int attributeMagicNumberOffset) {
         this.nodeCounter = initialCounter;
-        this.attributeMagicNumberOffset = attributeMaticNumberOffset;
+        this.attributeMagicNumberOffset = attributeMagicNumberOffset;
     }
 
     public NodeDto createNode() {

--- a/processor/src/test/java/org/mapstruct/ap/test/context/FactoryContextMethods.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/context/FactoryContextMethods.java
@@ -19,27 +19,21 @@
 package org.mapstruct.ap.test.context;
 
 import org.mapstruct.Context;
-import org.mapstruct.Mapper;
-import org.mapstruct.MappingTarget;
+import org.mapstruct.ObjectFactory;
 import org.mapstruct.ap.test.context.Node.Attribute;
 import org.mapstruct.ap.test.context.NodeDto.AttributeDto;
-import org.mapstruct.factory.Mappers;
 
 /**
  * @author Andreas Gudian
  */
-@Mapper(uses = { CycleContextLifecycleMethods.class, FactoryContextMethods.class })
-public interface NodeMapperWithContext {
-    NodeMapperWithContext INSTANCE = Mappers.getMapper( NodeMapperWithContext.class );
+public class FactoryContextMethods {
 
-    NodeDto nodeToNodeDto(@Context FactoryContext factoryContext, Node node, @Context CycleContext cycleContext);
+    public NodeDto createNodeDto(@Context FactoryContext context) {
+        return context.createNode();
+    }
 
-    void nodeToNodeDto(@Context FactoryContext factoryContext, Node node, @MappingTarget NodeDto nodeDto,
-            @Context CycleContext cycleContext);
-
-    AttributeDto attributeToAttributeDto(Attribute attribute, @Context CycleContext cycleContext,
-            @Context FactoryContext factoryContext);
-
-    void attributeToAttributeDto(Attribute attribute, @MappingTarget AttributeDto nodeDto,
-            @Context CycleContext cycleContext, @Context FactoryContext factoryContext);
+    @ObjectFactory
+    public AttributeDto createAttributeDto(Attribute source, @Context FactoryContext context) {
+        return context.createAttributeDto( source );
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/context/SelfContainingCycleContext.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/context/SelfContainingCycleContext.java
@@ -18,22 +18,30 @@
  */
 package org.mapstruct.ap.test.context;
 
+import java.util.IdentityHashMap;
+import java.util.Map;
+
+import org.mapstruct.BeforeMapping;
 import org.mapstruct.Context;
-import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
-import org.mapstruct.factory.Mappers;
+import org.mapstruct.TargetType;
 
 /**
+ * A type to be used as {@link Context} parameter to track cycles in graphs.
+ *
  * @author Andreas Gudian
  */
-@Mapper(uses = { CycleContextLifecycleMethods.class, FactoryContextMethods.class })
-public interface AutomappingNodeMapperWithContext {
+public class SelfContainingCycleContext {
+    private Map<Object, Object> knownInstances = new IdentityHashMap<Object, Object>();
 
-    AutomappingNodeMapperWithContext INSTANCE =
-        Mappers.getMapper( AutomappingNodeMapperWithContext.class );
+    @BeforeMapping
+    @SuppressWarnings("unchecked")
+    public <T> T getMappedInstance(Object source, @TargetType Class<T> targetType) {
+        return (T) knownInstances.get( source );
+    }
 
-    NodeDto nodeToNodeDto(Node node, @Context CycleContext cycleContext, @Context FactoryContext factoryContext);
-
-    void nodeToNodeDto(Node node, @MappingTarget NodeDto nodeDto, @Context CycleContext cycleContext,
-            @Context FactoryContext factoryContext);
+    @BeforeMapping
+    public void storeMappedInstance(Object source, @MappingTarget Object target) {
+        knownInstances.put( source, target );
+    }
 }


### PR DESCRIPTION
Only the last commit is new here, the first commits are identical to what's open in PR #1006.

I've already worked in the changes in the Javadoc of `Context` and `ObjectFactory`. I'll do the adaptation of `BeforeMapping` / `AfterMapping` seperately in a PR for #992, if that's okay.

The introduction of `@Context` in the ref-docs will be included in this PR later on (probably after christmas), but I wanted to show you how it's coming along. Code-wise, I'm finished with it so you could play around if you like.