### PR TITLE
Correctly use value mapping source parameters

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/EnumMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/EnumMappingMethod.java
@@ -209,6 +209,6 @@ public class EnumMappingMethod extends MappingMethod {
     }
 
     public Parameter getSourceParameter() {
-        return first( getParameters() );
+        return first( getSourceParameters() );
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
@@ -284,7 +284,7 @@ public class ValueMappingMethod extends MappingMethod {
     }
 
     public Parameter getSourceParameter() {
-        return first( getParameters() );
+        return first( getSourceParameters() );
     }
 
     public boolean isOverridden() {

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/EnumMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/EnumMappingMethod.ftl
@@ -20,7 +20,7 @@
 
 -->
 @Override
-public <@includeModel object=returnType/> ${name}(<@includeModel object=sourceParameter/>) {
+public <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>) {
     <#list beforeMappingReferencesWithoutMappingTarget as callback>
         <@includeModel object=callback targetBeanName=resultName targetType=resultType/>
         <#if !callback_has_next>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
@@ -20,7 +20,7 @@
 
 -->
 <#if overridden>@Override</#if>
-<#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<@includeModel object=sourceParameter/>) {
+<#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>) {
     <#list beforeMappingReferencesWithoutMappingTarget as callback>
         <@includeModel object=callback targetBeanName=resultName targetType=resultType/>
         <#if !callback_has_next>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1340/Issue1340Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1340/Issue1340Mapper.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1340;
+
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue1340Mapper {
+
+    Issue1340Mapper INSTANCE = Mappers.getMapper( Issue1340Mapper.class );
+
+    enum Quote {
+        SINGLE,
+        MULTI
+    }
+
+    enum QuoteDto {
+        SINGLE,
+        MULTI
+    }
+
+    QuoteDto map(Quote quote, @Context Integer locale);
+
+    Quote map(@Context Integer locale, QuoteDto quoteDto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1340/Issue1340Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1340/Issue1340Test.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1340;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses({
+    Issue1340Mapper.class
+})
+@IssueKey("1340")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue1340Test {
+
+    @Test
+    public void shouldCompile() {
+    }
+}


### PR DESCRIPTION
Fixes #1340 

* The Value / Enum Mappings should copy all the parameters from the method that is being overriden
* The source parameter should be the first source parameter