### PR TITLE
#1375 Allow using target references when there is no intermediary read accessor

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
@@ -195,8 +195,7 @@ public class TargetReference {
                 boolean isLast = i == entryNames.length - 1;
                 boolean isNotLast = i < entryNames.length - 1;
                 if ( isWriteAccessorNotValidWhenNotLast( targetWriteAccessor, isNotLast )
-                    || isWriteAccessorNotValidWhenLast( targetWriteAccessor, targetReadAccessor, mapping, isLast )
-                    || ( isNotLast && targetReadAccessor == null ) ) {
+                    || isWriteAccessorNotValidWhenLast( targetWriteAccessor, targetReadAccessor, mapping, isLast ) ) {
                     // there should always be a write accessor (except for the last when the mapping is ignored and
                     // there is a read accessor) and there should be read accessor mandatory for all but the last
                     setErrorMessage( targetWriteAccessor, targetReadAccessor, entryNames, i, nextType );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1375/Issue1375Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1375/Issue1375Mapper.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1375;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue1375Mapper {
+
+    Issue1375Mapper INSTANCE = Mappers.getMapper( Issue1375Mapper.class );
+
+    @Mapping(target = "nested.value", source = "value")
+    Target map(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1375/Issue1375Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1375/Issue1375Test.java
@@ -1,0 +1,50 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1375;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses( {
+    Target.class,
+    Source.class,
+    Issue1375Mapper.class
+} )
+@RunWith( AnnotationProcessorTestRunner.class )
+@IssueKey( "1375" )
+public class Issue1375Test {
+
+    @Test
+    public void shouldGenerateCorrectMapperWhenIntermediaryReadAccessorIsMissing() {
+
+        Target target = Issue1375Mapper.INSTANCE.map( new Source( "test value" ) );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.nested ).isNotNull();
+        assertThat( target.nested.getValue() ).isEqualTo( "test value" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1375/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1375/Source.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1375;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Source {
+
+    private final String value;
+
+    public Source(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1375/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1375/Target.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1375;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Target {
+
+    Nested nested;
+
+    public void setNested(Nested nested) {
+        this.nested = nested;
+    }
+
+    public static class Nested {
+
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #1375 

We can actually create a valid mapper when an intermediary read accessor is missing. Therefore I have removed that check (which actually was not reporting anything before)