### PR TITLE
#1124 Don't pass context parameters to forged methods for nested property mapping methods

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -48,6 +48,7 @@ import org.mapstruct.ap.internal.model.source.ForgedMethodHistory;
 import org.mapstruct.ap.internal.model.source.FormattingParameters;
 import org.mapstruct.ap.internal.model.source.MappingOptions;
 import org.mapstruct.ap.internal.model.source.Method;
+import org.mapstruct.ap.internal.model.source.ParameterProvidedMethods;
 import org.mapstruct.ap.internal.model.source.PropertyEntry;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.SourceReference;
@@ -504,8 +505,8 @@ public class PropertyMapping extends ModelElement {
                     sourceType,
                     config,
                     method.getExecutable(),
-                    method.getContextParameters(),
-                    method.getContextProvidedMethods() );
+                    Collections.<Parameter> emptyList(),
+                    ParameterProvidedMethods.empty() );
 
                 NestedPropertyMappingMethod.Builder builder = new NestedPropertyMappingMethod.Builder();
                 NestedPropertyMappingMethod nestedPropertyMapping = builder

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1124/Issue1124Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1124/Issue1124Mapper.java
@@ -1,0 +1,77 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1124;
+
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * @author Andreas Gudian
+ */
+@Mapper
+public interface Issue1124Mapper {
+    class Entity {
+        private Long id;
+        private Entity entity;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public Entity getEntity() {
+            return entity;
+        }
+
+        public void setEntity(Entity entity) {
+            this.entity = entity;
+        }
+    }
+
+    class DTO {
+        private Long id;
+        private DTO entity;
+
+        public Long getId() {
+            return id;
+        }
+
+        public void setId(Long id) {
+            this.id = id;
+        }
+
+        public DTO getEntity() {
+            return entity;
+        }
+
+        public void setEntity(DTO entity) {
+            this.entity = entity;
+        }
+    }
+
+    class MappingContext {
+    }
+
+    @Mapping(source = "entity.id", target = "id")
+    DTO map(Entity entity, @Context MappingContext context);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1124/Issue1124Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1124/Issue1124Test.java
@@ -1,0 +1,50 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1124;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.bugs._1124.Issue1124Mapper.DTO;
+import org.mapstruct.ap.test.bugs._1124.Issue1124Mapper.Entity;
+import org.mapstruct.ap.test.bugs._1124.Issue1124Mapper.MappingContext;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Andreas Gudian
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses(Issue1124Mapper.class)
+public class Issue1124Test {
+    @Test
+    public void nestedPropertyWithContextCompiles() {
+        Entity entity = new Entity();
+
+        Entity subEntity = new Entity();
+        subEntity.setId( 42L );
+        entity.setEntity( subEntity );
+
+        DTO dto = Mappers.getMapper( Issue1124Mapper.class ).map( entity, new MappingContext() );
+
+        assertThat( dto.getId() ).isEqualTo( 42L );
+    }
+}


### PR DESCRIPTION
`NestedPropertyMappingMethod` currently can't handle lifecycle methods anyway, so we can skip adding the context parameters.

Fixes #1124.

@sjaakd, I guess once the `SourceRHS` is refactored, it might be easier to add handling of the actual source call (e.g. the property accessor invocation, or as in this case, a call to the nested property mapping method via `MethodReference`) - is that on your map as well?
Initially I just assumed that lifecycle methods are considered in nested property mapping methods, but adding that right now would require some icky code... I guess we should revisit that later on... :)