### PR TITLE
#610 unmappedSourcePolicy

### DIFF
--- a/core-common/src/main/java/org/mapstruct/Mapper.java
+++ b/core-common/src/main/java/org/mapstruct/Mapper.java
@@ -55,6 +55,15 @@ public @interface Mapper {
     Class<?>[] imports() default { };
 
     /**
+     * How unmapped properties of the source type of a mapping should be
+     * reported. The method overrides an unmappedSourcePolicy set in a central
+     * configuration set by {@link #config() }
+     *
+     * @return The reporting policy for unmapped source properties.
+     */
+    ReportingPolicy unmappedSourcePolicy() default ReportingPolicy.IGNORE;
+
+    /**
      * How unmapped properties of the target type of a mapping should be
      * reported. The method overrides an unmappedTargetPolicy set in a central
      * configuration set by {@link #config() }

--- a/core-common/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core-common/src/main/java/org/mapstruct/MapperConfig.java
@@ -58,6 +58,14 @@ public @interface MapperConfig {
     Class<?>[] uses() default { };
 
     /**
+     * How unmapped properties of the source type of a mapping should be
+     * reported.
+     *
+     * @return The reporting policy for unmapped source properties.
+     */
+    ReportingPolicy unmappedSourcePolicy() default ReportingPolicy.IGNORE;
+
+    /**
      * How unmapped properties of the target type of a mapping should be
      * reported.
      *

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -257,6 +257,18 @@ Supported values are:
 
 If a policy is given for a specific mapper via `@Mapper#unmappedTargetPolicy()`, the value from the annotation takes precedence.
 |`WARN`
+
+|`mapstruct.unmappedSourcePolicy`
+|The default reporting policy to be applied in case an attribute of the source object of a mapping method is not populating an attribute of the target object.
+
+Supported values are:
+
+* `ERROR`: any unmapped source property will cause the mapping code generation to fail
+* `WARN`: any unmapped source property will cause a warning at build time
+* `IGNORE`: unmapped source properties are ignored
+
+If a policy is given for a specific mapper via `@Mapper#unmappedSourcePolicy()`, the value from the annotation takes precedence.
+|`IGNORE`
 |===
 
 === Using MapStruct on Java 9

--- a/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
@@ -91,6 +91,7 @@ import org.mapstruct.ap.internal.util.TypeHierarchyErroneousException;
     MappingProcessor.SUPPRESS_GENERATOR_TIMESTAMP,
     MappingProcessor.SUPPRESS_GENERATOR_VERSION_INFO_COMMENT,
     MappingProcessor.UNMAPPED_TARGET_POLICY,
+    MappingProcessor.UNMAPPED_SOURCE_POLICY,
     MappingProcessor.DEFAULT_COMPONENT_MODEL
 })
 public class MappingProcessor extends AbstractProcessor {
@@ -104,6 +105,7 @@ public class MappingProcessor extends AbstractProcessor {
     protected static final String SUPPRESS_GENERATOR_VERSION_INFO_COMMENT =
         "mapstruct.suppressGeneratorVersionInfoComment";
     protected static final String UNMAPPED_TARGET_POLICY = "mapstruct.unmappedTargetPolicy";
+    protected static final String UNMAPPED_SOURCE_POLICY = "mapstruct.unmappedSourcePolicy";
     protected static final String DEFAULT_COMPONENT_MODEL = "mapstruct.defaultComponentModel";
     protected static final String ALWAYS_GENERATE_SERVICE_FILE = "mapstruct.alwaysGenerateServicesFile";
 
@@ -132,11 +134,13 @@ public class MappingProcessor extends AbstractProcessor {
 
     private Options createOptions() {
         String unmappedTargetPolicy = processingEnv.getOptions().get( UNMAPPED_TARGET_POLICY );
+        String unmappedSourcePolicy = processingEnv.getOptions().get( UNMAPPED_SOURCE_POLICY );
 
         return new Options(
             Boolean.valueOf( processingEnv.getOptions().get( SUPPRESS_GENERATOR_TIMESTAMP ) ),
             Boolean.valueOf( processingEnv.getOptions().get( SUPPRESS_GENERATOR_VERSION_INFO_COMMENT ) ),
             unmappedTargetPolicy != null ? ReportingPolicyPrism.valueOf( unmappedTargetPolicy.toUpperCase() ) : null,
+            unmappedSourcePolicy != null ? ReportingPolicyPrism.valueOf( unmappedSourcePolicy.toUpperCase() ) : null,
             processingEnv.getOptions().get( DEFAULT_COMPONENT_MODEL ),
             Boolean.valueOf( processingEnv.getOptions().get( ALWAYS_GENERATE_SERVICE_FILE ) )
         );

--- a/processor/src/main/java/org/mapstruct/ap/internal/option/Options.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/option/Options.java
@@ -30,15 +30,18 @@ public class Options {
     private final boolean suppressGeneratorTimestamp;
     private final boolean suppressGeneratorVersionComment;
     private final ReportingPolicyPrism unmappedTargetPolicy;
+    private final ReportingPolicyPrism unmappedSourcePolicy;
     private final boolean alwaysGenerateSpi;
     private final String defaultComponentModel;
 
     public Options(boolean suppressGeneratorTimestamp, boolean suppressGeneratorVersionComment,
                    ReportingPolicyPrism unmappedTargetPolicy,
+                   ReportingPolicyPrism unmappedSourcePolicy,
                    String defaultComponentModel, boolean alwaysGenerateSpi) {
         this.suppressGeneratorTimestamp = suppressGeneratorTimestamp;
         this.suppressGeneratorVersionComment = suppressGeneratorVersionComment;
         this.unmappedTargetPolicy = unmappedTargetPolicy;
+        this.unmappedSourcePolicy = unmappedSourcePolicy;
         this.defaultComponentModel = defaultComponentModel;
         this.alwaysGenerateSpi = alwaysGenerateSpi;
     }
@@ -53,6 +56,10 @@ public class Options {
 
     public ReportingPolicyPrism getUnmappedTargetPolicy() {
         return unmappedTargetPolicy;
+    }
+
+    public ReportingPolicyPrism getUnmappedSourcePolicy() {
+        return unmappedSourcePolicy;
     }
 
     public String getDefaultComponentModel() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
@@ -129,6 +129,23 @@ public class MapperConfiguration {
         return ReportingPolicyPrism.valueOf( mapperPrism.unmappedTargetPolicy() );
     }
 
+    public ReportingPolicyPrism unmappedSourcePolicy(Options options) {
+        if ( mapperPrism.values.unmappedSourcePolicy() != null ) {
+            return ReportingPolicyPrism.valueOf( mapperPrism.unmappedSourcePolicy() );
+        }
+
+        if ( mapperConfigPrism != null && mapperConfigPrism.values.unmappedSourcePolicy() != null ) {
+            return ReportingPolicyPrism.valueOf( mapperConfigPrism.unmappedSourcePolicy() );
+        }
+
+        if ( options.getUnmappedSourcePolicy() != null ) {
+            return options.getUnmappedSourcePolicy();
+        }
+
+        // fall back to default defined in the annotation
+        return ReportingPolicyPrism.valueOf( mapperPrism.unmappedSourcePolicy() );
+    }
+
     public CollectionMappingStrategyPrism getCollectionMappingStrategy() {
         if ( mapperConfigPrism != null && mapperPrism.values.collectionMappingStrategy() == null ) {
             return CollectionMappingStrategyPrism.valueOf( mapperConfigPrism.collectionMappingStrategy() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -39,6 +39,8 @@ public enum Message {
     BEANMAPPING_UNMAPPED_TARGETS_ERROR( "Unmapped target %s." ),
     BEANMAPPING_UNMAPPED_FORGED_TARGETS_WARNING( "Unmapped target %s. Mapping from %s to %s.", Diagnostic.Kind.WARNING ),
     BEANMAPPING_UNMAPPED_FORGED_TARGETS_ERROR( "Unmapped target %s. Mapping from %s to %s." ),
+    BEANMAPPING_UNMAPPED_SOURCES_WARNING( "Unmapped source %s.", Diagnostic.Kind.WARNING ),
+    BEANMAPPING_UNMAPPED_SOURCES_ERROR( "Unmapped source %s." ),
     BEANMAPPING_CYCLE_BETWEEN_PROPERTIES( "Cycle(s) between properties given via dependsOn(): %s." ),
     BEANMAPPING_UNKNOWN_PROPERTY_IN_DEPENDS_ON( "\"%s\" is no property of the method return type." ),
 

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/Config.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/Config.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.unmappedsource;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.ReportingPolicy;
+
+/**
+ * @author Andreas Gudian
+ */
+@MapperConfig(unmappedSourcePolicy = ReportingPolicy.WARN)
+public interface Config {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/ErroneousStrictSourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/ErroneousStrictSourceTargetMapper.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.unmappedsource;
+
+import org.mapstruct.ap.test.unmappedtarget.Source;
+import org.mapstruct.ap.test.unmappedtarget.Target;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(unmappedSourcePolicy = ReportingPolicy.ERROR,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface ErroneousStrictSourceTargetMapper {
+
+    ErroneousStrictSourceTargetMapper INSTANCE = Mappers.getMapper( ErroneousStrictSourceTargetMapper.class );
+
+    Target sourceToTarget(Source source);
+
+    Source targetToSource(Target target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/SourceTargetMapper.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.unmappedsource;
+
+import org.mapstruct.ap.test.unmappedtarget.Source;
+import org.mapstruct.ap.test.unmappedtarget.Target;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(unmappedSourcePolicy = ReportingPolicy.WARN,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface SourceTargetMapper {
+
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    Target sourceToTarget(Source source);
+
+    Source targetToSource(Target target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/UnmappedSourceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/UnmappedSourceTest.java
@@ -1,0 +1,115 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.unmappedsource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import javax.tools.Diagnostic.Kind;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.test.unmappedtarget.Source;
+import org.mapstruct.ap.test.unmappedtarget.Target;
+
+/**
+ * Tests expected diagnostics for unmapped source properties.
+ *
+ * @author Gunnar Morling
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+public class UnmappedSourceTest {
+
+    @Test
+    @WithClasses({ Source.class, Target.class, SourceTargetMapper.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.SUCCEEDED,
+        diagnostics = {
+            @Diagnostic(type = SourceTargetMapper.class,
+                kind = Kind.WARNING,
+                line = 33,
+                messageRegExp = "Unmapped source property: \"qux\""),
+            @Diagnostic(type = SourceTargetMapper.class,
+                kind = Kind.WARNING,
+                line = 35,
+                messageRegExp = "Unmapped source property: \"bar\"")
+        }
+    )
+    public void shouldLeaveUnmappedSourcePropertyUnset() {
+        Source source = new Source();
+        source.setFoo( 42L );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFoo() ).isEqualTo( 42L );
+        assertThat( target.getBar() ).isEqualTo( 0 );
+    }
+
+    @Test
+    @WithClasses({ Source.class, Target.class, ErroneousStrictSourceTargetMapper.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousStrictSourceTargetMapper.class,
+                kind = Kind.ERROR,
+                line = 33,
+                messageRegExp = "Unmapped source property: \"qux\""),
+            @Diagnostic(type = ErroneousStrictSourceTargetMapper.class,
+                kind = Kind.ERROR,
+                line = 35,
+                messageRegExp = "Unmapped source property: \"bar\"")
+        }
+    )
+    public void shouldRaiseErrorDueToUnsetSourceProperty() {
+    }
+
+    @Test
+    @WithClasses({ Source.class, Target.class, org.mapstruct.ap.test.unmappedtarget.SourceTargetMapper.class })
+    @ProcessorOption(name = "mapstruct.unmappedSourcePolicy", value = "ERROR")
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = org.mapstruct.ap.test.unmappedtarget.SourceTargetMapper.class,
+                kind = Kind.ERROR,
+                line = 29,
+                messageRegExp = "Unmapped source property: \"qux\""),
+            @Diagnostic(type = org.mapstruct.ap.test.unmappedtarget.SourceTargetMapper.class,
+                kind = Kind.WARNING,
+                line = 29,
+                messageRegExp = "Unmapped target property: \"bar\""),
+            @Diagnostic(type = org.mapstruct.ap.test.unmappedtarget.SourceTargetMapper.class,
+                kind = Kind.ERROR,
+                line = 31,
+                messageRegExp = "Unmapped source property: \"bar\""),
+            @Diagnostic(type = org.mapstruct.ap.test.unmappedtarget.SourceTargetMapper.class,
+                kind = Kind.WARNING,
+                line = 31,
+                messageRegExp = "Unmapped target property: \"qux\"")
+        }
+    )
+    public void shouldRaiseErrorDueToUnsetSourcePropertyWithPolicySetViaProcessorOption() {
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/UnmappedSourceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/UnmappedSourceTest.java
@@ -112,4 +112,23 @@ public class UnmappedSourceTest {
     public void shouldRaiseErrorDueToUnsetSourcePropertyWithPolicySetViaProcessorOption() {
     }
 
+    @Test
+    @WithClasses({ Source.class, Target.class, UsesConfigFromAnnotationMapper.class, Config.class })
+    @ProcessorOption(name = "mapstruct.unmappedSourcePolicy", value = "ERROR")
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.SUCCEEDED,
+        diagnostics = {
+            @Diagnostic(type = UsesConfigFromAnnotationMapper.class,
+                kind = Kind.WARNING,
+                line = 33,
+                messageRegExp = "Unmapped source property: \"qux\""),
+            @Diagnostic(type = UsesConfigFromAnnotationMapper.class,
+                kind = Kind.WARNING,
+                line = 35,
+                messageRegExp = "Unmapped source property: \"bar\"")
+        }
+    )
+    public void shouldRaiseErrorBecauseConfiguredByAnnotation() {
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/UsesConfigFromAnnotationMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedsource/UsesConfigFromAnnotationMapper.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.unmappedsource;
+
+import org.mapstruct.ap.test.unmappedtarget.Source;
+import org.mapstruct.ap.test.unmappedtarget.Target;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(config = Config.class,
+        unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface UsesConfigFromAnnotationMapper {
+
+    UsesConfigFromAnnotationMapper INSTANCE = Mappers.getMapper( UsesConfigFromAnnotationMapper.class );
+
+    Target sourceToTarget(Source source);
+
+    Source targetToSource(Target target);
+}


### PR DESCRIPTION
Just like the unmappedTargetPolicy feature, defaulting the new configuration to IGNORE for backwards compatibility.