### PR TITLE
#1153 Do not use invalid TargetReferences when creating nested target mappings

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -322,7 +322,9 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
 
             // first we have to handle nested target mappings
             if ( method.getMappingOptions().hasNestedTargetReferences() ) {
-                handleDefinedNestedTargetMapping( handledTargets );
+                if ( handleDefinedNestedTargetMapping( handledTargets ) ) {
+                    errorOccurred = true;
+                }
             }
 
             for ( Map.Entry<String, List<Mapping>> entry : methodMappings.entrySet() ) {
@@ -335,7 +337,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                             }
                         }
                     }
-                    else if ( reportErrorOnTargetObject( mapping ) ) {
+                    else {
                         errorOccurred = true;
                     }
                 }
@@ -350,7 +352,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             return errorOccurred;
         }
 
-        private void handleDefinedNestedTargetMapping(Set<String> handledTargets) {
+        private boolean handleDefinedNestedTargetMapping(Set<String> handledTargets) {
 
             NestedTargetPropertyMappingHolder holder = new NestedTargetPropertyMappingHolder.Builder()
                 .mappingContext( ctx )
@@ -368,6 +370,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 }
                 unprocessedDefinedTargets.put( entry.getKey().getName(), entry.getValue() );
             }
+            return holder.isErrorOccurred();
         }
 
         private boolean handleDefinedMapping(Mapping mapping, Set<String> handledTargets) {
@@ -472,36 +475,6 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             }
 
             return errorOccured;
-        }
-
-        private boolean reportErrorOnTargetObject(Mapping mapping) {
-
-            boolean errorOccurred = false;
-
-            boolean hasReadAccessor
-                = method.getResultType().getPropertyReadAccessors().containsKey( mapping.getTargetName() );
-
-            if ( hasReadAccessor ) {
-                if ( !mapping.isIgnored() ) {
-                    ctx.getMessager().printMessage(
-                        method.getExecutable(),
-                        mapping.getMirror(),
-                        mapping.getSourceAnnotationValue(),
-                        Message.BEANMAPPING_PROPERTY_HAS_NO_WRITE_ACCESSOR_IN_RESULTTYPE,
-                        mapping.getTargetName() );
-                    errorOccurred = true;
-                }
-            }
-            else {
-                ctx.getMessager().printMessage(
-                    method.getExecutable(),
-                    mapping.getMirror(),
-                    mapping.getSourceAnnotationValue(),
-                    Message.BEANMAPPING_UNKNOWN_PROPERTY_IN_RESULTTYPE,
-                    mapping.getTargetName() );
-                errorOccurred = true;
-            }
-            return errorOccurred;
         }
 
         /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -322,9 +322,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
 
             // first we have to handle nested target mappings
             if ( method.getMappingOptions().hasNestedTargetReferences() ) {
-                if ( handleDefinedNestedTargetMapping( handledTargets ) ) {
-                    errorOccurred = true;
-                }
+                errorOccurred = handleDefinedNestedTargetMapping( handledTargets );
             }
 
             for ( Map.Entry<String, List<Mapping>> entry : methodMappings.entrySet() ) {
@@ -370,7 +368,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 }
                 unprocessedDefinedTargets.put( entry.getKey().getName(), entry.getValue() );
             }
-            return holder.isErrorOccurred();
+            return holder.hasErrorOccurred();
         }
 
         private boolean handleDefinedMapping(Mapping mapping, Set<String> handledTargets) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
