### PR TITLE
#1164 Make sure we don't do a null check all the time for SetterWrapperForCollections

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
@@ -1,0 +1,185 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model;
+
+import org.mapstruct.ap.internal.model.assignment.Assignment;
+import org.mapstruct.ap.internal.model.assignment.ExistingInstanceSetterWrapperForCollectionsAndMaps;
+import org.mapstruct.ap.internal.model.assignment.GetterWrapperForCollectionsAndMaps;
+import org.mapstruct.ap.internal.model.assignment.SetterWrapperForCollectionsAndMaps;
+import org.mapstruct.ap.internal.model.assignment.SetterWrapperForCollectionsAndMapsWithNullCheck;
+import org.mapstruct.ap.internal.model.assignment.UpdateWrapper;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.source.Method;
+import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
+import org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism;
+import org.mapstruct.ap.internal.util.Message;
+import org.mapstruct.ap.internal.util.accessor.Accessor;
+
+/**
+ * A builder that is used for creating an assignment to a collection.
+ *
+ * The created assignments to the following null checks:
+ * <ul>
+ *     <li>source-null-check - For this the {@link SetterWrapperForCollectionsAndMapsWithNullCheck} is used when a
+ *     direct assignment is done or the {@link org.mapstruct.NullValueCheckStrategy} is
+ *     {@link org.mapstruct.NullValueCheckStrategy#ALWAYS}. It is also done in
+ *     {@link ExistingInstanceSetterWrapperForCollectionsAndMaps} which extends
+ *     {@link SetterWrapperForCollectionsAndMapsWithNullCheck}</li>
+ *     <li>target-null-check - Done in the {@link ExistingInstanceSetterWrapperForCollectionsAndMaps}</li>
+ *     <li>local-var-null-check - Done in {@link ExistingInstanceSetterWrapperForCollectionsAndMaps}, and
+ *     {@link SetterWrapperForCollectionsAndMapsWithNullCheck}</li>
+ * </ul>
+ *
+ * A local-var-null-check is needed in the following cases:
+ *
+ * <ul>
+ *     <li>Presence check with direct assignment - We need a null check before setting, because we use the copy
+ *     constructor</li>
+ *     <li>Presence check for existing instance mapping - We need the null check because we call addAll / putAll.</li>
+ *     <li>No Presence check and direct assignment - We use the copy constructor</li>
+ *     <li>No Presence check and {@link org.mapstruct.NullValueCheckStrategy#ALWAYS} - the user requested one</li>
+ * </ul>
+ *
+ * @author Filip Hrisafov
+ */
+public class CollectionAssignmentBuilder {
+    private MappingBuilderContext ctx;
+    private Method method;
+    private Accessor targetReadAccessor;
+    private Type targetType;
+    private String targetPropertyName;
+    private PropertyMapping.TargetWriteAccessorType targetAccessorType;
+    private Assignment rhs;
+
+    public CollectionAssignmentBuilder mappingBuilderContext(MappingBuilderContext ctx) {
+        this.ctx = ctx;
+        return this;
+    }
+
+    public CollectionAssignmentBuilder method(Method method) {
+        this.method = method;
+        return this;
+    }
+
+    public CollectionAssignmentBuilder targetReadAccessor(Accessor targetReadAccessor) {
+        this.targetReadAccessor = targetReadAccessor;
+        return this;
+    }
+
+    public CollectionAssignmentBuilder targetType(Type targetType) {
+        this.targetType = targetType;
+        return this;
+    }
+
+    public CollectionAssignmentBuilder targetPropertyName(String targetPropertyName) {
+        this.targetPropertyName = targetPropertyName;
+        return this;
+    }
+
+    public CollectionAssignmentBuilder targetAccessorType(PropertyMapping.TargetWriteAccessorType targetAccessorType) {
+        this.targetAccessorType = targetAccessorType;
+        return this;
+    }
+
+    public CollectionAssignmentBuilder rightHandSide(Assignment rhs) {
+        this.rhs = rhs;
+        return this;
+    }
+
+    public Assignment build() {
+        Assignment result = rhs;
+
+        CollectionMappingStrategyPrism cms = method.getMapperConfiguration().getCollectionMappingStrategy();
+        boolean targetImmutable = cms == CollectionMappingStrategyPrism.TARGET_IMMUTABLE;
+
+        if ( targetAccessorType == PropertyMapping.TargetWriteAccessorType.SETTER ||
+            targetAccessorType == PropertyMapping.TargetWriteAccessorType.FIELD ) {
+
+            if ( result.isCallingUpdateMethod() && !targetImmutable ) {
+
+                // call to an update method
+                if ( targetReadAccessor == null ) {
+                    ctx.getMessager().printMessage(
+                        method.getExecutable(),
+                        Message.PROPERTYMAPPING_NO_READ_ACCESSOR_FOR_TARGET_TYPE,
+                        targetPropertyName
+                    );
+                }
+                Assignment factoryMethod = ctx.getMappingResolver().getFactoryMethod( method, targetType, null );
+                result = new UpdateWrapper(
+                    result,
+                    method.getThrownTypes(),
+                    factoryMethod,
+                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType ),
+                    targetType,
+                    true
+                );
+            }
+            else if ( method.isUpdateMethod() && !targetImmutable ) {
+                result = new ExistingInstanceSetterWrapperForCollectionsAndMaps(
+                    result,
+                    method.getThrownTypes(),
+                    targetType,
+                    method.getMapperConfiguration().getNullValueCheckStrategy(),
+                    ctx.getTypeFactory(),
+                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+                );
+            }
+            else if ( result.getType() == Assignment.AssignmentType.DIRECT ||
+                method.getMapperConfiguration().getNullValueCheckStrategy() == NullValueCheckStrategyPrism.ALWAYS ) {
+                result = new SetterWrapperForCollectionsAndMapsWithNullCheck(
+                    result,
+                    method.getThrownTypes(),
+                    targetType,
+                    ctx.getTypeFactory(),
+                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+                );
+            }
+            else {
+
+                // target accessor is setter, so wrap the setter in setter map/ collection handling
+                result = new SetterWrapperForCollectionsAndMaps(
+                    result,
+                    method.getThrownTypes(),
+                    targetType,
+                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+                );
+            }
+        }
+        else {
+            if ( targetImmutable ) {
+                ctx.getMessager().printMessage(
+                    method.getExecutable(),
+                    Message.PROPERTYMAPPING_NO_WRITE_ACCESSOR_FOR_TARGET_TYPE,
+                    targetPropertyName
+                );
+            }
+
+            // target accessor is getter, so wrap the setter in getter map/ collection handling
+            result = new GetterWrapperForCollectionsAndMaps(
+                result,
+                method.getThrownTypes(),
+                targetType,
+                PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+            );
+        }
+
+        return result;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.java
@@ -1,0 +1,66 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model.assignment;
+
+import java.util.List;
+
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.common.TypeFactory;
+import org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism;
+
+import static org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism.ALWAYS;
+
+/**
+ * This wrapper handles the situation where an assignment is done for an update method.
+ *
+ * In case of a pre-existing target the wrapper checks if there is an collection or map initialized on the target bean
+ * (not null). If so it uses the addAll (for collections) or putAll (for maps). The collection / map is cleared in case
+ * of a pre-existing target {@link org.mapstruct.MappingTarget }before adding the source entries.
+ *
+ * If there is no pre-existing target, or the target Collection / Map is not initialized (null) the setter is used to
+ * create a new Collection / Map with the copy constructor.
+ *
+ * @author Sjaak Derksen
+ */
+public class ExistingInstanceSetterWrapperForCollectionsAndMaps
+    extends SetterWrapperForCollectionsAndMapsWithNullCheck {
+
+    private final boolean includeSourceNullCheck;
+
+    public ExistingInstanceSetterWrapperForCollectionsAndMaps(Assignment decoratedAssignment,
+        List<Type> thrownTypesToExclude,
+        Type targetType,
+        NullValueCheckStrategyPrism nvms,
+        TypeFactory typeFactory,
+        boolean fieldAssignment) {
+
+        super(
+            decoratedAssignment,
+            thrownTypesToExclude,
+            targetType,
+            typeFactory,
+            fieldAssignment
+        );
+        this.includeSourceNullCheck = ALWAYS == nvms;
+    }
+
+    public boolean isIncludeSourceNullCheck() {
+        return includeSourceNullCheck;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.java
@@ -18,7 +18,9 @@
  */
 package org.mapstruct.ap.internal.model.assignment;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.Type;
 
@@ -56,4 +58,12 @@ public class GetterWrapperForCollectionsAndMaps extends WrapperForCollectionsAnd
         );
     }
 
+    @Override
+    public Set<Type> getImportTypes() {
+        Set<Type> imported = new HashSet<Type>( super.getImportTypes() );
+        if ( getSourcePresenceCheckerReference() == null ) {
+            imported.addAll( getNullCheckLocalVarType().getImportTypes() );
+        }
+        return imported;
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.java
@@ -18,44 +18,21 @@
  */
 package org.mapstruct.ap.internal.model.assignment;
 
-import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType.DIRECT;
-
-import java.util.EnumSet;
 import java.util.List;
-import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.Type;
-import org.mapstruct.ap.internal.model.common.TypeFactory;
-import org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism;
-
-import static org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism.ALWAYS;
 
 /**
- * This wrapper handles the situation were an assignment is done via the setter.
- *
- * In case of a pre-existing target the wrapper checks if there is an collection or map initialized on the target bean
- * (not null). If so it uses the addAll (for collections) or putAll (for maps). The collection / map is cleared in case
- * of a pre-existing target {@link org.mapstruct.MappingTarget }before adding the source entries.
- *
- * If there is no pre-existing target, or the target Collection / Map is not initialized (null) the setter is used to
- * create a new Collection / Map with the copy constructor.
+ * This wrapper handles the situation where an assignment is done via the setter, without doing anything special.
  *
  * @author Sjaak Derksen
  */
 public class SetterWrapperForCollectionsAndMaps extends WrapperForCollectionsAndMaps {
 
-    private final boolean includeSourceNullCheck;
-    private final Type targetType;
-    private final TypeFactory typeFactory;
-    private final boolean targetImmutable;
-
     public SetterWrapperForCollectionsAndMaps(Assignment decoratedAssignment,
-                                              List<Type> thrownTypesToExclude,
-                                              Type targetType,
-                                              NullValueCheckStrategyPrism nvms,
-                                              TypeFactory typeFactory,
-                                              boolean fieldAssignment,
-                                              boolean targetImmutable ) {
+        List<Type> thrownTypesToExclude,
+        Type targetType,
+        boolean fieldAssignment) {
 
         super(
             decoratedAssignment,
@@ -63,44 +40,5 @@ public class SetterWrapperForCollectionsAndMaps extends WrapperForCollectionsAnd
             targetType,
             fieldAssignment
         );
-        this.includeSourceNullCheck = ALWAYS == nvms;
-        this.targetType = targetType;
-        this.typeFactory = typeFactory;
-        this.targetImmutable = targetImmutable;
     }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        Set<Type> imported = super.getImportTypes();
-        if ( isDirectAssignment() ) {
-            if ( targetType.getImplementationType() != null ) {
-                imported.addAll( targetType.getImplementationType().getImportTypes() );
-            }
-            else {
-                imported.addAll( targetType.getImportTypes() );
-            }
-
-            if ( isEnumSet() ) {
-                imported.add( typeFactory.getType( EnumSet.class ) );
-            }
-        }
-        return imported;
-    }
-
-    public boolean isIncludeSourceNullCheck() {
-        return includeSourceNullCheck;
-    }
-
-    public boolean isDirectAssignment() {
-        return getType() == DIRECT;
-    }
-
-    public boolean isEnumSet() {
-        return "java.util.EnumSet".equals( targetType.getFullyQualifiedName() );
-    }
-
-    public boolean isTargetImmutable() {
-        return targetImmutable;
-    }
-
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.java
@@ -1,0 +1,85 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.model.assignment;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.common.TypeFactory;
+
+import static org.mapstruct.ap.internal.model.assignment.Assignment.AssignmentType.DIRECT;
+
+/**
+ * This wrapper handles the situation where an assignment is done via the setter and a null check is needed.
+ * This is needed when a direct assignment is used, or if the user has chosen the appropriate strategy
+ *
+ * @author Sjaak Derksen
+ */
+public class SetterWrapperForCollectionsAndMapsWithNullCheck extends WrapperForCollectionsAndMaps {
+
+    private final Type targetType;
+    private final TypeFactory typeFactory;
+
+    public SetterWrapperForCollectionsAndMapsWithNullCheck(Assignment decoratedAssignment,
+        List<Type> thrownTypesToExclude,
+        Type targetType,
+        TypeFactory typeFactory,
+        boolean fieldAssignment) {
+        super(
+            decoratedAssignment,
+            thrownTypesToExclude,
+            targetType,
+            fieldAssignment
+        );
+        this.targetType = targetType;
+        this.typeFactory = typeFactory;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        Set<Type> imported = new HashSet<Type>( super.getImportTypes() );
+        if ( isDirectAssignment() ) {
+            if ( targetType.getImplementationType() != null ) {
+                imported.addAll( targetType.getImplementationType().getImportTypes() );
+            }
+            else {
+                imported.addAll( targetType.getImportTypes() );
+            }
+
+            if ( isEnumSet() ) {
+                imported.add( typeFactory.getType( EnumSet.class ) );
+            }
+        }
+        if (isDirectAssignment() || getSourcePresenceCheckerReference() == null ) {
+            imported.addAll( getNullCheckLocalVarType().getImportTypes() );
+        }
+        return imported;
+    }
+
+    public boolean isDirectAssignment() {
+        return getType() == DIRECT;
+    }
+
+    public boolean isEnumSet() {
+        return "java.util.EnumSet".equals( targetType.getFullyQualifiedName() );
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/WrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/WrapperForCollectionsAndMaps.java
@@ -19,9 +19,7 @@
 package org.mapstruct.ap.internal.model.assignment;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.Type;
 
@@ -66,14 +64,6 @@ public class WrapperForCollectionsAndMaps extends AssignmentWrapper {
             }
         }
         return result;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        Set<Type> imported = new HashSet<Type>();
-        imported.addAll( super.getImportTypes() );
-        imported.addAll( nullCheckLocalVarType.getImportTypes() );
-        return imported;
     }
 
     public String getNullCheckLocalVarName() {

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.ftl
@@ -1,0 +1,56 @@
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.ExistingInstanceSetterWrapperForCollectionsAndMaps" -->
+<#--
+
+     Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+     and/or other contributors as indicated by the @authors tag. See the
+     copyright.txt file in the distribution for a full listing of all
+     contributors.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<#import "../macro/CommonMacros.ftl" as lib>
+<@lib.sourceLocalVarAssignment/>
+<@lib.handleExceptions>
+  if ( ${ext.targetBeanName}.${ext.targetReadAccessorName} != null ) {
+      <@lib.handleLocalVarNullCheck needs_explicit_local_var=false>
+      ${ext.targetBeanName}.${ext.targetReadAccessorName}.clear();
+      ${ext.targetBeanName}.${ext.targetReadAccessorName}.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( <@lib.handleWithAssignmentOrNullCheckVar/> );
+      </@lib.handleLocalVarNullCheck>
+      <#if !ext.defaultValueAssignment?? && !sourcePresenceCheckerReference?? && !includeSourceNullCheck>else {<#-- the opposite (defaultValueAssignment) case is handeld inside lib.handleLocalVarNullCheck -->
+      ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite>null</@lib.handleWrite>;
+      }
+      </#if>
+  }
+  else {
+      <@callTargetWriteAccessor/>
+  }
+</@lib.handleExceptions>
+<#--
+  assigns the target via the regular target write accessor (usually the setter)
+-->
+<#macro callTargetWriteAccessor>
+  <@lib.handleLocalVarNullCheck needs_explicit_local_var=directAssignment>
+    ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite><#if directAssignment><@wrapLocalVarInCollectionInitializer/><#else><@lib.handleWithAssignmentOrNullCheckVar/></#if></@lib.handleWrite>;
+  </@lib.handleLocalVarNullCheck>
+</#macro>
+<#--
+  wraps the local variable in a collection initializer (new collection, or EnumSet.copyOf)
+-->
+<#macro wrapLocalVarInCollectionInitializer><@compress single_line=true>
+    <#if enumSet>
+      EnumSet.copyOf( ${nullCheckLocalVarName} )
+    <#else>
+      new <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if>( ${nullCheckLocalVarName} )
+    </#if>
+</@compress></#macro>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.ftl
@@ -26,8 +26,8 @@ if ( ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesi
       <#if ext.existingInstanceMapping>
         ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing />.clear();
       </#if>
-      <@lib.handleLocalVarNullCheck>
-        ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing />.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( ${nullCheckLocalVarName} );
+      <@lib.handleLocalVarNullCheck needs_explicit_local_var=false>
+        ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing />.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( <@lib.handleWithAssignmentOrNullCheckVar/> );
       </@lib.handleLocalVarNullCheck>
     </@lib.handleExceptions>
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.ftl
@@ -22,39 +22,5 @@
 <#import "../macro/CommonMacros.ftl" as lib>
 <@lib.sourceLocalVarAssignment/>
 <@lib.handleExceptions>
-  <#if ext.existingInstanceMapping && !targetImmutable>
-    if ( ${ext.targetBeanName}.${ext.targetReadAccessorName} != null ) {
-        <@lib.handleLocalVarNullCheck>
-            ${ext.targetBeanName}.${ext.targetReadAccessorName}.clear();
-            ${ext.targetBeanName}.${ext.targetReadAccessorName}.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( ${nullCheckLocalVarName} );
-        </@lib.handleLocalVarNullCheck>
-        <#if !ext.defaultValueAssignment?? && !sourcePresenceCheckerReference?? && !includeSourceNullCheck>else {<#-- the opposite (defaultValueAssignment) case is handeld inside lib.handleLocalVarNullCheck -->
-          ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite>null</@lib.handleWrite>;
-        }
-        </#if>
-        }
-    else {
-      <@callTargetWriteAccessor/>
-    }
-  <#else>
-    <@callTargetWriteAccessor/>
-  </#if>
+  ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite><@lib.handleAssignment/></@lib.handleWrite>;
 </@lib.handleExceptions>
-<#--
-  assigns the target via the regular target write accessor (usually the setter)
--->
-<#macro callTargetWriteAccessor>
-    <@lib.handleLocalVarNullCheck>
-        ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite><#if directAssignment><@wrapLocalVarInCollectionInitializer/><#else>${nullCheckLocalVarName}</#if></@lib.handleWrite>;
-  </@lib.handleLocalVarNullCheck>
-</#macro>
-<#--
-  wraps the local variable in a collection initializer (new collection, or EnumSet.copyOf)
--->
-<#macro wrapLocalVarInCollectionInitializer><@compress single_line=true>
-    <#if enumSet>
-      EnumSet.copyOf( ${nullCheckLocalVarName} )
-    <#else>
-      new <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if>( ${nullCheckLocalVarName} )
-    </#if>
-</@compress></#macro>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.ftl
@@ -1,0 +1,48 @@
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.SetterWrapperForCollectionsAndMapsWithNullCheck" -->
+<#--
+
+     Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+     and/or other contributors as indicated by the @authors tag. See the
+     copyright.txt file in the distribution for a full listing of all
+     contributors.
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+         http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+
+-->
+<#import "../macro/CommonMacros.ftl" as lib>
+<@lib.sourceLocalVarAssignment/>
+<@lib.handleExceptions>
+  <@callTargetWriteAccessor/>
+  <#if !ext.defaultValueAssignment??>else {<#-- the opposite (defaultValueAssignment) case is handeld inside lib.handleLocalVarNullCheck -->
+    ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite>null</@lib.handleWrite>;
+  }
+  </#if>
+</@lib.handleExceptions>
+<#--
+  assigns the target via the regular target write accessor (usually the setter)
+-->
+<#macro callTargetWriteAccessor>
+  <@lib.handleLocalVarNullCheck needs_explicit_local_var=directAssignment>
+    ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite><#if directAssignment><@wrapLocalVarInCollectionInitializer/><#else><@lib.handleWithAssignmentOrNullCheckVar/></#if></@lib.handleWrite>;
+  </@lib.handleLocalVarNullCheck>
+</#macro>
+<#--
+  wraps the local variable in a collection initializer (new collection, or EnumSet.copyOf)
+-->
+<#macro wrapLocalVarInCollectionInitializer><@compress single_line=true>
+    <#if enumSet>
+      EnumSet.copyOf( ${nullCheckLocalVarName} )
+    <#else>
+      new <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if>( ${nullCheckLocalVarName} )
+    </#if>
+</@compress></#macro>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
@@ -62,11 +62,15 @@
            requires: caller to implement String:getNullCheckLocalVarName()
                      caller to implement Type:getNullCheckLocalVarType()
 -->
-<#macro handleLocalVarNullCheck>
+<#macro handleLocalVarNullCheck needs_explicit_local_var>
   <#if sourcePresenceCheckerReference??>
     if ( ${sourcePresenceCheckerReference} ) {
-      <@includeModel object=nullCheckLocalVarType/> ${nullCheckLocalVarName} = <@lib.handleAssignment/>;
-      <#nested>
+      <#if needs_explicit_local_var>
+        <@includeModel object=nullCheckLocalVarType/> ${nullCheckLocalVarName} = <@lib.handleAssignment/>;
+        <#nested>
+      <#else>
+        <#nested>
+      </#if>
     }
   <#else>
     <@includeModel object=nullCheckLocalVarType/> ${nullCheckLocalVarName} = <@lib.handleAssignment/>;
@@ -80,6 +84,13 @@
   }
   </#if>
 </#macro>
