### PR TITLE
Cleanup duplicates in MappingMethods

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -74,10 +74,7 @@ public class BeanMappingMethod extends ContainerMappingMethod {
     private final List<PropertyMapping> propertyMappings;
     private final Map<String, List<PropertyMapping>> mappingsByParameter;
     private final List<PropertyMapping> constantMappings;
-    private final MethodReference factoryMethod;
-    private final boolean mapNullToDefault;
     private final Type resultType;
-    private final boolean overridden;
 
     public static class Builder {
 
@@ -695,10 +692,7 @@ public class BeanMappingMethod extends ContainerMappingMethod {
                 }
             }
         }
-        this.factoryMethod = factoryMethod;
-        this.mapNullToDefault = mapNullToDefault;
         this.resultType = resultType;
-        this.overridden = method.overridesMethod();
     }
 
     public List<PropertyMapping> getPropertyMappings() {
@@ -711,16 +705,6 @@ public class BeanMappingMethod extends ContainerMappingMethod {
 
     public Map<String, List<PropertyMapping>> getPropertyMappingsByParameter() {
         return mappingsByParameter;
-    }
-
-    @Override
-    public boolean isMapNullToDefault() {
-        return mapNullToDefault;
-    }
-
-    @Override
-    public boolean isOverridden() {
-        return overridden;
     }
 
     @Override
@@ -763,11 +747,6 @@ public class BeanMappingMethod extends ContainerMappingMethod {
             }
         }
         return sourceParameters;
-    }
-
-    @Override
-    public MethodReference getFactoryMethod() {
-        return this.factoryMethod;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -69,7 +69,7 @@ import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
  *
  * @author Gunnar Morling
  */
-public class BeanMappingMethod extends ContainerMappingMethod {
+public class BeanMappingMethod extends NormalTypeMappingMethod {
 
     private final List<PropertyMapping> propertyMappings;
     private final Map<String, List<PropertyMapping>> mappingsByParameter;
@@ -667,13 +667,10 @@ public class BeanMappingMethod extends ContainerMappingMethod {
                               List<LifecycleCallbackMethodReference> afterMappingReferences) {
         super(
             method,
-            null,
             factoryMethod,
             mapNullToDefault,
-            null,
             beforeMappingReferences,
-            afterMappingReferences,
-            null
+            afterMappingReferences
         );
 
         this.propertyMappings = propertyMappings;
@@ -750,16 +747,9 @@ public class BeanMappingMethod extends ContainerMappingMethod {
     }
 
     @Override
-    public Type getResultElementType() {
-        return null;
-    }
-
-    @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ( ( getResultType() == null ) ? 0 : getResultType().hashCode() );
-        return result;
+        //Needed for Checkstyle, otherwise it fails due to EqualsHashCode rule
+        return super.hashCode();
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
@@ -20,7 +20,6 @@ package org.mapstruct.ap.internal.model;
 
 import java.util.List;
 import java.util.Set;
-import javax.lang.model.type.TypeKind;
 
 import org.mapstruct.ap.internal.model.assignment.Assignment;
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -77,27 +76,6 @@ public abstract class ContainerMappingMethod extends NormalTypeMappingMethod {
 
     public String getLoopVariableName() {
         return loopVariableName;
-    }
-
-    public String getDefaultValue() {
-        TypeKind kind = getResultElementType().getTypeMirror().getKind();
-        switch ( kind ) {
-            case BOOLEAN:
-                return "false";
-            case BYTE:
-            case SHORT:
-            case INT:
-            case CHAR:  /*"'\u0000'" would have been better, but depends on platformencoding */
-                return "0";
-            case LONG:
-                return "0L";
-            case FLOAT:
-                return "0.0f";
-            case DOUBLE:
-                return "0.0d";
-            default:
-                return "null";
-        }
     }
 
     public abstract Type getResultElementType();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
@@ -36,11 +36,8 @@ import org.mapstruct.ap.internal.util.Strings;
  *
  * @author Filip Hrisafov
  */
-public abstract class ContainerMappingMethod extends MappingMethod {
+public abstract class ContainerMappingMethod extends NormalTypeMappingMethod {
     private final Assignment elementAssignment;
-    private final MethodReference factoryMethod;
-    private final boolean overridden;
-    private final boolean mapNullToDefault;
     private final String loopVariableName;
     private final SelectionParameters selectionParameters;
 
@@ -49,11 +46,8 @@ public abstract class ContainerMappingMethod extends MappingMethod {
         List<LifecycleCallbackMethodReference> beforeMappingReferences,
         List<LifecycleCallbackMethodReference> afterMappingReferences,
         SelectionParameters selectionParameters) {
-        super( method, beforeMappingReferences, afterMappingReferences );
+        super( method, factoryMethod, mapNullToDefault, beforeMappingReferences, afterMappingReferences );
         this.elementAssignment = parameterAssignment;
-        this.factoryMethod = factoryMethod;
-        this.overridden = method.overridesMethod();
-        this.mapNullToDefault = mapNullToDefault;
         this.loopVariableName = loopVariableName;
         this.selectionParameters = selectionParameters;
     }
@@ -78,20 +72,7 @@ public abstract class ContainerMappingMethod extends MappingMethod {
         if ( elementAssignment != null ) {
             types.addAll( elementAssignment.getImportTypes() );
         }
-        if ( ( factoryMethod == null ) && ( !isExistingInstanceMapping() ) ) {
-            if ( getReturnType().getImplementationType() != null ) {
-                types.addAll( getReturnType().getImplementationType().getImportTypes() );
-            }
-        }
         return types;
-    }
-
-    public boolean isMapNullToDefault() {
-        return mapNullToDefault;
-    }
-
-    public boolean isOverridden() {
-        return overridden;
     }
 
     public String getLoopVariableName() {
@@ -119,10 +100,6 @@ public abstract class ContainerMappingMethod extends MappingMethod {
         }
     }
 
-    public MethodReference getFactoryMethod() {
-        return this.factoryMethod;
-    }
-
     public abstract Type getResultElementType();
 
     public String getIndex1Name() {
@@ -135,10 +112,8 @@ public abstract class ContainerMappingMethod extends MappingMethod {
 
     @Override
     public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + ( ( getResultType() == null ) ? 0 : getResultType().hashCode() );
-        return result;
+        //Needed for Checkstyle, otherwise it fails due to EqualsHashCode rule
+        return super.hashCode();
     }
 
     @Override
@@ -152,27 +127,12 @@ public abstract class ContainerMappingMethod extends MappingMethod {
         if ( getClass() != obj.getClass() ) {
             return false;
         }
+
+        if ( !super.equals( obj ) ) {
+            return false;
+        }
+
         ContainerMappingMethod other = (ContainerMappingMethod) obj;
-
-        if ( !getResultType().equals( other.getResultType() ) ) {
-            return false;
-        }
-
-        if ( getSourceParameters().size() != other.getSourceParameters().size() ) {
-            return false;
-        }
-
-        for ( int i = 0; i < getSourceParameters().size(); i++ ) {
-            if ( !getSourceParameters().get( i ).getType().equals( other.getSourceParameters().get( i ).getType() ) ) {
-                return false;
-            }
-            List<Type> thisTypeParameters = getSourceParameters().get( i ).getType().getTypeParameters();
-            List<Type> otherTypeParameters = other.getSourceParameters().get( i ).getType().getTypeParameters();
-
-            if ( !thisTypeParameters.equals( otherTypeParameters ) ) {
-                return false;
-            }
-        }
 
         if ( this.selectionParameters != null ) {
             if ( !this.selectionParameters.equals( other.selectionParameters ) ) {
@@ -183,7 +143,7 @@ public abstract class ContainerMappingMethod extends MappingMethod {
             return false;
         }
 
-        return isMapNullToDefault() == other.isMapNullToDefault();
+        return true;
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NormalTypeMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NormalTypeMappingMethod.java
@@ -1,0 +1,114 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.List;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.source.Method;
+
+/**
+ * A {@link MappingMethod} that is used by the main mapping methods ({@link BeanMappingMethod},
+ * {@link MapMappingMethod}, {@link IterableMappingMethod} and {@link StreamMappingMethod} (non-enum / non-value
+ * mapping)
+ *
+ * @author Filip Hrisafov
+ */
+public abstract class NormalTypeMappingMethod extends MappingMethod {
+    private final MethodReference factoryMethod;
+    private final boolean overridden;
+    private final boolean mapNullToDefault;
+
+    NormalTypeMappingMethod(Method method, MethodReference factoryMethod, boolean mapNullToDefault,
+        List<LifecycleCallbackMethodReference> beforeMappingReferences,
+        List<LifecycleCallbackMethodReference> afterMappingReferences) {
+        super( method, beforeMappingReferences, afterMappingReferences );
+        this.factoryMethod = factoryMethod;
+        this.overridden = method.overridesMethod();
+        this.mapNullToDefault = mapNullToDefault;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        Set<Type> types = super.getImportTypes();
+        if ( ( factoryMethod == null ) && ( !isExistingInstanceMapping() ) ) {
+            if ( getReturnType().getImplementationType() != null ) {
+                types.addAll( getReturnType().getImplementationType().getImportTypes() );
+            }
+        }
+        return types;
+    }
+
+    public boolean isMapNullToDefault() {
+        return mapNullToDefault;
+    }
+
+    public boolean isOverridden() {
+        return overridden;
+    }
+
+    public MethodReference getFactoryMethod() {
+        return this.factoryMethod;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( getResultType() == null ) ? 0 : getResultType().hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        NormalTypeMappingMethod other = (NormalTypeMappingMethod) obj;
+
+        if ( !getResultType().equals( other.getResultType() ) ) {
+            return false;
+        }
+
+        if ( getSourceParameters().size() != other.getSourceParameters().size() ) {
+            return false;
+        }
+
+        for ( int i = 0; i < getSourceParameters().size(); i++ ) {
+            if ( !getSourceParameters().get( i ).getType().equals( other.getSourceParameters().get( i ).getType() ) ) {
+                return false;
+            }
+            List<Type> thisTypeParameters = getSourceParameters().get( i ).getType().getTypeParameters();
+            List<Type> otherTypeParameters = other.getSourceParameters().get( i ).getType().getTypeParameters();
+
+            if ( !thisTypeParameters.equals( otherTypeParameters ) ) {
+                return false;
+            }
+        }
+
+        return isMapNullToDefault() == other.isMapNullToDefault();
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -758,10 +758,11 @@ public class Type extends ModelElement implements Comparable<Type> {
             return "0";
         }
         if ( "char".equals( getName() ) ) {
-            return "'\\u0000'";
+            //"'\u0000'" would have been better, but depends on platform encoding
+                return "0";
         }
         if ( "double".equals( getName() ) ) {
-            return "0.0";
+            return "0.0d";
         }
         if ( "float".equals( getName() ) ) {
             return "0.0f";

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
@@ -35,7 +35,7 @@
                 <#if existingInstanceMapping>
                     <#-- we can't clear an existing array, so we've got to clear by setting values to default -->
                     for (int ${index2Name} = 0; ${index2Name} < ${resultName}.length; ${index2Name}++ ) {
-                        ${resultName}[${index2Name}] = ${defaultValue};
+                        ${resultName}[${index2Name}] = ${resultElementType.null};
                     }
                     return<#if returnType.name != "void"> ${resultName}</#if>;
                 <#else>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
@@ -37,7 +37,7 @@
                 <#if existingInstanceMapping>
                     <#-- we can't clear an existing array, so we've got to clear by setting values to default -->
                     for (int ${index2Name} = 0; ${index2Name} < ${resultName}.length; ${index2Name}++ ) {
-                        ${resultName}[${index2Name}] = ${defaultValue};
+                        ${resultName}[${index2Name}] = ${resultElementType.null};
                     }
                     return<#if returnType.name != "void"> ${resultName}</#if>;
                 <#else>


### PR DESCRIPTION
I have created a new class for all the `MappingMethods` that have a factory method. There was a lot of duplication between all of the different methods.

Is it too much abstraction (with the new class)?