### PR TITLE
#1255 ReverseMapping should not apply automatically.

### DIFF
--- a/core-common/src/main/java/org/mapstruct/MappingInheritanceStrategy.java
+++ b/core-common/src/main/java/org/mapstruct/MappingInheritanceStrategy.java
@@ -32,8 +32,20 @@ public enum MappingInheritanceStrategy {
     EXPLICIT,
 
     /**
-     * Inherit the method-level configuration annotations automatically if source and target types of the prototype
-     * method are assignable from the types of a given mapping method.
+     * Inherit the method-level forward configuration annotations automatically if source and target types of the
+     * prototype method are assignable from the types of a given mapping method.
      */
-    AUTO_INHERIT_FROM_CONFIG;
+    AUTO_INHERIT_FROM_CONFIG,
+
+    /**
+     * Inherit the method-level reverse configuration annotations automatically if source and target types of the
+     * prototype method are assignable from the target and source types of a given mapping method.
+     */
+    AUTO_INHERIT_REVERSE_FROM_CONFIG,
+
+    /**
+     * Inherit the method-level forward and reverse configuration annotations automatically if source and target types
+     * of the prototype method are assignable from the types of a given mapping method.
+     */
+    AUTO_INHERIT_ALL_FROM_CONFIG;
 }

--- a/integrationtest/src/test/resources/fullFeatureTest/src/test/java/org/mapstruct/itest/simple/AnimalTest.java
+++ b/integrationtest/src/test/resources/fullFeatureTest/src/test/java/org/mapstruct/itest/simple/AnimalTest.java
@@ -47,18 +47,6 @@ public class AnimalTest {
     }
 
     @Test