@@ -108,7 +108,7 @@ public class NestedTargetPropertyMappingHolder {
     /**
      * @return {@code true} if an error occurred during the creation of the nested mappings
      */
-    public boolean isErrorOccurred() {
+    public boolean hasErrorOccurred() {
         return errorOccurred;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
@@ -31,6 +31,7 @@ import org.mapstruct.ap.internal.model.source.MappingOptions;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.PropertyEntry;
 import org.mapstruct.ap.internal.model.source.SourceReference;
+import org.mapstruct.ap.internal.model.source.TargetReference;
 import org.mapstruct.ap.internal.util.Extractor;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
@@ -63,15 +64,17 @@ public class NestedTargetPropertyMappingHolder {
     private final Set<String> handledTargets;
     private final List<PropertyMapping> propertyMappings;
     private final Map<PropertyEntry, List<Mapping>> unprocessedDefinedTarget;
+    private final boolean errorOccurred;
 
     public NestedTargetPropertyMappingHolder(
         List<Parameter> processedSourceParameters, Set<String> handledTargets,
         List<PropertyMapping> propertyMappings,
-        Map<PropertyEntry, List<Mapping>> unprocessedDefinedTarget) {
+        Map<PropertyEntry, List<Mapping>> unprocessedDefinedTarget, boolean errorOccurred) {
         this.processedSourceParameters = processedSourceParameters;
         this.handledTargets = handledTargets;
         this.propertyMappings = propertyMappings;
         this.unprocessedDefinedTarget = unprocessedDefinedTarget;
+        this.errorOccurred = errorOccurred;
     }
 
     /**
@@ -100,6 +103,13 @@ public class NestedTargetPropertyMappingHolder {
      */
     public Map<PropertyEntry, List<Mapping>> getUnprocessedDefinedTarget() {
         return unprocessedDefinedTarget;
+    }
+
+    /**
+     * @return {@code true} if an error occurred during the creation of the nested mappings
+     */
+    public boolean isErrorOccurred() {
+        return errorOccurred;
     }
 
     public static class Builder {
@@ -227,7 +237,8 @@ public class NestedTargetPropertyMappingHolder {
                 processedSourceParameters,
                 handledTargets,
                 propertyMappings,
-                unprocessedDefinedTarget
+                unprocessedDefinedTarget,
+                groupedByTP.errorOccurred
             );
         }
 
@@ -284,9 +295,16 @@ public class NestedTargetPropertyMappingHolder {
                 = new LinkedHashMap<PropertyEntry, List<Mapping>>();
             Map<PropertyEntry, List<Mapping>> singleTargetReferences
                 = new LinkedHashMap<PropertyEntry, List<Mapping>>();
+            boolean errorOccurred = false;
             for ( List<Mapping> mapping : mappings.values() ) {
-                PropertyEntry property = first( first( mapping ).getTargetReference().getPropertyEntries() );
-                Mapping newMapping = first( mapping ).popTargetReference();
+                Mapping firstMapping = first( mapping );
+                TargetReference targetReference = firstMapping.getTargetReference();
+                if ( !targetReference.isValid() ) {
+                    errorOccurred = true;
+                    continue;
+                }
+                PropertyEntry property = first( targetReference.getPropertyEntries() );
+                Mapping newMapping = firstMapping.popTargetReference();
                 if ( newMapping != null ) {
                     // group properties on current name.
                     if ( !mappingsKeyedByProperty.containsKey( property ) ) {
@@ -298,11 +316,11 @@ public class NestedTargetPropertyMappingHolder {
                     if ( !singleTargetReferences.containsKey( property ) ) {
                         singleTargetReferences.put( property, new ArrayList<Mapping>() );
                     }
-                    singleTargetReferences.get( property ).add( first( mapping ) );
+                    singleTargetReferences.get( property ).add( firstMapping );
                 }
             }
 
-            return new GroupedTargetReferences( mappingsKeyedByProperty, singleTargetReferences );
+            return new GroupedTargetReferences( mappingsKeyedByProperty, singleTargetReferences, errorOccurred );
         }
 
         /**
@@ -576,11 +594,13 @@ public class NestedTargetPropertyMappingHolder {
     private static class GroupedTargetReferences {
         private final Map<PropertyEntry, List<Mapping>> poppedTargetReferences;
         private final Map<PropertyEntry, List<Mapping>> singleTargetReferences;
+        private final boolean errorOccurred;
 
         private GroupedTargetReferences(Map<PropertyEntry, List<Mapping>> poppedTargetReferences,
-            Map<PropertyEntry, List<Mapping>> singleTargetReferences) {
+            Map<PropertyEntry, List<Mapping>> singleTargetReferences, boolean errorOccurred) {
             this.poppedTargetReferences = poppedTargetReferences;
             this.singleTargetReferences = singleTargetReferences;
+            this.errorOccurred = errorOccurred;
         }
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
@@ -252,7 +252,21 @@ public class Mapping {
             ( (DeclaredType) mirror ).asElement().getKind() == ElementKind.ENUM;
     }
 
-    public void init(SourceMethod method, FormattingMessager messager, TypeFactory typeFactory, boolean isReverse) {
+    public void init(SourceMethod method, FormattingMessager messager, TypeFactory typeFactory) {
+        init( method, messager, typeFactory, false, null );
+    }
+
+    /**
+     * Initialize the Mapping.
+     *
+     * @param method the source method that the mapping belongs to
+     * @param messager the messager that can be used for outputting messages
+     * @param typeFactory the type factory
+     * @param isReverse whether the init is for a reverse mapping
+     * @param reverseSourceParameter the source parameter from the revers mapping
+     */
+    private void init(SourceMethod method, FormattingMessager messager, TypeFactory typeFactory, boolean isReverse,
+        Parameter reverseSourceParameter) {
 
         if ( !method.isEnumMapping() ) {
             sourceReference = new SourceReference.BuilderFromMapping()
@@ -268,6 +282,7 @@ public class Mapping {
                 .method( method )
                 .messager( messager )
                 .typeFactory( typeFactory )
+                .reverseSourceParameter( reverseSourceParameter )
                 .build();
         }
     }
@@ -408,7 +423,13 @@ public class Mapping {
             Collections.<String>emptyList()
         );
 
-        reverse.init( method, messager, typeFactory, true );
+        reverse.init(
+            method,
+            messager,
+            typeFactory,
+            true,
+            sourceReference != null ? sourceReference.getParameter() : null
+        );
         return reverse;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -200,7 +200,7 @@ public class SourceMethod implements Method {
             if ( mappings != null ) {
                 for ( Map.Entry<String, List<Mapping>> entry : mappings.entrySet() ) {
                     for ( Mapping mapping : entry.getValue() ) {
-                        mapping.init( sourceMethod, messager, typeFactory, false );
+                        mapping.init( sourceMethod, messager, typeFactory );
                     }
                 }
             }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1153/ErroneousIssue1153Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1153/ErroneousIssue1153Mapper.java
@@ -1,0 +1,99 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1153;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface ErroneousIssue1153Mapper {
+
+    @Mappings( {
+        @Mapping( target = "readOnly", source = "nonNested"),
+        @Mapping( target = "nestedTarget.readOnly", source = "nestedSource.nested"),
+        @Mapping( target = "nestedTarget.writable", source = "nestedSource.writable"),
+        @Mapping( target = "nestedTarget2.readOnly", ignore = true),
+        @Mapping( target = "nestedTarget2.writable2", source = "nestedSource.writable"),
+    } )
+    Target map(Source source);
+
+    class Source {
+
+        public static class NestedSource {
+            //CHECKSTYLE:OFF
+            public String nested;
+            public String writable;
+            //CHECKSTYLE:ON
+        }
+
+        //CHECKSTYLE:OFF
+        public String nonNested;
+        public NestedSource nestedSource;
+        public NestedSource nestedSource2;
+        //CHECKSTYLE:ON
+    }
+
+    class Target {
+
+        public static class NestedTarget {
+            private String readOnly;
+            private String writable;
+
+            public String getReadOnly() {
+                return readOnly;
+            }
+
+            public String getWritable() {
+                return writable;
+            }
+
+            public void setWritable(String writable) {
+                this.writable = writable;
+            }
+        }
+
+        private String readOnly;
+        private NestedTarget nestedTarget;
+        private NestedTarget nestedTarget2;
+
+        public String getReadOnly() {
+            return readOnly;
+        }
+
+        public NestedTarget getNestedTarget() {
+            return nestedTarget;
+        }
+
+        public void setNestedTarget(NestedTarget nestedTarget) {
+            this.nestedTarget = nestedTarget;
+        }
+
+        public NestedTarget getNestedTarget2() {
+            return nestedTarget2;
+        }
+
+        public void setNestedTarget2(NestedTarget nestedTarget2) {
+            this.nestedTarget2 = nestedTarget2;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1153/Issue1153Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1153/Issue1153Test.java
@@ -1,0 +1,56 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1153;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses(ErroneousIssue1153Mapper.class)
+@IssueKey("1153")
+public class Issue1153Test {
+
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousIssue1153Mapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 32,
+                messageRegExp = "Property \"readOnly\" has no write accessor\\."),
+            @Diagnostic(type = ErroneousIssue1153Mapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 33,
+                messageRegExp = "Property \"nestedTarget.readOnly\" has no write accessor\\."),
+            @Diagnostic(type = ErroneousIssue1153Mapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 36,
+                messageRegExp = "Unknown property \"nestedTarget2.writable2\" in return type\\.")
+        })
+    @Test
+    public void shouldReportErrorsCorrectly() {
+    }
+}


### PR DESCRIPTION
* Move the error generation for the invalid TargetReference into the BuilderFromTargetMapping
* TargetReference will strip the first entry name in the following cases only if the first entry name matches the MappingTarget parameter, or for reverse mappings it matches the source parameter name
* Pass the reverse source parameter when initializing a reverse mapping

Fixes #1153.

This PR and #1168 are changing the same code.