+<#--
+    Gives the value that needs to be assigned. If there is a sourcePresenceCheckerReference then a direct
+    lib.handleAssignment is done, otherwise nullCheckLocalVarName is used.
+
+    requires:        caller to implement String:getNullCheckLocalVarName()
+-->
+<#macro handleWithAssignmentOrNullCheckVar><#if sourcePresenceCheckerReference??><@lib.handleAssignment/><#else>${nullCheckLocalVarName}</#if></#macro>
 <#--
   macro: handleExceptions
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Domain.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Domain.java
@@ -18,6 +18,7 @@
  */
 package org.mapstruct.ap.test.bugs._913;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -26,9 +27,11 @@ import java.util.Set;
  * @author Sjaak Derksen
  */
 public class Domain {
+    static final Set<String> DEFAULT_STRINGS = new HashSet<String>();
+    static final Set<Long> DEFAULT_LONGS = new HashSet<Long>();
 
-    private Set<String> strings;
-    private Set<Long> longs;
+    private Set<String> strings = DEFAULT_STRINGS;
+    private Set<Long> longs = DEFAULT_LONGS;
     private Set<String> stringsInitialized;
     private Set<Long> longsInitialized;
     private List<String> stringsWithDefault;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Issue913SetterMapperForCollectionsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Issue913SetterMapperForCollectionsTest.java
@@ -63,6 +63,10 @@ public class Issue913SetterMapperForCollectionsTest {
      * The null value mapping strategy on type level (Mapper) should generate forged methods for the
      * conversion from string to long that return null in the entire mapper, so also for the forged
      * mapper. Note the default NVMS is RETURN_NULL.
+     *
+     * The generated code should not use a local variable for setting {@code longs}, but it should use a local
+     * variable for setting {@code strings} as a direct assignment and the copy constructor is used, in case the
+     * assignment is {@code null} then {@code null} should be set for {@code string}
      */
     @Test
     public void shouldReturnNullForNvmsReturnNullForCreate() {
@@ -173,6 +177,7 @@ public class Issue913SetterMapperForCollectionsTest {
         Dto dto = new Dto();
         Domain domain = new Domain();
         Set<Long> longIn = new HashSet<Long>();
+        longIn.add( 10L );
         domain.setLongs( longIn );
         domain.setStrings( new HashSet<String>() );
         DomainDtoWithNvmsDefaultMapper.INSTANCE.update( dto, domain );
@@ -198,10 +203,13 @@ public class Issue913SetterMapperForCollectionsTest {
         Dto dto = new Dto();
         Domain domain1 = new Domain();
         Set<Long> longIn = new HashSet<Long>();
+        longIn.add( 10L );
         domain1.setLongs( longIn );
         domain1.setStrings( new HashSet<String>() );
+        domain1.getStrings().add( "30" );
         Domain domain2 = DomainDtoWithNvmsDefaultMapper.INSTANCE.updateWithReturn( dto, domain1 );
 
+        assertThat( domain2 ).isSameAs( domain1 );
         doControlAsserts( domain1, domain2 );
         assertThat( domain1.getLongs() ).isEqualTo( domain2.getLongs() );
         assertThat( domain1.getStrings() ).isNull();
@@ -240,12 +248,14 @@ public class Issue913SetterMapperForCollectionsTest {
         DtoWithPresenceCheck dto = new DtoWithPresenceCheck();
         Domain domain = new Domain();
         domain.setLongs( new HashSet<Long>() );
+        domain.getLongs().add( 10L );
         domain.setStrings( new HashSet<String>() );
+        domain.getStrings().add( "30" );
         DomainDtoWithPresenceCheckMapper.INSTANCE.update( dto, domain );
 
         doControlAsserts( domain );
-        assertThat( domain.getStrings() ).isEmpty();
-        assertThat( domain.getLongs() ).isEmpty();
+        assertThat( domain.getStrings() ).containsExactly( "30" );
+        assertThat( domain.getLongs() ).containsExactly( 10L );
     }
 
     /**
@@ -261,15 +271,18 @@ public class Issue913SetterMapperForCollectionsTest {
         DtoWithPresenceCheck dto = new DtoWithPresenceCheck();
         Domain domain1 = new Domain();
         domain1.setLongs( new HashSet<Long>() );
+        domain1.getLongs().add( 10L );
         domain1.setStrings( new HashSet<String>() );
+        domain1.getStrings().add( "30" );
         Domain domain2 = DomainDtoWithPresenceCheckMapper.INSTANCE.updateWithReturn( dto, domain1 );
 
+        assertThat( domain2 ).isSameAs( domain1 );
         doControlAsserts( domain1, domain2 );
         assertThat( domain1.getLongs() ).isEqualTo( domain2.getLongs() );
-        assertThat( domain1.getStrings() ).isEmpty();
-        assertThat( domain1.getLongs() ).isEmpty();
-        assertThat( domain2.getStrings() ).isEmpty();
-        assertThat( domain2.getLongs() ).isEmpty();
+        assertThat( domain1.getStrings() ).containsExactly( "30" );
+        assertThat( domain1.getLongs() ).containsExactly( 10L );
+        assertThat( domain2.getStrings() ).containsExactly( "30" );
+        assertThat( domain2.getLongs() ).containsExactly( 10L );
     }
 
     /**
@@ -301,12 +314,14 @@ public class Issue913SetterMapperForCollectionsTest {
         DtoWithPresenceCheck dto = new DtoWithPresenceCheck();
         Domain domain = new Domain();
         domain.setLongs( new HashSet<Long>() );
+        domain.getLongs().add( 10L );
         domain.setStrings( new HashSet<String>() );
+        domain.getStrings().add( "30" );
         DomainDtoWithNcvsAlwaysMapper.INSTANCE.update( dto, domain );
 
         doControlAsserts( domain );
-        assertThat( domain.getStrings() ).isEmpty();
-        assertThat( domain.getLongs() ).isEmpty();
+        assertThat( domain.getStrings() ).containsExactly( "30" );
+        assertThat( domain.getLongs() ).containsExactly( 10L );
     }
 
     /**
@@ -322,15 +337,18 @@ public class Issue913SetterMapperForCollectionsTest {
         DtoWithPresenceCheck dto = new DtoWithPresenceCheck();
         Domain domain1 = new Domain();
         domain1.setLongs( new HashSet<Long>() );
+        domain1.getLongs().add( 10L );
         domain1.setStrings( new HashSet<String>() );
+        domain1.getStrings().add( "30" );
         Domain domain2 = DomainDtoWithNcvsAlwaysMapper.INSTANCE.updateWithReturn( dto, domain1 );
 
+        assertThat( domain2 ).isSameAs( domain1 );
         doControlAsserts( domain1, domain2 );
         assertThat( domain1.getLongs() ).isEqualTo( domain2.getLongs() );
-        assertThat( domain1.getStrings() ).isEmpty();
-        assertThat( domain1.getLongs() ).isEmpty();
-        assertThat( domain2.getStrings() ).isEmpty();
-        assertThat( domain2.getLongs() ).isEmpty();
+        assertThat( domain1.getStrings() ).containsExactly( "30" );
+        assertThat( domain1.getLongs() ).containsExactly( 10L );
+        assertThat( domain2.getStrings() ).containsExactly( "30" );
+        assertThat( domain2.getLongs() ).containsExactly( 10L );
     }
 
     /**

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
@@ -26,8 +26,8 @@ import javax.annotation.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2016-12-30T19:07:28+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+    date = "2017-04-22T09:19:18+0200",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_131 (Oracle Corporation)"
 )
 public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlwaysMapper {
 
@@ -42,16 +42,23 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         Domain domain = new Domain();
 
         if ( source.hasStringsInitialized() ) {
-            Set<Long> set = stringListToLongSet( source.getStringsInitialized() );
-            domain.setLongsInitialized( set );
+            domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+        }
+        else {
+            domain.setLongsInitialized( null );
         }
         if ( source.hasStrings() ) {
-            Set<Long> set1 = stringListToLongSet( source.getStrings() );
-            domain.setLongs( set1 );
+            domain.setLongs( stringListToLongSet( source.getStrings() ) );
+        }
+        else {
+            domain.setLongs( null );
         }
         if ( source.hasStrings() ) {
             List<String> list = source.getStrings();
             domain.setStrings( new HashSet<String>( list ) );
+        }
+        else {
+            domain.setStrings( null );
         }
         if ( source.hasStringsWithDefault() ) {
             List<String> list1 = source.getStringsWithDefault();
@@ -63,6 +70,9 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         if ( source.hasStringsInitialized() ) {
             List<String> list2 = source.getStringsInitialized();
             domain.setStringsInitialized( new HashSet<String>( list2 ) );
+        }
+        else {
+            domain.setStringsInitialized( null );
         }
 
         return domain;
@@ -76,22 +86,19 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
 
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
                 target.getLongs().clear();
-                target.getLongs().addAll( set );
+                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
-                target.setLongs( set );
+                target.setLongs( stringListToLongSet( source.getStrings() ) );
             }
         }
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
                 target.getStrings().clear();
-                target.getStrings().addAll( list );
+                target.getStrings().addAll( source.getStrings() );
             }
         }
         else {
@@ -102,22 +109,19 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( set1 );
+                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
-                target.setLongsInitialized( set1 );
+                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list1 = source.getStringsWithDefault();
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( list1 );
+                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -134,9 +138,8 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                List<String> list2 = source.getStringsInitialized();
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( list2 );
+                target.getStringsInitialized().addAll( source.getStringsInitialized() );
             }
         }
         else {
@@ -155,22 +158,19 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
 
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
                 target.getLongs().clear();
-                target.getLongs().addAll( set );
+                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
-                target.setLongs( set );
+                target.setLongs( stringListToLongSet( source.getStrings() ) );
             }
         }
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
                 target.getStrings().clear();
-                target.getStrings().addAll( list );
+                target.getStrings().addAll( source.getStrings() );
             }
         }
         else {
@@ -181,22 +181,19 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( set1 );
+                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
-                target.setLongsInitialized( set1 );
+                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list1 = source.getStringsWithDefault();
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( list1 );
+                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -213,9 +210,8 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                List<String> list2 = source.getStringsInitialized();
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( list2 );
+                target.getStringsInitialized().addAll( source.getStringsInitialized() );
             }
         }
         else {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
@@ -26,8 +26,8 @@ import javax.annotation.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2016-12-30T19:07:27+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+    date = "2017-04-09T23:02:48+0200",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_121 (Oracle Corporation)"
 )
 public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefaultMapper {
 
@@ -39,17 +39,14 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
         Domain domain = new Domain();
 
         if ( source != null ) {
-            Set<Long> set = stringListToLongSet( source.getStringsInitialized() );
-            if ( set != null ) {
-                domain.setLongsInitialized( set );
-            }
-            Set<Long> set1 = stringListToLongSet( source.getStrings() );
-            if ( set1 != null ) {
-                domain.setLongs( set1 );
-            }
+            domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+            domain.setLongs( stringListToLongSet( source.getStrings() ) );
             List<String> list = source.getStrings();
             if ( list != null ) {
                 domain.setStrings( new HashSet<String>( list ) );
+            }
+            else {
+                domain.setStrings( null );
             }
             List<String> list1 = source.getStringsWithDefault();
             if ( list1 != null ) {
@@ -61,6 +58,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             List<String> list2 = source.getStringsInitialized();
             if ( list2 != null ) {
                 domain.setStringsInitialized( new HashSet<String>( list2 ) );
+            }
+            else {
+                domain.setStringsInitialized( null );
             }
         }
 

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
@@ -26,8 +26,8 @@ import javax.annotation.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2016-12-30T19:07:28+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+    date = "2017-04-09T23:02:47+0200",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_121 (Oracle Corporation)"
 )
 public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMapper {
 
@@ -41,17 +41,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
 
         Domain domain = new Domain();
 
-        Set<Long> set = stringListToLongSet( source.getStringsInitialized() );
-        if ( set != null ) {
-            domain.setLongsInitialized( set );
-        }
-        Set<Long> set1 = stringListToLongSet( source.getStrings() );
-        if ( set1 != null ) {
-            domain.setLongs( set1 );
-        }
+        domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+        domain.setLongs( stringListToLongSet( source.getStrings() ) );
         List<String> list = source.getStrings();
         if ( list != null ) {
             domain.setStrings( new HashSet<String>( list ) );
+        }
+        else {
+            domain.setStrings( null );
         }
         List<String> list1 = source.getStringsWithDefault();
         if ( list1 != null ) {
@@ -63,6 +60,9 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         List<String> list2 = source.getStringsInitialized();
         if ( list2 != null ) {
             domain.setStringsInitialized( new HashSet<String>( list2 ) );
+        }
+        else {
+            domain.setStringsInitialized( null );
         }
 
         return domain;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
@@ -26,8 +26,8 @@ import javax.annotation.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2016-12-30T19:07:28+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+    date = "2017-04-22T09:19:17+0200",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_131 (Oracle Corporation)"
 )
 public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresenceCheckMapper {
 
@@ -41,17 +41,14 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
 
         Domain domain = new Domain();
 
-        if ( source.hasStringsInitialized() ) {
-            Set<Long> set = stringListToLongSet( source.getStringsInitialized() );
-            domain.setLongsInitialized( set );
-        }
-        if ( source.hasStrings() ) {
-            Set<Long> set1 = stringListToLongSet( source.getStrings() );
-            domain.setLongs( set1 );
-        }
+        domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+        domain.setLongs( stringListToLongSet( source.getStrings() ) );
         if ( source.hasStrings() ) {
             List<String> list = source.getStrings();
             domain.setStrings( new HashSet<String>( list ) );
+        }
+        else {
+            domain.setStrings( null );
         }
         if ( source.hasStringsWithDefault() ) {
             List<String> list1 = source.getStringsWithDefault();
@@ -63,6 +60,9 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         if ( source.hasStringsInitialized() ) {
             List<String> list2 = source.getStringsInitialized();
             domain.setStringsInitialized( new HashSet<String>( list2 ) );
+        }
+        else {
+            domain.setStringsInitialized( null );
         }
 
         return domain;
@@ -76,22 +76,19 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
 
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
                 target.getLongs().clear();
-                target.getLongs().addAll( set );
+                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
-                target.setLongs( set );
+                target.setLongs( stringListToLongSet( source.getStrings() ) );
             }
         }
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
                 target.getStrings().clear();
-                target.getStrings().addAll( list );
+                target.getStrings().addAll( source.getStrings() );
             }
         }
         else {
@@ -102,22 +99,19 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( set1 );
+                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
-                target.setLongsInitialized( set1 );
+                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list1 = source.getStringsWithDefault();
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( list1 );
+                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -134,9 +128,8 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                List<String> list2 = source.getStringsInitialized();
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( list2 );
+                target.getStringsInitialized().addAll( source.getStringsInitialized() );
             }
         }
         else {
@@ -155,22 +148,19 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
 
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
                 target.getLongs().clear();
-                target.getLongs().addAll( set );
+                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
-                target.setLongs( set );
+                target.setLongs( stringListToLongSet( source.getStrings() ) );
             }
         }
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
                 target.getStrings().clear();
-                target.getStrings().addAll( list );
+                target.getStrings().addAll( source.getStrings() );
             }
         }
         else {
@@ -181,22 +171,19 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( set1 );
+                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
-                target.setLongsInitialized( set1 );
+                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list1 = source.getStringsWithDefault();
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( list1 );
+                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -213,9 +200,8 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                List<String> list2 = source.getStringsInitialized();
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( list2 );
+                target.getStringsInitialized().addAll( source.getStringsInitialized() );
             }
         }
         else {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/collection/adder/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/collection/adder/SourceTargetMapperImpl.java
@@ -18,7 +18,6 @@
  */
 package org.mapstruct.ap.test.collection.adder;
 
-import java.util.List;
 import javax.annotation.Generated;
 import org.mapstruct.ap.test.collection.adder._target.IndoorPet;
 import org.mapstruct.ap.test.collection.adder._target.Target;
@@ -32,8 +31,8 @@ import org.mapstruct.ap.test.collection.adder.source.SourceTeeth;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2016-12-30T19:10:39+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+    date = "2017-04-09T23:05:40+0200",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_121 (Oracle Corporation)"
 )
 public class SourceTargetMapperImpl implements SourceTargetMapper {
 
@@ -71,10 +70,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
         Source source1 = new Source();
 
         try {
-            List<String> list = petMapper.toSourcePets( source.getPets() );
-            if ( list != null ) {
-                source1.setPets( list );
-            }
+            source1.setPets( petMapper.toSourcePets( source.getPets() ) );
         }
         catch ( CatException e ) {
             throw new RuntimeException( e );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/collection/adder/SourceTargetMapperStrategyDefaultImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/collection/adder/SourceTargetMapperStrategyDefaultImpl.java
@@ -18,15 +18,14 @@
  */
 package org.mapstruct.ap.test.collection.adder;
 
-import java.util.List;
 import javax.annotation.Generated;
 import org.mapstruct.ap.test.collection.adder._target.Target;
 import org.mapstruct.ap.test.collection.adder.source.Source;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2016-12-30T19:10:39+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+    date = "2017-04-09T23:05:40+0200",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_121 (Oracle Corporation)"
 )
 public class SourceTargetMapperStrategyDefaultImpl implements SourceTargetMapperStrategyDefault {
 
@@ -41,10 +40,7 @@ public class SourceTargetMapperStrategyDefaultImpl implements SourceTargetMapper
         Target target = new Target();
 
         try {
-            List<Long> list = petMapper.toPets( source.getPets() );
-            if ( list != null ) {
-                target.setPets( list );
-            }
+            target.setPets( petMapper.toPets( source.getPets() ) );
         }
         catch ( CatException e ) {
             throw new RuntimeException( e );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoMapperClassicImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoMapperClassicImpl.java
@@ -24,8 +24,8 @@ import javax.annotation.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2017-03-01T22:15:21+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+    date = "2017-04-09T23:25:54+0200",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_121 (Oracle Corporation)"
 )
 public class UserDtoMapperClassicImpl implements UserDtoMapperClassic {
 
@@ -55,10 +55,7 @@ public class UserDtoMapperClassicImpl implements UserDtoMapperClassic {
 
         carDto.setName( car.getName() );
         carDto.setYear( car.getYear() );
-        List<WheelDto> list = mapWheels( car.getWheels() );
-        if ( list != null ) {
-            carDto.setWheels( list );
-        }
+        carDto.setWheels( mapWheels( car.getWheels() ) );
 
         return carDto;
     }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoMapperSmartImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoMapperSmartImpl.java
@@ -24,8 +24,8 @@ import javax.annotation.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2017-03-01T22:15:23+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+    date = "2017-04-09T23:25:54+0200",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_121 (Oracle Corporation)"
 )
 public class UserDtoMapperSmartImpl implements UserDtoMapperSmart {
 
@@ -95,10 +95,7 @@ public class UserDtoMapperSmartImpl implements UserDtoMapperSmart {
 
         carDto.setName( car.getName() );
         carDto.setYear( car.getYear() );
-        List<WheelDto> list = wheelListToWheelDtoList( car.getWheels() );
-        if ( list != null ) {
-            carDto.setWheels( list );
-        }
+        carDto.setWheels( wheelListToWheelDtoList( car.getWheels() ) );
 
         return carDto;
     }
@@ -185,10 +182,7 @@ public class UserDtoMapperSmartImpl implements UserDtoMapperSmart {
 
         carDto.setName( car.getName() );
         carDto.setYear( car.getYear() );
-        List<org.mapstruct.ap.test.nestedbeans.other.WheelDto> list = wheelListToWheelDtoList1( car.getWheels() );
-        if ( list != null ) {
-            carDto.setWheels( list );
-        }
+        carDto.setWheels( wheelListToWheelDtoList1( car.getWheels() ) );
 
         return carDto;
     }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedtargetproperties/ChartEntryToArtistImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedtargetproperties/ChartEntryToArtistImpl.java
@@ -29,8 +29,8 @@ import org.mapstruct.ap.test.nestedsourceproperties.source.Studio;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2017-02-07T21:05:06+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+    date = "2017-04-09T23:27:41+0200",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_121 (Oracle Corporation)"
 )
 public class ChartEntryToArtistImpl extends ChartEntryToArtist {
 
@@ -152,10 +152,7 @@ public class ChartEntryToArtistImpl extends ChartEntryToArtist {
         Song song = new Song();
 
         song.setArtist( chartEntryToArtist( chartEntry ) );
-        List<Integer> list = mapPosition( chartEntry.getPosition() );
-        if ( list != null ) {
-            song.setPositions( list );
-        }
+        song.setPositions( mapPosition( chartEntry.getPosition() ) );
         song.setTitle( chartEntry.getSongTitle() );
 
         return song;


### PR DESCRIPTION
When using set in the SetterWrapperForCollections do null check only direct assignment or when the NullValueCheckStrategy is ALWAYS.

This one fixed the second part of #1164