### PR TITLE
#1320 Properly create additional options for unprocessed defined targets

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -650,10 +650,9 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             if ( unprocessedDefinedTargets.containsKey( targetProperty ) ) {
 
                 Map<String, List<Mapping>> mappings = new HashMap<String, List<Mapping>>();
-                mappings.put(
-                    targetProperty,
-                    unprocessedDefinedTargets.get( targetProperty )
-                );
+                for ( Mapping mapping : unprocessedDefinedTargets.get( targetProperty ) ) {
+                    mappings.put( mapping.getTargetName(), Collections.singletonList( mapping ) );
+                }
                 additionalOptions = MappingOptions.forMappingsOnly( mappings, restrictToDefinedMappings );
             }
             return additionalOptions;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1320/Issue1320Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1320/Issue1320Mapper.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1320;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue1320Mapper {
+
+    Issue1320Mapper INSTANCE = Mappers.getMapper( Issue1320Mapper.class );
+
+    @Mappings({
+        @Mapping(target = "address.city.cityName", constant = "myCity"),
+        @Mapping(target = "address.city.stateName", constant = "myState")
+    })
+    Target map(Integer dummy);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1320/Issue1320Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1320/Issue1320Test.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1320;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("1320")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    Issue1320Mapper.class,
+    Target.class
+})
+public class Issue1320Test {
+
+    @Test
+    public void shouldCreateDeepNestedConstantsCorrectly() {
+        Target target = Issue1320Mapper.INSTANCE.map( 10 );
+
+        assertThat( target.getAddress() ).isNotNull();
+        assertThat( target.getAddress().getCity() ).isNotNull();
+        assertThat( target.getAddress().getCity().getCityName() ).isEqualTo( "myCity" );
+        assertThat( target.getAddress().getCity().getStateName() ).isEqualTo( "myState" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1320/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1320/Target.java
@@ -1,0 +1,68 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1320;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Target {
+
+    private Address address;
+
+    public Address getAddress() {
+        return address;
+    }
+
+    public void setAddress(Address address) {
+        this.address = address;
+    }
+
+    public static class Address {
+        private City city;
+
+        public City getCity() {
+            return city;
+        }
+
+        public void setCity(City city) {
+            this.city = city;
+        }
+    }
+
+    public static class City {
+        private String cityName;
+        private String stateName;
+
+        public String getCityName() {
+            return cityName;
+        }
+
+        public void setCityName(String cityName) {
+            this.cityName = cityName;
+        }
+
+        public String getStateName() {
+            return stateName;
+        }
+
+        public void setStateName(String stateName) {
+            this.stateName = stateName;
+        }
+    }
+}


### PR DESCRIPTION
Create mappings for each unprocessed defined target based on their name and the mapping.

Fixes #1320.

@sjaakd guess what, the `Map<String, List<Mapping>>` hitting us again :). Really looking forward to 2.0.