### PR TITLE
#1367 aligning @InheritConfiguration and @InheritReverseConfiguration with AUTO_INHERIT_ALL_FROM_CONFIG.

### DIFF
--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -681,7 +681,7 @@ A mapper which uses other mapper classes (see <<invoking-other-mappers>>) will o
 [[injection-strategy]]
 === Injection strategy
 
-When using <<using-dependency-injection,dependency injection>>, you can choose between field and constructor injection. 
+When using <<using-dependency-injection,dependency injection>>, you can choose between field and constructor injection.
 This can be done by either providing the injection strategy via `@Mapper` or `@MapperConfig` annotation.
 
 .Using constructor injection
@@ -696,10 +696,10 @@ public interface CarMapper {
 ----
 ====
 
-The generated mapper will inject all classes defined in the **uses** attribute. 
-When `InjectionStrategy#CONSTRUCTOR` is used, the constructor will have the appropriate annotation and the fields won't. 
-When `InjectionStrategy#FIELD` is used, the annotation is on the field itself. 
-For now, the default injection strategy is field injection. 
+The generated mapper will inject all classes defined in the **uses** attribute.
+When `InjectionStrategy#CONSTRUCTOR` is used, the constructor will have the appropriate annotation and the fields won't.
+When `InjectionStrategy#FIELD` is used, the annotation is on the field itself.
+For now, the default injection strategy is field injection.
 It is recommended to use constructor injection to simplify testing.
 
 [TIP]
@@ -2129,11 +2129,17 @@ Methods that are considered for inverse inheritance need to be defined in the cu
 
 If multiple methods qualify, the method from which to inherit the configuration needs to be specified using the `name` property like this: `@InheritInverseConfiguration(name = "carToDto")`.
 
-Expressions and constants are excluded (silently ignored). Reverse mapping of nested source properties is experimental as of the 1.1.0.Beta2 release. Reverse mapping will take place automatically when the source property name and target property name are identical. Otherwise, `@Mapping` should specify both the target name and source name. In all cases, a suitable mapping method needs to be in place for the reverse mapping.
+`@InheritConfiguration` takes, in case of conflict precedence over `@InheritInverseConfiguration`.
+
+Configurations are inherited transitively. So if method `C` defines a mapping `@Mapping( target = "x", ignore = true)`, `B` defines a mapping `@Mapping( target = "y", ignore = true)`, then if `A` inherits from `B` inherits from `C`, `A` will inherit mappings for both property `x` and `y`.
+
+Expressions and constants are excluded (silently ignored) in `@InheritInverseConfiguration`.
+
+Reverse mapping of nested source properties is experimental as of the 1.1.0.Beta2 release. Reverse mapping will take place automatically when the source property name and target property name are identical. Otherwise, `@Mapping` should specify both the target name and source name. In all cases, a suitable mapping method needs to be in place for the reverse mapping.
 
 [NOTE]
 ====
-`@InheritInverseConfiguration` cannot refer to methods in a used mapper.
+`@InheritConfiguration` or `@InheritInverseConfiguration` cannot refer to methods in a used mapper.
 ====
 
 [[shared-configurations]]
@@ -2207,7 +2213,9 @@ public interface SourceTargetMapper {
 The attributes `@Mapper#mappingInheritanceStrategy()` / `@MapperConfig#mappingInheritanceStrategy()` configure when the method-level mapping configuration annotations are inherited from prototype methods in the interface to methods in the mapper:
 
 * `EXPLICIT` (default): the configuration will only be inherited, if the target mapping method is annotated with `@InheritConfiguration` and the source and target types are assignable to the corresponding types of the prototype method, all as described in <<mapping-configuration-inheritance>>.
-* `AUTO_INHERIT_FROM_CONFIG`: the configuration will be inherited automatically, if the source and target types of the target mapping method are assignable to the corresponding types of the prototype method. If multiple prototype methods match, the ambiguity must be resolved using `@InheritConfiguration(name = ...)`.
+* `AUTO_INHERIT_FROM_CONFIG`: the configuration will be inherited automatically, if the source and target types of the target mapping method are assignable to the corresponding types of the prototype method. If multiple prototype methods match, the ambiguity must be resolved using `@InheritConfiguration(name = ...)` which will cause `AUTO_INHERIT_FROM_CONFIG` to be ignored.
+* `AUTO_INHERIT_REVERSE_FROM_CONFIG`: the inverse configuration will be inherited automatically, if the source and target types of the target mapping method are assignable to the corresponding types of the prototype method. If multiple prototype methods match, the ambiguity must be resolved using `@InheritInverseConfiguration(name = ...)` which will cause ``AUTO_INHERIT_REVERSE_FROM_CONFIG` to be ignored.
+* `AUTO_INHERIT_ALL_FROM_CONFIG`: both the configuration and the inverse configuration will be inherited automatically. The same rules apply as for `AUTO_INHERIT_FROM_CONFIG` or `AUTO_INHERIT_REVERSE_FROM_CONFIG`.
 
 == Customizing mappings
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -115,7 +115,6 @@ public enum Message {
     RETRIEVAL_WILDCARD_EXTENDS_BOUND_RESULT( "Can't generate mapping method for a wildcard extends bound result." ),
     RETRIEVAL_CONTEXT_PARAMS_WITH_SAME_TYPE( "The types of @Context parameters must be unique." ),
 
-    INHERITCONFIGURATION_BOTH( "Method cannot be annotated with both a @InheritConfiguration and @InheritInverseConfiguration." ),
     INHERITINVERSECONFIGURATION_DUPLICATES( "Several matching inverse methods exist: %s(). Specify a name explicitly." ),
     INHERITINVERSECONFIGURATION_INVALID_NAME( "None of the candidates %s() matches given name: \"%s\"." ),
     INHERITINVERSECONFIGURATION_DUPLICATE_MATCHES( "Given name \"%s\" matches several candidate methods: %s." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/BaseDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/BaseDto.java
@@ -1,0 +1,45 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig.multiple;
+
+import java.util.List;
+
+public class BaseDto {
+
+    private Long dbId;
+
+    private List<String> links;
+
+    public Long getDbId() {
+        return dbId;
+    }
+
+    public void setDbId(Long dbId) {
+        this.dbId = dbId;
+    }
+
+    public List<String> getLinks() {
+        return links;
+    }
+
+    public void setLinks(List<String> links) {
+        this.links = links;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/BaseEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/BaseEntity.java
@@ -1,0 +1,75 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig.multiple;
+
+import java.util.Date;
+
+public abstract class BaseEntity {
+
+    private Long id;
+
+    protected String createdBy;
+
+    protected Date creationDate;
+
+    protected String lastModifiedBy;
+
+    protected Date lastModifiedDate;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    public String getLastModifiedBy() {
+        return lastModifiedBy;
+    }
+
+    public void setLastModifiedBy(String lastModifiedBy) {
+        this.lastModifiedBy = lastModifiedBy;
+    }
+
+    public Date getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+
+    public void setLastModifiedDate(Date lastModifiedDate) {
+        this.lastModifiedDate = lastModifiedDate;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/Car2Dto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/Car2Dto.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig.multiple;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Car2Dto {
+
+    private int seatCount;
+
+    private String maker;
+
+    public int getSeatCount() {
+        return seatCount;
+    }
+
+    public void setSeatCount(int seatCount) {
+        this.seatCount = seatCount;
+    }
+
+    public String getMaker() {
+        return maker;
+    }
+
+    public void setMaker(String maker) {
+        this.maker = maker;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/Car2Entity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/Car2Entity.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig.multiple;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Car2Entity {
+
+    private String manufacturer;
+
+    private int numberOfSeats;
+
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    public void setManufacturer(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+
+    public int getNumberOfSeats() {
+        return numberOfSeats;
+    }
+
+    public void setNumberOfSeats(int numberOfSeats) {
+        this.numberOfSeats = numberOfSeats;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/CarDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/CarDto.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig.multiple;
+
+public class CarDto extends BaseDto {
+
+    private int seatCount;
+
+    private String maker;
+
+    public int getSeatCount() {
+        return seatCount;
+    }
+
+    public void setSeatCount(int seatCount) {
+        this.seatCount = seatCount;
+    }
+
+    public String getMaker() {
+        return maker;
+    }
+
+    public void setMaker(String maker) {
+        this.maker = maker;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/CarEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/CarEntity.java
@@ -1,0 +1,43 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig.multiple;
+
+public class CarEntity extends BaseEntity {
+
+    private String manufacturer;
+
+    private int numberOfSeats;
+
+    public String getManufacturer() {
+        return manufacturer;
+    }
+
+    public void setManufacturer(String manufacturer) {
+        this.manufacturer = manufacturer;
+    }
+
+    public int getNumberOfSeats() {
+        return numberOfSeats;
+    }
+
+    public void setNumberOfSeats(int numberOfSeats) {
+        this.numberOfSeats = numberOfSeats;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/CarMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/CarMapper.java
@@ -1,0 +1,55 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig.multiple;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(config = EntityToDtoMappingConfig.class)
+public abstract class CarMapper {
+
+    public static final CarMapper MAPPER = Mappers.getMapper( CarMapper.class );
+
+    @Mappings({
+        @Mapping(target = "maker", source = "manufacturer"),
+        @Mapping(target = "seatCount", source = "numberOfSeats")
+    })
+    // additional mapping inherited from EntityToDtoMappingConfig.entityToDto method :
+    //  @Mapping(target = "dbId", source = "id")
+    //  @Mapping(target = "links", ignore = true)
+    @InheritConfiguration(name = "entityToDto")
+    public abstract CarDto mapTo(CarEntity car);
+
+    @InheritInverseConfiguration(name = "mapTo")
+    @InheritConfiguration(name = "dtoToEntity")
+    // @inheritInverseConfiguration should map both maker and seatCount properties.
+    // additional mapping should also be inherited from EntityToDtoMappingConfig.dtoToEntity method,
+    //    @Mapping(target = "id", source = "dbId")
+    //    @Mapping(target = "createdBy", ignore = true)
+    //    @Mapping(target = "creationDate", ignore = true)
+    //    @Mapping(target = "lastModifiedBy", constant = "restApiUser")
+    //    @Mapping(target = "lastModifiedDate", ignore = true)
+    public abstract CarEntity mapFrom(CarDto carDto);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/CarMapper2.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/CarMapper2.java
@@ -1,0 +1,52 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig.multiple;
+
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class CarMapper2 {
+    public static final CarMapper2 MAPPER = Mappers.getMapper( CarMapper2.class );
+
+    @Mappings({
+        @Mapping(target = "maker", source = "manufacturer"),
+        @Mapping(target = "seatCount", source = "numberOfSeats")
+    })
+    public abstract Car2Dto mapToBase(Car2Entity car);
+
+    @Mappings({
+        @Mapping(target = "manufacturer", constant = "ford"),
+        @Mapping(target = "numberOfSeats", ignore = true)
+    })
+    public abstract Car2Entity mapFromBase(Car2Dto carDto);
+
+    @InheritConfiguration(name = "mapToBase")
+    @InheritInverseConfiguration(name = "mapFromBase")
+    public abstract Car2Dto mapTo(Car2Entity car);
+
+    @InheritConfiguration(name = "mapFromBase")
+    @InheritInverseConfiguration(name = "mapToBase")
+    public abstract Car2Entity mapFrom(Car2Dto carDto);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/CarMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/CarMapperTest.java
@@ -1,0 +1,101 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig.multiple;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Date;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    BaseDto.class,
+    BaseEntity.class,
+    CarDto.class,
+    CarEntity.class,
+    CarMapper.class,
+    EntityToDtoMappingConfig.class,
+    Car2Dto.class,
+    Car2Entity.class,
+    CarMapper2.class
+})
+@IssueKey("1367")
+public class CarMapperTest {
+
+    @Test
+    public void testMapEntityToDto() {
+        CarDto dto = CarMapper.MAPPER.mapTo( newCar() );
+        assertThat( dto.getDbId() ).isEqualTo( 9L );
+        assertThat( dto.getMaker() ).isEqualTo( "Nissan" );
+        assertThat( dto.getSeatCount() ).isEqualTo( 5 );
+    }
+
+    @Test
+    public void testMapDtoToEntity() {
+        CarEntity car = CarMapper.MAPPER.mapFrom( newCarDto() );
+        assertThat( car.getId() ).isEqualTo( 9L );
+        assertThat( car.getManufacturer() ).isEqualTo( "Nissan" );
+        assertThat( car.getNumberOfSeats() ).isEqualTo( 5 );
+        assertThat( car.getLastModifiedBy() ).isEqualTo( "restApiUser" );
+        assertThat( car.getCreationDate() ).isNull();
+    }
+
+    @Test
+    public void testForwardMappingShouldTakePrecedence() {
+        Car2Dto dto = new Car2Dto();
+        dto.setMaker( "mazda" );
+        dto.setSeatCount( 5 );
+
+        Car2Entity entity = CarMapper2.MAPPER.mapFrom( dto );
+        assertThat( entity.getManufacturer() ).isEqualTo( "ford" );
+        assertThat( entity.getNumberOfSeats( ) ).isEqualTo( 0 );
+
+        Car2Entity entity2 = new Car2Entity();
+        entity2.setManufacturer( "mazda" );
+        entity2.setNumberOfSeats( 5 );
+
+        Car2Dto dto2 = CarMapper2.MAPPER.mapTo( entity2 );
+        assertThat( dto2.getMaker() ).isEqualTo( "mazda" );
+        assertThat( dto2.getSeatCount() ).isEqualTo( 5 );
+    }
+
+    private CarEntity newCar() {
+        CarEntity car = new CarEntity();
+        car.setId( 9L );
+        car.setCreatedBy( "admin" );
+        car.setCreationDate( new Date() );
+        car.setManufacturer( "Nissan" );
+        car.setNumberOfSeats( 5 );
+        return car;
+    }
+
+    private CarDto newCarDto() {
+        CarDto carDto = new CarDto();
+        carDto.setDbId( 9L );
+        carDto.setMaker( "Nissan" );
+        carDto.setSeatCount( 5 );
+        return carDto;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/EntityToDtoMappingConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritfromconfig/multiple/EntityToDtoMappingConfig.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.inheritfromconfig.multiple;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+/**
+ * Shared configuration from Entities to Dto instances
+ */
+@MapperConfig
+public interface EntityToDtoMappingConfig {
+
+    @Mappings({
+        @Mapping(target = "dbId", source = "id"),
+        @Mapping(target = "links", ignore = true)
+    })
+    BaseDto entityToDto(BaseEntity entity);
+
+    @Mappings({
+        @Mapping(target = "id", source = "dbId"),
+        @Mapping(target = "createdBy", ignore = true),
+        @Mapping(target = "creationDate", ignore = true),
+        @Mapping(target = "lastModifiedBy", constant = "restApiUser"), // force modifiedBy with restApiUser constant
+        @Mapping(target = "lastModifiedDate", ignore = true)
+    })
+    BaseEntity dtoToEntity(BaseDto dto);
+
+}


### PR DESCRIPTION
Fixes #1367 

Whereas its not possible to combine forward and reverse explicit configurations (you get a warning:  `Method cannot be annotated with both a @InheritConfiguration and @InheritInverseConfiguration`) it seems to be possible with the current auto-inheritance options. Here you have the possibilities: `AUTO_INHERIT_FROM_CONFIG`, `AUTO_INHERIT_REVERSE_FROM_CONFIG`, and **`AUTO_INHERIT_ALL_FROM_CONFIG`** .

This PR removes that restriction and aligns the strategy for auto inheritance. So it will be possible to define an `@InheritConfiguration` together with `@InheritReverseConfiguration` on  the same method.

Forward mappings (`@InheritConfiguration`) takes precedence over reverse mappings (`@InheritInverseConfiguration`)