### PR TITLE
#993 Add support for disabling the generation of forged mapping methods

### DIFF
--- a/core-common/src/main/java/org/mapstruct/Mapper.java
+++ b/core-common/src/main/java/org/mapstruct/Mapper.java
@@ -159,4 +159,23 @@ public @interface Mapper {
      * @return strategy how to do null checking
      */
     NullValueCheckStrategy nullValueCheckStrategy() default ON_IMPLICIT_CONVERSION;
+
+    /**
+     * If MapStruct could not find another mapping method or apply an automatic conversion it will try to generate a
+     * sub-mapping method between the two beans. If this property is set to {@code true} MapStruct will not try to
+     * automatically generate sub-mapping methods.
+     * <p>
+     * Can be configured by the {@link MapperConfig#disableSubMappingMethodsGeneration()} as well.
+     * <p>
+     * Note: If you need to use {@code disableSubMappingMethodsGeneration} please contact the MapStruct team at
+     * <a href="http://mapstruct.org">mapstruct.org</a> or
+     * <a href="https://github.com/mapstruct/mapstruct">github.com/mapstruct/mapstruct</a> to share what problem you
+     * are facing with the automatic sub-mapping generation.
+     *
+     * @return whether the automatic generation of sub-mapping methods is disabled
+     *
+     * @since 1.2
+     */
+    boolean disableSubMappingMethodsGeneration() default false;
+
 }

