### PR TITLE
#1150 Improve error reporting for nested properties

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -324,7 +324,9 @@ public class PropertyMapping extends ModelElement {
          */
         private void reportCannotCreateMapping() {
             if ( method instanceof ForgedMethod && ( (ForgedMethod) method ).getHistory() != null ) {
-                ForgedMethodHistory history =  ( (ForgedMethod) method ).getHistory();
+                // The history that is part of the ForgedMethod misses the information from the current right hand
+                // side. Therefore we need to extract the most relevant history and use that in the error reporting.
+                ForgedMethodHistory history = getForgedMethodHistory( rightHandSide );
                 reportCannotCreateMapping(
                     method,
                     history.createSourcePropertyErrorMessage(),

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exclusions/ErroneousJavaInternalTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exclusions/ErroneousJavaInternalTest.java
@@ -57,7 +57,13 @@ public class ErroneousJavaInternalTest {
                 line = 29,
                 messageRegExp = "Can't map property \".*List<.*MyType> types\" to \".*List<.*String> types\"\\" +
                     ". Consider to declare/implement a mapping method: \".*List<.*String> map\\(.*List<.*MyType> " +
-                    "value\\)\"\\.")
+                    "value\\)\"\\."),
+            @Diagnostic(type = ErroneousJavaInternalMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 29,
+                messageRegExp = "Can't map property \".*List<.*MyType> nestedMyType\\.deepNestedType\\.types\" to \"" +
+                    ".*List<.*String> nestedMyType\\.deepNestedType\\.types\"\\. Consider to declare/implement a " +
+                    "mapping method: \".*List<.*String> map\\(.*List<.*MyType> value\\)\"\\.")
         })
     @Test
     public void shouldNotNestIntoJavaPackageObjects() throws Exception {

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exclusions/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exclusions/Source.java
@@ -47,8 +47,6 @@ class Source {
     public MyType date;
     public MyType calendar;
     public List<MyType> types;
-    //TODO Nested error messages do not work yet. I think that this should be solved as part of #1150
-    // (or we solve that one first :))
-    //public NestedMyType nestedMyType;
+    public NestedMyType nestedMyType;
     //CHECKSTYLE:ON
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exclusions/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exclusions/Target.java
@@ -43,6 +43,6 @@ class Target {
     public Date date;
     public GregorianCalendar calendar;
     public List<String> types;
-    //public TargetNested nestedMyType;
+    public TargetNested nestedMyType;
     //CHECKSTYLE:ON
 }


### PR DESCRIPTION
Fixes #1150. I think that I have found a good way to display the mapping not found for deep nested properties