### PR TITLE
#1244 Fix problems with special word for FreeMarker in some cases

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -760,8 +760,9 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         return constantMappings;
     }
 
-    public Map<String, List<PropertyMapping>> getPropertyMappingsByParameter() {
-        return mappingsByParameter;
+    public List<PropertyMapping> propertyMappingsByParameter(Parameter parameter) {
+        // issues: #909 and #1244. FreeMarker has problem getting values from a map when the search key is size or value
+        return mappingsByParameter.get( parameter.getName() );
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
@@ -44,8 +44,7 @@ public class Parameter extends ModelElement {
     private final boolean mappingContext;
 
     private Parameter(String name, Type type, boolean mappingTarget, boolean targetType, boolean mappingContext) {
-        // issue #909: FreeMarker doesn't like "values" as a parameter name
-        this.name = "values".equals( name ) ? "values_" : name;
+        this.name = name;
         this.originalName = name;
         this.type = type;
         this.mappingTarget = mappingTarget;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -45,24 +45,24 @@
     </#list>
     <#if (sourceParameters?size > 1)>
         <#list sourceParametersExcludingPrimitives as sourceParam>
-            <#if (propertyMappingsByParameter[sourceParam.name]?size > 0)>
+            <#if (propertyMappingsByParameter(sourceParam)?size > 0)>
                 if ( ${sourceParam.name} != null ) {
-                    <#list propertyMappingsByParameter[sourceParam.name] as propertyMapping>
+                    <#list propertyMappingsByParameter(sourceParam) as propertyMapping>
                         <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
                     </#list>
                 }
             </#if>
         </#list>
         <#list sourcePrimitiveParameters as sourceParam>
-            <#if (propertyMappingsByParameter[sourceParam.name]?size > 0)>
-                <#list propertyMappingsByParameter[sourceParam.name] as propertyMapping>
+            <#if (propertyMappingsByParameter(sourceParam)?size > 0)>
+                <#list propertyMappingsByParameter(sourceParam) as propertyMapping>
                     <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
                 </#list>
             </#if>
         </#list>
     <#else>
         <#if mapNullToDefault>if ( ${sourceParameters[0].name} != null ) {</#if>
-        <#list propertyMappingsByParameter[sourceParameters[0].name] as propertyMapping>
+        <#list propertyMappingsByParameter(sourceParameters[0]) as propertyMapping>
             <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
         </#list>
         <#if mapNullToDefault>}</#if>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1244/Issue1244Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1244/Issue1244Test.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1244;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.factory.Mappers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("1244")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses( SizeMapper.class )
+public class Issue1244Test {
+
+    @Test
+    public void properlyCreatesMapperWithSizeAsParameterName() {
+        SizeMapper.SizeHolder sizeHolder = new SizeMapper.SizeHolder();
+        sizeHolder.setSize( "size" );
+
+        SizeMapper.SizeHolderDto dto = Mappers.getMapper( SizeMapper.class ).convert( sizeHolder );
+        assertThat( dto.getSize() ).isEqualTo( "size" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1244/SizeMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1244/SizeMapper.java
@@ -16,42 +16,43 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.bugs._909;
+package org.mapstruct.ap.test.bugs._1244;
 
 import org.mapstruct.Mapper;
 
 /**
- * @author Andreas Gudian
+ * @author Filip Hrisafov
  */
 @Mapper
-public interface ValuesMapper {
-    ValuesHolderDto convert(ValuesHolder values);
+public interface SizeMapper {
 
-    ValuesHolderDto convert(ValuesHolder values, int test);
+    SizeHolderDto convert(SizeHolder size);
 
-    ValuesHolderDto convertOther(ValuesHolder valuesHolder, int values);
+    SizeHolderDto convert(SizeHolder size, int test);
 
-    class ValuesHolder {
-        private String values;
+    SizeHolderDto convertOther(SizeHolder sizeHolder, int size);
 
-        public String getValues() {
-            return values;
+    class SizeHolder {
+        private String size;
+
+        public String getSize() {
+            return size;
         }
 
-        public void setValues(String values) {
-            this.values = values;
+        public void setSize(String size) {
+            this.size = size;
         }
     }
 
-    class ValuesHolderDto {
-        private String values;
+    class SizeHolderDto {
+        private String size;
 
-        public String getValues() {
-            return values;
+        public String getSize() {
+            return size;
         }
 
-        public void setValues(String values) {
-            this.values = values;
+        public void setSize(String size) {
+            this.size = size;
         }
     }
 }


### PR DESCRIPTION
FreeMarker has problems getting values from a map when the key
is "values" or "size" (there might be other cases, this are the ones we know).
Therefore, instead of using a Map, MapStruct will pass the Parameter to the
function and return List<PropertyMapping>

Fixes: #1244

I decided for a different approach in solving this, as there might be other cases where FreeMarker fails. It should be much safer like this. We just pass the `Parameter` to a function and we get back a `List<PropertyMapping>`.