### PR TITLE
Primitive Context parameters should be skipped when looking for lifecycle methods

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -276,6 +276,9 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
 
         ParameterProvidedMethods.Builder builder = ParameterProvidedMethods.builder();
         for ( Parameter contextParam : contextParameters ) {
+            if ( contextParam.getType().isPrimitive() ) {
+                continue;
+            }
             List<SourceMethod> contextParamMethods = retrieveMethods(
                 contextParam.getType().getTypeElement(),
                 mapperToImplement,

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1339/Callback.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1339/Callback.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1339;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Context;
+import org.mapstruct.MappingTarget;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Callback {
+
+    @AfterMapping
+    public void afterMapping(@MappingTarget Issue1339Mapper.Target target, @Context int primitive) {
+        target.otherField = primitive;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1339/Issue1339Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1339/Issue1339Mapper.java
@@ -1,0 +1,51 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1339;
+
+import org.mapstruct.Context;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(uses = {
+    Callback.class
+})
+public interface Issue1339Mapper {
+
+    Issue1339Mapper INSTANCE = Mappers.getMapper( Issue1339Mapper.class );
+
+    class Source {
+        //CHECKSTYLE:OFF
+        public String field;
+        //CHECKSTYLE:ON
+    }
+
+    class Target {
+        //CHECKSTYLE:OFF
+        public String field;
+        public int otherField;
+        //CHECKSTYLE:ON
+    }
+
+    @Mapping(target = "otherField", ignore = true)
+    Target map(Source source, int primitive1, @Context int primitive2);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1339/Issue1339Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1339/Issue1339Test.java
@@ -1,0 +1,49 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1339;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses({
+    Issue1339Mapper.class,
+    Callback.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1339")
+public class Issue1339Test {
+
+    @Test
+    public void shouldCompile() {
+        Issue1339Mapper.Source source = new Issue1339Mapper.Source();
+        source.field = "test";
+        Issue1339Mapper.Target target = Issue1339Mapper.INSTANCE.map( source, 10, 50 );
+
+        assertThat( target.otherField ).isEqualTo( 50 );
+        assertThat( target.field ).isEqualTo( "test" );
+    }
+}


### PR DESCRIPTION
Fixes #1339 

Primitive context parameters should not be searched for lifecycle methods