### PR TITLE
Coverage analysis setup

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        threshold: 0.05
+comment: off

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ jdk:
   - oraclejdk8
 install: true
 script: mvn clean install -DprocessorIntegrationTest.toolchainsFile=etc/toolchains-travis-jenkins.xml -B -V
+after_success:
+  - mvn jacoco:report && bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 
 sudo: false
 cache:

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -494,7 +494,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.1.201405082137</version>
+                    <version>0.7.9</version>
                 </plugin>
                 <plugin>
                     <groupId>org.jvnet.jaxb2.maven2</groupId>

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,11 @@
 
 [![Latest Stable Version](https://img.shields.io/badge/Latest%20Stable%20Version-1.1.0.Final-blue.svg)](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.mapstruct%20AND%20v%3A1.*.Final)
 [![Latest Version](https://img.shields.io/maven-central/v/org.mapstruct/mapstruct-processor.svg?maxAge=3600&label=Latest%20Release)](http://search.maven.org/#search%7Cga%7C1%7Cg%3Aorg.mapstruct)
+[![License](https://img.shields.io/badge/License-Apache%202.0-yellowgreen.svg)](https://github.com/mapstruct/mapstruct/blob/master/LICENSE.txt)
+
+[![Build Status](https://img.shields.io/travis/mapstruct/mapstruct.svg)](https://travis-ci.org/mapstruct/mapstruct)
+[![Coverage Status](https://img.shields.io/codecov/c/github/mapstruct/mapstruct.svg)](https://codecov.io/gh/mapstruct/mapstruct)
+[![Gitter](https://img.shields.io/gitter/room/mapstruct/mapstruct.svg)](https://gitter.im/mapstruct/mapstruct-users)
 
 * [What is MapStruct?](#what-is-mapstruct)
 * [Requirements](#requirements)


### PR DESCRIPTION
Fixes #1194 

I decided to integrate with [codecov.io](https://codecov.io/). I think that they have better integration with github and much better GUI. Also with them you can easily configure the bot to use our own bot. If we want to do that it can be configured like [this](https://docs.codecov.io/docs/team-bot)