### PR TITLE
DON'T MERGE: #1113 Small example for AST-based code generation

### DIFF
--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -44,6 +44,12 @@
             <artifactId>freemarker</artifactId>
         </dependency>
 
+<dependency>
+    <groupId>com.github.javaparser</groupId>
+    <artifactId>javaparser-core</artifactId>
+    <version>3.1.0</version>
+</dependency>
+
         <!-- Compile-only; Using "provided" scope as there is no such scope in Maven;
         these dependencies are not required at runtime, only for prism generation
         and tests -->

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Annotation.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Annotation.java
@@ -25,6 +25,10 @@ import java.util.Set;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Type;
 
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.expr.NormalAnnotationExpr;
+
 /**
  * Represents a Java 5 annotation.
  *
@@ -59,5 +63,12 @@ public class Annotation extends ModelElement {
 
     public List<String> getProperties() {
         return properties;
+    }
+
+    @Override
+    public Node getAst(Context context) {
+        NormalAnnotationExpr node = new NormalAnnotationExpr();
+        node.setName( new Name( type.isImported() ? type.getName() : type.getFullyQualifiedName() ) );
+        return node;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -24,6 +24,7 @@ import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -62,6 +63,24 @@ import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
+
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.VariableDeclarator;
+import com.github.javaparser.ast.expr.BinaryExpr;
+import com.github.javaparser.ast.expr.BinaryExpr.Operator;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.NullLiteralExpr;
+import com.github.javaparser.ast.expr.ObjectCreationExpr;
+import com.github.javaparser.ast.expr.VariableDeclarationExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
+import com.github.javaparser.ast.stmt.IfStmt;
+import com.github.javaparser.ast.stmt.ReturnStmt;
+import com.github.javaparser.ast.stmt.Statement;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
 
 /**
  * A {@link MappingMethod} implemented by a {@link Mapper} class which maps one bean type to another, optionally
@@ -809,6 +828,76 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             }
         }
         return sourceParameters;
+    }
+
+    @Override
+    public MethodDeclaration getAst(Context context) {
+        final Map<String, Object> ext = new HashMap<String, Object>();
+
+        context = new Context() {
+
+            @Override
+            public <T> T get(Class<T> type) {
+                if ( type == Map.class ) {
+                    ext.put( "targetBeanName", getResultName() );
+                    return (T) ext;
+                }
+
+                return null;
+            }
+        };
+
+        NodeList<com.github.javaparser.ast.body.Parameter> parameters = new NodeList<com.github.javaparser.ast.body.Parameter>();
+
+        for ( Parameter parameter : getParameters() ) {
+            parameters.add( parameter.getAst( context ) );
+        }
+        MethodDeclaration ast = new MethodDeclaration(
+            EnumSet.of( Modifier.PUBLIC ),
+            getName(),
+            getResultType().getAst( context ),
+            parameters
+        );
+
+        NodeList<Statement> returnNull = new NodeList<Statement>();
+        returnNull.add( new ReturnStmt( new NullLiteralExpr() ) );
+
+        IfStmt paramNullCheck = new IfStmt(
+            new BinaryExpr( new NameExpr( parameters.get( 0 ).getName() ), new NullLiteralExpr(), Operator.EQUALS ),
+            new BlockStmt( NodeList.<Statement>nodeList( new ReturnStmt( new NullLiteralExpr() ) ) ),
+            null
+        );
+
+        ExpressionStmt returnValueInstantiation = new ExpressionStmt(
+            new VariableDeclarationExpr(
+                new VariableDeclarator(
+                    getResultType().getAst( context ),
+                    getResultName(),
+                    new ObjectCreationExpr(
+                        null,
+                        new ClassOrInterfaceType( getResultType().getName() ),
+                        new NodeList<Expression>()
+                    )
+                )
+            )
+        );
+
+        NodeList<Statement> statements = new NodeList<Statement>();
+        statements.add( paramNullCheck );
+        statements.add( returnValueInstantiation );
+
+        for ( PropertyMapping propertyMapping : propertyMappings ) {
+            statements.add( propertyMapping.getAst( context ) );
+        }
+
+        statements.add( new ReturnStmt( new NameExpr( getResultName() ) ) );
+        BlockStmt body = new BlockStmt( statements );
+
+        ast.setBody( body );
+
+        return ast;
+
+
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
@@ -33,6 +33,8 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
 
+import com.github.javaparser.ast.Node;
+
 /**
  * A method implemented or referenced by a {@link Mapper} class.
  *
@@ -215,6 +217,11 @@ public abstract class MappingMethod extends ModelElement {
 
     public List<LifecycleCallbackMethodReference> getBeforeMappingReferencesWithoutMappingTarget() {
         return beforeMappingReferencesWithoutMappingTarget;
+    }
+
+    @Override
+    public Node getAst(Context context) {
+        return null;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MethodReference.java
@@ -32,6 +32,11 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.builtin.BuiltInMethod;
 
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.SimpleName;
+
 /**
  * Represents a reference to another method, e.g. used to map a bean property from source to target type or to
  * instantiate the return value of a mapping method (rather than calling the {@code new} operator).
@@ -232,6 +237,15 @@ public class MethodReference extends MappingMethod implements Assignment {
 
     public List<ParameterBinding> getParameterBindings() {
         return parameterBindings;
+    }
+
+    @Override
+    public Expression getAst(Context context) {
+        return new MethodCallExpr(
+                null,
+                new SimpleName( getName() ),
+                NodeList.<Expression>nodeList( assignment.getAst( context ) )
+        );
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.lang.model.element.ExecutableElement;
@@ -58,6 +59,10 @@ import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.ValueProvider;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.stmt.ExpressionStmt;
 
 /**
  * Represents the mapping between a source and target property, e.g. from {@code String Source#foo} to
@@ -474,7 +479,12 @@ public class PropertyMapping extends ModelElement {
             else if ( propertyEntries.size() == 1 ) {
                 PropertyEntry propertyEntry = propertyEntries.get( 0 );
                 String sourceRef = sourceParam.getName() + "." + ValueProvider.of( propertyEntry.getReadAccessor() );
-                return new SourceRHS( sourceParam.getName(),
+                MethodCallExpr ast = new MethodCallExpr(
+                        new NameExpr( sourceParam.getName() ),
+                        propertyEntry.getReadAccessor().getSimpleName().toString()
+                );
+                return new SourceRHS( ast,
+                                      sourceParam.getName(),
                                       sourceRef,
                                       getSourcePresenceCheckerRef( sourceReference ),
                                       propertyEntry.getType(),
@@ -521,7 +531,8 @@ public class PropertyMapping extends ModelElement {
                     forgedName = ctx.getExistingMappingMethod( nestedPropertyMapping ).getName();
                 }
                 String sourceRef = forgedName + "( " + sourceParam.getName() + " )";
-                SourceRHS sourceRhs = new SourceRHS( sourceParam.getName(),
+                SourceRHS sourceRhs = new SourceRHS( null,
+                                                     sourceParam.getName(),
                                                      sourceRef,
                                                      getSourcePresenceCheckerRef( sourceReference ),
                                                      sourceType,
@@ -940,6 +951,13 @@ public class PropertyMapping extends ModelElement {
 
     public List<String> getDependsOn() {
         return dependsOn;
+    }
+
+    @Override
+    public ExpressionStmt getAst(Context context) {
+        Map<String, Object> ext = context.get( Map.class );
+        ext.put( "targetWriteAccessorName", targetWriteAccessorName );
+        return new ExpressionStmt( assignment.getAst( context ) );
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/SourceRHS.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/SourceRHS.java
@@ -27,6 +27,8 @@ import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Strings;
 
+import com.github.javaparser.ast.expr.Expression;
+
 /**
  * SourceRHS Assignment. Right Hand Side (RHS), source part of the assignment.
  *
@@ -44,14 +46,16 @@ public class SourceRHS extends ModelElement implements Assignment {
     private final String sourcePresenceCheckerReference;
     private boolean useElementAsSourceTypeForMatching = false;
     private final String sourceParameterName;
+    private Expression ast;
 
     public SourceRHS(String sourceReference, Type sourceType, Set<String> existingVariableNames,
         String sourceErrorMessagePart ) {
-        this( sourceReference, sourceReference, null, sourceType, existingVariableNames, sourceErrorMessagePart );
+        this( null, sourceReference, sourceReference, null, sourceType, existingVariableNames, sourceErrorMessagePart );
     }
 
-    public SourceRHS(String sourceParameterName, String sourceReference, String sourcePresenceCheckerReference,
+    public SourceRHS(Expression ast, String sourceParameterName, String sourceReference, String sourcePresenceCheckerReference,
         Type sourceType, Set<String> existingVariableNames,  String sourceErrorMessagePart ) {
+        this.ast = ast;
         this.sourceReference = sourceReference;
         this.sourceType = sourceType;
         this.existingVariableNames = existingVariableNames;
@@ -155,4 +159,8 @@ public class SourceRHS extends ModelElement implements Assignment {
         return sourceParameterName;
     }
 
+    @Override
+    public Expression getAst(Context context) {
+        return ast;
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/TypeConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/TypeConversion.java
@@ -26,6 +26,10 @@ import org.mapstruct.ap.internal.model.assignment.Assignment;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Type;
 
+import com.github.javaparser.ast.expr.CastExpr;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.type.PrimitiveType;
+
 /**
  * An inline conversion between source and target type of a mapping.
  *
@@ -142,5 +146,14 @@ public class TypeConversion extends ModelElement implements Assignment {
     @Override
     public boolean isCallingUpdateMethod() {
        return false;
+    }
+
+    @Override
+    public Expression getAst(Context context) {
+        if ( "(long) ".equals( openExpression ) ) {
+            return new CastExpr( PrimitiveType.longType(), assignment.getAst( context ) );
+        }
+
+        return null;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Assignment.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/Assignment.java
@@ -22,6 +22,9 @@ import java.util.List;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.writer.Writable.Context;
+
+import com.github.javaparser.ast.expr.Expression;
 
 /**
  * Assignment represents all kind of manners a source can be assigned to a target.
@@ -154,4 +157,6 @@ public interface Assignment {
     AssignmentType getType();
 
     boolean isCallingUpdateMethod();
+
+    Expression getAst(Context context);
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AssignmentWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AssignmentWrapper.java
@@ -24,6 +24,8 @@ import java.util.Set;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Type;
 
+import com.github.javaparser.ast.expr.Expression;
+
 /**
  * Base class for decorators (wrappers). Decorator pattern is used to decorate assignments.
  *
@@ -114,5 +116,10 @@ public abstract class AssignmentWrapper extends ModelElement implements Assignme
      */
     public boolean isFieldAssignment() {
         return fieldAssignment;
+    }
+
+    @Override
+    public Expression getAst(Context context) {
+        return null;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapper.java
@@ -18,13 +18,20 @@
  */
 package org.mapstruct.ap.internal.model.assignment;
 
+import static org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism.ALWAYS;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism;
 
-import static org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism.ALWAYS;
+import com.github.javaparser.ast.NodeList;
+import com.github.javaparser.ast.expr.Expression;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.SimpleName;
 
 /**
  * Wraps the assignment in a target setter.
@@ -69,6 +76,18 @@ public class SetterWrapper extends AssignmentWrapper {
 
     public boolean isIncludeSourceNullCheck() {
         return includeSourceNullCheck;
+    }
+
+    @Override
+    public Expression getAst(Context context) {
+        Map<String, Object> ext = context.get( Map.class );
+        NodeList<Expression> args = new NodeList<Expression>();
+        args.add( getAssignment().getAst( context ) );
+        return new MethodCallExpr(
+                new NameExpr( ext.get( "targetBeanName" ).toString() ),
+                new SimpleName( ext.get( "targetWriteAccessorName" ).toString() ),
+                args
+        );
     }
 
    /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/ModelElement.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/ModelElement.java
@@ -18,10 +18,8 @@
  */
 package org.mapstruct.ap.internal.model.common;
 
-import java.io.Writer;
 import java.util.Set;
 
-import org.mapstruct.ap.internal.writer.FreeMarkerModelElementWriter;
 import org.mapstruct.ap.internal.writer.FreeMarkerWritable;
 import org.mapstruct.ap.internal.writer.Writable;
 
@@ -32,11 +30,6 @@ import org.mapstruct.ap.internal.writer.Writable;
  * @author Gunnar Morling
  */
 public abstract class ModelElement extends FreeMarkerWritable {
-
-    @Override
-    public void write(Context context, Writer writer) throws Exception {
-        new FreeMarkerModelElementWriter().write( this, context, writer );
-    }
 
     /**
      * Returns a set containing those {@link Type}s referenced by this model element for which an import statement needs

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
@@ -95,6 +95,11 @@ public class Parameter extends ModelElement {
     }
 
     @Override
+    public com.github.javaparser.ast.body.Parameter getAst(Context context) {
+        return new com.github.javaparser.ast.body.Parameter( type.getAst( context ), name );
+    }
+
+    @Override
     public int hashCode() {
         int hash = 5;
         hash = 23 * hash + (this.name != null ? this.name.hashCode() : 0);

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -50,6 +50,9 @@ import org.mapstruct.ap.internal.util.Nouns;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
 
+import com.github.javaparser.ast.expr.SimpleName;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+
 /**
  * Represents (a reference to) the type of a bean property, parameter etc. Types are managed per generated source file.
  * Each type corresponds to a {@link TypeMirror}, i.e. there are different instances for e.g. {@code Set<String>} and
@@ -881,5 +884,13 @@ public class Type extends ModelElement implements Comparable<Type> {
         }
 
         return null;
+    }
+
+    @Override
+    public com.github.javaparser.ast.type.Type getAst(Context context) {
+        // TODO imports, generic bounds
+        ClassOrInterfaceType ast = new ClassOrInterfaceType();
+        ast.setName( new SimpleName( getName() ) );
+        return ast;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/writer/FreeMarkerWritable.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/writer/FreeMarkerWritable.java
@@ -20,6 +20,8 @@ package org.mapstruct.ap.internal.writer;
 
 import java.io.Writer;
 
+import com.github.javaparser.ast.Node;
+
 /**
  * A {@link Writable} which uses the FreeMarker template engine to generate the output.
  *
@@ -29,7 +31,18 @@ public abstract class FreeMarkerWritable implements Writable {
 
     @Override
     public void write(Context context, Writer writer) throws Exception {
-        new FreeMarkerModelElementWriter().write( this, context, writer );
+        Node ast = getAst( context );
+
+        if ( ast != null ) {
+            writer.append( ast.toString() );
+        }
+        else {
+            new FreeMarkerModelElementWriter().write( this, context, writer );
+        }
+    }
+
+    public Node getAst(Context context) {
+        return null;
     }
 
     /**

--- a/processor/src/test/java/org/mapstruct/ap/test/oneway/OnewayTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/oneway/OnewayTest.java
@@ -24,6 +24,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.DisableCheckstyle;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
@@ -34,6 +35,7 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
  */
 @WithClasses({ Source.class, Target.class, SourceTargetMapper.class })
 @RunWith(AnnotationProcessorTestRunner.class)
+@DisableCheckstyle
 public class OnewayTest {
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/parser/Bar.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/parser/Bar.java
@@ -1,0 +1,7 @@
+package org.mapstruct.ap.test.parser;
+
+public class Bar {
+
+    public void setLong(Long myLong) {
+     }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/parser/CuPrinter.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/parser/CuPrinter.java
@@ -1,0 +1,102 @@
+package org.mapstruct.ap.test.parser;
+
+import java.io.FileInputStream;
+import java.util.EnumSet;
+
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.PackageDeclaration;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.Parameter;
+import com.github.javaparser.ast.expr.FieldAccessExpr;
+import com.github.javaparser.ast.expr.MethodCallExpr;
+import com.github.javaparser.ast.expr.Name;
+import com.github.javaparser.ast.expr.NameExpr;
+import com.github.javaparser.ast.expr.StringLiteralExpr;
+import com.github.javaparser.ast.stmt.BlockStmt;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.VoidType;
+import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
+
+public class CuPrinter {
+
+    public static void main(String[] args) throws Exception {
+        // creates an input stream for the file to be parsed
+        FileInputStream in = new FileInputStream( "/Users/gunnar/Development/mapstruct/mapstruct/processor/src/test/java/org/mapstruct/ap/test/parser/Test.java" );
+
+        // parse the file
+        CompilationUnit cu = JavaParser.parse( in );
+
+        System.out.println( cu.toString() );
+        // visit and print the methods names
+        new MethodVisitor().visit(cu, null);
+
+        cu = createCU();
+
+        // prints the created compilation unit
+        System.out.println(cu.toString());
+    }
+
+    /**
+     * creates the compilation unit
+     */
+    private static CompilationUnit createCU() {
+        CompilationUnit cu = new CompilationUnit();
+        // set the package
+        cu.setPackageDeclaration(new PackageDeclaration(Name.parse("java.parser.test")));
+
+        // or a shortcut
+        cu.setPackageDeclaration("java.parser.test");
+
+        // create the type declaration
+        ClassOrInterfaceDeclaration type = cu.addClass("GeneratedClass");
+
+        // create a method
+        EnumSet<Modifier> modifiers = EnumSet.of(Modifier.PUBLIC);
+        MethodDeclaration method = new MethodDeclaration(modifiers, new VoidType(), "main");
+        modifiers.add(Modifier.STATIC);
+        method.setModifiers(modifiers);
+        type.addMember(method);
+
+        // or a shortcut
+        MethodDeclaration main2 = type.addMethod("main2", Modifier.PUBLIC, Modifier.STATIC);
+
+        // add a parameter to the method
+        Parameter param = new Parameter(new ClassOrInterfaceType("String"), "args");
+        param.setVarArgs(true);
+        method.addParameter(param);
+
+        // or a shortcut
+        main2.addAndGetParameter(String.class, "args").setVarArgs(true);
+
+        // add a body to the method
+        BlockStmt block = new BlockStmt();
+        method.setBody(block);
+
+        // add a statement do the method body
+        NameExpr clazz = new NameExpr("System");
+        FieldAccessExpr field = new FieldAccessExpr(clazz, "out");
+        MethodCallExpr call = new MethodCallExpr(field, "println");
+        call.addArgument(new StringLiteralExpr("Hello World!"));
+        block.addStatement(call);
+
+        return cu;
+    }
+
+
+    /**
+     * Simple visitor implementation for visiting MethodDeclaration nodes.
+     */
+    private static class MethodVisitor extends VoidVisitorAdapter<Void> {
+        @Override
+        public void visit(MethodDeclaration n, Void arg) {
+            /* here you can access the attributes of the method.
+             this method will be called for all methods in this
+             CompilationUnit, including inner class methods */
+            System.out.println(n.getName());
+            super.visit(n, arg);
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/parser/Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/parser/Test.java
@@ -1,0 +1,19 @@
+package org.mapstruct.ap.test.parser;
+
+import javax.annotation.Generated;
+
+@Generated(value = "hello")
+public class Test {
+
+    public Bar getFoo(String param) {
+        if ( param == null ) {
+            return null;
+        }
+
+        Bar bar = new Bar();
+
+        bar.setLong( (long) param.getBytes().length );
+
+        return bar;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/prism/ConstantTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/prism/ConstantTest.java
@@ -33,8 +33,8 @@ public class ConstantTest {
 
     @Test
     public void constantsShouldBeEqual() {
-        assertThat( MappingConstants.ANY_REMAINING ).isEqualTo( MappingConstantsPrism.ANY_REMAINING );
-        assertThat( MappingConstants.ANY_UNMAPPED ).isEqualTo( MappingConstantsPrism.ANY_UNMAPPED );
+        assertThat( MappingConstants.ANY_REMAINING )
+            .isEqualTo( MappingConstantsPrism.ANY_REMAINING ); assertThat( MappingConstants.ANY_UNMAPPED ).isEqualTo( MappingConstantsPrism.ANY_UNMAPPED );
         assertThat( MappingConstants.NULL ).isEqualTo( MappingConstantsPrism.NULL );
     }
 }


### PR DESCRIPTION
This uses the [JavaParser](https://github.com/javaparser/javaparser/) project for assembling an AST of the code to be generated. The build fails and only a few tests pass. Take a look at `OnewayTest` for one that works.

Essentially, each `ModelElement` has a `getAst()` method which returns the AST of this sub-tree (calling `getAst()` of any sub-nodes). I think it works well for the inner, more logic-intensive model elements (`SetterWrapper` and friends). For the higher-level nodes (e.g. `BeanMappingMethod`) it's not so clear, the templates may be more easily comprehensible here. But one could think of actually _parsing_ templates here (not FreeMarker templates necessarily) instead of assembling these ASTs from scratch and then only replace those nodes which need to be customized.

Hope it makes sense. Looking forward to your thoughts. I think it'd be a great win for the entire `Assignment` hierarchy, I'm feeling we're hitting a dead end with templates here.