### PR TITLE
#1073 Change NestedPropertyMappingMethod to not use name in its equality

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
@@ -118,9 +118,10 @@ public class NestedPropertyMappingMethod extends MappingMethod {
         if ( getClass() != obj.getClass() ) {
             return false;
         }
+
         NestedPropertyMappingMethod other = (NestedPropertyMappingMethod) obj;
 
-        if ( !getReturnType().equals( other.getReturnType() ) ) {
+        if ( !super.equals( obj ) ) {
             return false;
         }
 
@@ -134,7 +135,7 @@ public class NestedPropertyMappingMethod extends MappingMethod {
             }
         }
 
-        if ( !getName().equals( other.getName() ) ) {
+        if ( !safePropertyEntries.equals( other.safePropertyEntries ) ) {
             return false;
         }
 
@@ -176,6 +177,40 @@ public class NestedPropertyMappingMethod extends MappingMethod {
             return type;
         }
 
+        @Override
+        public boolean equals(Object o) {
+            if ( this == o ) {
+                return true;
+            }
+            if ( !( o instanceof SafePropertyEntry ) ) {
+                return false;
+            }
+
+            SafePropertyEntry that = (SafePropertyEntry) o;
+
+            if ( readAccessorName != null ? !readAccessorName.equals( that.readAccessorName ) :
+                that.readAccessorName != null ) {
+                return false;
+            }
+
+            if ( presenceCheckerName != null ? !presenceCheckerName.equals( that.presenceCheckerName ) :
+                that.presenceCheckerName != null ) {
+                return false;
+            }
+
+            if ( type != null ? !type.equals( that.type ) : that.type != null ) {
+                return false;
+            }
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = readAccessorName != null ? readAccessorName.hashCode() : 0;
+            result = 31 * result + ( presenceCheckerName != null ? presenceCheckerName.hashCode() : 0 );
+            result = 31 * result + ( type != null ? type.hashCode() : 0 );
+            return result;
+        }
     }
 }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/NestedSourcePropertiesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/NestedSourcePropertiesTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.test.nestedsourceproperties._target.AdderUsageObserver;
@@ -40,6 +41,7 @@ import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
 /**
  * @author Sjaak Derksen
@@ -49,9 +51,13 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 @RunWith(AnnotationProcessorTestRunner.class)
 public class NestedSourcePropertiesTest {
 
+    @Rule
+    public final GeneratedSource generatedSource = new GeneratedSource();
+
     @Test
     @WithClasses({ ArtistToChartEntry.class })
     public void shouldGenerateImplementationForPropertyNamesOnly() {
+        generatedSource.addComparisonToFixtureFor( ArtistToChartEntry.class );
 
         Studio studio = new Studio();
         studio.setName( "Abbey Road" );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedsourceproperties/ArtistToChartEntryImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedsourceproperties/ArtistToChartEntryImpl.java
@@ -1,0 +1,170 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedsourceproperties;
+
+import javax.annotation.Generated;
+import org.mapstruct.ap.test.nestedsourceproperties._target.ChartEntry;
+import org.mapstruct.ap.test.nestedsourceproperties.source.Artist;
+import org.mapstruct.ap.test.nestedsourceproperties.source.Chart;
+import org.mapstruct.ap.test.nestedsourceproperties.source.Label;
+import org.mapstruct.ap.test.nestedsourceproperties.source.Song;
+import org.mapstruct.ap.test.nestedsourceproperties.source.Studio;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2017-02-17T20:44:15+0100",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+)
+public class ArtistToChartEntryImpl implements ArtistToChartEntry {
+
+    @Override
+    public ChartEntry map(Chart chart, Song song, Integer position) {
+        if ( chart == null && song == null && position == null ) {
+            return null;
+        }
+
+        ChartEntry chartEntry = new ChartEntry();
+
+        if ( chart != null ) {
+            chartEntry.setChartName( chart.getName() );
+        }
+        if ( song != null ) {
+            chartEntry.setSongTitle( song.getTitle() );
+            String city = songArtistLabelStudioCity( song );
+            if ( city != null ) {
+                chartEntry.setCity( city );
+            }
+            String name = songArtistLabelStudioName( song );
+            if ( name != null ) {
+                chartEntry.setRecordedAt( name );
+            }
+            String name1 = songArtistName( song );
+            if ( name1 != null ) {
+                chartEntry.setArtistName( name1 );
+            }
+        }
+        if ( position != null ) {
+            chartEntry.setPosition( position );
+        }
+
+        return chartEntry;
+    }
+
+    @Override
+    public ChartEntry map(Song song) {
+        if ( song == null ) {
+            return null;
+        }
+
+        ChartEntry chartEntry = new ChartEntry();
+
+        chartEntry.setSongTitle( song.getTitle() );
+        String city = songArtistLabelStudioCity( song );
+        if ( city != null ) {
+            chartEntry.setCity( city );
+        }
+        String name = songArtistLabelStudioName( song );
+        if ( name != null ) {
+            chartEntry.setRecordedAt( name );
+        }
+        String name1 = songArtistName( song );
+        if ( name1 != null ) {
+            chartEntry.setArtistName( name1 );
+        }
+
+        return chartEntry;
+    }
+
+    @Override
+    public ChartEntry map(Chart name) {
+        if ( name == null ) {
+            return null;
+        }
+
+        ChartEntry chartEntry = new ChartEntry();
+
+        chartEntry.setChartName( name.getName() );
+
+        return chartEntry;
+    }
+
+    private String songArtistLabelStudioCity(Song song) {
+
+        if ( song == null ) {
+            return null;
+        }
+        Artist artist = song.getArtist();
+        if ( artist == null ) {
+            return null;
+        }
+        Label label = artist.getLabel();
+        if ( label == null ) {
+            return null;
+        }
+        Studio studio = label.getStudio();
+        if ( studio == null ) {
+            return null;
+        }
+        String city = studio.getCity();
+        if ( city == null ) {
+            return null;
+        }
+        return city;
+    }
+
+    private String songArtistLabelStudioName(Song song) {
+
+        if ( song == null ) {
+            return null;
+        }
+        Artist artist = song.getArtist();
+        if ( artist == null ) {
+            return null;
+        }
+        Label label = artist.getLabel();
+        if ( label == null ) {
+            return null;
+        }
+        Studio studio = label.getStudio();
+        if ( studio == null ) {
+            return null;
+        }
+        String name = studio.getName();
+        if ( name == null ) {
+            return null;
+        }
+        return name;
+    }
+
+    private String songArtistName(Song song) {
+
+        if ( song == null ) {
+            return null;
+        }
+        Artist artist = song.getArtist();
+        if ( artist == null ) {
+            return null;
+        }
+        String name = artist.getName();
+        if ( name == null ) {
+            return null;
+        }
+        return name;
+    }
+}


### PR DESCRIPTION
`NestedPropertyMappingMethod` was using the name in its `equals` method. This is not correct, because we always generate safe names, which leads to never reusing a `NestedPropertyMappingMethod`. 

With this PR a `NestedPropertyMappingMethod` is considered equals if it additionally has equal `SafePropertyEntry` entries.