### PR TITLE
#1395 Unused mappers should not be used in constructor injection

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/AnnotationBasedComponentModelProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/AnnotationBasedComponentModelProcessor.java
@@ -134,10 +134,9 @@ public abstract class AnnotationBasedComponentModelProcessor implements ModelEle
             new ArrayList<AnnotationMapperReference>( mapper.getReferencedMappers().size() );
 
         for ( MapperReference mapperReference : mapper.getReferencedMappers() ) {
-            if ( !mapperReference.isUsed() ) {
-                continue;
+            if ( mapperReference.isUsed() ) {
+                mapperReferencesForConstructor.add( (AnnotationMapperReference) mapperReference );
             }
-            mapperReferencesForConstructor.add( (AnnotationMapperReference) mapperReference );
         }
 
         List<Annotation> mapperReferenceAnnotations = getMapperReferenceAnnotations();

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/AnnotationBasedComponentModelProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/AnnotationBasedComponentModelProcessor.java
@@ -134,6 +134,9 @@ public abstract class AnnotationBasedComponentModelProcessor implements ModelEle
             new ArrayList<AnnotationMapperReference>( mapper.getReferencedMappers().size() );
 
         for ( MapperReference mapperReference : mapper.getReferencedMappers() ) {
+            if ( !mapperReference.isUsed() ) {
+                continue;
+            }
             mapperReferencesForConstructor.add( (AnnotationMapperReference) mapperReference );
         }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/Issue1395Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/Issue1395Mapper.java
@@ -1,0 +1,31 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1395;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(injectionStrategy = InjectionStrategy.CONSTRUCTOR, componentModel = "spring", uses = NotUsedService.class)
+public interface Issue1395Mapper {
+
+    Target map(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/Issue1395Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/Issue1395Test.java
@@ -1,0 +1,44 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1395;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses( {
+    Issue1395Mapper.class,
+    NotUsedService.class,
+    Source.class,
+    Target.class
+} )
+@RunWith( AnnotationProcessorTestRunner.class )
+@IssueKey( "1395" )
+public class Issue1395Test {
+
+    @Test
+    public void shouldGenerateValidCode() {
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/NotUsedService.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/NotUsedService.java
@@ -1,0 +1,25 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1395;
+
+/**
+ * @author Filip Hrisafov
+ */
+public interface NotUsedService {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/Source.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1395;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Source {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/Target.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1395;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Target {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
Fixes #1395.

Unused mappers should not be used in constructors of constructor injection