### PR TITLE
#1091 Map ANY_REMAINING Enum source to null

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
@@ -105,7 +105,9 @@ public class ValueMappingMethod extends MappingMethod {
                     nullTarget = nullTargetValue.getTarget();
                 }
                 if ( defaultTargetValue != null ) {
-                    defaultTarget = defaultTargetValue.getTarget();
+                    // If the default target value is NULL then we should map it to null
+                    defaultTarget = MappingConstantsPrism.NULL.equals( defaultTargetValue.getTarget() ) ? null :
+                        defaultTargetValue.getTarget();
                 }
                 else {
                     throwIllegalArgumentException = true;

--- a/processor/src/test/java/org/mapstruct/ap/test/value/EnumToEnumMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/EnumToEnumMappingTest.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import javax.tools.Diagnostic.Kind;
 
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
@@ -30,6 +31,7 @@ import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
 /**
  * Test for the generation and invocation of enum mapping methods.
@@ -41,6 +43,13 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
     OrderType.class, OrderDto.class, ExternalOrderType.class })
 @RunWith(AnnotationProcessorTestRunner.class)
 public class EnumToEnumMappingTest {
+
+    @Rule
+    public final GeneratedSource generatedSource = new GeneratedSource().addComparisonToFixtureFor(
+        DefaultOrderMapper.class,
+        OrderMapper.class,
+        SpecialOrderMapper.class
+    );
 
     @Test
     public void shouldGenerateEnumMappingMethod() {
@@ -186,6 +195,29 @@ public class EnumToEnumMappingTest {
         assertThat( orderDto ).isNotNull();
         assertThat( orderDto.getOrderType() ).isEqualTo( ExternalOrderType.DEFAULT );
 
+    }
+
+    @IssueKey( "1091" )
+    @Test
+    public void shouldMapAnyRemainingToNullCorrectly() throws Exception {
+        ExternalOrderType externalOrderType = SpecialOrderMapper.INSTANCE.anyRemainingToNull( OrderType.RETAIL );
+        assertThat( externalOrderType )
+            .isNotNull()
+            .isEqualTo( ExternalOrderType.RETAIL );
+
+        externalOrderType = SpecialOrderMapper.INSTANCE.anyRemainingToNull( OrderType.B2B );
+        assertThat( externalOrderType )
+            .isNotNull()
+            .isEqualTo( ExternalOrderType.B2B );
+
+        externalOrderType = SpecialOrderMapper.INSTANCE.anyRemainingToNull( OrderType.EXTRA );
+        assertThat( externalOrderType ).isNull();
+
+        externalOrderType = SpecialOrderMapper.INSTANCE.anyRemainingToNull( OrderType.STANDARD );
+        assertThat( externalOrderType ).isNull();
+
+        externalOrderType = SpecialOrderMapper.INSTANCE.anyRemainingToNull( OrderType.NORMAL );
+        assertThat( externalOrderType ).isNull();
     }
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/value/SpecialOrderMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/SpecialOrderMapper.java
@@ -20,7 +20,9 @@ package org.mapstruct.ap.test.value;
 
 import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
+import org.mapstruct.Named;
 import org.mapstruct.ValueMapping;
 import org.mapstruct.ValueMappings;
 import org.mapstruct.factory.Mappers;
@@ -33,8 +35,11 @@ public interface SpecialOrderMapper {
 
     SpecialOrderMapper INSTANCE = Mappers.getMapper( SpecialOrderMapper.class );
 
+
+    @Mapping(target = "orderType", source = "orderType", qualifiedByName = "orderTypeToExternalOrderType")
     OrderDto orderEntityToDto(OrderEntity order);
 
+    @Named("orderTypeToExternalOrderType")
     @ValueMappings({
         @ValueMapping( source = MappingConstants.NULL, target = "DEFAULT" ),
         @ValueMapping( source = "STANDARD", target = MappingConstants.NULL ),
@@ -42,7 +47,14 @@ public interface SpecialOrderMapper {
     })
     ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
 
-    @InheritInverseConfiguration
+    @InheritInverseConfiguration(name = "orderTypeToExternalOrderType")
     @ValueMapping( target = "EXTRA", source = "SPECIAL" )
     OrderType externalOrderTypeToOrderType(ExternalOrderType orderType);
+
+    @ValueMappings({
+        @ValueMapping(source = MappingConstants.NULL, target = "DEFAULT"),
+        @ValueMapping(source = "STANDARD", target = MappingConstants.NULL),
+        @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)
+    })
+    ExternalOrderType anyRemainingToNull(OrderType orderType);
 }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/DefaultOrderMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/DefaultOrderMapperImpl.java
@@ -1,0 +1,57 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.value;
+
+import javax.annotation.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2017-02-20T21:25:45+0100",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+)
+public class DefaultOrderMapperImpl implements DefaultOrderMapper {
+
+    @Override
+    public OrderDto orderEntityToDto(OrderEntity order) {
+        if ( order == null ) {
+            return null;
+        }
+
+        OrderDto orderDto = new OrderDto();
+
+        orderDto.setOrderType( orderTypeToExternalOrderType( order.getOrderType() ) );
+
+        return orderDto;
+    }
+
+    @Override
+    public ExternalOrderType orderTypeToExternalOrderType(OrderType orderType) {
+        if ( orderType == null ) {
+            return null;
+        }
+
+        ExternalOrderType externalOrderType;
+
+        switch ( orderType ) {
+            default: externalOrderType = ExternalOrderType.DEFAULT;
+        }
+
+        return externalOrderType;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/OrderMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/OrderMapperImpl.java
@@ -1,0 +1,90 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.value;
+
+import javax.annotation.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2017-02-20T21:25:45+0100",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+)
+public class OrderMapperImpl implements OrderMapper {
+
+    @Override
+    public OrderDto orderEntityToDto(OrderEntity order) {
+        if ( order == null ) {
+            return null;
+        }
+
+        OrderDto orderDto = new OrderDto();
+
+        orderDto.setOrderType( orderTypeToExternalOrderType( order.getOrderType() ) );
+
+        return orderDto;
+    }
+
+    @Override
+    public ExternalOrderType orderTypeToExternalOrderType(OrderType orderType) {
+        if ( orderType == null ) {
+            return null;
+        }
+
+        ExternalOrderType externalOrderType;
+
+        switch ( orderType ) {
+            case EXTRA: externalOrderType = ExternalOrderType.SPECIAL;
+            break;
+            case STANDARD: externalOrderType = ExternalOrderType.DEFAULT;
+            break;
+            case NORMAL: externalOrderType = ExternalOrderType.DEFAULT;
+            break;
+            case RETAIL: externalOrderType = ExternalOrderType.RETAIL;
+            break;
+            case B2B: externalOrderType = ExternalOrderType.B2B;
+            break;
+            default: throw new IllegalArgumentException( "Unexpected enum constant: " + orderType );
+        }
+
+        return externalOrderType;
+    }
+
+    @Override
+    public OrderType externalOrderTypeToOrderType(ExternalOrderType orderType) {
+        if ( orderType == null ) {
+            return null;
+        }
+
+        OrderType orderType1;
+
+        switch ( orderType ) {
+            case SPECIAL: orderType1 = OrderType.EXTRA;
+            break;
+            case DEFAULT: orderType1 = OrderType.STANDARD;
+            break;
+            case RETAIL: orderType1 = OrderType.RETAIL;
+            break;
+            case B2B: orderType1 = OrderType.B2B;
+            break;
+            default: throw new IllegalArgumentException( "Unexpected enum constant: " + orderType );
+        }
+
+        return orderType1;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/SpecialOrderMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/SpecialOrderMapperImpl.java
@@ -1,0 +1,107 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.value;
+
+import javax.annotation.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2017-02-20T21:25:45+0100",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+)
+public class SpecialOrderMapperImpl implements SpecialOrderMapper {
+
+    @Override
+    public OrderDto orderEntityToDto(OrderEntity order) {
+        if ( order == null ) {
+            return null;
+        }
+
+        OrderDto orderDto = new OrderDto();
+
+        orderDto.setOrderType( orderTypeToExternalOrderType( order.getOrderType() ) );
+
+        return orderDto;
+    }
+
+    @Override
+    public ExternalOrderType orderTypeToExternalOrderType(OrderType orderType) {
+        if ( orderType == null ) {
+            return ExternalOrderType.DEFAULT;
+        }
+
+        ExternalOrderType externalOrderType;
+
+        switch ( orderType ) {
+            case STANDARD: externalOrderType = null;
+            break;
+            case RETAIL: externalOrderType = ExternalOrderType.RETAIL;
+            break;
+            case B2B: externalOrderType = ExternalOrderType.B2B;
+            break;
+            default: externalOrderType = ExternalOrderType.SPECIAL;
+        }
+
+        return externalOrderType;
+    }
+
+    @Override
+    public OrderType externalOrderTypeToOrderType(ExternalOrderType orderType) {
+        if ( orderType == null ) {
+            return OrderType.STANDARD;
+        }
+
+        OrderType orderType1;
+
+        switch ( orderType ) {
+            case SPECIAL: orderType1 = OrderType.EXTRA;
+            break;
+            case DEFAULT: orderType1 = null;
+            break;
+            case RETAIL: orderType1 = OrderType.RETAIL;
+            break;
+            case B2B: orderType1 = OrderType.B2B;
+            break;
+            default: throw new IllegalArgumentException( "Unexpected enum constant: " + orderType );
+        }
+
+        return orderType1;
+    }
+
+    @Override
+    public ExternalOrderType anyRemainingToNull(OrderType orderType) {
+        if ( orderType == null ) {
+            return ExternalOrderType.DEFAULT;
+        }
+
+        ExternalOrderType externalOrderType;
+
+        switch ( orderType ) {
+            case STANDARD: externalOrderType = null;
+            break;
+            case RETAIL: externalOrderType = ExternalOrderType.RETAIL;
+            break;
+            case B2B: externalOrderType = ExternalOrderType.B2B;
+            break;
+            default: externalOrderType = null;
+        }
+
+        return externalOrderType;
+    }
+}


### PR DESCRIPTION
Fixes #1091. 

`ValueMapping` defined like:
```java
@ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)
```

Should create compilable code and should map all remaining values to `null`.