### PR TITLE
#1353 Add a trim for source and target mappings

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
@@ -108,8 +108,14 @@ public class SourceReference {
             boolean isValid = true;
             boolean foundEntryMatch;
 
+            String sourceNameTrimmed = sourceName.trim();
+            if ( !sourceName.equals( sourceNameTrimmed ) ) {
+                messager.printMessage( method.getExecutable(), mapping.getMirror(), mapping.getSourceAnnotationValue(),
+                                       Message.PROPERTYMAPPING_WHITESPACE_TRIMMED, mapping.getSourceName()
+                );
+            }
             String[] sourcePropertyNames = new String[0];
-            String[] segments = sourceName.split( "\\." );
+            String[] segments = sourceNameTrimmed.split( "\\." );
             Parameter parameter = null;
 
             List<PropertyEntry> entries = new ArrayList<PropertyEntry>();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
@@ -110,8 +110,13 @@ public class SourceReference {
 
             String sourceNameTrimmed = sourceName.trim();
             if ( !sourceName.equals( sourceNameTrimmed ) ) {
-                messager.printMessage( method.getExecutable(), mapping.getMirror(), mapping.getSourceAnnotationValue(),
-                                       Message.PROPERTYMAPPING_WHITESPACE_TRIMMED, mapping.getSourceName()
+                messager.printMessage(
+                    method.getExecutable(),
+                    mapping.getMirror(),
+                    mapping.getSourceAnnotationValue(),
+                    Message.PROPERTYMAPPING_WHITESPACE_TRIMMED,
+                    sourceName,
+                    sourceNameTrimmed
                 );
             }
             String[] sourcePropertyNames = new String[0];

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
@@ -138,8 +138,13 @@ public class TargetReference {
                 return null;
             }
 
-
-            String[] segments = targetName.split( "\\." );
+            String targetNameTrimmed = targetName.trim();
+            if ( !targetName.equals( targetNameTrimmed ) ) {
+                messager.printMessage( method.getExecutable(), mapping.getMirror(), mapping.getSourceAnnotationValue(),
+                                       Message.PROPERTYMAPPING_WHITESPACE_TRIMMED, mapping.getTargetName()
+                );
+            }
+            String[] segments = targetNameTrimmed.split( "\\." );
             Parameter parameter = method.getMappingTargetParameter();
 
             boolean foundEntryMatch;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
@@ -140,8 +140,13 @@ public class TargetReference {
 
             String targetNameTrimmed = targetName.trim();
             if ( !targetName.equals( targetNameTrimmed ) ) {
-                messager.printMessage( method.getExecutable(), mapping.getMirror(), mapping.getSourceAnnotationValue(),
-                                       Message.PROPERTYMAPPING_WHITESPACE_TRIMMED, mapping.getTargetName()
+                messager.printMessage(
+                    method.getExecutable(),
+                    mapping.getMirror(),
+                    mapping.getTargetAnnotationValue(),
+                    Message.PROPERTYMAPPING_WHITESPACE_TRIMMED,
+                    targetName,
+                    targetNameTrimmed
                 );
             }
             String[] segments = targetNameTrimmed.split( "\\." );

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -61,7 +61,7 @@ public enum Message {
     PROPERTYMAPPING_NO_PRESENCE_CHECKER_FOR_SOURCE_TYPE( "Using custom source value presence checking strategy, but no presence checker found for %s in source type." ),
     PROPERTYMAPPING_NO_READ_ACCESSOR_FOR_TARGET_TYPE( "No read accessor found for property \"%s\" in target type." ),
     PROPERTYMAPPING_NO_WRITE_ACCESSOR_FOR_TARGET_TYPE( "No write accessor found for property \"%s\" in target type." ),
-    PROPERTYMAPPING_WHITESPACE_TRIMMED( "The property name \"%s\" has whitespace that was trimmed.", Diagnostic.Kind.WARNING ),
+    PROPERTYMAPPING_WHITESPACE_TRIMMED( "The property named \"%s\" has whitespaces, using trimmed property \"%s\" instead.", Diagnostic.Kind.WARNING ),
 
     CONSTANTMAPPING_MAPPING_NOT_FOUND( "Can't map \"%s %s\" to \"%s %s\"." ),
     CONSTANTMAPPING_NO_READ_ACCESSOR_FOR_TARGET_TYPE( "No read accessor found for property \"%s\" in target type." ),

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -61,6 +61,7 @@ public enum Message {
     PROPERTYMAPPING_NO_PRESENCE_CHECKER_FOR_SOURCE_TYPE( "Using custom source value presence checking strategy, but no presence checker found for %s in source type." ),
     PROPERTYMAPPING_NO_READ_ACCESSOR_FOR_TARGET_TYPE( "No read accessor found for property \"%s\" in target type." ),
     PROPERTYMAPPING_NO_WRITE_ACCESSOR_FOR_TARGET_TYPE( "No write accessor found for property \"%s\" in target type." ),
+    PROPERTYMAPPING_WHITESPACE_TRIMMED( "The property name \"%s\" has whitespace that was trimmed.", Diagnostic.Kind.WARNING ),
 
     CONSTANTMAPPING_MAPPING_NOT_FOUND( "Can't map \"%s %s\" to \"%s %s\"." ),
     CONSTANTMAPPING_NO_READ_ACCESSOR_FOR_TARGET_TYPE( "No read accessor found for property \"%s\" in target type." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1353/Issue1353Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1353/Issue1353Mapper.java
@@ -1,0 +1,38 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1353;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Jeffrey Smyth
+ */
+@Mapper
+public interface Issue1353Mapper {
+
+    Issue1353Mapper INSTANCE = Mappers.getMapper( Issue1353Mapper.class );
+
+    @Mappings ({
+        @Mapping (target = "string2 ", source = " source.string1")
+    })
+    Target sourceToTarget(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1353/Issue1353Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1353/Issue1353Test.java
@@ -48,12 +48,14 @@ public class Issue1353Test {
             @Diagnostic (type = Issue1353Mapper.class,
                 kind = javax.tools.Diagnostic.Kind.WARNING,
                 line = 35,
-                messageRegExp = "The property name \" source.string1\" has whitespace that was trimmed."
+                messageRegExp = "The property named \" source.string1\" has whitespaces,"
+                                + " using trimmed property \"source.string1\" instead."
             ),
             @Diagnostic (type = Issue1353Mapper.class,
                 kind = javax.tools.Diagnostic.Kind.WARNING,
                 line = 35,
-                messageRegExp = "The property name \"string2 \" has whitespace that was trimmed."
+                messageRegExp = "The property named \"string2 \" has whitespaces,"
+                                + " using trimmed property \"string2\" instead."
             )
         }
     )

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1353/Issue1353Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1353/Issue1353Test.java
@@ -1,0 +1,69 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1353;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Jeffrey Smyth
+ */
+@IssueKey ("1353")
+@RunWith (AnnotationProcessorTestRunner.class)
+@WithClasses ({
+    Issue1353Mapper.class,
+    Source.class,
+    Target.class
+})
+public class Issue1353Test {
+
+    @Test
+    @ExpectedCompilationOutcome (
+        value = CompilationResult.SUCCEEDED,
+        diagnostics = {
+            @Diagnostic (type = Issue1353Mapper.class,
+                kind = javax.tools.Diagnostic.Kind.WARNING,
+                line = 35,
+                messageRegExp = "The property name \" source.string1\" has whitespace that was trimmed."
+            ),
+            @Diagnostic (type = Issue1353Mapper.class,
+                kind = javax.tools.Diagnostic.Kind.WARNING,
+                line = 35,
+                messageRegExp = "The property name \"string2 \" has whitespace that was trimmed."
+            )
+        }
+    )
+    public void shouldTrimArguments() {
+        Source source = new Source();
+        source.setString1( "TestString" );
+
+        Target target = Issue1353Mapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target.getString2() ).isNotNull();
+        assertThat( target.getString2() ).isEqualTo( source.getString1() );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1353/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1353/Source.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1353;
+
+/**
+ * @author Jeffrey Smyth
+ */
+public class Source {
+
+    private String string1;
+
+    public String getString1() {
+        return string1;
+    }
+
+    public void setString1(String string1) {
+        this.string1 = string1;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1353/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1353/Target.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1353;
+
+/**
+ * @author Jeffrey Smyth
+ */
+public class Target {
+
+    private String string2;
+
+    public String getString2() {
+        return string2;
+    }
+
+    public void setString2(String string2) {
+        this.string2 = string2;
+    }
+}


### PR DESCRIPTION
Add a trim for source and target mappings, but throw a warning message if trimmed.

Fixes #1353 