-    public void shouldNotPropagateIgnoredPropertyInReverseMappingWhenNameIsSame() {
-        AnimalDto animalDto = new AnimalDto( "Bruno", 100, 23, "black" );
-
-        Animal animal = AnimalMapper.INSTANCE.animalDtoToAnimal( animalDto );
-
-        assertThat( animal ).isNotNull();
-        assertThat( animalDto.getName() ).isEqualTo( "Bruno" );
-        assertThat( animalDto.getSize() ).isEqualTo( 100 );
-        assertThat( animal.getAge() ).isNull();
-    }
-
-    @Test
     public void shouldNotPropagateIgnoredPropertyInReverseMappingWhenSourceAndTargetAreSpecified() {
         AnimalDto animalDto = new AnimalDto( "Bruno", 100, 23, "black" );
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
@@ -398,15 +398,9 @@ public class Mapping {
     public Mapping reverse(SourceMethod method, FormattingMessager messager, TypeFactory typeFactory) {
 
         // mapping can only be reversed if the source was not a constant nor an expression nor a nested property
-        if ( constant != null || javaExpression != null ) {
+        // and the mapping is not a 'target-source-ignore' mapping
+        if ( constant != null || javaExpression != null || ( isIgnored && sourceName == null ) ) {
             return null;
-        }
-
-        // should only ignore a property when 1) there is a sourceName defined or 2) there's a name match
-        if ( isIgnored ) {
-            if ( sourceName == null && !hasPropertyInReverseMethod( targetName, method ) ) {
-                return null;
-            }
         }
 
         Mapping reverse = new Mapping(

--- a/processor/src/main/java/org/mapstruct/ap/internal/prism/MappingInheritanceStrategyPrism.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/prism/MappingInheritanceStrategyPrism.java
@@ -25,6 +25,32 @@ package org.mapstruct.ap.internal.prism;
  * @author Andreas Gudian
  */
 public enum MappingInheritanceStrategyPrism {
-    EXPLICIT,
-    AUTO_INHERIT_FROM_CONFIG;
+
+    EXPLICIT( false, false, false ),
+    AUTO_INHERIT_FROM_CONFIG( true, true, false ),
+    AUTO_INHERIT_REVERSE_FROM_CONFIG( true, false, true ),
+    AUTO_INHERIT_ALL_FROM_CONFIG( true, true, true );
+
+    private final boolean autoInherit;
+    private final boolean applyForward;
+    private final boolean applyReverse;
+
+    MappingInheritanceStrategyPrism(boolean isAutoInherit, boolean applyForward, boolean applyReverse) {
+        this.autoInherit = isAutoInherit;
+        this.applyForward = applyForward;
+        this.applyReverse = applyReverse;
+    }
+
+    public boolean isAutoInherit() {
+        return autoInherit;
+    }
+
+    public boolean isApplyForward() {
+        return applyForward;
+    }
+
+    public boolean isApplyReverse() {
+        return applyReverse;
+    }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -47,6 +47,7 @@ public enum Message {
     PROPERTYMAPPING_DUPLICATE_TARGETS( "Target property \"%s\" must not be mapped more than once." ),
     PROPERTYMAPPING_EMPTY_TARGET( "Target must not be empty in @Mapping." ),
     PROPERTYMAPPING_SOURCE_AND_CONSTANT_BOTH_DEFINED( "Source and constant are both defined in @Mapping, either define a source or a constant." ),
+    PROPERTYMAPPING_SOURCE_AND_IGNORE_BOTH_DEFINED( "Source and ignore are both defined in @Mapping, make explicit in reverse mapping when the intent is to ignore the reverse mapping." ),
     PROPERTYMAPPING_SOURCE_AND_EXPRESSION_BOTH_DEFINED( "Source and expression are both defined in @Mapping, either define a source or an expression." ),
     PROPERTYMAPPING_EXPRESSION_AND_CONSTANT_BOTH_DEFINED( "Expression and constant are both defined in @Mapping, either define an expression or a constant." ),
     PROPERTYMAPPING_EXPRESSION_AND_DEFAULT_VALUE_BOTH_DEFINED( "Expression and default value are both defined in @Mapping, either define a defaultValue or an expression." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/AbstractA.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/AbstractA.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1255;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public abstract class AbstractA {
+
+    private String field1;
+
+    public String getField1() {
+        return field1;
+    }
+
+    public void setField1(String field1) {
+        this.field1 = field1;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/Issue1255Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/Issue1255Test.java
@@ -1,0 +1,67 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1255;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@IssueKey("1255")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    AbstractA.class,
+    SomeA.class,
+    SomeB.class,
+    SomeMapper.class,
+    SomeMapperConfig.class})
+public class Issue1255Test {
+
+    @Test
+    public void shouldMapSomeBToSomeAWithoutField1() throws Exception {
+        SomeB someB = new SomeB();
+        someB.setField1( "value1" );
+        someB.setField2( "value2" );
+
+        SomeA someA = SomeMapper.INSTANCE.toSomeA( someB );
+
+        assertThat( someA.getField1() )
+            .isNotEqualTo( someB.getField1() )
+            .isNull();
+        assertThat( someA.getField2() ).isEqualTo( someB.getField2() );
+    }
+
+    @Test
+    public void shouldMapSomeAToSomeB() throws Exception {
+        SomeA someA = new SomeA();
+        someA.setField1( "value1" );
+        someA.setField2( "value2" );
+
+        SomeB someB = SomeMapper.INSTANCE.toSomeB( someA );
+
+        assertThat( someB.getField1() ).isEqualTo( someA.getField1() );
+        assertThat( someB.getField2() ).isEqualTo( someA.getField2() );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/SomeA.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/SomeA.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1255;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class SomeA extends AbstractA {
+
+    private String field2;
+
+    public String getField2() {
+        return field2;
+    }
+
+    public void setField2(String field2) {
+        this.field2 = field2;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/SomeB.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/SomeB.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1255;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class SomeB {
+
+    private String field1;
+    private String field2;
+
+    public String getField1() {
+        return field1;
+    }
+
+    public void setField1(String field1) {
+        this.field1 = field1;
+    }
+
+    public String getField2() {
+        return field2;
+    }
+
+    public void setField2(String field2) {
+        this.field2 = field2;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/SomeMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/SomeMapper.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1255;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper(config = SomeMapperConfig.class)
+public interface SomeMapper {
+
+    SomeMapper INSTANCE = Mappers.getMapper( SomeMapper.class );
+
+    SomeA toSomeA(SomeB source);
+
+    SomeB toSomeB(SomeA source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/SomeMapperConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/SomeMapperConfig.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1255;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingInheritanceStrategy;
+import org.mapstruct.Mappings;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@MapperConfig(
+    mappingInheritanceStrategy = MappingInheritanceStrategy.AUTO_INHERIT_FROM_CONFIG
+)
+public interface SomeMapperConfig {
+
+    @Mappings({
+        @Mapping(target = "field1", ignore = true)
+    })
+    AbstractA toAbstractA(SomeB source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/IgnorePropertyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/IgnorePropertyTest.java
@@ -57,22 +57,8 @@ public class IgnorePropertyTest {
     }
 
     @Test
-    @IssueKey("72")
-    public void shouldNotPropagateIgnoredPropertyInReverseMappingWhenNameIsSame() {
-        AnimalDto animalDto = new AnimalDto( "Bruno", 100, 23, "black" );
-
-        Animal animal = AnimalMapper.INSTANCE.animalDtoToAnimal( animalDto );
-
-        assertThat( animal ).isNotNull();
-        assertThat( animalDto.getName() ).isEqualTo( "Bruno" );
-        assertThat( animalDto.getSize() ).isEqualTo( 100 );
-        assertThat( animal.getAge() ).isNull();
-        assertThat( animal.publicAge ).isNull();
-    }
-
-    @Test
     @IssueKey("337")
-    public void shouldNotPropagateIgnoredPropertyInReverseMappingWhenSourceAndTargetAreSpecified() {
+    public void propertyIsIgnoredInReverseMappingWhenSourceIsAlsoSpecifiedICWIgnore() {
         AnimalDto animalDto = new AnimalDto( "Bruno", 100, 23, "black" );
 
         Animal animal = AnimalMapper.INSTANCE.animalDtoToAnimal( animalDto );

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/AutoInheritedAllConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/AutoInheritedAllConfig.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingInheritanceStrategy;
+import org.mapstruct.Mappings;
+import org.mapstruct.ReportingPolicy;
+
+/**
+ * @author Sjaak Derksen
+ */
+@MapperConfig(
+    mappingInheritanceStrategy = MappingInheritanceStrategy.AUTO_INHERIT_ALL_FROM_CONFIG,
+    unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface AutoInheritedAllConfig {
+    @Mappings({
+        @Mapping(target = "primaryKey", source = "id"),
+        @Mapping(target = "auditTrail", ignore = true)
+    })
+    BaseVehicleEntity baseDtoToEntity(BaseVehicleDto dto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/AutoInheritedReverseConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/AutoInheritedReverseConfig.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingInheritanceStrategy;
+import org.mapstruct.Mappings;
+import org.mapstruct.ReportingPolicy;
+
+/**
+ * @author Sjaak Derksen
+ */
+@MapperConfig(
+    mappingInheritanceStrategy = MappingInheritanceStrategy.AUTO_INHERIT_REVERSE_FROM_CONFIG,
+    unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface AutoInheritedReverseConfig {
+    @Mappings({
+        @Mapping(target = "primaryKey", source = "id"),
+        @Mapping(target = "auditTrail", ignore = true)
+    })
+    BaseVehicleEntity baseDtoToEntity(BaseVehicleDto dto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/CarMapperAllWithAutoInheritance.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/CarMapperAllWithAutoInheritance.java
@@ -1,0 +1,41 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Sjaak Derksen
+ */
+@Mapper(
+    config = AutoInheritedAllConfig.class
+)
+public abstract class CarMapperAllWithAutoInheritance {
+    public static final CarMapperAllWithAutoInheritance INSTANCE =
+        Mappers.getMapper( CarMapperAllWithAutoInheritance.class );
+
+    @Mapping(target = "color", source = "colour")
+    public abstract CarEntity toCarEntity(CarDto carDto);
+
+    @Mapping( target = "colour", source = "color" )
+    public abstract CarDto toCarDto(CarEntity entity);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/CarMapperReverseWithAutoInheritance.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/CarMapperReverseWithAutoInheritance.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Sjaak Derksen
+ */
+@Mapper(
+    config = AutoInheritedReverseConfig.class
+)
+public abstract class CarMapperReverseWithAutoInheritance {
+    public static final CarMapperReverseWithAutoInheritance INSTANCE =
+        Mappers.getMapper( CarMapperReverseWithAutoInheritance.class );
+
+    @Mapping( target = "colour", source = "color" )
+    public abstract CarDto toCarDto(CarEntity entity);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/Erroneous3Config.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/Erroneous3Config.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingInheritanceStrategy;
+import org.mapstruct.Mappings;
+import org.mapstruct.ReportingPolicy;
+
+/**
+ * @author Sjaak Derksen
+ */
+@MapperConfig(
+    mappingInheritanceStrategy = MappingInheritanceStrategy.AUTO_INHERIT_REVERSE_FROM_CONFIG,
+    unmappedTargetPolicy = ReportingPolicy.ERROR
+)
+public interface Erroneous3Config {
+    @Mappings({
+        @Mapping(target = "primaryKey", source = "id"),
+        @Mapping(target = "auditTrail", ignore = true)
+    })
+    BaseVehicleEntity baseDtoToEntity(BaseVehicleDto dto);
+
+    @Mappings({
+        @Mapping(target = "primaryKey", source = "id"),
+        @Mapping(target = "auditTrail", ignore = true)
+    })
+    BaseVehicleEntity baseDtoToEntity2(BaseVehicleDto dto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/Erroneous3Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/Erroneous3Mapper.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Sjaak Derksen
+ */
+@Mapper(
+    config = Erroneous3Config.class
+)
+public abstract class Erroneous3Mapper {
+    public static final Erroneous3Mapper INSTANCE = Mappers.getMapper( Erroneous3Mapper.class );
+
+    @Mapping( target = "colour", source = "color" )
+    public abstract CarDto toCarDto(CarEntity entity);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/ErroneousMapperAutoInheritance.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/ErroneousMapperAutoInheritance.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Sjaak Derksen
+ */
+@Mapper(
+    config = AutoInheritedReverseConfig.class
+)
+public interface ErroneousMapperAutoInheritance {
+    ErroneousMapperAutoInheritance INSTANCE = Mappers.getMapper( ErroneousMapperAutoInheritance.class );
+
+    @Mapping(target = "color", source = "colour")
+    CarEntity toCarEntity(CarDto carDto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/ErroneousMapperReverseWithAutoInheritance.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/ErroneousMapperReverseWithAutoInheritance.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Sjaak Derksen
+ */
+@Mapper(
+    config = AutoInheritedConfig.class
+)
+public abstract class ErroneousMapperReverseWithAutoInheritance {
+    public static final ErroneousMapperReverseWithAutoInheritance INSTANCE =
+        Mappers.getMapper( ErroneousMapperReverseWithAutoInheritance.class );
+
+    @Mapping( target = "colour", source = "color" )
+    public abstract CarDto toCarDto(CarEntity entity);
+
+}


### PR DESCRIPTION
The problem reproduces by means of the provided test case. However, it seems to be deliberate functionality, at one time introduced after issue #72.

It is possible to include a `source` name besides `target` in the `@Mapping`. Also, ignore should be applied when there is a target property with the same name in the source. The testcases in `org.mapstruct.ap.test.ignore.IgnorePropertyTest` start to fail once the fix in the second [commit](https://github.com/sjaakd/mapstruct/commit/9db22395ae3b354efa27ff5ac8bdd4065c0d50f1) is in place. 

@gunnarmorling , @agudian , @filiphr : do we still want this functionality? Seems to me it is more straightforward and better explainable to 'ignore' the `ignore=true` in the reverse mapping just as we do for expressions and constants. But that would be breaking existing functionality.

