### PR TITLE
Use anchors for the sections

### DIFF
--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -1,7 +1,8 @@
 = MapStruct {mapstructVersion} Reference Guide
 :revdate: {docdate}
 :toc: right
-:Author: Gunnar Morling, Andreas Gudian, Sjaak Derksen and the MapStruct community
+:sectanchors:
+:Author: Gunnar Morling, Andreas Gudian, Sjaak Derksen, Filip Hrisafov and the MapStruct community
 
 [[Preface]]
 == Preface


### PR DESCRIPTION
Uses `:sectanchors:` to add anchors to the sections. See [this](http://asciidoctor.org/docs/user-manual/#anchors) for more information.

And ads a small change to the authors :)