### PR TITLE
Handle no suitable empty constructor during BeanMappingMethod creation

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -190,11 +190,26 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                             Message.BEANMAPPING_NOT_ASSIGNABLE, resultType, method.getResultType()
                         );
                     }
+                    else if ( !resultType.hasEmptyAccessibleContructor() ) {
+                        ctx.getMessager().printMessage(
+                            method.getExecutable(),
+                            beanMappingPrism.mirror,
+                            Message.GENERAL_NO_SUITABLE_CONSTRUCTOR,
+                            resultType
+                        );
+                    }
                 }
                 else if ( !method.isUpdateMethod() && method.getReturnType().isAbstract() ) {
                     ctx.getMessager().printMessage(
                         method.getExecutable(),
                         Message.GENERAL_ABSTRACT_RETURN_TYPE,
+                        method.getReturnType()
+                    );
+                }
+                else if ( !method.isUpdateMethod() && !method.getReturnType().hasEmptyAccessibleContructor() ) {
+                    ctx.getMessager().printMessage(
+                        method.getExecutable(),
+                        Message.GENERAL_NO_SUITABLE_CONSTRUCTOR,
                         method.getReturnType()
                     );
                 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -863,8 +863,7 @@ public class Type extends ModelElement implements Comparable<Type> {
             hasEmptyAccessibleContructor = false;
             List<ExecutableElement> constructors = ElementFilter.constructorsIn( typeElement.getEnclosedElements() );
             for ( ExecutableElement constructor : constructors ) {
-                if ( (constructor.getModifiers().contains( Modifier.PUBLIC )
-                    || constructor.getModifiers().contains( Modifier.PROTECTED ) )
+                if ( !constructor.getModifiers().contains( Modifier.PRIVATE )
                     && constructor.getParameters().isEmpty() ) {
                     hasEmptyAccessibleContructor = true;
                     break;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -386,17 +386,6 @@ public class SourceMethod implements Method {
         return isEnumMapping;
     }
 
-    public boolean isBeanMapping() {
-        if ( isBeanMapping == null ) {
-            isBeanMapping = !isIterableMapping()
-                && !isMapMapping()
-                && !isEnumMapping()
-                && !isValueMapping()
-                && !isStreamMapping();
-        }
-        return isBeanMapping;
-    }
-
     /**
      * The default enum mapping (no mappings specified) will from now on be handled as a value mapping. If there
      * are any @Mapping / @Mappings defined on the method, then the deprecated enum behavior should be executed.

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -517,15 +517,6 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
 
         if ( reversePrism != null ) {
 
-            // is there a suitable constructor
-            if ( method.isBeanMapping()
-                && !method.isUpdateMethod()
-                && !method.getReturnType().isCollectionOrMapType()
-                && !method.getReturnType().hasEmptyAccessibleContructor() ) {
-                reportErrorWhenNoSuitableConstrutor( method, reversePrism );
-                return null;
-            }
-
             // method is configured as being reverse method, collect candidates
             List<SourceMethod> candidates = new ArrayList<SourceMethod>();
             for ( SourceMethod oneMethod : rawMethods ) {
@@ -687,17 +678,6 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
 
             );
         }
-    }
-
-    private void reportErrorWhenNoSuitableConstrutor( SourceMethod method,
-                                                     InheritInverseConfigurationPrism reversePrism ) {
-
-        messager.printMessage( method.getExecutable(),
-            reversePrism.mirror,
-            Message.INHERITINVERSECONFIGURATION_NO_SUITABLE_CONSTRUCTOR,
-            reversePrism.name()
-
-        );
     }
 
     private void reportErrorWhenSeveralNamesMatch(List<SourceMethod> candidates, SourceMethod method,

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -89,7 +89,7 @@ public enum Message {
     GENERAL_VALID_DATE( "Given date format \"%s\" is valid.", Diagnostic.Kind.NOTE ),
     GENERAL_INVALID_DATE( "Given date format \"%s\" is invalid. Message: \"%s\"." ),
     GENERAL_NOT_ALL_FORGED_CREATED( "Internal Error in creation of Forged Methods, it was expected all Forged Methods to finished with creation, but %s did not" ),
-    GENERAL_NO_SUITABLE_CONSTRUCTOR( "%s does not have a suitable empty constructor." ),
+    GENERAL_NO_SUITABLE_CONSTRUCTOR( "%s does not have an accessible empty constructor." ),
 
     RETRIEVAL_NO_INPUT_ARGS( "Can't generate mapping method with no input arguments." ),
     RETRIEVAL_DUPLICATE_MAPPING_TARGETS( "Can't generate mapping method with more than one @MappingTarget parameter." ),

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -89,6 +89,7 @@ public enum Message {
     GENERAL_VALID_DATE( "Given date format \"%s\" is valid.", Diagnostic.Kind.NOTE ),
     GENERAL_INVALID_DATE( "Given date format \"%s\" is invalid. Message: \"%s\"." ),
     GENERAL_NOT_ALL_FORGED_CREATED( "Internal Error in creation of Forged Methods, it was expected all Forged Methods to finished with creation, but %s did not" ),
+    GENERAL_NO_SUITABLE_CONSTRUCTOR( "%s does not have a suitable empty constructor." ),
 
     RETRIEVAL_NO_INPUT_ARGS( "Can't generate mapping method with no input arguments." ),
     RETRIEVAL_DUPLICATE_MAPPING_TARGETS( "Can't generate mapping method with more than one @MappingTarget parameter." ),
@@ -111,7 +112,6 @@ public enum Message {
     INHERITINVERSECONFIGURATION_DUPLICATES( "Several matching inverse methods exist: %s(). Specify a name explicitly." ),
     INHERITINVERSECONFIGURATION_INVALID_NAME( "None of the candidates %s() matches given name: \"%s\"." ),
     INHERITINVERSECONFIGURATION_DUPLICATE_MATCHES( "Given name \"%s\" matches several candidate methods: %s." ),
-    INHERITINVERSECONFIGURATION_NO_SUITABLE_CONSTRUCTOR( "There is no suitable result type constructor for reversing this method." ),
     INHERITINVERSECONFIGURATION_NO_NAME_MATCH( "Given name \"%s\" does not match the only candidate. Did you mean: \"%s\"." ),
     INHERITCONFIGURATION_DUPLICATES( "Several matching methods exist: %s(). Specify a name explicitly." ),
     INHERITCONFIGURATION_INVALIDNAME( "None of the candidates %s() matches given name: \"%s\"." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1242/Issue1242Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1242/Issue1242Test.java
@@ -76,7 +76,11 @@ public class Issue1242Test {
                     + " .*TargetB .*TargetFactories\\.createTargetB\\(.*SourceB source,"
                     + " @TargetType .*Class<.*TargetB> clazz\\),"
                     + " .*TargetB .*TargetFactories\\.createTargetB\\(@TargetType java.lang.Class<.*TargetB> clazz\\),"
-                    + " .*TargetB .*TargetFactories\\.createTargetB\\(\\).")
+                    + " .*TargetB .*TargetFactories\\.createTargetB\\(\\)."),
+            @Diagnostic(type = ErroneousIssue1242MapperMultipleSources.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 33,
+                messageRegExp = ".*TargetB does not have a suitable empty constructor\\.")
         })
     public void ambiguousMethodErrorForTwoFactoryMethodsWithSourceParam() {
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1242/Issue1242Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1242/Issue1242Test.java
@@ -80,7 +80,7 @@ public class Issue1242Test {
             @Diagnostic(type = ErroneousIssue1242MapperMultipleSources.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 33,
-                messageRegExp = ".*TargetB does not have a suitable empty constructor\\.")
+                messageRegExp = ".*TargetB does not have an accessible empty constructor\\.")
         })
     public void ambiguousMethodErrorForTwoFactoryMethodsWithSourceParam() {
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/ErroneousInverseTargetHasNoSuitableConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/ErroneousInverseTargetHasNoSuitableConstructorMapper.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1283;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface ErroneousInverseTargetHasNoSuitableConstructorMapper {
+
+    @Mapping(target = "target", source = "source")
+    Target fromSource(Source source);
+
+    @InheritInverseConfiguration
+    Source fromTarget(Target target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/ErroneousTargetHasNoSuitableConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/ErroneousTargetHasNoSuitableConstructorMapper.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1283;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface ErroneousTargetHasNoSuitableConstructorMapper {
+
+    @Mapping(target = "source", source = "target")
+    Source fromTarget(Target target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/Issue1283Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/Issue1283Test.java
@@ -16,11 +16,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.erroneous.ambiguousfactorymethod;
+package org.mapstruct.ap.test.bugs._1283;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mapstruct.ap.test.erroneous.ambiguousfactorymethod.a.BarFactory;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
@@ -29,35 +28,43 @@ import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutco
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
 /**
- * @author Sjaak Derksen
+ * @author Filip Hrisafov
  */
-@IssueKey("81")
+@IssueKey("1283")
+@RunWith(AnnotationProcessorTestRunner.class)
 @WithClasses({
-    Bar.class, Foo.class, BarFactory.class, Source.class, SourceTargetMapperAndBarFactory.class,
+    Source.class,
     Target.class
 })
-@RunWith(AnnotationProcessorTestRunner.class)
-public class FactoryTest {
+public class Issue1283Test {
 
     @Test
-    @IssueKey("81")
+    @WithClasses(ErroneousInverseTargetHasNoSuitableConstructorMapper.class)
     @ExpectedCompilationOutcome(
         value = CompilationResult.FAILED,
         diagnostics = {
-            @Diagnostic(type = SourceTargetMapperAndBarFactory.class,
+            @Diagnostic(type = ErroneousInverseTargetHasNoSuitableConstructorMapper.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
-                line = 35,
-                messageRegExp = "Ambiguous factory methods found for creating "
-                        + "org.mapstruct.ap.test.erroneous.ambiguousfactorymethod.Bar: "
-                        + "org.mapstruct.ap.test.erroneous.ambiguousfactorymethod.Bar createBar\\(\\), "
-                        + "org.mapstruct.ap.test.erroneous.ambiguousfactorymethod.Bar .*BarFactory.createBar\\(\\)."),
-            @Diagnostic(type = SourceTargetMapperAndBarFactory.class,
-                kind = javax.tools.Diagnostic.Kind.ERROR,
-                line = 35,
-                messageRegExp = ".*\\.ambiguousfactorymethod\\.Bar does not have a suitable empty constructor\\.")
-
+                line = 35L,
+                messageRegExp = ".*\\._1283\\.Source does not have a suitable empty constructor"
+            )
         }
     )
-    public void shouldUseTwoFactoryMethods() {
+    public void inheritInverseConfigurationReturnTypeHasNoSuitableConstructor() {
+    }
+
+    @Test
+    @WithClasses(ErroneousTargetHasNoSuitableConstructorMapper.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousTargetHasNoSuitableConstructorMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 31L,
+                messageRegExp = ".*\\._1283\\.Source does not have a suitable empty constructor"
+            )
+        }
+    )
+    public void returnTypeHasNoSuitableConstructor() {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/Issue1283Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/Issue1283Test.java
@@ -46,7 +46,7 @@ public class Issue1283Test {
             @Diagnostic(type = ErroneousInverseTargetHasNoSuitableConstructorMapper.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 35L,
-                messageRegExp = ".*\\._1283\\.Source does not have a suitable empty constructor"
+                messageRegExp = ".*\\._1283\\.Source does not have an accessible empty constructor"
             )
         }
     )
@@ -61,7 +61,7 @@ public class Issue1283Test {
             @Diagnostic(type = ErroneousTargetHasNoSuitableConstructorMapper.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 31L,
-                messageRegExp = ".*\\._1283\\.Source does not have a suitable empty constructor"
+                messageRegExp = ".*\\._1283\\.Source does not have an accessible empty constructor"
             )
         }
     )

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/Source.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1283;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Source {
+
+    private String source;
+
+    public Source(String source) {
+        this.source = source;
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public void setSource(String source) {
+        this.source = source;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/Target.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1283;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Target {
+
+    private String target;
+
+    public String getTarget() {
+        return target;
+    }
+
+    public void setTarget(String target) {
+        this.target = target;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/AmbiguousAnnotatedFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/AmbiguousAnnotatedFactoryTest.java
@@ -49,7 +49,13 @@ public class AmbiguousAnnotatedFactoryTest {
                         + "createBar\\(org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod.Foo foo\\), "
                         + "org.mapstruct.ap.test.erroneous.ambiguousannotatedfactorymethod.Bar "
                         + ".*AmbiguousBarFactory.createBar\\(org.mapstruct.ap.test.erroneous."
-                        + "ambiguousannotatedfactorymethod.Foo foo\\)." )
+                    + "ambiguousannotatedfactorymethod.Foo foo\\)."),
+            @Diagnostic(type = SourceTargetMapperAndBarFactory.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 35,
+                messageRegExp = ".*\\.ambiguousannotatedfactorymethod.Bar does not have a suitable empty " +
+                    "constructor\\.")
+
         }
     )
     public void shouldUseTwoFactoryMethods() {

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/AmbiguousAnnotatedFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/AmbiguousAnnotatedFactoryTest.java
@@ -53,7 +53,7 @@ public class AmbiguousAnnotatedFactoryTest {
             @Diagnostic(type = SourceTargetMapperAndBarFactory.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 35,
-                messageRegExp = ".*\\.ambiguousannotatedfactorymethod.Bar does not have a suitable empty " +
+                messageRegExp = ".*\\.ambiguousannotatedfactorymethod.Bar does not have an accessible empty " +
                     "constructor\\.")
 
         }

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousfactorymethod/FactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousfactorymethod/FactoryTest.java
@@ -54,7 +54,7 @@ public class FactoryTest {
             @Diagnostic(type = SourceTargetMapperAndBarFactory.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 35,
-                messageRegExp = ".*\\.ambiguousfactorymethod\\.Bar does not have a suitable empty constructor\\.")
+                messageRegExp = ".*\\.ambiguousfactorymethod\\.Bar does not have an accessible empty constructor\\.")
 
         }
     )

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/NestedSourcePropertiesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/NestedSourcePropertiesTest.java
@@ -184,7 +184,7 @@ public class NestedSourcePropertiesTest {
                 @Diagnostic( type = ArtistToChartEntryErroneous.class,
                         kind = javax.tools.Diagnostic.Kind.ERROR,
                         line = 46,
-                        messageRegExp = "There is no suitable result type constructor for reversing this method\\." )
+                        messageRegExp = "Unknown property \"position\" in result type java\\.lang\\.Integer\\." )
             }
     )
     @WithClasses({ ArtistToChartEntryErroneous.class })

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
@@ -181,8 +181,8 @@ public class ConversionTest {
             @Diagnostic(type = ErroneousSourceTargetMapper6.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 29,
-                messageRegExp = ".*\\.generics\\.WildCardSuperWrapper<.*\\.generics\\.TypeA> does not have a suitable" +
-                    " empty constructor\\.")
+                messageRegExp = ".*\\.generics\\.WildCardSuperWrapper<.*\\.generics\\.TypeA> does not have an " +
+                    "accessible empty constructor\\.")
 
         })
     public void shouldFailOnNonMatchingWildCards() {

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
@@ -177,7 +177,13 @@ public class ConversionTest {
                 messageRegExp = "Can't map property \".*NoProperties "
                     + "foo\\.wrapped\" to"
                     + " \"org.mapstruct.ap.test.selection.generics.TypeA " +
-                    "foo\\.wrapped\"")
+                    "foo\\.wrapped\""),
+            @Diagnostic(type = ErroneousSourceTargetMapper6.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 29,
+                messageRegExp = ".*\\.generics\\.WildCardSuperWrapper<.*\\.generics\\.TypeA> does not have a suitable" +
+                    " empty constructor\\.")
+
         })
     public void shouldFailOnNonMatchingWildCards() {
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/ErroneousResultTypeNoEmptyConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/ErroneousResultTypeNoEmptyConstructorMapper.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.selection.resulttype;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface ErroneousResultTypeNoEmptyConstructorMapper {
+
+    @BeanMapping(resultType = Banana.class)
+    @Mapping(target = "type", ignore = true)
+    Fruit map(FruitDto source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
@@ -60,10 +60,29 @@ public class InheritanceSelectionTest {
                 line = 36,
                 messageRegExp = "Ambiguous factory methods found for creating .*Fruit: "
                     + ".*Apple .*ConflictingFruitFactory\\.createApple\\(\\), "
-                    + ".*Banana .*ConflictingFruitFactory\\.createBanana\\(\\)\\.")
+                    + ".*Banana .*ConflictingFruitFactory\\.createBanana\\(\\)\\."),
+            @Diagnostic(type = ErroneousFruitMapper.class,
+                kind = Kind.ERROR,
+                line = 36,
+                messageRegExp = ".*Fruit does not have a suitable empty constructor\\.")
         }
     )
     public void testForkedInheritanceHierarchyShouldResultInAmbigousMappingMethod() {
+    }
+
+    @IssueKey("1283")
+    @Test
+    @WithClasses( { ErroneousResultTypeNoEmptyConstructorMapper.class, Banana.class } )
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousResultTypeNoEmptyConstructorMapper.class,
+                kind = Kind.ERROR,
+                line = 31,
+                messageRegExp = ".*\\.resulttype\\.Banana does not have a suitable empty constructor\\.")
+        }
+    )
+    public void testResultTypeHasNoSuitableEmptyConstructor() {
     }
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
@@ -64,7 +64,7 @@ public class InheritanceSelectionTest {
             @Diagnostic(type = ErroneousFruitMapper.class,
                 kind = Kind.ERROR,
                 line = 36,
-                messageRegExp = ".*Fruit does not have a suitable empty constructor\\.")
+                messageRegExp = ".*Fruit does not have an accessible empty constructor\\.")
         }
     )
     public void testForkedInheritanceHierarchyShouldResultInAmbigousMappingMethod() {
@@ -79,7 +79,7 @@ public class InheritanceSelectionTest {
             @Diagnostic(type = ErroneousResultTypeNoEmptyConstructorMapper.class,
                 kind = Kind.ERROR,
                 line = 31,
-                messageRegExp = ".*\\.resulttype\\.Banana does not have a suitable empty constructor\\.")
+                messageRegExp = ".*\\.resulttype\\.Banana does not have an accessible empty constructor\\.")
         }
     )
     public void testResultTypeHasNoSuitableEmptyConstructor() {

--- a/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
@@ -188,7 +188,8 @@ public class UpdateMethodsTest {
             @Diagnostic(type = ErroneousOrganizationMapper2.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 48,
-                messageRegExp = ".*\\.updatemethods\\.DepartmentEntity does not have a suitable empty constructor\\.")
+                messageRegExp = ".*\\.updatemethods\\.DepartmentEntity does not have an accessible empty " +
+                    "constructor\\.")
 
         })
     public void testShouldFailOnConstantMappingNoPropertyGetter() { }

--- a/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
@@ -184,8 +184,13 @@ public class UpdateMethodsTest {
             @Diagnostic(type = ErroneousOrganizationMapper2.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 37,
-                messageRegExp = "No read accessor found for property \"type\" in target type.")
-    } )
+                messageRegExp = "No read accessor found for property \"type\" in target type."),
+            @Diagnostic(type = ErroneousOrganizationMapper2.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 48,
+                messageRegExp = ".*\\.updatemethods\\.DepartmentEntity does not have a suitable empty constructor\\.")
+
+        })
     public void testShouldFailOnConstantMappingNoPropertyGetter() { }
 
     @Test


### PR DESCRIPTION
Fixes #1283.

This PR fixes #1283 by moving the no suitable empty constructor check during the `BeanMappingMethod` creation (only if there is no factory method). With this we additionally get the same check for non-reverse methods and `BeanMapping#resultType`