### PR TITLE
#1135 added test and implementation for overloading

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -437,6 +437,11 @@ public class Type extends ModelElement implements Comparable<Type> {
         return presenceCheckers;
     }
 
+    public Map<String, Accessor> getPropertyWriteAccessors( CollectionMappingStrategyPrism cmStrategy ) {
+        return getPropertyWriteAccessors( cmStrategy, Collections.<String, Accessor>emptyMap() );
+    }
+
+
     /**
      * getPropertyWriteAccessors returns a map of the write accessors according to the CollectionMappingStrategy. These
      * accessors include:
@@ -450,7 +455,8 @@ public class Type extends ModelElement implements Comparable<Type> {
      * @param cmStrategy collection mapping strategy
      * @return an unmodifiable map of all write accessors indexed by property name
      */
-    public Map<String, Accessor> getPropertyWriteAccessors( CollectionMappingStrategyPrism cmStrategy ) {
+    public Map<String, Accessor> getPropertyWriteAccessors( CollectionMappingStrategyPrism cmStrategy,
+                                                            Map<String, Accessor> sourceAccessor ) {
         // collect all candidate target accessors
         List<Accessor> candidates = new ArrayList<Accessor>( getSetters() );
         candidates.addAll( getAlternativeTargetAccessors() );
@@ -495,13 +501,47 @@ public class Type extends ModelElement implements Comparable<Type> {
             }
 
             Accessor previousCandidate = result.get( targetPropertyName );
-            if ( previousCandidate == null || preferredType == null || ( targetType != null
-                && typeUtils.isAssignable( preferredType.getTypeMirror(), targetType.getTypeMirror() ) ) ) {
+
+
+            if (previousCandidate != null
+                    && sourceAccessor != null
+                    && sourceAccessor.get( targetPropertyName ) != null
+                    && isBetter( previousCandidate, candidate,
+                    sourceAccessor.get( targetPropertyName ).getAccessedType() ) ) {
+                result.put( targetPropertyName, candidate );
+                continue;
+            }
+
+
+            if (previousCandidate == null || preferredType == null || (targetType != null
+                    && typeUtils.isAssignable( preferredType.getTypeMirror(), targetType.getTypeMirror() ) ) ) {
                 result.put( targetPropertyName, candidate );
             }
         }
 
         return result;
+    }
+
+    private TypeMirror extractTypeMirror( Accessor accessor ) {
+        return accessor.getExecutable().getParameters().get( 0 ).asType();
+    }
+
+    private boolean isBetter( Accessor previousCandidate, Accessor nextCandidate, TypeMirror preferredType ) {
+        TypeMirror previousType = extractTypeMirror( previousCandidate );
+        TypeMirror nextType = extractTypeMirror( nextCandidate );
+
+        if (typeUtils.isSameType( previousType, preferredType )) {
+            return false;
+        }
+
+        if (typeUtils.isSameType( nextType, preferredType )) {
+            return true;
+        }
+        if (typeUtils.isAssignable( nextType, preferredType )
+                && !typeUtils.isAssignable( previousType, preferredType )) {
+            return true;
+        }
+        return false;
     }
 
     private Type determinePreferredType(Accessor readAccessor) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.LinkedHashMap;
 
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
@@ -40,6 +41,7 @@ import org.mapstruct.ap.internal.util.Executables;
 import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Strings;
+import org.mapstruct.ap.internal.util.accessor.Accessor;
 
 /**
  * Represents a mapping method with source and target type and the mappings between the properties of source and target
@@ -74,6 +76,7 @@ public class SourceMethod implements Method {
     private final ParameterProvidedMethods contextProvidedMethods;
 
     private List<String> parameterNames;
+    private Map<String, Accessor> getSourceReadAccessors;
 
     private List<SourceMethod> applicablePrototypeMethods;
     private List<SourceMethod> applicableReversePrototypeMethods;
@@ -611,5 +614,20 @@ public class SourceMethod implements Method {
     @Override
     public boolean isUpdateMethod() {
         return getMappingTargetParameter() != null;
+    }
+
+    public Map<String, Accessor> getGetSourceReadAccessors() {
+
+        if (getSourceReadAccessors == null) {
+            Map<String, Accessor> map = new LinkedHashMap<String, Accessor>();
+
+            for (Parameter parameter : getSourceParameters()) {
+                map.putAll( parameter.getType().getPropertyReadAccessors() );
+            }
+            getSourceReadAccessors = Collections.unmodifiableMap( map );
+
+        }
+
+        return getSourceReadAccessors;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
@@ -141,7 +141,8 @@ public class TargetReference {
             for ( int i = 0; i < entryNames.length; i++ ) {
 
                 Accessor targetReadAccessor = nextType.getPropertyReadAccessors().get( entryNames[i] );
-                Accessor targetWriteAccessor = nextType.getPropertyWriteAccessors( cms ).get( entryNames[i] );
+                Accessor targetWriteAccessor = nextType.getPropertyWriteAccessors( cms,
+                        method.getGetSourceReadAccessors() ).get( entryNames[i] );
                 if ( targetWriteAccessor == null || ( i < entryNames.length - 1 && targetReadAccessor == null) ) {
                     // there should always be a write accessor and there should be read accessor mandatory for all
                     // but the last

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
@@ -203,7 +203,10 @@ public class Executables {
      *
      * @return the executable elements usable in the type
      */
-    public static List<Accessor> getAllEnclosedAccessors(Elements elementUtils, TypeElement element) {
+    public static List<Accessor> getAllEnclosedAccessors( Elements elementUtils, TypeElement element ) {
+        if (element == null) {
+            return java.util.Collections.emptyList();
+        }
         List<Accessor> enclosedElements = new ArrayList<Accessor>();
         element = replaceTypeElementIfNecessary( elementUtils, element );
         addEnclosedElementsInHierarchy( elementUtils, enclosedElements, element, element );

--- a/processor/src/test/java/org/mapstruct/ap/test/overloading/OverloadingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/overloading/OverloadingTest.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.overloading;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import java.util.Date;
+
+@WithClasses({
+        SourceTargetMapper.class,
+        Source.class,
+        Target.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class OverloadingTest {
+
+    @Test
+    public void testShouldGenerateCorrectMapperImplementation() {
+        Source source = new Source( new Date() );
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+        Assert.assertTrue( target.getUpdatedOn() > 0 );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/overloading/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/overloading/Source.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.overloading;
+
+import java.util.Date;
+
+public class Source {
+
+    private Date updatedOn;
+
+    public Source(Date updatedOn) {
+        this.updatedOn = updatedOn;
+    }
+
+    public Date getUpdatedOn() {
+        return updatedOn;
+    }
+
+    public void setUpdatedOn(Date updatedOn) {
+        this.updatedOn = updatedOn;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/overloading/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/overloading/SourceTargetMapper.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.overloading;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface SourceTargetMapper {
+
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    @Mapping(target = "updatedOn", source = "updatedOn")
+    Target sourceToTarget( Source source );
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/overloading/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/overloading/Target.java
@@ -1,0 +1,42 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.overloading;
+
+import java.util.Date;
+
+public class Target {
+
+    private long updatedOn;
+
+    public long getUpdatedOn() {
+        return updatedOn;
+    }
+
+    public void setUpdatedOn( long updatedOn ) {
+        this.updatedOn = updatedOn;
+    }
+
+    public void setUpdatedOn( Date updatedOn ) {
+        if (updatedOn == null) {
+            return;
+        }
+        this.updatedOn = updatedOn.getTime();
+    }
+
+}


### PR DESCRIPTION
Mapstruct does support overloading of target setters(see: Issue892Test test) but choosing preferred type logic is based on getter type of target - not source, which looks a bit strange.
Here is straightforward implementation of this