### PR TITLE
#1227 Make sure that only types belonging to java.lang are not imported

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -235,7 +235,9 @@ public abstract class GeneratedType extends ModelElement {
         }
 
         if ( typeToAdd.getPackageName() != null ) {
-            if ( typeToAdd.getPackageName().startsWith( JAVA_LANG_PACKAGE ) ) {
+            if ( typeToAdd.getPackageName().equals( JAVA_LANG_PACKAGE ) ) {
+                // only the types in the java.lang package are implicitly imported, the packages under java.lang
+                // like java.lang.management are not.
                 return false;
             }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1227/Issue1227Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1227/Issue1227Mapper.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1227;
+
+import java.lang.management.ThreadInfo;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue1227Mapper {
+
+    ThreadDto map(ThreadInfo source, String s);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1227/Issue1227Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1227/Issue1227Test.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1227;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("1227")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    Issue1227Mapper.class,
+    ThreadDto.class
+})
+public class Issue1227Test {
+
+    @Test
+    public void shouldCompile() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1227/ThreadDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1227/ThreadDto.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1227;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class ThreadDto {
+
+    private String threadName;
+
+    public String getThreadName() {
+        return threadName;
+    }
+
+    public void setThreadName(String threadName) {
+        this.threadName = threadName;
+    }
+}


### PR DESCRIPTION
Fixes #1227.

I am not sure if we need to add the types from the other `java.lang` sub-packages. Like `java.lang.ref`, `java.lang.reflect` etc.