### PR TITLE
#1215 Add import correctly for array types

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -199,6 +199,14 @@ public abstract class GeneratedType extends ModelElement {
         return importedTypes;
     }
 
+    public SortedSet<String> getImportTypeNames() {
+        SortedSet<String> importTypeNames = new TreeSet<String>();
+        for ( Type type : getImportTypes() ) {
+            importTypeNames.add( type.getImportName() );
+        }
+        return importTypeNames;
+    }
+
     public Constructor getConstructor() {
         return constructor;
     }
@@ -222,7 +230,7 @@ public abstract class GeneratedType extends ModelElement {
             return false;
         }
 
-        if ( typeToAdd.getTypeMirror().getKind() != TypeKind.DECLARED ) {
+        if ( typeToAdd.getTypeMirror().getKind() != TypeKind.DECLARED && !typeToAdd.isArrayType() ) {
             return false;
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -290,7 +290,7 @@ public class Type extends ModelElement implements Comparable<Type> {
      * @return The name of this type as to be used within import statements.
      */
     public String getImportName() {
-        return isArrayType() ? qualifiedName.substring( 0, qualifiedName.length() - 2 ) : qualifiedName;
+        return isArrayType() ? TypeFactory.trimSimpleClassName( qualifiedName ) : qualifiedName;
     }
 
     @Override

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/GeneratedType.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/GeneratedType.ftl
@@ -23,8 +23,8 @@
 package ${packageName};
 </#if>
 
-<#list importTypes as importedType>
-import ${importedType.importName};
+<#list importTypeNames as importedType>
+import ${importedType};
 </#list>
 
 <#if !generatedTypeAvailable>/*</#if>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/Issue1215Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/Issue1215Test.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1215;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.bugs._1215.dto.EntityDTO;
+import org.mapstruct.ap.test.bugs._1215.entity.AnotherTag;
+import org.mapstruct.ap.test.bugs._1215.entity.Entity;
+import org.mapstruct.ap.test.bugs._1215.entity.Tag;
+import org.mapstruct.ap.test.bugs._1215.mapper.Issue1215Mapper;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses( {
+    EntityDTO.class,
+    Entity.class,
+    Tag.class,
+    AnotherTag.class,
+    Issue1215Mapper.class
+} )
+@IssueKey( "1215" )
+@RunWith( AnnotationProcessorTestRunner.class )
+public class Issue1215Test {
+
+    @Test
+    public void shouldCompile() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/dto/EntityDTO.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/dto/EntityDTO.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1215.dto;
+
+import org.mapstruct.ap.test.bugs._1215.entity.AnotherTag;
+import org.mapstruct.ap.test.bugs._1215.entity.Tag;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class EntityDTO {
+    private Tag[] tags;
+    private AnotherTag[][] otherTags;
+
+    public Tag[] getTags() {
+        return tags;
+    }
+
+    public void setTags(Tag[] tags) {
+        this.tags = tags;
+    }
+
+    public AnotherTag[][] getOtherTags() {
+        return otherTags;
+    }
+
+    public void setOtherTags(AnotherTag[][] otherTags) {
+        this.otherTags = otherTags;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/entity/AnotherTag.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/entity/AnotherTag.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1215.entity;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class AnotherTag {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/entity/Entity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/entity/Entity.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1215.entity;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Entity {
+    private Tag[] tags;
+    private AnotherTag[][] otherTags;
+
+    public Tag[] getTags() {
+        return tags;
+    }
+
+    public void setTags(Tag[] tags) {
+        this.tags = tags;
+    }
+
+    public AnotherTag[][] getOtherTags() {
+        return otherTags;
+    }
+
+    public void setOtherTags(AnotherTag[][] otherTags) {
+        this.otherTags = otherTags;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/entity/Tag.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/entity/Tag.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1215.entity;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Tag {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/mapper/Issue1215Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1215/mapper/Issue1215Mapper.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1215.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.bugs._1215.dto.EntityDTO;
+import org.mapstruct.ap.test.bugs._1215.entity.Entity;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue1215Mapper {
+    Entity fromDTO(EntityDTO dto);
+}


### PR DESCRIPTION
Fixes #1215.

This makes sure that a type is considered as an import event if if is of an array type. The array suffix `[]` is always stripped in the import name of the `Type`