--- a/core-common/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core-common/src/main/java/org/mapstruct/MapperConfig.java
@@ -146,4 +146,22 @@ public @interface MapperConfig {
      * @return strategy how to do null checking
      */
     NullValueCheckStrategy nullValueCheckStrategy() default ON_IMPLICIT_CONVERSION;
+
+    /**
+     * If MapStruct could not find another mapping method or apply an automatic conversion it will try to generate a
+     * sub-mapping method between the two beans. If this property is set to {@code true} MapStruct will not try to
+     * automatically generate sub-mapping methods.
+     * <p>
+     * Can be overridden by {@link Mapper#disableSubMappingMethodsGeneration()}
+     * <p>
+     * Note: If you need to use {@code disableSubMappingMethodsGeneration} please contact the MapStruct team at
+     * <a href="http://mapstruct.org">mapstruct.org</a> or
+     * <a href="https://github.com/mapstruct/mapstruct">github.com/mapstruct/mapstruct</a> to share what problem you
+     * are facing with the automatic sub-mapping generation.
+     *
+     * @return whether the automatic generation of sub-mapping methods is disabled
+     *
+     * @since 1.2
+     */
+    boolean disableSubMappingMethodsGeneration() default false;
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractBaseBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractBaseBuilder.java
@@ -20,9 +20,12 @@ package org.mapstruct.ap.internal.model;
 
 import org.mapstruct.ap.internal.model.assignment.Assignment;
 import org.mapstruct.ap.internal.model.common.ParameterBinding;
+import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.ForgedMethod;
 import org.mapstruct.ap.internal.model.source.MappingMethodUtils;
 import org.mapstruct.ap.internal.model.source.Method;
+import org.mapstruct.ap.internal.util.MapperConfiguration;
+import org.mapstruct.ap.internal.util.Message;
 
 /**
  * @author Filip Hrisafov
@@ -45,6 +48,11 @@ class AbstractBaseBuilder<B extends AbstractBaseBuilder<B>> {
     public B method(Method sourceMethod) {
         this.method = sourceMethod;
         return myself;
+    }
+
+    boolean isDisableSubMappingMethodsGeneration() {
+        MapperConfiguration configuration = MapperConfiguration.getInstanceOn( ctx.getMapperTypeElement() );
+        return configuration.isDisableSubMappingMethodsGeneration();
     }
 
     /**
@@ -108,5 +116,27 @@ class AbstractBaseBuilder<B extends AbstractBaseBuilder<B>> {
         assignment.setAssignment( source );
 
         return assignment;
+    }
+
+    /**
+     * Reports that a mapping could not be created.
+     *
+     * @param method the method that should be mapped
+     * @param sourceErrorMessagePart the error message part for the source
+     * @param sourceRHS the {@link SourceRHS}
+     * @param targetType the type of the target mapping
+     * @param targetPropertyName the name of the target property
+     */
+    void reportCannotCreateMapping(Method method, String sourceErrorMessagePart, SourceRHS sourceRHS, Type targetType,
+        String targetPropertyName) {
+        ctx.getMessager().printMessage(
+            method.getExecutable(),
+            Message.PROPERTYMAPPING_MAPPING_NOT_FOUND,
+            sourceErrorMessagePart,
+            targetType,
+            targetPropertyName,
+            targetType,
+            sourceRHS.getSourceType() /* original source type */
+        );
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
@@ -45,6 +45,9 @@ public abstract class AbstractMappingMethodBuilder<B extends AbstractMappingMeth
     protected abstract boolean shouldUsePropertyNamesInHistory();
 
     Assignment forgeMapping(SourceRHS sourceRHS, Type sourceType, Type targetType) {
+        if ( isDisableSubMappingMethodsGeneration() ) {
+            return null;
+        }
 
         String name = getName( sourceType, targetType );
         name = Strings.getSaveVariableName( name, ctx.getNamesOfMappingsToGenerate() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
@@ -112,6 +112,21 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
                 forgedMethod.addThrownTypes( assignment.getThrownTypes() );
             }
         }
+        if ( assignment == null ) {
+            if ( method instanceof ForgedMethod ) {
+                // leave messaging to calling property mapping
+                return null;
+            }
+            else {
+                reportCannotCreateMapping(
+                    method,
+                    String.format( "%s \"%s\"", sourceRHS.getSourceErrorMessagePart(), sourceRHS.getSourceType() ),
+                    sourceRHS,
+                    targetElementType,
+                    ""
+                );
+            }
+        }
 
         assignment = getWrapper( assignment, method );
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -110,6 +110,27 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
                 keyAssignment = forgeMapping( keySourceRHS, keySourceType, keyTargetType );
             }
 
+
+            if ( keyAssignment == null ) {
+                if ( method instanceof ForgedMethod ) {
+                    // leave messaging to calling property mapping
+                    return null;
+                }
+                else {
+                    reportCannotCreateMapping(
+                        method,
+                        String.format(
+                            "%s \"%s\"",
+                            keySourceRHS.getSourceErrorMessagePart(),
+                            keySourceRHS.getSourceType()
+                        ),
+                        keySourceRHS,
+                        keyTargetType,
+                        ""
+                    );
+                }
+            }
+
             // find mapping method or conversion for value
             Type valueSourceType = sourceTypeParams.get( 1 ).getTypeBound();
             Type valueTargetType = resultTypeParams.get( 1 ).getTypeBound();
@@ -138,6 +159,26 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
 
             if ( valueAssignment == null ) {
                 valueAssignment = forgeMapping( valueSourceRHS, valueSourceType, valueTargetType );
+            }
+
+            if ( valueAssignment == null ) {
+                if ( method instanceof ForgedMethod ) {
+                    // leave messaging to calling property mapping
+                    return null;
+                }
+                else {
+                    reportCannotCreateMapping(
+                        method,
+                        String.format(
+                            "%s \"%s\"",
+                            valueSourceRHS.getSourceErrorMessagePart(),
+                            valueSourceRHS.getSourceType()
+                        ),
+                        valueSourceRHS,
+                        valueTargetType,
+                        ""
+                    );
+                }
             }
 
             // mapNullToDefault

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -302,14 +302,12 @@ public class PropertyMapping extends ModelElement {
                 }
             }
             else {
-                ctx.getMessager().printMessage(
-                    method.getExecutable(),
-                    Message.PROPERTYMAPPING_MAPPING_NOT_FOUND,
+                reportCannotCreateMapping(
+                    method,
                     rightHandSide.getSourceErrorMessagePart(),
+                    rightHandSide,
                     targetType,
-                    targetPropertyName,
-                    targetType,
-                    rightHandSide.getSourceType() /* original source type */
+                    targetPropertyName
                 );
             }
 
@@ -635,6 +633,9 @@ public class PropertyMapping extends ModelElement {
         }
 
         private Assignment forgeMapping(SourceRHS sourceRHS) {
+            if ( forgedNamedBased && isDisableSubMappingMethodsGeneration() ) {
+                return null;
+            }
 
             Type sourceType = sourceRHS.getSourceType();
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
@@ -194,6 +194,18 @@ public class MapperConfiguration {
         return mapperPrism.componentModel(); // fall back to default defined in the annotation
     }
 
+    public boolean isDisableSubMappingMethodsGeneration() {
+        if ( mapperPrism.disableSubMappingMethodsGeneration() ) {
+            return mapperPrism.disableSubMappingMethodsGeneration();
+        }
+
+        if ( mapperConfigPrism != null && mapperConfigPrism.disableSubMappingMethodsGeneration() ) {
+            return mapperConfigPrism.disableSubMappingMethodsGeneration();
+        }
+
+        return mapperPrism.disableSubMappingMethodsGeneration(); // fall back to default defined in the annotation
+    }
+
     public DeclaredType config() {
         return config;
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionMappingTest.java
@@ -124,6 +124,23 @@ public class ErroneousCollectionMappingTest {
     }
 
     @Test
+    @IssueKey("993")
+    @WithClasses({ ErroneousCollectionNoElementMappingFoundDisabledAuto.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousCollectionNoElementMappingFoundDisabledAuto.class,
+                kind = Kind.ERROR,
+                line = 32,
+                messageRegExp =
+                    "Can't map collection element \".*AttributedString\" to \".*String \". " +
+                        "Consider to declare/implement a mapping method: \".*String map\\(.*AttributedString value\\)")
+        }
+    )
+    public void shouldFailOnNoElementMappingFoundWithDisabledAuto() {
+    }
+
+    @Test
     @IssueKey("459")
     @WithClasses({ ErroneousCollectionNoKeyMappingFound.class })
     @ExpectedCompilationOutcome(
@@ -140,6 +157,22 @@ public class ErroneousCollectionMappingTest {
     }
 
     @Test
+    @IssueKey("993")
+    @WithClasses({ ErroneousCollectionNoKeyMappingFoundDisabledAuto.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousCollectionNoKeyMappingFoundDisabledAuto.class,
+                kind = Kind.ERROR,
+                line = 32,
+                messageRegExp = "Can't map map key \".*AttributedString\" to \".*String \". " +
+                    "Consider to declare/implement a mapping method: \".*String map\\(.*AttributedString value\\)")
+        }
+    )
+    public void shouldFailOnNoKeyMappingFoundWithDisabledAuto() {
+    }
+
+    @Test
     @IssueKey("459")
     @WithClasses({ ErroneousCollectionNoValueMappingFound.class })
     @ExpectedCompilationOutcome(
@@ -153,5 +186,21 @@ public class ErroneousCollectionMappingTest {
         }
     )
     public void shouldFailOnNoValueMappingFound() {
+    }
+
+    @Test
+    @IssueKey("993")
+    @WithClasses({ ErroneousCollectionNoValueMappingFoundDisabledAuto.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousCollectionNoValueMappingFoundDisabledAuto.class,
+                kind = Kind.ERROR,
+                line = 32,
+                messageRegExp = "Can't map map value \".*AttributedString\" to \".*String \". " +
+                    "Consider to declare/implement a mapping method: \".*String map(.*AttributedString value)")
+        }
+    )
+    public void shouldFailOnNoValueMappingFoundWithDisabledAuto() {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionNoElementMappingFoundDisabledAuto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionNoElementMappingFoundDisabledAuto.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.erroneous;
+
+import java.text.AttributedString;
+import java.util.List;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(disableSubMappingMethodsGeneration = true)
+public interface ErroneousCollectionNoElementMappingFoundDisabledAuto {
+
+    List<String> map(List<AttributedString> source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionNoKeyMappingFoundDisabledAuto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionNoKeyMappingFoundDisabledAuto.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.erroneous;
+
+import java.text.AttributedString;
+import java.util.Map;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(disableSubMappingMethodsGeneration = true)
+public interface ErroneousCollectionNoKeyMappingFoundDisabledAuto {
+
+    Map<String, String> map(Map<AttributedString, String> source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionNoValueMappingFoundDisabledAuto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/erroneous/ErroneousCollectionNoValueMappingFoundDisabledAuto.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.collection.erroneous;
+
+import java.text.AttributedString;
+import java.util.Map;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(disableSubMappingMethodsGeneration = true)
+public interface ErroneousCollectionNoValueMappingFoundDisabledAuto {
+
+    Map<String, String> map(Map<String, AttributedString> source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousListToStreamNoElementMappingFoundDisabledAuto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousListToStreamNoElementMappingFoundDisabledAuto.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+import java.text.AttributedString;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(disableSubMappingMethodsGeneration = true)
+public interface ErroneousListToStreamNoElementMappingFoundDisabledAuto {
+
+    Stream<String> mapCollectionToStream(List<AttributedString> source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamMappingTest.java
@@ -115,11 +115,28 @@ public class ErroneousStreamMappingTest {
             @Diagnostic(type = ErroneousStreamToStreamNoElementMappingFound.class,
                 kind = Kind.ERROR,
                 line = 36,
-                messageRegExp = "Can't map Stream element .*AttributedString attributedString\" to .*String string\"." +
-                        " Consider to declare/implement a mapping method: \".*String map(.*AttributedString value)")
+                messageRegExp = "Can't map Stream element \".*AttributedString attributedString\" to \".*String " +
+                    "string\". Consider to declare/implement a mapping method: \".*String map(.*AttributedString " +
+                    "value)")
         }
     )
     public void shouldFailOnNoElementMappingFoundForStreamToStream() {
+    }
+
+    @Test
+    @IssueKey("993")
+    @WithClasses({ ErroneousStreamToStreamNoElementMappingFoundDisabledAuto.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousStreamToStreamNoElementMappingFoundDisabledAuto.class,
+                kind = Kind.ERROR,
+                line = 32,
+                messageRegExp = "Can't map stream element \".*AttributedString\" to \".*String \". Consider to " +
+                    "declare/implement a mapping method: \".*String map(.*AttributedString value)")
+        }
+    )
+    public void shouldFailOnNoElementMappingFoundForStreamToStreamWithDisabledAuto() {
     }
 
     @Test
@@ -130,11 +147,28 @@ public class ErroneousStreamMappingTest {
             @Diagnostic(type = ErroneousListToStreamNoElementMappingFound.class,
                 kind = Kind.ERROR,
                 line = 37,
-                messageRegExp = "Can't map .*AttributedString attributedString\" to .*String string\". " +
-                    "Consider to declare/implement a mapping method: \".*String map(.*AttributedString value)")
+                messageRegExp =
+                    "Can't map Stream element \".*AttributedString attributedString\" to \".*String string\". " +
+                        "Consider to declare/implement a mapping method: \".*String map\\(.*AttributedString value\\)")
         }
     )
     public void shouldFailOnNoElementMappingFoundForListToStream() {
+    }
+
+    @Test
+    @IssueKey("993")
+    @WithClasses({ ErroneousListToStreamNoElementMappingFoundDisabledAuto.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousListToStreamNoElementMappingFoundDisabledAuto.class,
+                kind = Kind.ERROR,
+                line = 33,
+                messageRegExp = "Can't map stream element \".*AttributedString\" to \".*String \". Consider to " +
+                    "declare/implement a mapping method: \".*String map\\(.*AttributedString value\\)")
+        }
+    )
+    public void shouldFailOnNoElementMappingFoundForListToStreamWithDisabledAuto() {
     }
 
     @Test
@@ -145,10 +179,27 @@ public class ErroneousStreamMappingTest {
             @Diagnostic(type = ErroneousStreamToListNoElementMappingFound.class,
                 kind = Kind.ERROR,
                 line = 37,
-                messageRegExp = "Can't map Stream element .*AttributedString attributedString\" to .*String string\"." +
+                messageRegExp =
+                    "Can't map Stream element \".*AttributedString attributedString\" to .*String string\"." +
                         " Consider to declare/implement a mapping method: \".*String map(.*AttributedString value)")
         }
     )
     public void shouldFailOnNoElementMappingFoundForStreamToList() {
+    }
+
+    @Test
+    @IssueKey("993")
+    @WithClasses({ ErroneousStreamToListNoElementMappingFoundDisabledAuto.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousStreamToListNoElementMappingFoundDisabledAuto.class,
+                kind = Kind.ERROR,
+                line = 33,
+                messageRegExp = "Can't map stream element \".*AttributedString\" to .*String \". Consider to " +
+                    "declare/implement a mapping method: \".*String map(.*AttributedString value)")
+        }
+    )
+    public void shouldFailOnNoElementMappingFoundForStreamToListWithDisabledAuto() {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToListNoElementMappingFoundDisabledAuto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToListNoElementMappingFoundDisabledAuto.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+import java.text.AttributedString;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(disableSubMappingMethodsGeneration = true)
+public interface ErroneousStreamToListNoElementMappingFoundDisabledAuto {
+
+    List<String> mapStreamToCollection(Stream<AttributedString> source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToStreamNoElementMappingFoundDisabledAuto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/erroneous/ErroneousStreamToStreamNoElementMappingFoundDisabledAuto.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.java8stream.erroneous;
+
+import java.text.AttributedString;
+import java.util.stream.Stream;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(disableSubMappingMethodsGeneration = true)
+public interface ErroneousStreamToStreamNoElementMappingFoundDisabledAuto {
+
+    Stream<String> mapStreamToStream(Stream<AttributedString> source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/DisableConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/DisableConfig.java
@@ -1,0 +1,28 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+import org.mapstruct.MapperConfig;
+
+/**
+ * @author Filip Hrisafov
+ */
+@MapperConfig(disableSubMappingMethodsGeneration = true)
+public interface DisableConfig {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/DisablingNestedSimpleBeansMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/DisablingNestedSimpleBeansMappingTest.java
@@ -1,0 +1,73 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses({
+    House.class, HouseDto.class,
+    Wheel.class, WheelDto.class,
+    Roof.class, RoofDto.class,
+    RoofType.class, ExternalRoofType.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class DisablingNestedSimpleBeansMappingTest {
+
+    @WithClasses({
+        ErroneousDisabledHouseMapper.class
+    })
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousDisabledHouseMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 29,
+                messageRegExp = "Can't map property \".*\\.Roof roof\" to \".*\\.RoofDto roof\"\\. Consider to " +
+                    "declare/implement a mapping method: \".*\\.RoofDto map\\(.*\\.Roof value\\)\"\\."
+            )
+        })
+    @Test
+    public void shouldUseDisabledMethodGenerationOnMapper() throws Exception {
+    }
+
+    @WithClasses({
+        ErroneousDisabledViaConfigHouseMapper.class,
+        DisableConfig.class
+    })
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousDisabledViaConfigHouseMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 29,
+                messageRegExp = "Can't map property \".*\\.Roof roof\" to \".*\\.RoofDto roof\"\\. Consider to " +
+                    "declare/implement a mapping method: \".*\\.RoofDto map\\(.*\\.Roof value\\)\"\\."
+            )
+        })
+    @Test
+    public void shouldUseDisabledMethodGenerationOnMapperConfig() throws Exception {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/ErroneousDisabledHouseMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/ErroneousDisabledHouseMapper.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(disableSubMappingMethodsGeneration = true)
+public interface ErroneousDisabledHouseMapper {
+
+    HouseDto houseToHouseDto(House house);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/ErroneousDisabledViaConfigHouseMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/ErroneousDisabledViaConfigHouseMapper.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(config = DisableConfig.class)
+public interface ErroneousDisabledViaConfigHouseMapper {
+
+    HouseDto houseToHouseDto(House house);
+}


### PR DESCRIPTION
Fixes #993.

Please have a look at the field name in the API and the Javadoc. The field is a bit verbose, but I couldn't think of something else. I am open to ideas :)