### PR TITLE
#611 Allow nested declaration of Mappers

### DIFF
--- a/core-common/src/test/java/org/mapstruct/factory/MappersTest.java
+++ b/core-common/src/test/java/org/mapstruct/factory/MappersTest.java
@@ -19,9 +19,11 @@
 package org.mapstruct.factory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 import org.mapstruct.test.model.Foo;
+import org.mapstruct.test.model.SomeClass;
 
 /**
  * Unit test for {@link Mappers}.
@@ -35,5 +37,15 @@ public class MappersTest {
 
         Foo mapper = Mappers.getMapper( Foo.class );
         assertThat( mapper ).isNotNull();
+    }
+
+    /**
+     * Checks if an implementation of a nested mapper can be found. This is a special case since
+     * it is named
+     */
+    @Test
+    public void findsNestedMapperImpl() throws Exception {
+        assertNotNull( Mappers.getMapper( SomeClass.Foo.class ) );
+        assertNotNull( Mappers.getMapper( SomeClass.NestedClass.Foo.class ) );
     }
 }

--- a/core-common/src/test/java/org/mapstruct/factory/MappersTest.java
+++ b/core-common/src/test/java/org/mapstruct/factory/MappersTest.java
@@ -19,7 +19,6 @@
 package org.mapstruct.factory;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertNotNull;
 
 import org.junit.Test;
 import org.mapstruct.test.model.Foo;
@@ -45,7 +44,7 @@ public class MappersTest {
      */
     @Test
     public void findsNestedMapperImpl() throws Exception {
-        assertNotNull( Mappers.getMapper( SomeClass.Foo.class ) );
-        assertNotNull( Mappers.getMapper( SomeClass.NestedClass.Foo.class ) );
+        assertThat( Mappers.getMapper( SomeClass.Foo.class ) ).isNotNull();
+        assertThat( Mappers.getMapper( SomeClass.NestedClass.Foo.class ) ).isNotNull();
     }
 }

--- a/core-common/src/test/java/org/mapstruct/test/model/SomeClass$FooImpl.java
+++ b/core-common/src/test/java/org/mapstruct/test/model/SomeClass$FooImpl.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.test.model;
+
+/**
+ * For testing naming of implementations of nested mappers (issue 611).
+ *
+ * @author Tillmann Gaida
+ */
+/*
+ * Turn off checkstyle since the underscore introduced by issue 611 violates the class naming
+ * convention.
+ */
+// CHECKSTYLE:OFF
+public class SomeClass$FooImpl implements SomeClass.Foo {
+
+}

--- a/core-common/src/test/java/org/mapstruct/test/model/SomeClass$NestedClass$FooImpl.java
+++ b/core-common/src/test/java/org/mapstruct/test/model/SomeClass$NestedClass$FooImpl.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.test.model;
+
+/**
+ * For testing naming of implementations of nested mappers (issue 611).
+ *
+ * @author Tillmann Gaida
+ */
+/*
+ * Turn off checkstyle since the underscore introduced by issue 611 violates the class naming
+ * convention.
+ */
+// CHECKSTYLE:OFF
+public class SomeClass$NestedClass$FooImpl implements SomeClass.NestedClass.Foo {
+
+}

