### PR TITLE
#1345 ignoring reversed mappings with no target accessor silently

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
@@ -37,7 +37,6 @@ import javax.lang.model.util.Types;
 import org.mapstruct.ap.internal.model.common.FormattingParameters;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
-import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
 import org.mapstruct.ap.internal.prism.MappingPrism;
 import org.mapstruct.ap.internal.prism.MappingsPrism;
 import org.mapstruct.ap.internal.util.FormattingMessager;
@@ -390,11 +389,6 @@ public class Mapping {
         return dependsOn;
     }
 
-    private boolean hasPropertyInReverseMethod(String name, SourceMethod method) {
-        CollectionMappingStrategyPrism cms = method.getMapperConfiguration().getCollectionMappingStrategy();
-        return method.getResultType().getPropertyWriteAccessors( cms ).containsKey( name );
-    }
-
     public Mapping reverse(SourceMethod method, FormattingMessager messager, TypeFactory typeFactory) {
 
         // mapping can only be reversed if the source was not a constant nor an expression nor a nested property
@@ -426,6 +420,12 @@ public class Mapping {
             true,
             sourceReference != null ? sourceReference.getParameter() : null
         );
+
+        // check if the reverse mapping has indeed a write accessor, otherwise the mapping cannot be reversed
+        if ( !reverse.targetReference.isValid() ) {
+            return null;
+        }
+
         return reverse;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
@@ -30,7 +30,6 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
-import org.mapstruct.ap.internal.prism.InheritInverseConfigurationPrism;
 import org.mapstruct.ap.internal.util.Executables;
 import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.Message;
@@ -172,7 +171,7 @@ public class TargetReference {
 
             if ( !foundEntryMatch && errorMessage != null && !isReverse ) {
                 // This is called only for reporting errors
-                errorMessage.report( isReverse );
+                errorMessage.report( );
             }
 
             // foundEntryMatch = isValid, errors are handled here, and the BeanMapping uses that to ignore
@@ -375,20 +374,14 @@ public class TargetReference {
             this.messager = messager;
         }
 
-        abstract void report(boolean isReverse);
+        abstract void report();
 
-        protected void printErrorMessage(Message message, boolean isReverse, Object... args) {
+        protected void printErrorMessage(Message message, Object... args) {
             Object[] errorArgs = new Object[args.length + 2];
             errorArgs[0] = mapping.getTargetName();
             errorArgs[1] = method.getResultType();
             System.arraycopy( args, 0, errorArgs, 2, args.length );
             AnnotationMirror annotationMirror = mapping.getMirror();
-            if ( isReverse ) {
-                InheritInverseConfigurationPrism reversePrism = InheritInverseConfigurationPrism.getInstanceOn(
-                    method.getExecutable() );
-
-                annotationMirror = reversePrism == null ? annotationMirror : reversePrism.mirror;
-            }
             messager.printMessage( method.getExecutable(), annotationMirror, mapping.getSourceAnnotationValue(),
                 message, errorArgs
             );
@@ -402,8 +395,8 @@ public class TargetReference {
         }
 
         @Override
-        public void report(boolean isReverse) {
-            printErrorMessage( Message.BEANMAPPING_PROPERTY_HAS_NO_WRITE_ACCESSOR_IN_RESULTTYPE, isReverse );
+        public void report() {
+            printErrorMessage( Message.BEANMAPPING_PROPERTY_HAS_NO_WRITE_ACCESSOR_IN_RESULTTYPE );
         }
     }
 
@@ -422,22 +415,15 @@ public class TargetReference {
         }
 
         @Override
-        public void report(boolean isReverse) {
+        public void report() {
 
             Set<String> readAccessors = nextType.getPropertyReadAccessors().keySet();
-            String mostSimilarProperty = Strings.getMostSimilarWord(
-                entryNames[index],
-                readAccessors
-            );
+            String mostSimilarProperty = Strings.getMostSimilarWord( entryNames[index], readAccessors );
 
             List<String> elements = new ArrayList<String>( Arrays.asList( entryNames ).subList( 0, index ) );
             elements.add( mostSimilarProperty );
 
-            printErrorMessage(
-                Message.BEANMAPPING_UNKNOWN_PROPERTY_IN_RESULTTYPE,
-                isReverse,
-                Strings.join( elements, "." )
-            );
+            printErrorMessage( Message.BEANMAPPING_UNKNOWN_PROPERTY_IN_RESULTTYPE, Strings.join( elements, "." ) );
         }
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
@@ -170,7 +170,7 @@ public class TargetReference {
                 foundEntryMatch = (entries.size() == targetPropertyNames.length);
             }
 
-            if ( !foundEntryMatch && errorMessage != null) {
+            if ( !foundEntryMatch && errorMessage != null && !isReverse ) {
                 // This is called only for reporting errors
                 errorMessage.report( isReverse );
             }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -92,7 +92,7 @@ public enum Message {
     GENERAL_VALID_DATE( "Given date format \"%s\" is valid.", Diagnostic.Kind.NOTE ),
     GENERAL_INVALID_DATE( "Given date format \"%s\" is invalid. Message: \"%s\"." ),
     GENERAL_NOT_ALL_FORGED_CREATED( "Internal Error in creation of Forged Methods, it was expected all Forged Methods to finished with creation, but %s did not" ),
-    GENERAL_NO_SUITABLE_CONSTRUCTOR( "%s does not have an accessible empty constructor." ),
+    GENERAL_NO_SUITABLE_CONSTRUCTOR( "%s does not have an accessible parameterless constructor." ),
 
     RETRIEVAL_NO_INPUT_ARGS( "Can't generate mapping method with no input arguments." ),
     RETRIEVAL_DUPLICATE_MAPPING_TARGETS( "Can't generate mapping method with more than one @MappingTarget parameter." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1242/Issue1242Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1242/Issue1242Test.java
@@ -80,7 +80,7 @@ public class Issue1242Test {
             @Diagnostic(type = ErroneousIssue1242MapperMultipleSources.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 33,
-                messageRegExp = ".*TargetB does not have an accessible empty constructor\\.")
+                messageRegExp = ".*TargetB does not have an accessible parameterless constructor\\.")
         })
     public void ambiguousMethodErrorForTwoFactoryMethodsWithSourceParam() {
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/Issue1283Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1283/Issue1283Test.java
@@ -46,7 +46,7 @@ public class Issue1283Test {
             @Diagnostic(type = ErroneousInverseTargetHasNoSuitableConstructorMapper.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 35L,
-                messageRegExp = ".*\\._1283\\.Source does not have an accessible empty constructor"
+                messageRegExp = ".*\\._1283\\.Source does not have an accessible parameterless constructor"
             )
         }
     )
@@ -61,7 +61,7 @@ public class Issue1283Test {
             @Diagnostic(type = ErroneousTargetHasNoSuitableConstructorMapper.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 31L,
-                messageRegExp = ".*\\._1283\\.Source does not have an accessible empty constructor"
+                messageRegExp = ".*\\._1283\\.Source does not have an accessible parameterless constructor"
             )
         }
     )

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1345/Issue1345Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1345/Issue1345Mapper.java
@@ -1,0 +1,62 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1345;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+@Mapper
+public interface Issue1345Mapper {
+
+    Issue1345Mapper INSTANCE = Mappers.getMapper( Issue1345Mapper.class );
+
+    @Mapping(target = "property", source = "readOnlyProperty")
+    B a2B(A a);
+
+    @InheritInverseConfiguration(name = "a2B")
+    A b2A(B b);
+
+    class A {
+
+        private String readOnlyProperty;
+
+        public String getReadOnlyProperty() {
+            return readOnlyProperty;
+        }
+    }
+
+    class B {
+
+        private String property;
+
+        public String getProperty() {
+            return property;
+        }
+
+        public void setProperty(String property) {
+            this.property = property;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1345/Issue1345Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1345/Issue1345Test.java
@@ -1,0 +1,40 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1345;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Sjaak Derksen
+ */
+@WithClasses({
+    Issue1345Mapper.class
+})
+@IssueKey("1345")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue1345Test {
+
+    @Test
+    public void shouldCompile() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/AmbiguousAnnotatedFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousannotatedfactorymethod/AmbiguousAnnotatedFactoryTest.java
@@ -53,7 +53,7 @@ public class AmbiguousAnnotatedFactoryTest {
             @Diagnostic(type = SourceTargetMapperAndBarFactory.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 35,
-                messageRegExp = ".*\\.ambiguousannotatedfactorymethod.Bar does not have an accessible empty " +
+                messageRegExp = ".*\\.ambiguousannotatedfactorymethod.Bar does not have an accessible parameterless " +
                     "constructor\\.")
 
         }

--- a/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousfactorymethod/FactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/erroneous/ambiguousfactorymethod/FactoryTest.java
@@ -54,7 +54,8 @@ public class FactoryTest {
             @Diagnostic(type = SourceTargetMapperAndBarFactory.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 35,
-                messageRegExp = ".*\\.ambiguousfactorymethod\\.Bar does not have an accessible empty constructor\\.")
+                messageRegExp = ".*\\.ambiguousfactorymethod\\.Bar does not have an accessible parameterless "
+                    + "constructor\\.")
 
         }
     )

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/NestedSourcePropertiesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/NestedSourcePropertiesTest.java
@@ -183,8 +183,8 @@ public class NestedSourcePropertiesTest {
             diagnostics = {
                 @Diagnostic( type = ArtistToChartEntryErroneous.class,
                         kind = javax.tools.Diagnostic.Kind.ERROR,
-                        line = 46,
-                        messageRegExp = "Unknown property \"position\" in result type java\\.lang\\.Integer\\." )
+                        line = 47,
+                        messageRegExp = "java.lang.Integer does not have an accessible empty constructor." )
             }
     )
     @WithClasses({ ArtistToChartEntryErroneous.class })

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/NestedSourcePropertiesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/NestedSourcePropertiesTest.java
@@ -184,7 +184,7 @@ public class NestedSourcePropertiesTest {
                 @Diagnostic( type = ArtistToChartEntryErroneous.class,
                         kind = javax.tools.Diagnostic.Kind.ERROR,
                         line = 47,
-                        messageRegExp = "java.lang.Integer does not have an accessible empty constructor." )
+                        messageRegExp = "java.lang.Integer does not have an accessible parameterless constructor." )
             }
     )
     @WithClasses({ ArtistToChartEntryErroneous.class })

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
@@ -182,7 +182,7 @@ public class ConversionTest {
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 29,
                 messageRegExp = ".*\\.generics\\.WildCardSuperWrapper<.*\\.generics\\.TypeA> does not have an " +
-                    "accessible empty constructor\\.")
+                    "accessible parameterless constructor\\.")
 
         })
     public void shouldFailOnNonMatchingWildCards() {

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/resulttype/InheritanceSelectionTest.java
@@ -64,7 +64,7 @@ public class InheritanceSelectionTest {
             @Diagnostic(type = ErroneousFruitMapper.class,
                 kind = Kind.ERROR,
                 line = 36,
-                messageRegExp = ".*Fruit does not have an accessible empty constructor\\.")
+                messageRegExp = ".*Fruit does not have an accessible parameterless constructor\\.")
         }
     )
     public void testForkedInheritanceHierarchyShouldResultInAmbigousMappingMethod() {
@@ -79,7 +79,7 @@ public class InheritanceSelectionTest {
             @Diagnostic(type = ErroneousResultTypeNoEmptyConstructorMapper.class,
                 kind = Kind.ERROR,
                 line = 31,
-                messageRegExp = ".*\\.resulttype\\.Banana does not have an accessible empty constructor\\.")
+                messageRegExp = ".*\\.resulttype\\.Banana does not have an accessible parameterless constructor\\.")
         }
     )
     public void testResultTypeHasNoSuitableEmptyConstructor() {

--- a/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/updatemethods/UpdateMethodsTest.java
@@ -188,7 +188,7 @@ public class UpdateMethodsTest {
             @Diagnostic(type = ErroneousOrganizationMapper2.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 48,
-                messageRegExp = ".*\\.updatemethods\\.DepartmentEntity does not have an accessible empty " +
+                messageRegExp = ".*\\.updatemethods\\.DepartmentEntity does not have an accessible parameterless " +
                     "constructor\\.")
 
         })


### PR DESCRIPTION
There seems to be functionality to deliberately do something with the fact that MapStruct cannot perform a reverse mapping when there's no target write accessor.

However there are no testcases for it.

There is however a test case failing when the solution is implemented, see #838. However, this is funny because now the fault message is actually covering #838 in stead of "unknown property". 

So: what should we do: 
1. should we indeed automatically ignore a reverse mapping if there's no write accessor in the reverse situation as is introduced with this PR? I personally think so.
2. if we agree on that, it most likely makes no sense to pass this `isReverse` boolean  to ` errorMessage.report( isReverse );` on line 175 in `TargetReference` and remove subsequent functionality in the message implementations.

@gunnarmorling : WDYT about point 1.?
@filiphr : I saw you put this error messages in (also handling the reverse case as error) together with @navpil . What was the reasoning behind this? Do I miss anything ?