### PR TITLE
#1304 Add thrown exceptions to the generated nested mapping methods

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -226,6 +226,10 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             List<LifecycleCallbackMethodReference> afterMappingMethods =
                 LifecycleCallbackFactory.afterMappingMethods( method, selectionParameters, ctx, existingVariableNames );
 
+            if (factoryMethod != null && method instanceof ForgedMethod ) {
+                ( (ForgedMethod) method ).addThrownTypes( factoryMethod.getThrownTypes() );
+            }
+
             return new BeanMappingMethod(
                 method,
                 existingVariableNames,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
@@ -107,12 +107,7 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
         if ( assignment == null ) {
             assignment = forgeMapping( sourceRHS, sourceElementType, targetElementType );
         }
-        else {
-            if ( method instanceof ForgedMethod ) {
-                ForgedMethod forgedMethod = (ForgedMethod) method;
-                forgedMethod.addThrownTypes( assignment.getThrownTypes() );
-            }
-        }
+
         if ( assignment == null ) {
             if ( method instanceof ForgedMethod ) {
                 // leave messaging to calling property mapping
@@ -127,6 +122,10 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
                     ""
                 );
             }
+        }
+        else if ( method instanceof ForgedMethod ) {
+            ForgedMethod forgedMethod = (ForgedMethod) method;
+            forgedMethod.addThrownTypes( assignment.getThrownTypes() );
         }
 
         assignment = getWrapper( assignment, method );

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/EntityFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/EntityFactory.java
@@ -1,0 +1,48 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans.exceptions;
+
+import org.mapstruct.ObjectFactory;
+import org.mapstruct.TargetType;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class EntityFactory {
+
+    @ObjectFactory
+    public <T> T createEntity(@TargetType Class<T> entityClass) throws MappingException {
+        T entity;
+
+        try {
+            entity = entityClass.newInstance();
+        }
+        catch ( IllegalAccessException exception ) {
+            throw new MappingException( "Rare exception thrown, refer to stack trace", exception );
+        }
+        catch ( InstantiationException exception ) {
+            throw new MappingException( "Rare exception thrown, refer to stack trace", exception );
+        }
+        catch ( Exception exception ) {
+            throw new MappingException( "I don't know how you got here, refer to stack trace", exception );
+        }
+
+        return entity;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/EntityFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/EntityFactory.java
@@ -23,6 +23,7 @@ import org.mapstruct.TargetType;
 
 /**
  * @author Filip Hrisafov
+ * @author Darren Rambaud
  */
 public class EntityFactory {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/MappingException.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/MappingException.java
@@ -1,0 +1,29 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans.exceptions;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class MappingException extends Exception {
+
+    public MappingException(String message, Throwable cause) {
+        super( message, cause );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/MappingException.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/MappingException.java
@@ -20,6 +20,7 @@ package org.mapstruct.ap.test.nestedbeans.exceptions;
 
 /**
  * @author Filip Hrisafov
+ * @author Darren Rambaud
  */
 public class MappingException extends Exception {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/NestedMappingsWithExceptionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/NestedMappingsWithExceptionTest.java
@@ -1,0 +1,51 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans.exceptions;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.nestedbeans.exceptions._target.DeveloperDto;
+import org.mapstruct.ap.test.nestedbeans.exceptions._target.ProjectDto;
+import org.mapstruct.ap.test.nestedbeans.exceptions.source.Developer;
+import org.mapstruct.ap.test.nestedbeans.exceptions.source.Project;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses({
+    DeveloperDto.class,
+    ProjectDto.class,
+    Developer.class,
+    Project.class,
+    ProjectMapper.class,
+    MappingException.class,
+    EntityFactory.class
+})
+@IssueKey("1304")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class NestedMappingsWithExceptionTest {
+
+    @Test
+    public void shouldGenerateCodeThatCompiles() {
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/ProjectMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/ProjectMapper.java
@@ -24,6 +24,7 @@ import org.mapstruct.ap.test.nestedbeans.exceptions.source.Project;
 
 /**
  * @author Filip Hrisafov
+ * @author Darren Rambaud
  */
 @Mapper(uses = EntityFactory.class)
 public interface ProjectMapper {

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/ProjectMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/ProjectMapper.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans.exceptions;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.nestedbeans.exceptions._target.ProjectDto;
+import org.mapstruct.ap.test.nestedbeans.exceptions.source.Project;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(uses = EntityFactory.class)
+public interface ProjectMapper {
+
+    Project map(ProjectDto source) throws MappingException;
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/DeveloperDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/DeveloperDto.java
@@ -20,6 +20,7 @@ package org.mapstruct.ap.test.nestedbeans.exceptions._target;
 
 /**
  * @author Filip Hrisafov
+ * @author Darren Rambaud
  */
 public class DeveloperDto {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/DeveloperDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/DeveloperDto.java
@@ -24,25 +24,7 @@ package org.mapstruct.ap.test.nestedbeans.exceptions._target;
  */
 public class DeveloperDto {
 
-    private Long id;
-
     private String firstName;
-
-    private String lastName;
-
-    private String department;
-
-    private Integer experience;
-
-    private Double salary;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getFirstName() {
         return firstName;
@@ -50,37 +32,5 @@ public class DeveloperDto {
 
     public void setFirstName(String firstName) {
         this.firstName = firstName;
-    }
-
-    public String getLastName() {
-        return lastName;
-    }
-
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
-    }
-
-    public String getDepartment() {
-        return department;
-    }
-
-    public void setDepartment(String department) {
-        this.department = department;
-    }
-
-    public Integer getExperience() {
-        return experience;
-    }
-
-    public void setExperience(Integer experience) {
-        this.experience = experience;
-    }
-
-    public Double getSalary() {
-        return salary;
-    }
-
-    public void setSalary(Double salary) {
-        this.salary = salary;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/DeveloperDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/DeveloperDto.java
@@ -1,0 +1,85 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans.exceptions._target;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class DeveloperDto {
+
+    private Long id;
+
+    private String firstName;
+
+    private String lastName;
+
+    private String department;
+
+    private Integer experience;
+
+    private Double salary;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public Integer getExperience() {
+        return experience;
+    }
+
+    public void setExperience(Integer experience) {
+        this.experience = experience;
+    }
+
+    public Double getSalary() {
+        return salary;
+    }
+
+    public void setSalary(Double salary) {
+        this.salary = salary;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/ProjectDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/ProjectDto.java
@@ -1,0 +1,97 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans.exceptions._target;
+
+import java.util.List;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class ProjectDto {
+    private Long id;
+
+    private String name;
+
+    private Integer priority;
+
+    private List<DeveloperDto> assignedDevelopers;
+
+    private Double burnDownRate;
+
+    private Integer hoursWasted;
+
+    private Long potentialCashFlow;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Integer priority) {
+        this.priority = priority;
+    }
+
+    public List<DeveloperDto> getAssignedDevelopers() {
+        return assignedDevelopers;
+    }
+
+    public void setAssignedDevelopers(
+        List<DeveloperDto> assignedDevelopers) {
+        this.assignedDevelopers = assignedDevelopers;
+    }
+
+    public Double getBurnDownRate() {
+        return burnDownRate;
+    }
+
+    public void setBurnDownRate(Double burnDownRate) {
+        this.burnDownRate = burnDownRate;
+    }
+
+    public Integer getHoursWasted() {
+        return hoursWasted;
+    }
+
+    public void setHoursWasted(Integer hoursWasted) {
+        this.hoursWasted = hoursWasted;
+    }
+
+    public Long getPotentialCashFlow() {
+        return potentialCashFlow;
+    }
+
+    public void setPotentialCashFlow(Long potentialCashFlow) {
+        this.potentialCashFlow = potentialCashFlow;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/ProjectDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/ProjectDto.java
@@ -25,74 +25,14 @@ import java.util.List;
  * @author Darren Rambaud
  */
 public class ProjectDto {
-    private Long id;
-
-    private String name;
-
-    private Integer priority;
 
     private List<DeveloperDto> assignedDevelopers;
-
-    private Double burnDownRate;
-
-    private Integer hoursWasted;
-
-    private Long potentialCashFlow;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public Integer getPriority() {
-        return priority;
-    }
-
-    public void setPriority(Integer priority) {
-        this.priority = priority;
-    }
 
     public List<DeveloperDto> getAssignedDevelopers() {
         return assignedDevelopers;
     }
 
-    public void setAssignedDevelopers(
-        List<DeveloperDto> assignedDevelopers) {
+    public void setAssignedDevelopers(List<DeveloperDto> assignedDevelopers) {
         this.assignedDevelopers = assignedDevelopers;
-    }
-
-    public Double getBurnDownRate() {
-        return burnDownRate;
-    }
-
-    public void setBurnDownRate(Double burnDownRate) {
-        this.burnDownRate = burnDownRate;
-    }
-
-    public Integer getHoursWasted() {
-        return hoursWasted;
-    }
-
-    public void setHoursWasted(Integer hoursWasted) {
-        this.hoursWasted = hoursWasted;
-    }
-
-    public Long getPotentialCashFlow() {
-        return potentialCashFlow;
-    }
-
-    public void setPotentialCashFlow(Long potentialCashFlow) {
-        this.potentialCashFlow = potentialCashFlow;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/ProjectDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/_target/ProjectDto.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 /**
  * @author Filip Hrisafov
+ * @author Darren Rambaud
  */
 public class ProjectDto {
     private Long id;

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Developer.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Developer.java
@@ -1,0 +1,85 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans.exceptions.source;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Developer {
+
+    private Long id;
+
+    private String firstName;
+
+    private String lastName;
+
+    private String department;
+
+    private Integer experience;
+
+    private Double salary;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public String getDepartment() {
+        return department;
+    }
+
+    public void setDepartment(String department) {
+        this.department = department;
+    }
+
+    public Integer getExperience() {
+        return experience;
+    }
+
+    public void setExperience(Integer experience) {
+        this.experience = experience;
+    }
+
+    public Double getSalary() {
+        return salary;
+    }
+
+    public void setSalary(Double salary) {
+        this.salary = salary;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Developer.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Developer.java
@@ -20,6 +20,7 @@ package org.mapstruct.ap.test.nestedbeans.exceptions.source;
 
 /**
  * @author Filip Hrisafov
+ * @author Darren Rambaud
  */
 public class Developer {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Developer.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Developer.java
@@ -24,25 +24,7 @@ package org.mapstruct.ap.test.nestedbeans.exceptions.source;
  */
 public class Developer {
 
-    private Long id;
-
     private String firstName;
-
-    private String lastName;
-
-    private String department;
-
-    private Integer experience;
-
-    private Double salary;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
 
     public String getFirstName() {
         return firstName;
@@ -50,37 +32,5 @@ public class Developer {
 
     public void setFirstName(String firstName) {
         this.firstName = firstName;
-    }
-
-    public String getLastName() {
-        return lastName;
-    }
-
-    public void setLastName(String lastName) {
-        this.lastName = lastName;
-    }
-
-    public String getDepartment() {
-        return department;
-    }
-
-    public void setDepartment(String department) {
-        this.department = department;
-    }
-
-    public Integer getExperience() {
-        return experience;
-    }
-
-    public void setExperience(Integer experience) {
-        this.experience = experience;
-    }
-
-    public Double getSalary() {
-        return salary;
-    }
-
-    public void setSalary(Double salary) {
-        this.salary = salary;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Project.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Project.java
@@ -26,74 +26,13 @@ import java.util.List;
  */
 public class Project {
 
-    private Long id;
-
-    private String name;
-
-    private Integer priority;
-
     private List<Developer> assignedDevelopers;
-
-    private Double burnDownRate;
-
-    private Integer hoursWasted;
-
-    private Long potentialCashFlow;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public Integer getPriority() {
-        return priority;
-    }
-
-    public void setPriority(Integer priority) {
-        this.priority = priority;
-    }
 
     public List<Developer> getAssignedDevelopers() {
         return assignedDevelopers;
     }
 
-    public void setAssignedDevelopers(
-        List<Developer> assignedDevelopers) {
+    public void setAssignedDevelopers(List<Developer> assignedDevelopers) {
         this.assignedDevelopers = assignedDevelopers;
-    }
-
-    public Double getBurnDownRate() {
-        return burnDownRate;
-    }
-
-    public void setBurnDownRate(Double burnDownRate) {
-        this.burnDownRate = burnDownRate;
-    }
-
-    public Integer getHoursWasted() {
-        return hoursWasted;
-    }
-
-    public void setHoursWasted(Integer hoursWasted) {
-        this.hoursWasted = hoursWasted;
-    }
-
-    public Long getPotentialCashFlow() {
-        return potentialCashFlow;
-    }
-
-    public void setPotentialCashFlow(Long potentialCashFlow) {
-        this.potentialCashFlow = potentialCashFlow;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Project.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Project.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 /**
  * @author Filip Hrisafov
+ * @author Darren Rambaud
  */
 public class Project {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Project.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/source/Project.java
@@ -1,0 +1,98 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedbeans.exceptions.source;
+
+import java.util.List;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Project {
+
+    private Long id;
+
+    private String name;
+
+    private Integer priority;
+
+    private List<Developer> assignedDevelopers;
+
+    private Double burnDownRate;
+
+    private Integer hoursWasted;
+
+    private Long potentialCashFlow;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Integer priority) {
+        this.priority = priority;
+    }
+
+    public List<Developer> getAssignedDevelopers() {
+        return assignedDevelopers;
+    }
+
+    public void setAssignedDevelopers(
+        List<Developer> assignedDevelopers) {
+        this.assignedDevelopers = assignedDevelopers;
+    }
+
+    public Double getBurnDownRate() {
+        return burnDownRate;
+    }
+
+    public void setBurnDownRate(Double burnDownRate) {
+        this.burnDownRate = burnDownRate;
+    }
+
+    public Integer getHoursWasted() {
+        return hoursWasted;
+    }
+
+    public void setHoursWasted(Integer hoursWasted) {
+        this.hoursWasted = hoursWasted;
+    }
+
+    public Long getPotentialCashFlow() {
+        return potentialCashFlow;
+    }
+
+    public void setPotentialCashFlow(Long potentialCashFlow) {
+        this.potentialCashFlow = potentialCashFlow;
+    }
+}


### PR DESCRIPTION
Fixes #1304.

Exceptions that can be thrown in assignments in nested methods are added to the throws clause to the generated nested methods as well