### PR TITLE
#1027 do not consider Inherit(Inverse)Configuration in used mappers

### DIFF
--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -1869,6 +1869,11 @@ In case more than one method is applicable as source for the inheritance, the me
 
 A method can use `@InheritConfiguration` and override or amend the configuration by additionally applying `@Mapping`, `@BeanMapping`, etc.
 
+[NOTE]
+====
+`@InheritConfiguration` cannot refer to methods in a used mapper.
+====
+
 [[inverse-mappings]]
 === Inverse mappings
 
@@ -1904,6 +1909,11 @@ Methods that are considered for inverse inheritance need to be defined in the cu
 If multiple methods qualify, the method from which to inherit the configuration needs to be specified using the `name` property like this: `@InheritInverseConfiguration(name = "carToDto")`.
 
 Expressions and constants are excluded (silently ignored). Reverse mapping of nested source properties is experimental as of the 1.1.0.Beta2. Reverse mapping will take place automatically when the source property name and target property name are identical. Otherwise, `@Mapping` should specify both the target name and source name. In all cases, a suitable mapping method needs to be in place for the reverse mapping.
+
+[NOTE]
+====
+`@InheritInverseConfiguration` cannot refer to methods in a used mapper.
+====
 
 [[shared-configurations]]
 === Shared configurations

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -334,7 +334,8 @@ public class SourceMethod implements Method {
     }
 
     public boolean reverses(SourceMethod method) {
-        return isAbstract()
+        return getDeclaringMapper() == null
+            && isAbstract()
             && getSourceParameters().size() == 1 && method.getSourceParameters().size() == 1
             && equals( first( getSourceParameters() ).getType(), method.getResultType() )
             && equals( getResultType(), first( method.getSourceParameters() ).getType() );
@@ -347,7 +348,8 @@ public class SourceMethod implements Method {
     }
 
     public boolean canInheritFrom(SourceMethod method) {
-        return method.isAbstract()
+        return method.getDeclaringMapper() == null
+            && method.isAbstract()
             && isMapMapping() == method.isMapMapping()
             && isIterableMapping() == method.isIterableMapping()
             && isEnumMapping() == method.isEnumMapping()

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/CarMapperWithExplicitInheritance.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/CarMapperWithExplicitInheritance.java
@@ -30,6 +30,7 @@ import org.mapstruct.factory.Mappers;
  * @author Andreas Gudian
  */
 @Mapper(
+    uses = NotToBeUsedMapper.class,
     config = AutoInheritedConfig.class,
     mappingInheritanceStrategy = MappingInheritanceStrategy.EXPLICIT
 )

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/InheritFromConfigTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/InheritFromConfigTest.java
@@ -42,7 +42,8 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
     CarEntity.class,
     CarMapperWithAutoInheritance.class,
     CarMapperWithExplicitInheritance.class,
-    AutoInheritedConfig.class
+    AutoInheritedConfig.class,
+    NotToBeUsedMapper.class
 })
 @IssueKey("168")
 public class InheritFromConfigTest {

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/NotToBeUsedMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/NotToBeUsedMapper.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper
+public interface NotToBeUsedMapper {
+
+    @Mappings({
+        @Mapping(target = "primaryKey", ignore = true),
+        @Mapping(target = "auditTrail", ignore = true),
+        @Mapping(target = "color", ignore = true)
+    })
+    CarEntity toCarEntity(CarDto carDto);
+}


### PR DESCRIPTION
Currently MapStruct can refer to used mappers to inherit(reverse)configurations. However, it could be that these mappings are not available (for instance: the used mapper is part of another jar library or the concerning used mapper is not yet generated in the processor). I don't think we intended that so I explicitly disabled it.