### PR TITLE
#1103 

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
@@ -19,7 +19,9 @@
 package org.mapstruct.ap.internal.model;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.lang.model.element.TypeElement;
@@ -29,6 +31,7 @@ import javax.lang.model.util.Types;
 import org.mapstruct.ap.internal.model.assignment.Assignment;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
+import org.mapstruct.ap.internal.model.source.ForgedMethod;
 import org.mapstruct.ap.internal.model.source.FormattingParameters;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
@@ -120,6 +123,8 @@ public class MappingBuilderContext {
     private final List<MapperReference> mapperReferences;
     private final MappingResolver mappingResolver;
     private final List<MappingMethod> mappingsToGenerate = new ArrayList<MappingMethod>();
+    private final Map<ForgedMethod, ForgedMethod> forgedMethodsUnderCreation =
+        new HashMap<ForgedMethod, ForgedMethod>(  );
 
     public MappingBuilderContext(TypeFactory typeFactory,
                           Elements elementUtils,
@@ -139,6 +144,19 @@ public class MappingBuilderContext {
         this.mapperTypeElement = mapper;
         this.sourceModel = sourceModel;
         this.mapperReferences = mapperReferences;
+    }
+
+    /**
+     * Returns a map which is used to track which forged methods are under creation.
+     * Used for cutting the possible infinite recursion of forged method creation.
+     *
+     * Map is used instead of set because not all fields of ForgedMethods are used in equals/hashCode and we are
+     * interested only in the first created ForgedMethod
+     *
+     * @return map of forged methods
+     */
+    public Map<ForgedMethod, ForgedMethod> getForgedMethodsUnderCreation() {
+        return forgedMethodsUnderCreation;
     }
 
     public TypeElement getMapperTypeElement() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
@@ -19,7 +19,7 @@
 package org.mapstruct.ap.internal.model;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -131,7 +131,8 @@ public class NestedTargetPropertyMappingHolder {
             // first we group by the first property in the target properties and for each of those
             // properties we get the new mappings as if the first property did not exist.
             GroupedTargetReferences groupedByTP = groupByTargetReferences( method.getMappingOptions() );
-            Map<PropertyEntry, List<Mapping>> unprocessedDefinedTarget = new HashMap<PropertyEntry, List<Mapping>>();
+            Map<PropertyEntry, List<Mapping>> unprocessedDefinedTarget
+                = new LinkedHashMap<PropertyEntry, List<Mapping>>();
 
             for ( Map.Entry<PropertyEntry, List<Mapping>> entryByTP : groupedByTP.poppedTargetReferences.entrySet() ) {
                 PropertyEntry targetProperty = entryByTP.getKey();
@@ -279,8 +280,10 @@ public class NestedTargetPropertyMappingHolder {
         private GroupedTargetReferences groupByTargetReferences(MappingOptions mappingOptions) {
             Map<String, List<Mapping>> mappings = mappingOptions.getMappings();
             // group all mappings based on the top level name before popping
-            Map<PropertyEntry, List<Mapping>> mappingsKeyedByProperty = new HashMap<PropertyEntry, List<Mapping>>();
-            Map<PropertyEntry, List<Mapping>> singleTargetReferences = new HashMap<PropertyEntry, List<Mapping>>();
+            Map<PropertyEntry, List<Mapping>> mappingsKeyedByProperty
+                = new LinkedHashMap<PropertyEntry, List<Mapping>>();
+            Map<PropertyEntry, List<Mapping>> singleTargetReferences
+                = new LinkedHashMap<PropertyEntry, List<Mapping>>();
             for ( List<Mapping> mapping : mappings.values() ) {
                 PropertyEntry property = first( first( mapping ).getTargetReference().getPropertyEntries() );
                 Mapping newMapping = first( mapping ).popTargetReference();
@@ -388,7 +391,7 @@ public class NestedTargetPropertyMappingHolder {
         private GroupedBySourceParameters groupBySourceParameter(List<Mapping> mappings,
             List<Mapping> singleTargetReferences) {
 
-            Map<Parameter, List<Mapping>> mappingsKeyedByParameter = new HashMap<Parameter, List<Mapping>>();
+            Map<Parameter, List<Mapping>> mappingsKeyedByParameter = new LinkedHashMap<Parameter, List<Mapping>>();
             List<Mapping> appliesToAll = new ArrayList<Mapping>();
             for ( Mapping mapping : mappings ) {
                 if ( mapping.getSourceReference() != null && mapping.getSourceReference().isValid() ) {
@@ -453,7 +456,8 @@ public class NestedTargetPropertyMappingHolder {
             List<Mapping> nonNested = new ArrayList<Mapping>();
             List<Mapping> appliesToAll = new ArrayList<Mapping>();
             // group all mappings based on the top level name before popping
-            Map<PropertyEntry, List<Mapping>> mappingsKeyedByProperty = new HashMap<PropertyEntry, List<Mapping>>();
+            Map<PropertyEntry, List<Mapping>> mappingsKeyedByProperty
+                = new LinkedHashMap<PropertyEntry, List<Mapping>>();
             for ( Mapping mapping : mappings ) {
 
                 Mapping newMapping = mapping.popSourceReference();
@@ -499,7 +503,7 @@ public class NestedTargetPropertyMappingHolder {
         }
 
         private Map<String, List<Mapping>> groupByTargetName(List<Mapping> mappingList) {
-            Map<String, List<Mapping>> result = new HashMap<String, List<Mapping>>();
+            Map<String, List<Mapping>> result = new LinkedHashMap<String, List<Mapping>>();
             for ( Mapping mapping : mappingList ) {
                 if ( !result.containsKey( mapping.getTargetName() ) ) {
                     result.put( mapping.getTargetName(), new ArrayList<Mapping>() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
@@ -96,24 +96,27 @@ public class Parameter extends ModelElement {
 
     @Override
     public int hashCode() {
-        int hash = 5;
-        hash = 23 * hash + (this.name != null ? this.name.hashCode() : 0);
-        return hash;
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + ( type != null ? type.hashCode() : 0 );
+        return result;
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if ( obj == null ) {
+    public boolean equals(Object o) {
+        if ( this == o ) {
+            return true;
+        }
+        if ( o == null || getClass() != o.getClass() ) {
             return false;
         }
-        if ( getClass() != obj.getClass() ) {
+
+        Parameter parameter = (Parameter) o;
+
+        if ( name != null ? !name.equals( parameter.name ) : parameter.name != null ) {
             return false;
         }
-        final Parameter other = (Parameter) obj;
-        if ( (this.name == null) ? (other.name != null) : !this.name.equals( other.name ) ) {
-            return false;
-        }
-        return true;
+        return type != null ? type.equals( parameter.type ) : parameter.type == null;
+
     }
 
     public static Parameter forElementAndType(VariableElement element, Type parameterType) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
@@ -335,10 +335,7 @@ public class ForgedMethod implements Method {
         if ( parameters != null ? !parameters.equals( that.parameters ) : that.parameters != null ) {
             return false;
         }
-        if ( returnType != null ? !returnType.equals( that.returnType ) : that.returnType != null ) {
-            return false;
-        }
-        return name != null ? name.equals( that.name ) : that.name == null;
+        return returnType != null ? returnType.equals( that.returnType ) : that.returnType == null;
 
     }
 
@@ -346,7 +343,6 @@ public class ForgedMethod implements Method {
     public int hashCode() {
         int result = parameters != null ? parameters.hashCode() : 0;
         result = 31 * result + ( returnType != null ? returnType.hashCode() : 0 );
-        result = 31 * result + ( name != null ? name.hashCode() : 0 );
         return result;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -168,6 +168,11 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
             .implPackage( mapperConfig.implementationPackage() )
             .build();
 
+        if ( !mappingContext.getForgedMethodsUnderCreation().isEmpty() ) {
+            messager.printMessage( element, Message.GENERAL_NOT_ALL_FORGED_CREATED,
+                mappingContext.getForgedMethodsUnderCreation().keySet() );
+        }
+
         return mapper;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -87,6 +87,7 @@ public enum Message {
     GENERAL_UNSUPPORTED_DATE_FORMAT_CHECK( "No dateFormat check is supported for types %s, %s" ),
     GENERAL_VALID_DATE( "Given date format \"%s\" is valid.", Diagnostic.Kind.NOTE ),
     GENERAL_INVALID_DATE( "Given date format \"%s\" is invalid. Message: \"%s\"." ),
+    GENERAL_NOT_ALL_FORGED_CREATED( "Internal Error in creation of Forged Methods, it was expected all Forged Methods to finished with creation, but %s did not" ),
 
     RETRIEVAL_NO_INPUT_ARGS( "Can't generate mapping method with no input arguments." ),
     RETRIEVAL_DUPLICATE_MAPPING_TARGETS( "Can't generate mapping method with more than one @MappingTarget parameter." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/RecursionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/RecursionTest.java
@@ -1,0 +1,131 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.nestedbeans.recursive.RecursionMapper;
+import org.mapstruct.ap.test.nestedbeans.recursive.TreeRecursionMapper;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+@RunWith(AnnotationProcessorTestRunner.class)
+public class RecursionTest {
+
+    @WithClasses({
+        RecursionMapper.class
+    })
+    @Test
+    @IssueKey("1103")
+    public void testRecursiveAutoMap() {
+        RecursionMapper.RootDto rootDto = new RecursionMapper.RootDto(
+            new RecursionMapper.ChildDto( "Sub Root", new RecursionMapper.ChildDto(
+                "Sub child", null
+            ) )
+        );
+        RecursionMapper.Root root = RecursionMapper.INSTANCE.mapRoot( rootDto );
+
+        assertRootEquals( rootDto, root );
+    }
+
+    private void assertRootEquals(RecursionMapper.RootDto rootDto, RecursionMapper.Root root) {
+        if (bothNull( root, rootDto )) {
+            return;
+        }
+        assertNotNull( root );
+        assertNotNull( rootDto );
+        assertChildEquals( rootDto.getChild(), root.getChild() );
+    }
+
+    private void assertChildEquals(RecursionMapper.ChildDto childDto, RecursionMapper.Child child) {
+        if ( bothNull( childDto, child ) ) {
+            return;
+        }
+        assertNotNull( childDto );
+        assertNotNull( child );
+        assertEquals( childDto.getName(), child.getName() );
+        assertChildEquals( childDto.getChild(), child.getChild() );
+    }
+
+    @WithClasses({
+        TreeRecursionMapper.class
+    })
+    @Test
+    @IssueKey("1103")
+    public void testRecursiveTreeAutoMap() {
+        TreeRecursionMapper.RootDto rootDto = new TreeRecursionMapper.RootDto(
+            Collections.singletonList( new TreeRecursionMapper.ChildDto(
+                "Sub Root",
+                Collections.singletonList( new TreeRecursionMapper.ChildDto(
+                    "Sub child", null
+                ) )
+            ) )
+        );
+        TreeRecursionMapper.Root root = TreeRecursionMapper.INSTANCE.mapRoot( rootDto );
+
+        assertTreeRootEquals(
+            rootDto,
+            root
+        );
+    }
+
+    private void assertTreeRootEquals(TreeRecursionMapper.RootDto rootDto, TreeRecursionMapper.Root root) {
+        if (bothNull( root, rootDto )) {
+            return;
+        }
+        assertNotNull( root );
+        assertNotNull( rootDto );
+        assertChildrenEqual( rootDto.getChild(), root.getChild() );
+    }
+
+    private void assertChildrenEqual(List<TreeRecursionMapper.ChildDto> childrenDto,
+                                     List<TreeRecursionMapper.Child> children) {
+        if (bothNull( children, childrenDto )) {
+            return;
+        }
+        assertNotNull( childrenDto );
+        assertNotNull( children );
+        assertEquals( children.size(), childrenDto.size() );
+        Iterator<TreeRecursionMapper.Child> iterator = children.iterator();
+        Iterator<TreeRecursionMapper.ChildDto> dtoIterator = childrenDto.iterator();
+        while ( iterator.hasNext() ) {
+            assertTreeTreeChildEquals( dtoIterator.next(), iterator.next() );
+        }
+    }
+
+    private void assertTreeTreeChildEquals(TreeRecursionMapper.ChildDto childDto, TreeRecursionMapper.Child child) {
+        assertNotNull( child );
+        assertNotNull( childDto );
+        assertEquals( child.getName(), childDto.getName() );
+        assertChildrenEqual( childDto.getChild(), child.getChild() );
+    }
+
+    private boolean bothNull(Object o1, Object o2) {
+        return o1 == null && o2 == null;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/recursive/RecursionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/recursive/RecursionMapper.java
@@ -1,0 +1,130 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans.recursive;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class RecursionMapper {
+
+    public static final RecursionMapper INSTANCE = Mappers.getMapper( RecursionMapper.class );
+
+    public abstract Root mapRoot(RootDto rootDto);
+
+    public static class Root {
+        private Child child;
+
+        public Root() {
+        }
+
+        public Root(Child child) {
+            this.child = child;
+        }
+
+        public Child getChild() {
+            return child;
+        }
+
+        public void setChild(Child child) {
+            this.child = child;
+        }
+
+    }
+
+    public static class Child {
+        private String name;
+        private Child child;
+
+        public Child() {
+        }
+
+        public Child(String name, Child child) {
+            this.name = name;
+            this.child = child;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public Child getChild() {
+            return child;
+        }
+
+        public void setChild(Child child) {
+            this.child = child;
+        }
+
+    }
+
+    public static class RootDto {
+        private ChildDto child;
+
+        public RootDto() {
+        }
+
+        public RootDto(ChildDto child) {
+            this.child = child;
+        }
+
+        public ChildDto getChild() {
+            return child;
+        }
+
+        public void setChild(ChildDto child) {
+            this.child = child;
+        }
+
+    }
+
+    public static class ChildDto {
+        private String name;
+        private ChildDto child;
+
+        public ChildDto() {
+        }
+
+        public ChildDto(String name, ChildDto child) {
+            this.name = name;
+            this.child = child;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public ChildDto getChild() {
+            return child;
+        }
+
+        public void setChild(ChildDto child) {
+            this.child = child;
+        }
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/recursive/TreeRecursionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/recursive/TreeRecursionMapper.java
@@ -1,0 +1,132 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans.recursive;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class TreeRecursionMapper {
+
+    public static final TreeRecursionMapper INSTANCE = Mappers.getMapper( TreeRecursionMapper.class );
+
+    public abstract Root mapRoot(RootDto rootDto);
+
+    public static class Root {
+        private List<Child> child;
+
+        public Root() {
+        }
+
+        public Root(List<Child> child) {
+            this.child = child;
+        }
+
+        public List<Child> getChild() {
+            return child;
+        }
+
+        public void setChild(List<Child> child) {
+            this.child = child;
+        }
+
+    }
+
+    public static class Child {
+        private String name;
+        private List<Child> child;
+
+        public Child() {
+        }
+
+        public Child(String name, List<Child> child) {
+            this.name = name;
+            this.child = child;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public List<Child> getChild() {
+            return child;
+        }
+
+        public void setChild(List<Child> child) {
+            this.child = child;
+        }
+
+    }
+
+    public static class RootDto {
+        private List<ChildDto> child;
+
+        public RootDto() {
+        }
+
+        public RootDto(List<ChildDto> child) {
+            this.child = child;
+        }
+
+        public List<ChildDto> getChild() {
+            return child;
+        }
+
+        public void setChild(List<ChildDto> child) {
+            this.child = child;
+        }
+
+    }
+
+    public static class ChildDto {
+        private String name;
+        private List<ChildDto> child;
+
+        public ChildDto() {
+        }
+
+        public ChildDto(String name, List<ChildDto> child) {
+            this.name = name;
+            this.child = child;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public List<ChildDto> getChild() {
+            return child;
+        }
+
+        public void setChild(List<ChildDto> child) {
+            this.child = child;
+        }
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedtargetproperties/NestedTargetPropertiesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedtargetproperties/NestedTargetPropertiesTest.java
@@ -18,7 +18,6 @@
  */
 package org.mapstruct.ap.test.nestedtargetproperties;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -32,6 +31,8 @@ import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  *

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/mixed/FishTankMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/mixed/FishTankMapperImpl.java
@@ -52,8 +52,8 @@ public class FishTankMapperImpl implements FishTankMapper {
 
         FishTankDto fishTankDto = new FishTankDto();
 
-        fishTankDto.setMaterial( fishTankToMaterialDto( source ) );
         fishTankDto.setFish( fishToFishDto( source.getFish() ) );
+        fishTankDto.setMaterial( fishTankToMaterialDto( source ) );
         fishTankDto.setQuality( waterQualityToWaterQualityDto( source.getQuality() ) );
         Ornament ornament = sourceInteriorOrnament( source );
         if ( ornament != null ) {
@@ -73,8 +73,8 @@ public class FishTankMapperImpl implements FishTankMapper {
 
         FishTankDto fishTankDto = new FishTankDto();
 
-        fishTankDto.setMaterial( fishTankToMaterialDto( source ) );
         fishTankDto.setFish( fishToFishDto( source.getFish() ) );
+        fishTankDto.setMaterial( fishTankToMaterialDto( source ) );
         fishTankDto.setQuality( waterQualityToWaterQualityDto( source.getQuality() ) );
         Ornament ornament = sourceInteriorOrnament( source );
         if ( ornament != null ) {
@@ -107,6 +107,18 @@ public class FishTankMapperImpl implements FishTankMapper {
         return fishTank;
     }
 
+    protected FishDto fishToFishDto(Fish fish) {
+        if ( fish == null ) {
+            return null;
+        }
+
+        FishDto fishDto = new FishDto();
+
+        fishDto.setKind( fish.getType() );
+
+        return fishDto;
+    }
+
     protected MaterialTypeDto materialTypeToMaterialTypeDto(MaterialType materialType) {
         if ( materialType == null ) {
             return null;
@@ -129,18 +141,6 @@ public class FishTankMapperImpl implements FishTankMapper {
         materialDto.setMaterialType( materialTypeToMaterialTypeDto( fishTank.getMaterial() ) );
 
         return materialDto;
-    }
-
-    protected FishDto fishToFishDto(Fish fish) {
-        if ( fish == null ) {
-            return null;
-        }
-
-        FishDto fishDto = new FishDto();
-
-        fishDto.setKind( fish.getType() );
-
-        return fishDto;
     }
 
     protected WaterQualityOrganisationDto waterQualityReportToWaterQualityOrganisationDto(WaterQualityReport waterQualityReport) {


### PR DESCRIPTION
Try to fix the issue #1103 "1.2.0-Beta1 Automapping Feature: cycle tree let the compiler crash with StackOverflowError."

Initially when there was a non-recursive implementation there was a HashSet which excluded already created Forged Mappings. With the recursive implementation I see no way except using some global state or passing the set of created forged methods as a parameter.
I decided to use the first solution. This fix is added only for the usual property mappings, I did not check how would the recursive iterable mappings behave.

Is this a fine approach?