### PR TITLE
#1126 adding the option to handle immutable collections in update methods

### DIFF
--- a/core-common/src/main/java/org/mapstruct/CollectionMappingStrategy.java
+++ b/core-common/src/main/java/org/mapstruct/CollectionMappingStrategy.java
@@ -30,7 +30,8 @@ public enum CollectionMappingStrategy {
      * {@code orderDto.setOrderLines(order.getOrderLines)}.
      * <p>
      * If no setter is available but a getter method, this will be used, under the assumption it has been initialized:
-     * {@code orderDto.getOrderLines().addAll(order.getOrderLines)}.
+     * {@code orderDto.getOrderLines().addAll(order.getOrderLines)}. This will also be the case when using
+     * {@link MappingTarget} (updating existing instances).
      */
     ACCESSOR_ONLY,
 
@@ -51,5 +52,13 @@ public enum CollectionMappingStrategy {
      * Identical to {@link #SETTER_PREFERRED}, only that adder methods will be preferred over setter methods, if both
      * are present for a given collection-typed property.
      */
-    ADDER_PREFERRED;
+    ADDER_PREFERRED,
+
+    /**
+     * Identical to {@link #SETTER_PREFERRED}, however the target collection will not be cleared and accessed via
+     * addAll in case of updating existing bean instances, see: {@link MappingTarget}.
+     *
+     * Instead the target accessor (e.g. set) will be used on the target bean to set the collection.
+     */
+    TARGET_IMMUTABLE;
 }

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -466,7 +466,7 @@ Specifying the parameter in which the property resides is mandatory when using t
 Mapping methods with several source parameters will return `null` in case all the source parameters are `null`. Otherwise the target object will be instantiated and all properties from the provided parameters will be propagated.
 ====
 
-MapStruct also offers the possibility to directly refer to a source parameter. 
+MapStruct also offers the possibility to directly refer to a source parameter.
 
 .Mapping method directly referring to a source parameter
 ====
@@ -1338,7 +1338,7 @@ public Map<Long, Date> stringStringMapToLongDateMap(Map<String, String> source) 
 [[collection-mapping-strategies]]
 === Collection mapping strategies
 
-MapStruct has a `CollectionMappingStrategy`, with the possible values: `ACCESSOR_ONLY`, `SETTER_PREFERRED` and `ADDER_PREFERRED`.
+MapStruct has a `CollectionMappingStrategy`, with the possible values: `ACCESSOR_ONLY`, `SETTER_PREFERRED`, `ADDER_PREFERRED` and `TARGET_IMMUTABLE`.
 
 In the table below, the dash `-` indicates a property name. Next, the trailing `s` indicates the plural form. The table explains the options and how they are apply to the presence/absense of a `set-s`, `add-` and / or `get-s` method on the target object:
 
@@ -1366,6 +1366,13 @@ In the table below, the dash `-` indicates a property name. Next, the trailing `
 |add-
 |get-s
 |get-s
+
+|`TARGET_IMMUTABLE`
+|set-s
+|exception
+|set-s
+|exception
+|set-s
 |===
 
 Some background: An `adder` method is typically used in case of http://www.eclipse.org/webtools/dali/[generated (JPA) entities], to add a single element (entity) to an underlying collection. Invoking the adder establishes a parent-child relation between parent - the bean (entity) on which the adder is invoked - and its child(ren), the elements (entities) in the collection. To find the appropriate `adder`, MapStruct will try to make a match between the generic parameter type of the underlying collection and the single argument of a candidate `adder`. When there are more candidates, the plural `setter` / `getter` name is converted to singular and will be used in addition to make a match.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.java
@@ -47,13 +47,15 @@ public class SetterWrapperForCollectionsAndMaps extends WrapperForCollectionsAnd
     private final boolean includeSourceNullCheck;
     private final Type targetType;
     private final TypeFactory typeFactory;
+    private final boolean targetImmutable;
 
     public SetterWrapperForCollectionsAndMaps(Assignment decoratedAssignment,
                                               List<Type> thrownTypesToExclude,
                                               Type targetType,
                                               NullValueCheckStrategyPrism nvms,
                                               TypeFactory typeFactory,
-                                              boolean fieldAssignment) {
+                                              boolean fieldAssignment,
+                                              boolean targetImmutable ) {
 
         super(
             decoratedAssignment,
@@ -64,6 +66,7 @@ public class SetterWrapperForCollectionsAndMaps extends WrapperForCollectionsAnd
         this.includeSourceNullCheck = ALWAYS == nvms;
         this.targetType = targetType;
         this.typeFactory = typeFactory;
+        this.targetImmutable = targetImmutable;
     }
 
     @Override
@@ -94,6 +97,10 @@ public class SetterWrapperForCollectionsAndMaps extends WrapperForCollectionsAnd
 
     public boolean isEnumSet() {
         return "java.util.EnumSet".equals( targetType.getFullyQualifiedName() );
+    }
+
+    public boolean isTargetImmutable() {
+        return targetImmutable;
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -469,7 +469,8 @@ public class Type extends ModelElement implements Comparable<Type> {
             // the current target accessor can also be a getter method.
             // The following if block, checks if the target accessor should be overruled by an add method.
             if ( cmStrategy == CollectionMappingStrategyPrism.SETTER_PREFERRED
-                || cmStrategy == CollectionMappingStrategyPrism.ADDER_PREFERRED ) {
+                || cmStrategy == CollectionMappingStrategyPrism.ADDER_PREFERRED
+                || cmStrategy == CollectionMappingStrategyPrism.TARGET_IMMUTABLE ) {
 
                 // first check if there's a setter method.
                 Accessor adderMethod = null;

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -55,6 +55,7 @@ public enum Message {
     PROPERTYMAPPING_INVALID_PROPERTY_NAME( "No property named \"%s\" exists in source parameter(s)." ),
     PROPERTYMAPPING_NO_PRESENCE_CHECKER_FOR_SOURCE_TYPE( "Using custom source value presence checking strategy, but no presence checker found for %s in source type." ),
     PROPERTYMAPPING_NO_READ_ACCESSOR_FOR_TARGET_TYPE( "No read accessor found for property \"%s\" in target type." ),
+    PROPERTYMAPPING_NO_WRITE_ACCESSOR_FOR_TARGET_TYPE( "No write accessor found for property \"%s\" in target type." ),
 
     CONSTANTMAPPING_MAPPING_NOT_FOUND( "Can't map \"%s %s\" to \"%s %s\"." ),
     CONSTANTMAPPING_NO_READ_ACCESSOR_FOR_TARGET_TYPE( "No read accessor found for property \"%s\" in target type." ),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.ftl
@@ -22,7 +22,7 @@
 <#import "../macro/CommonMacros.ftl" as lib>
 <@lib.sourceLocalVarAssignment/>
 <@lib.handleExceptions>
-  <#if ext.existingInstanceMapping>
+  <#if ext.existingInstanceMapping && !targetImmutable>
     if ( ${ext.targetBeanName}.${ext.targetReadAccessorName} != null ) {
         <@lib.handleLocalVarNullCheck>
             ${ext.targetBeanName}.${ext.targetReadAccessorName}.clear();

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/CupboardDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/CupboardDto.java
@@ -16,17 +16,23 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.internal.prism;
+package org.mapstruct.ap.test.collection.immutabletarget;
+
+import java.util.List;
 
 /**
- * Prism for the enum {@link org.mapstruct.CollectionMappingStrategy}
  *
- * @author Andreas Gudian
+ * @author Sjaak Derksen
  */
-public enum CollectionMappingStrategyPrism {
+public class CupboardDto {
 
-    ACCESSOR_ONLY,
-    SETTER_PREFERRED,
-    ADDER_PREFERRED,
-    TARGET_IMMUTABLE;
+    private List<String> content;
+
+    public List<String> getContent() {
+        return content;
+    }
+
+    public void setContent(List<String> content) {
+        this.content = content;
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/CupboardEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/CupboardEntity.java
@@ -16,17 +16,23 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.internal.prism;
+package org.mapstruct.ap.test.collection.immutabletarget;
+
+import java.util.List;
 
 /**
- * Prism for the enum {@link org.mapstruct.CollectionMappingStrategy}
  *
- * @author Andreas Gudian
+ * @author Sjaak Derksen
  */
-public enum CollectionMappingStrategyPrism {
+public class CupboardEntity {
 
-    ACCESSOR_ONLY,
-    SETTER_PREFERRED,
-    ADDER_PREFERRED,
-    TARGET_IMMUTABLE;
+    private List<String> content;
+
+    public List<String> getContent() {
+        return content;
+    }
+
+    public void setContent(List<String> content) {
+        this.content = content;
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/CupboardEntityOnlyGetter.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/CupboardEntityOnlyGetter.java
@@ -16,17 +16,20 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.internal.prism;
+package org.mapstruct.ap.test.collection.immutabletarget;
+
+import java.util.List;
 
 /**
- * Prism for the enum {@link org.mapstruct.CollectionMappingStrategy}
  *
- * @author Andreas Gudian
+ * @author Sjaak Derksen
  */
-public enum CollectionMappingStrategyPrism {
+public class CupboardEntityOnlyGetter {
 
-    ACCESSOR_ONLY,
-    SETTER_PREFERRED,
-    ADDER_PREFERRED,
-    TARGET_IMMUTABLE;
+    private List<String> content;
+
+    public List<String> getContent() {
+        return content;
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/CupboardMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/CupboardMapper.java
@@ -16,17 +16,21 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.internal.prism;
+package org.mapstruct.ap.test.collection.immutabletarget;
+
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
 
 /**
- * Prism for the enum {@link org.mapstruct.CollectionMappingStrategy}
  *
- * @author Andreas Gudian
+ * @author Sjaak Derksen
  */
-public enum CollectionMappingStrategyPrism {
+@Mapper( collectionMappingStrategy = CollectionMappingStrategy.TARGET_IMMUTABLE )
+public interface CupboardMapper {
 
-    ACCESSOR_ONLY,
-    SETTER_PREFERRED,
-    ADDER_PREFERRED,
-    TARGET_IMMUTABLE;
+    CupboardMapper INSTANCE = Mappers.getMapper( CupboardMapper.class );
+
+    void map( CupboardDto in, @MappingTarget CupboardEntity out );
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/ErroneousCupboardMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/ErroneousCupboardMapper.java
@@ -16,17 +16,21 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.internal.prism;
+package org.mapstruct.ap.test.collection.immutabletarget;
+
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
 
 /**
- * Prism for the enum {@link org.mapstruct.CollectionMappingStrategy}
  *
- * @author Andreas Gudian
+ * @author Sjaak Derksen
  */
-public enum CollectionMappingStrategyPrism {
+@Mapper( collectionMappingStrategy = CollectionMappingStrategy.TARGET_IMMUTABLE )
+public interface ErroneousCupboardMapper {
 
-    ACCESSOR_ONLY,
-    SETTER_PREFERRED,
-    ADDER_PREFERRED,
-    TARGET_IMMUTABLE;
+    ErroneousCupboardMapper INSTANCE = Mappers.getMapper( ErroneousCupboardMapper.class );
+
+    void map( CupboardDto in, @MappingTarget CupboardEntityOnlyGetter out );
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/ImmutableTargetTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/immutabletarget/ImmutableTargetTest.java
@@ -1,0 +1,75 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.immutabletarget;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({CupboardDto.class, CupboardEntity.class, CupboardMapper.class})
+@IssueKey( "1126" )
+public class ImmutableTargetTest {
+
+    @Test
+    public void shouldHandleImmutableTarget() {
+
+        CupboardDto in = new CupboardDto();
+        in.setContent( Arrays.asList( "cups", "soucers" ) );
+        CupboardEntity out = new CupboardEntity();
+        out.setContent( Collections.<String>emptyList() );
+
+        CupboardMapper.INSTANCE.map( in, out );
+
+        assertThat( out.getContent() ).isNotNull();
+        assertThat( out.getContent() ).containsExactly( "cups", "soucers"  );
+    }
+
+    @Test
+    @WithClasses({
+        ErroneousCupboardMapper.class,
+        CupboardEntityOnlyGetter.class
+    })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousCupboardMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 35,
+                messageRegExp = "No write accessor found for property \"content\" in target type.")
+        }
+    )
+    public void testShouldFailOnPropertyMappingNoPropertySetterOnlyGetter() {
+    }
+
+}


### PR DESCRIPTION
A new `CollectionMappingStrategy.TARGET_IMMUTABLE` has been introduced. The solution does not call the clear/addAll on the target collection. Instead it uses the setter on the target.

Pending: while handling the nice table in the documentation: what do we do when we encounter conflicting situations: e.g. there's no setter? Probably we should generate an error. 

I'll add that scenario, when we agree in general on this approach.