### PR TITLE
#1332 Fix exceptions declaration missing in nested mapping methods

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -504,6 +504,7 @@ public class PropertyMapping extends ModelElement {
                 NestedPropertyMappingMethod nestedPropertyMapping = builder
                     .method( methodRef )
                     .propertyEntries( sourceReference.getPropertyEntries() )
+                    .mappingContext( ctx )
                     .build();
 
                 // add if not yet existing

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -382,7 +382,24 @@ public class TypeFactory {
     public List<Type> getThrownTypes(ExecutableType method) {
         List<Type> thrownTypes = new ArrayList<Type>();
         for ( TypeMirror exceptionType : method.getThrownTypes() ) {
-            thrownTypes.add( getType( exceptionType ) );
+            Type t = getType( exceptionType );
+            if (!thrownTypes.contains( t )) {
+                thrownTypes.add( t );
+            }
+        }
+        return thrownTypes;
+    }
+
+    public List<Type> getThrownTypes(Accessor accessor) {
+        if (accessor.getExecutable() == null) {
+            return new ArrayList<Type>();
+        }
+        List<Type> thrownTypes = new ArrayList<Type>();
+        for (TypeMirror thrownType : accessor.getExecutable().getThrownTypes()) {
+            Type t = getType( thrownType );
+            if (!thrownTypes.contains( t )) {
+                thrownTypes.add( t );
+            }
         }
         return thrownTypes;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-<#lt>private <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>) {
+<#lt>private <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     if ( ${sourceParameter.name} == null ) {
         return ${returnType.null};
     }
@@ -43,3 +43,11 @@
 </#list>
 }
 <#macro localVarName index><#if index == 0>${sourceParameter.name}<#else>${propertyEntries[index-1].name}</#if></#macro>
+<#macro throws>
+    <#if (thrownTypes?size > 0)><#lt> throws </#if><@compress single_line=true>
+        <#list thrownTypes as exceptionType>
+            <@includeModel object=exceptionType/>
+            <#if exceptionType_has_next>, </#if><#t>
+        </#list>
+    </@compress>
+</#macro>

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/Bucket.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/Bucket.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedsource.exceptions;
+
+/**
+ *
+ * @author Richard Lea <chigix@zoho.com>
+ */
+public class Bucket {
+
+    String userId;
+
+    public Bucket(String userId) {
+        this.userId = userId;
+    }
+
+    public User getUser() throws NoSuchUser {
+        throw new NoSuchUser();
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/NestedExceptionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/NestedExceptionTest.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedsource.exceptions;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ *
+ * @author Richard Lea <chigix@zoho.com>
+ */
+@WithClasses({
+    Bucket.class,
+    User.class,
+    Resource.class,
+    ResourceDto.class,
+    NoSuchUser.class,
+    ResourceMapper.class
+})
+@IssueKey("1332")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class NestedExceptionTest {
+
+    @Test
+    public void shouldGenerateCodeThatCompiles() {
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/NoSuchUser.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/NoSuchUser.java
@@ -1,0 +1,30 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedsource.exceptions;
+
+/**
+ *
+ * @author Richard Lea <chigix@zoho.com>
+ */
+public class NoSuchUser extends Exception {
+
+    public NoSuchUser() {
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/Resource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/Resource.java
@@ -1,0 +1,32 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedsource.exceptions;
+
+/**
+ *
+ * @author Richard Lea <chigix@zoho.com>
+ */
+public class Resource {
+
+    private final Bucket bucket = new Bucket("2345");
+
+    public Bucket getBucket() {
+        return bucket;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/ResourceDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/ResourceDto.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedsource.exceptions;
+
+/**
+ *
+ * @author Richard Lea <chigix@zoho.com>
+ */
+public class ResourceDto {
+
+    private String userId;
+
+    public String getUserId() {
+        return userId;
+    }
+
+    public void setUserId(String userId) {
+        this.userId = userId;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/ResourceMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/ResourceMapper.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedsource.exceptions;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+/**
+ *
+ * @author Richard Lea <chigix@zoho.com>
+ */
+@Mapper()
+public interface ResourceMapper {
+
+    @Mappings({
+        @Mapping(source = "bucket.user.uuid", target = "userId")
+    })
+    ResourceDto map(Resource r) throws NoSuchUser;
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/User.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsource/exceptions/User.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.nestedsource.exceptions;
+
+/**
+ *
+ * @author Richard Lea <chigix@zoho.com>
+ */
+public class User {
+
+    private final String uuid;
+
+    private final String name;
+
+    public User(String uuid, String name) {
+        this.uuid = uuid;
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getUuid() {
+        return uuid;
+    }
+
+}


### PR DESCRIPTION
Issue occurs when exceptions declared in nested source mapping, which would make compilation failures for unreported exceptions.

Reference to the testing case: https://github.com/chigix/mapstruct/tree/Exception_in_nested_mapping

Signed-off-by: RichardLea <chigix@zoho.com>