--- a/core-common/src/test/java/org/mapstruct/test/model/SomeClass.java
+++ b/core-common/src/test/java/org/mapstruct/test/model/SomeClass.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.test.model;
+
+/**
+ * The sole purpose of this class is to have a place to nest the Foo interface.
+ *
+ * @author Tillmann Gaida
+ */
+public class SomeClass {
+    public interface Foo { }
+
+    public static class NestedClass {
+        public interface Foo { }
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Decorator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Decorator.java
@@ -111,7 +111,7 @@ public class Decorator extends GeneratedType {
 
         public Decorator build() {
             String implementationName = implName.replace( Mapper.CLASS_NAME_PLACEHOLDER,
-                                                          mapperElement.getSimpleName() );
+                                                          Mapper.getFlatName( mapperElement ) );
 
             Type decoratorType = typeFactory.getType( decoratorPrism.value() );
             DecoratorConstructor decoratorConstructor = new DecoratorConstructor(

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
@@ -21,6 +21,7 @@ package org.mapstruct.ap.internal.model;
 import java.util.List;
 import java.util.SortedSet;
 
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
@@ -153,7 +154,7 @@ public class Mapper extends GeneratedType {
         }
 
         public Mapper build() {
-            String implementationName = implName.replace( CLASS_NAME_PLACEHOLDER, element.getSimpleName() ) +
+            String implementationName = implName.replace( CLASS_NAME_PLACEHOLDER, getFlatName( element ) ) +
                     ( decorator == null ? "" : "_" );
 
             String elementPackage = elementUtils.getPackageOf( element ).getQualifiedName().toString();
@@ -198,5 +199,21 @@ public class Mapper extends GeneratedType {
     @Override
     protected String getTemplateName() {
         return getTemplateNameForClass( GeneratedType.class );
+    }
+
+    /**
+     * Returns the same as {@link Class#getName()} but without the package declaration.
+     */
+    public static String getFlatName(TypeElement element) {
+        if (!(element.getEnclosingElement() instanceof TypeElement)) {
+            return element.getSimpleName().toString();
+        }
+        StringBuilder nameBuilder = new StringBuilder( element.getSimpleName().toString() );
+        for (Element enclosing = element.getEnclosingElement(); enclosing instanceof TypeElement; enclosing =
+                enclosing.getEnclosingElement()) {
+            nameBuilder.insert( 0, '$' );
+            nameBuilder.insert( 0, enclosing.getSimpleName().toString() );
+        }
+        return nameBuilder.toString();
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_611/Issue611Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_611/Issue611Test.java
@@ -1,0 +1,71 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._611;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Tillmann Gaida
+ */
+@IssueKey("611")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue611Test {
+    /**
+     * Checks if an implementation of a nested mapper can be loaded at all.
+     */
+    @Test
+    @WithClasses(SomeClass.class)
+    public void mapperIsFound() throws Exception {
+        assertNotNull( SomeClass.InnerMapper.INSTANCE );
+    }
+
+    /**
+     * Checks if an implementation of a nested mapper can be loaded which is nested into an already
+     * nested class.
+     */
+    @Test
+    @WithClasses(SomeClass.class)
+    public void mapperNestedInsideNestedClassIsFound() throws Exception {
+        assertNotNull( SomeClass.SomeInnerClass.InnerMapper.INSTANCE );
+    }
+
+    /**
+     * Checks if it is possible to load two mapper implementations which have equal simple names
+     * in the same package.
+     */
+    @Test
+    @WithClasses({ SomeClass.class, SomeOtherClass.class })
+    public void rightMapperIsFound() throws Exception {
+        SomeClass.InnerMapper.Source source1 = new SomeClass.InnerMapper.Source();
+        SomeOtherClass.InnerMapper.Source source2 = new SomeOtherClass.InnerMapper.Source();
+
+        SomeClass.InnerMapper.Target target1 = SomeClass.InnerMapper.INSTANCE.toTarget( source1 );
+        SomeOtherClass.InnerMapper.Target target2 = SomeOtherClass.InnerMapper.INSTANCE.toTarget( source2 );
+
+        assertTrue( target1 instanceof SomeClass.InnerMapper.Target );
+        assertTrue( target2 instanceof SomeOtherClass.InnerMapper.Target );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_611/Issue611Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_611/Issue611Test.java
@@ -18,28 +18,30 @@
  */
 package org.mapstruct.ap.test.bugs._611;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 /**
  * @author Tillmann Gaida
  */
 @IssueKey("611")
 @RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    SomeClass.class,
+    SomeOtherClass.class
+})
 public class Issue611Test {
     /**
      * Checks if an implementation of a nested mapper can be loaded at all.
      */
     @Test
-    @WithClasses(SomeClass.class)
-    public void mapperIsFound() throws Exception {
-        assertNotNull( SomeClass.InnerMapper.INSTANCE );
+    public void mapperIsFound() {
+        assertThat( SomeClass.InnerMapper.INSTANCE ).isNotNull();
     }
 
     /**
@@ -47,9 +49,8 @@ public class Issue611Test {
      * nested class.
      */
     @Test
-    @WithClasses(SomeClass.class)
-    public void mapperNestedInsideNestedClassIsFound() throws Exception {
-        assertNotNull( SomeClass.SomeInnerClass.InnerMapper.INSTANCE );
+    public void mapperNestedInsideNestedClassIsFound() {
+        assertThat( SomeClass.SomeInnerClass.InnerMapper.INSTANCE ).isNotNull();
     }
 
     /**
@@ -57,15 +58,14 @@ public class Issue611Test {
      * in the same package.
      */
     @Test
-    @WithClasses({ SomeClass.class, SomeOtherClass.class })
-    public void rightMapperIsFound() throws Exception {
+    public void rightMapperIsFound() {
         SomeClass.InnerMapper.Source source1 = new SomeClass.InnerMapper.Source();
         SomeOtherClass.InnerMapper.Source source2 = new SomeOtherClass.InnerMapper.Source();
 
         SomeClass.InnerMapper.Target target1 = SomeClass.InnerMapper.INSTANCE.toTarget( source1 );
         SomeOtherClass.InnerMapper.Target target2 = SomeOtherClass.InnerMapper.INSTANCE.toTarget( source2 );
 
-        assertTrue( target1 instanceof SomeClass.InnerMapper.Target );
-        assertTrue( target2 instanceof SomeOtherClass.InnerMapper.Target );
+        assertThat( target1 ).isExactlyInstanceOf( SomeClass.InnerMapper.Target.class );
+        assertThat( target2 ).isExactlyInstanceOf( SomeOtherClass.InnerMapper.Target.class );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_611/SomeClass.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_611/SomeClass.java
@@ -1,0 +1,55 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._611;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Tillmann Gaida
+ */
+public class SomeClass {
+    @Mapper
+    public interface InnerMapper {
+        InnerMapper INSTANCE = Mappers.getMapper( InnerMapper.class );
+
+        Target toTarget(Source in);
+
+        class Source {
+        }
+
+        class Target {
+        }
+    }
+
+    public static class SomeInnerClass {
+        @Mapper
+        public interface InnerMapper {
+            InnerMapper INSTANCE = Mappers.getMapper( InnerMapper.class );
+
+            Target toTarget(Source in);
+
+            class Source {
+            }
+
+            class Target {
+            }
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_611/SomeOtherClass.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_611/SomeOtherClass.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._611;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Tillmann Gaida
+ */
+public class SomeOtherClass {
+    @Mapper
+    public interface InnerMapper {
+        InnerMapper INSTANCE = Mappers.getMapper( InnerMapper.class );
+
+        Target toTarget(Source in);
+
+        class Source {
+        }
+
+        class Target {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #611.

The method name "getFlatName" is supposed to imply that it squashes/flattens several class names into one.