### PR TITLE
#1171 Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: java
+jdk:
+  - oraclejdk8
+install: true
+script: mvn clean install -DprocessorIntegrationTest.toolchainsFile=etc/toolchains-travis-jenkins.xml -B -V
+
+sudo: false
+cache:
+  directories:
+  - $HOME/.m2
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer

--- a/etc/toolchains-travis-jenkins.xml
+++ b/etc/toolchains-travis-jenkins.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.6</version>
+            <vendor>oracle</vendor>
+            <id>jdk1.6</id>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/java-6-openjdk-amd64/</jdkHome>
+        </configuration>
+    </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.7</version>
+            <vendor>oracle</vendor>
+            <id>jdk1.7</id>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/java-7-oracle/</jdkHome>
+        </configuration>
+    </toolchain>
+    <toolchain>
+        <type>jdk</type>
+        <provides>
+            <version>1.8</version>
+            <vendor>oracle</vendor>
+            <id>jdk1.8</id>
+        </provides>
+        <configuration>
+            <jdkHome>/usr/lib/jvm/java-8-oracle/</jdkHome>
+        </configuration>
+    </toolchain>
+    
+</toolchains>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -397,6 +397,8 @@
                     <version>${org.apache.maven.plugins.surefire.version}</version>
                     <configuration>
                         <forkCount>${forkCount}</forkCount>
+                        <!-- Travis build workaround -->
+                        <argLine>-Xms1024m -Xmx3072m</argLine>
                     </configuration>
                     <dependencies>
                         <dependency>


### PR DESCRIPTION
Fixes #1171.

This adds the travis.yml and the toolchains for the Travis build.

Someone with admin rights (@gunnarmorling, @agudian, @sjaakd) on the repository should activate Travis for it [here](https://travis-ci.org/profile/mapstruct). Best would be before merging this pull request so the merge of this would trigger the first build and activate it