### PR TITLE
#1061 Support for generating Mappers in the default package

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -31,6 +31,7 @@ import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.option.Options;
+import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.version.VersionInformation;
 
 /**
@@ -106,6 +107,10 @@ public abstract class GeneratedType extends ModelElement {
 
     public String getPackageName() {
         return packageName;
+    }
+
+    public boolean hasPackageName() {
+        return !Strings.isEmpty( packageName );
     }
 
     public String getName() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperRenderingProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperRenderingProcessor.java
@@ -57,7 +57,11 @@ public class MapperRenderingProcessor implements ModelElementProcessor<Mapper, M
     }
 
     private void createSourceFile(GeneratedType model, ModelWriter modelWriter, Filer filer) {
-        String fileName = model.getPackageName() + "." + model.getName();
+        String fileName = "";
+        if ( model.hasPackageName() ) {
+            fileName += model.getPackageName() + ".";
+        }
+        fileName += model.getName();
 
         JavaFileObject sourceFile;
         try {

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/GeneratedType.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/GeneratedType.ftl
@@ -1,3 +1,4 @@
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.GeneratedType" -->
 <#--
 
      Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
@@ -18,7 +19,9 @@
      limitations under the License.
 
 -->
+<#if hasPackageName()>
 package ${packageName};
+</#if>
 
 <#list importTypes as importedType>
 import ${importedType.importName};

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1061/Issue1061Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1061/Issue1061Test.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1061;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("1061")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses(SourceTargetMapper.class)
+public class Issue1061Test {
+
+    @Test
+    public void shouldCompile() throws Exception {
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1061/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1061/SourceTargetMapper.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1061;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(implementationPackage = "")
+public interface SourceTargetMapper {
+
+    List<Integer> map(List<String> strings);
+}


### PR DESCRIPTION
This PR makes sure that we generate a valid name for the Mappers that are created in the default package and that no `package` is added to the generated file.