### PR TITLE
When adder has multi candidates, check element name match pluralPropertyName

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -589,7 +589,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         else {
             for ( Accessor candidate : candidates ) {
                 String elementName = Executables.getElementNameForAdder( candidate );
-                if ( elementName != null && elementName.equals( Nouns.singularize( pluralPropertyName ) ) ) {
+                if ( elementName != null && ( elementName.equals( pluralPropertyName ) || elementName.equals( Nouns.singularize( pluralPropertyName ) ) ) ) {
                     return candidate;
                 }
             }


### PR DESCRIPTION
Relate issues https://github.com/mapstruct/mapstruct/issues/1336

MapStruct should check adder name match "expected plural name" not only singularize property name.