### PR TITLE
#285 JAXB selection mechanism for List

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Field.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Field.java
@@ -105,4 +105,27 @@ public class Field extends ModelElement {
         this.typeRequiresImport = typeRequiresImport;
     }
 
+    @Override
+    public int hashCode() {
+        int hash = 5;
+        hash = 43 * hash + (this.variableName != null ? this.variableName.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        final Field other = (Field) obj;
+        return !( (this.variableName == null) ?
+            (other.variableName != null) : !this.variableName.equals( other.variableName ) );
+    }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -64,6 +64,7 @@ public class IterableMappingMethod extends MappingMethod {
         private FormattingParameters formattingParameters;
         private NullValueMappingStrategyPrism nullValueMappingStrategy;
         private ForgedMethod forgedMethod;
+        private String callingContextTargetPropertyName;
 
         public Builder mappingContext(MappingBuilderContext mappingContext) {
             this.ctx = mappingContext;
@@ -90,6 +91,11 @@ public class IterableMappingMethod extends MappingMethod {
             return this;
         }
 
+        public Builder callingContextTargetPropertyName(String callingContextTargetPropertyName) {
+            this.callingContextTargetPropertyName = callingContextTargetPropertyName;
+            return this;
+        }
+
         public IterableMappingMethod build() {
 
 
@@ -111,7 +117,7 @@ public class IterableMappingMethod extends MappingMethod {
             Assignment assignment = ctx.getMappingResolver().getTargetAssignment(
                 method,
                 targetElementType,
-                null, // there is no targetPropertyName
+                callingContextTargetPropertyName,
                 formattingParameters,
                 selectionParameters,
                 sourceRHS,
@@ -377,6 +383,15 @@ public class IterableMappingMethod extends MappingMethod {
             }
         }
         else if ( other.selectionParameters != null ) {
+            return false;
+        }
+
+        if ( this.factoryMethod != null ) {
+            if ( !this.factoryMethod.equals( other.factoryMethod ) ) {
+                return false;
+            }
+        }
+        else if ( other.factoryMethod != null ) {
             return false;
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -368,6 +368,15 @@ public class MapMappingMethod extends MappingMethod {
             }
         }
 
+        if ( this.factoryMethod != null ) {
+            if ( !this.factoryMethod.equals( other.factoryMethod ) ) {
+                return false;
+            }
+        }
+        else if ( other.factoryMethod != null ) {
+            return false;
+        }
+
         return isMapNullToDefault() == other.isMapNullToDefault();
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
@@ -242,4 +242,40 @@ public abstract class MappingMethod extends ModelElement {
     public List<ForgedMethod> getForgedMethods() {
         return forgedMethods;
     }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 83 * hash + (this.name != null ? this.name.hashCode() : 0);
+        hash = 83 * hash + (this.parameters != null ? this.parameters.hashCode() : 0);
+        hash = 83 * hash + (this.returnType != null ? this.returnType.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        final MappingMethod other = (MappingMethod) obj;
+        if ( (this.name == null) ? (other.name != null) : !this.name.equals( other.name ) ) {
+            return false;
+        }
+        if ( this.parameters != other.parameters &&
+            (this.parameters == null || !this.parameters.equals( other.parameters )) ) {
+            return false;
+        }
+        if ( this.returnType != other.returnType &&
+            (this.returnType == null || !this.returnType.equals( other.returnType )) ) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MethodReference.java
@@ -221,4 +221,30 @@ public class MethodReference extends MappingMethod implements Assignment {
     public List<ParameterBinding> getParameterBindings() {
         return parameterBindings;
     }
+
+    @Override
+    public int hashCode() {
+        int hash = 7;
+        hash = 19 * hash + (this.declaringMapper != null ? this.declaringMapper.hashCode() : 0);
+        return hash;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        final MethodReference other = (MethodReference) obj;
+        if ( this.declaringMapper != other.declaringMapper && (this.declaringMapper == null
+            || !this.declaringMapper.equals( other.declaringMapper )) ) {
+            return false;
+        }
+        return super.equals( obj );
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -562,6 +562,7 @@ public class PropertyMapping extends ModelElement {
                 .mappingContext( ctx )
                 .method( methodRef )
                 .selectionParameters( selectionParameters )
+                .callingContextTargetPropertyName( targetPropertyName )
                 .build();
 
             if ( iterableMappingMethod != null ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/XmlElementDeclSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/XmlElementDeclSelector.java
@@ -66,18 +66,11 @@ public class XmlElementDeclSelector implements MethodSelector {
                                                                           List<Type> sourceTypes, Type targetType,
                                                                           SelectionCriteria criteria) {
 
-        // only true source methods are qualifying
-        if ( !(mappingMethod instanceof SourceMethod) ) {
-            return methods;
-        }
-
-        SourceMethod sourceMappingMethod = (SourceMethod) mappingMethod;
-
         List<SelectedMethod<T>> nameMatches = new ArrayList<SelectedMethod<T>>();
         List<SelectedMethod<T>> scopeMatches = new ArrayList<SelectedMethod<T>>();
         List<SelectedMethod<T>> nameAndScopeMatches = new ArrayList<SelectedMethod<T>>();
         XmlElementRefInfo xmlElementRefInfo =
-            findXmlElementRef( sourceMappingMethod.getResultType(), criteria.getTargetPropertyName() );
+            findXmlElementRef( mappingMethod.getResultType(), criteria.getTargetPropertyName() );
 
         for ( SelectedMethod<T> candidate : methods ) {
             if ( !( candidate.getMethod() instanceof SourceMethod ) ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/OrderDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/OrderDto.java
@@ -18,6 +18,8 @@
  */
 package org.mapstruct.ap.test.selection.jaxb;
 
+import java.util.List;
+
 /**
  * @author Sjaak Derksen
  */
@@ -26,6 +28,7 @@ public class OrderDto {
     private Long orderNumber1;
     private Long orderNumber2;
     private OrderShippingDetailsDto shippingDetails;
+    private List<String> description;
 
     public Long getOrderNumber1() {
         return orderNumber1;
@@ -50,4 +53,13 @@ public class OrderDto {
     public void setShippingDetails(OrderShippingDetailsDto shippingDetails) {
         this.shippingDetails = shippingDetails;
     }
+
+    public List<String> getDescription() {
+        return description;
+    }
+
+    public void setDescription(List<String> description) {
+        this.description = description;
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/OrderMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/OrderMapper.java
@@ -18,8 +18,6 @@
  */
 package org.mapstruct.ap.test.selection.jaxb;
 
-import javax.xml.bind.JAXBElement;
-
 import org.mapstruct.Mapper;
 import org.mapstruct.ap.test.selection.jaxb.test1.ObjectFactory;
 import org.mapstruct.ap.test.selection.jaxb.test1.OrderType;
@@ -42,9 +40,4 @@ public abstract class OrderMapper {
 
     public abstract OrderShippingDetailsType dtoToOrderShippingDetailsType(OrderShippingDetailsDto target);
 
-    // TODO, remove this method when #134 is fixed
-    public JAXBElement<OrderShippingDetailsType> dtoToOrderShippingDetailsTypeJB(OrderShippingDetailsDto target) {
-        ObjectFactory of1 = new ObjectFactory();
-        return of1.createOrderTypeShippingDetails( INSTANCE.dtoToOrderShippingDetailsType( target ) );
-    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/test1/ObjectFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/test1/ObjectFactory.java
@@ -36,6 +36,8 @@ public class ObjectFactory {
         new QName( "http://www.mapstruct.org/ap/test/jaxb/selection/test1", "orderNumber2" );
     public static final QName ORDER_TYPE_SHIPPING_DETAILS_QNAME =
         new QName( "http://www.mapstruct.org/ap/test/jaxb/selection/test1", "shippingDetails" );
+    public static final QName ORDER_TYPE_DESCRIPTION_QNAME =
+        new QName("http://www.mapstruct.org/itest/jaxb/xsd/test1", "description");
 
     public ObjectFactory() {
     }
@@ -68,6 +70,12 @@ public class ObjectFactory {
             ORDER_TYPE_SHIPPING_DETAILS_QNAME,
             OrderShippingDetailsType.class, OrderType.class, value
         );
+    }
+
+    @XmlElementDecl(namespace = "http://www.mapstruct.org/itest/jaxb/xsd/test1",
+        name = "description", scope = OrderType.class)
+    public JAXBElement<String> createOrderTypeDescription(String value) {
+        return new JAXBElement<String>(ORDER_TYPE_DESCRIPTION_QNAME, String.class, OrderType.class, value);
     }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/test1/OrderType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/test1/OrderType.java
@@ -18,6 +18,7 @@
  */
 package org.mapstruct.ap.test.selection.jaxb.test1;
 
+import java.util.List;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -43,6 +44,9 @@ public class OrderType {
     @XmlElementRef(name = "shippingDetails", namespace = "http://www.mapstruct.org/ap/test/jaxb/selection/test1",
         type = JAXBElement.class)
     private JAXBElement<OrderShippingDetailsType> shippingDetails;
+    @XmlElementRef(name = "description", namespace = "http://www.mapstruct.org/itest/jaxb/xsd/test1",
+        type = JAXBElement.class)
+    protected List<JAXBElement<String>> description;
 
     public JAXBElement<Long> getOrderNumber1() {
         return orderNumber1;
@@ -66,6 +70,14 @@ public class OrderType {
 
     public void setShippingDetails(JAXBElement<OrderShippingDetailsType> value) {
         this.shippingDetails = value;
+    }
+
+    public List<JAXBElement<String>> getDescription() {
+        return description;
+    }
+
+    public void setDescription(List<JAXBElement<String>> description) {
+        this.description = description;
     }
 
 }


### PR DESCRIPTION
XmlElementDeclSelector should receive its context from the calling property mapping. This is possible for forged methods. However for non-forged methods we should find another solution. Perhaps extend the annotation with jaxbCallingElemName or something along that lines.. Or leave it as is.

The equals methods needed to be implemented since which factory is called in a forged method is a discriminating element in its uniqueness.