### PR TITLE
#1392 add option to default ignoreAll mappings in a bean mapping method

### DIFF
--- a/core-common/src/main/java/org/mapstruct/BeanMapping.java
+++ b/core-common/src/main/java/org/mapstruct/BeanMapping.java
@@ -73,4 +73,14 @@ public @interface BeanMapping {
      * @return The strategy to be applied when {@code null} is passed as source value to the methods of this mapping.
      */
     NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.RETURN_NULL;
+
+    /**
+     * Default ignore all mappings. All mappings have to be defined manually. No automatic mapping will take place. No
+     * warning will be issued on missing target properties.
+     *
+     * @return The ignore strategy (default false).
+     *
+     * @since 1.3
+     */
+    boolean ignoreByDefault() default false;
 }

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -305,13 +305,19 @@ public interface CarMapper {
 
 The `@Mapper` annotation causes the MapStruct code generator to create an implementation of the `CarMapper` interface during build-time.
 
-In the generated method implementations all readable properties from the source type (e.g. `Car`) will be copied into the corresponding property in the target type (e.g. `CarDto`). If a property has a different name in the target entity, its name can be specified via the `@Mapping` annotation.
+In the generated method implementations all readable properties from the source type (e.g. `Car`) will be copied into the corresponding property in the target type (e.g. `CarDto`):
+
+* When a property has the same name as its target entity counterpart, it will be mapped implicitly.
+* When a property has a different name in the target entity, its name can be specified via the `@Mapping` annotation.
 
 [TIP]
 ====
 The property name as defined in the http://www.oracle.com/technetwork/java/javase/documentation/spec-136004.html[JavaBeans specification] must be specified in the `@Mapping` annotation, e.g. _seatCount_ for a property with the accessor methods `getSeatCount()` and `setSeatCount()`.
 ====
-
+[TIP]
+====
+By means of the `@BeanMapping(ignoreByDefault = true)` the default behavior will be *explicit mapping*, meaning that all mappings have to be specified by means of the `@Mapping` and no warnings will be issued on missing target properties.
+====
 [TIP]
 ====
 Fluent setters are also supported.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
@@ -38,6 +38,17 @@ public class BeanMapping {
     private final SelectionParameters selectionParameters;
     private final NullValueMappingStrategyPrism nullValueMappingStrategy;
     private final ReportingPolicyPrism reportingPolicy;
+    private final boolean ignoreByDefault;
+
+    /**
+     * creates a mapping for inheritance. Will set ignoreByDefault to false.
+     *
+     * @param map
+     * @return
+     */
+    public static BeanMapping forInheritance( BeanMapping map ) {
+        return new BeanMapping( map.selectionParameters, map.nullValueMappingStrategy, map.reportingPolicy, false );
+    }
 
     public static BeanMapping fromPrism(BeanMappingPrism beanMapping, ExecutableElement method,
         FormattingMessager messager, Types typeUtils) {
@@ -53,8 +64,9 @@ public class BeanMapping {
                             ? null
                             : NullValueMappingStrategyPrism.valueOf( beanMapping.nullValueMappingStrategy() );
 
+        boolean ignoreByDefault = beanMapping.ignoreByDefault();
         if ( !resultTypeIsDefined && beanMapping.qualifiedBy().isEmpty() && beanMapping.qualifiedByName().isEmpty()
-            && ( nullValueMappingStrategy == null ) ) {
+            && ( nullValueMappingStrategy == null ) && !ignoreByDefault ) {
 
             messager.printMessage( method, Message.BEANMAPPING_NO_ELEMENTS );
         }
@@ -67,7 +79,7 @@ public class BeanMapping {
         );
 
         //TODO Do we want to add the reporting policy to the BeanMapping as well? To give more granular support?
-        return new BeanMapping( cmp, nullValueMappingStrategy, null );
+        return new BeanMapping( cmp, nullValueMappingStrategy, null, ignoreByDefault );
     }
 
     /**
@@ -77,14 +89,15 @@ public class BeanMapping {
      * @return bean mapping that needs to be used for Mappings
      */
     public static BeanMapping forForgedMethods() {
-        return new BeanMapping( null, null, ReportingPolicyPrism.IGNORE );
+        return new BeanMapping( null, null, ReportingPolicyPrism.IGNORE, false );
     }
 
     private BeanMapping(SelectionParameters selectionParameters, NullValueMappingStrategyPrism nvms,
-        ReportingPolicyPrism reportingPolicy) {
+        ReportingPolicyPrism reportingPolicy, boolean ignoreByDefault) {
         this.selectionParameters = selectionParameters;
         this.nullValueMappingStrategy = nvms;
         this.reportingPolicy = reportingPolicy;
+        this.ignoreByDefault = ignoreByDefault;
     }
 
     public SelectionParameters getSelectionParameters() {
@@ -98,4 +111,9 @@ public class BeanMapping {
     public ReportingPolicyPrism getReportingPolicy() {
         return reportingPolicy;
     }
+
+    public boolean isignoreByDefault() {
+        return ignoreByDefault;
+    }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
@@ -211,6 +211,25 @@ public class Mapping {
         );
     }
 
+   public static Mapping forIgnore( String targetName) {
+        return new Mapping(
+            null,
+            null,
+            null,
+            null,
+            targetName,
+            null,
+            true,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            new ArrayList()
+        );
+    }
+
     @SuppressWarnings("checkstyle:parameternumber")
     private Mapping( String sourceName, String constant, String javaExpression, String defaultJavaExpression,
                      String targetName, String defaultValue, boolean isIgnored, AnnotationMirror mirror,

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -495,6 +495,11 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
             }
         }
 
+        // @BeanMapping( ignoreByDefault = true )
+        if ( mappingOptions.getBeanMapping() != null && mappingOptions.getBeanMapping().isignoreByDefault() ) {
+            mappingOptions.applyIgnoreAll( mappingOptions, method, messager, typeFactory );
+        }
+
         mappingOptions.markAsFullyInitialized();
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/IgnorePropertyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/IgnorePropertyTest.java
@@ -57,6 +57,22 @@ public class IgnorePropertyTest {
     }
 
     @Test
+    @IssueKey("1392")
+    public void shouldIgnoreAllTargetPropertiesWithNoUnmappedTargetWarnings() {
+        Animal animal = new Animal( "Bruno", 100, 23, "black" );
+
+        AnimalDto animalDto = AnimalMapper.INSTANCE.animalToDtoIgnoreAll( animal );
+
+        assertThat( animalDto ).isNotNull();
+        assertThat( animalDto.getName() ).isNull();
+        assertThat( animalDto.getSize() ).isNull();
+        assertThat( animalDto.getAge() ).isNull();
+        assertThat( animalDto.publicAge ).isNull();
+        assertThat( animalDto.getColor() ).isNull();
+        assertThat( animalDto.publicColor ).isNull();
+    }
+
+    @Test
     @IssueKey("337")
     public void propertyIsIgnoredInReverseMappingWhenSourceIsAlsoSpecifiedICWIgnore() {
         AnimalDto animalDto = new AnimalDto( "Bruno", 100, 23, "black" );

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/ExpandedToolbox.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/ExpandedToolbox.java
@@ -1,0 +1,55 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.expand;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class ExpandedToolbox {
+
+    private String brand;
+    private Hammer hammer;
+    private Wrench wrench;
+
+    public String getBrand() {
+        return brand;
+    }
+
+    public void setBrand(String brand) {
+        this.brand = brand;
+    }
+
+    public Hammer getHammer() {
+        return hammer;
+    }
+
+    public void setHammer(Hammer hammer) {
+        this.hammer = hammer;
+    }
+
+    public Wrench getWrench() {
+        return wrench;
+    }
+
+    public void setWrench(Wrench wrench) {
+        this.wrench = wrench;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/FlattenedToolBox.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/FlattenedToolBox.java
@@ -1,0 +1,73 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.expand;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class FlattenedToolBox {
+
+    private String brand;
+    private String hammerDescription;
+    private Integer hammerSize;
+    private Boolean wrenchIsBahco;
+    private String wrenchDescription;
+
+    public String getBrand() {
+        return brand;
+    }
+
+    public void setBrand(String brand) {
+        this.brand = brand;
+    }
+
+    public String getHammerDescription() {
+        return hammerDescription;
+    }
+
+    public void setHammerDescription(String hammerDescription) {
+        this.hammerDescription = hammerDescription;
+    }
+
+    public Integer getHammerSize() {
+        return hammerSize;
+    }
+
+    public void setHammerSize(Integer hammerSize) {
+        this.hammerSize = hammerSize;
+    }
+
+    public Boolean getWrenchIsBahco() {
+        return wrenchIsBahco;
+    }
+
+    public void setWrenchIsBahco(Boolean wrenchIsBahco) {
+        this.wrenchIsBahco = wrenchIsBahco;
+    }
+
+    public String getWrenchDescription() {
+        return wrenchDescription;
+    }
+
+    public void setWrenchDescription(String wrenchDescription) {
+        this.wrenchDescription = wrenchDescription;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/Hammer.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/Hammer.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.expand;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Hammer {
+
+    private Integer size;
+    private String description;
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/IgnorePropertyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/IgnorePropertyTest.java
@@ -1,0 +1,64 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.expand;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Test for ignoring properties during the mapping.
+ *
+ * @author Sjaak Derksen
+ */
+@WithClasses({
+    ExpandedToolbox.class,
+    Hammer.class,
+    Wrench.class,
+    FlattenedToolBox.class,
+    ToolBoxMapper.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class IgnorePropertyTest {
+
+    @Test
+    @IssueKey("1392")
+    public void shouldIgnoreAll() {
+        FlattenedToolBox toolboxSource = new FlattenedToolBox();
+        toolboxSource.setBrand( "Stanley" );
+        toolboxSource.setHammerDescription( "heavy" );
+        toolboxSource.setHammerSize( 5 );
+        toolboxSource.setWrenchIsBahco( Boolean.TRUE );
+        toolboxSource.setWrenchDescription( "generic use" );
+
+        ExpandedToolbox toolboxTarget = ToolBoxMapper.INSTANCE.expand( toolboxSource );
+
+        assertThat( toolboxTarget ).isNotNull();
+        assertThat( toolboxTarget.getBrand() ).isNull();
+        assertThat( toolboxTarget.getHammer() ).isNotNull();
+        assertThat( toolboxTarget.getHammer().getDescription() ).isEqualTo( "heavy" );
+        assertThat( toolboxTarget.getHammer().getSize() ).isNull();
+        assertThat( toolboxTarget.getWrench() ).isNull();
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/ToolBoxMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/ToolBoxMapper.java
@@ -16,31 +16,24 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.ignore;
+package org.mapstruct.ap.test.ignore.expand;
 
 import org.mapstruct.BeanMapping;
-import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Mappings;
 import org.mapstruct.factory.Mappers;
 
+/**
+ *
+ * @author Sjaak Derksen
+ */
 @Mapper
-public interface AnimalMapper {
+public interface ToolBoxMapper {
 
-    AnimalMapper INSTANCE = Mappers.getMapper( AnimalMapper.class );
+    ToolBoxMapper INSTANCE = Mappers.getMapper( ToolBoxMapper.class );
 
-    @Mappings({
-        @Mapping(target = "publicAge", ignore = true),
-        @Mapping(target = "age", ignore = true),
-        @Mapping(target = "publicColor", source = "publicColour", ignore = true),
-        @Mapping(target = "color", source = "colour", ignore = true)
-    })
-    AnimalDto animalToDto(Animal animal);
+    @BeanMapping(ignoreByDefault = true)
+    @Mapping( target = "hammer.description", source = "hammerDescription" )
+    ExpandedToolbox expand( FlattenedToolBox toolbox );
 
-    @BeanMapping( ignoreByDefault = true )
-    AnimalDto animalToDtoIgnoreAll(Animal animal);
-
-    @InheritInverseConfiguration( name = "animalToDto" )
-    Animal animalDtoToAnimal(AnimalDto animalDto);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/Wrench.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/expand/Wrench.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.expand;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class Wrench {
+
+    boolean bahco;
+    String description;
+
+    public boolean isBahco() {
+        return bahco;
+    }
+
+    public void setBahco(boolean bahco) {
+        this.bahco = bahco;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/BaseEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/BaseEntity.java
@@ -1,0 +1,57 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.inherit;
+
+import java.util.Date;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class BaseEntity {
+
+    private Long key;
+    private Date creationDate;
+    private Date modificationDate;
+
+    public Long getKey() {
+        return key;
+    }
+
+    public void setKey(Long key) {
+        this.key = key;
+    }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public void setCreationDate(Date creationDate) {
+        this.creationDate = creationDate;
+    }
+
+    public Date getModificationDate() {
+        return modificationDate;
+    }
+
+    public void setModificationDate(Date modificationDate) {
+        this.modificationDate = modificationDate;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/HammerDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/HammerDto.java
@@ -1,0 +1,36 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.inherit;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class HammerDto extends ToolDto {
+
+    private Integer toolSize;
+
+    public Integer getToolSize() {
+        return toolSize;
+    }
+
+    public void setToolSize(Integer toolSize) {
+        this.toolSize = toolSize;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/HammerEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/HammerEntity.java
@@ -1,0 +1,35 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.inherit;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class HammerEntity extends ToolEntity {
+    private Integer size;
+
+    public Integer getSize() {
+        return size;
+    }
+
+    public void setSize(Integer size) {
+        this.size = size;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/IgnorePropertyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/IgnorePropertyTest.java
@@ -1,0 +1,90 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.inherit;
+
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * Test for ignoring properties during the mapping.
+ *
+ * @author Sjaak Derksen
+ */
+@WithClasses({
+    HammerDto.class,
+    HammerEntity.class,
+    ToolEntity.class,
+    BaseEntity.class,
+    ToolDto.class,
+    WorkBenchDto.class,
+    WorkBenchEntity.class,
+    ToolMapper.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class IgnorePropertyTest {
+
+    @Test
+    @IssueKey("1392")
+    /**
+     * Should not issue warnings on unmapped target properties
+     */
+    public void shouldIgnoreAllExeptOveriddenInherited() {
+        HammerDto hammer = new HammerDto();
+        hammer.setToolType( "smash" );
+        hammer.setToolSize( 5 );
+
+        HammerEntity toolTarget = ToolMapper.INSTANCE.mapHammer( hammer );
+
+        assertThat( toolTarget ).isNotNull();
+        assertThat( toolTarget.getSize() ).isNull();
+        assertThat( toolTarget.getType() ).isEqualTo( "smash" );
+        assertThat( toolTarget.getKey() ).isNull();
+        assertThat( toolTarget.getCreationDate() ).isNull();
+        assertThat( toolTarget.getModificationDate() ).isNull();
+
+    }
+
+    @Test
+    @IssueKey("1392")
+    public void shouldIgnoreBase() {
+
+        WorkBenchDto workBenchDto = new WorkBenchDto();
+        workBenchDto.setArticleName( "MyBench" );
+        workBenchDto.setArticleDescription( "Beautiful" );
+        workBenchDto.setCreationDate( new Date() );
+        workBenchDto.setModificationDate( new Date() );
+
+        WorkBenchEntity benchTarget = ToolMapper.INSTANCE.mapBench( workBenchDto );
+
+        assertThat( benchTarget ).isNotNull();
+        assertThat( benchTarget.getArticleName() ).isEqualTo( "MyBench" );
+        assertThat( benchTarget.getDescription() ).isEqualTo( "Beautiful" );
+        assertThat( benchTarget.getKey() ).isNull();
+        assertThat( benchTarget.getModificationDate() ).isNull();
+        assertThat( benchTarget.getCreationDate() ).isNull();
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/ToolDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/ToolDto.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.inherit;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class ToolDto {
+
+    private String toolType;
+
+    public String getToolType() {
+        return toolType;
+    }
+
+    public void setToolType(String toolType) {
+        this.toolType = toolType;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/ToolEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/ToolEntity.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.inherit;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class ToolEntity extends BaseEntity {
+
+    private String type;
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/ToolMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/ToolMapper.java
@@ -16,31 +16,38 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.ignore;
+package org.mapstruct.ap.test.ignore.inherit;
 
 import org.mapstruct.BeanMapping;
-import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.InheritConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Mappings;
 import org.mapstruct.factory.Mappers;
 
+/**
+ *
+ * @author Sjaak Derksen
+ */
 @Mapper
-public interface AnimalMapper {
+public interface ToolMapper {
 
-    AnimalMapper INSTANCE = Mappers.getMapper( AnimalMapper.class );
+    ToolMapper INSTANCE = Mappers.getMapper( ToolMapper.class );
 
-    @Mappings({
-        @Mapping(target = "publicAge", ignore = true),
-        @Mapping(target = "age", ignore = true),
-        @Mapping(target = "publicColor", source = "publicColour", ignore = true),
-        @Mapping(target = "color", source = "colour", ignore = true)
-    })
-    AnimalDto animalToDto(Animal animal);
-
+    //
+    @InheritConfiguration( name = "mapTool" )
     @BeanMapping( ignoreByDefault = true )
-    AnimalDto animalToDtoIgnoreAll(Animal animal);
+    HammerEntity mapHammer(HammerDto source);
 
-    @InheritInverseConfiguration( name = "animalToDto" )
-    Animal animalDtoToAnimal(AnimalDto animalDto);
+    @Mapping( target = "type", source = "toolType" )
+    @InheritConfiguration( name = "mapBase" )
+    ToolEntity mapTool(ToolDto source);
+
+    // demonstrates that all the businss stuff is mapped (implicit-by-name and defined)
+    @InheritConfiguration( name = "mapBase" )
+    @Mapping(target = "description", source = "articleDescription")
+    WorkBenchEntity mapBench(WorkBenchDto source);
+
+    // ignore all the base properties by default
+    @BeanMapping( ignoreByDefault = true )
+    BaseEntity mapBase(Object o);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/WorkBenchDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/WorkBenchDto.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.inherit;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class WorkBenchDto extends BaseEntity {
+
+    private String articleName;
+    private String articleDescription;
+
+    public String getArticleName() {
+        return articleName;
+    }
+
+    public void setArticleName(String articleName) {
+        this.articleName = articleName;
+    }
+
+    public String getArticleDescription() {
+        return articleDescription;
+    }
+
+    public void setArticleDescription(String articleDescription) {
+        this.articleDescription = articleDescription;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/WorkBenchEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignore/inherit/WorkBenchEntity.java
@@ -1,0 +1,46 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.ignore.inherit;
+
+/**
+ *
+ * @author Sjaak Derksen
+ */
+public class WorkBenchEntity extends BaseEntity {
+
+    private String articleName;
+    private String description;
+
+    public String getArticleName() {
+        return articleName;
+    }
+
+    public void setArticleName(String articleName) {
+        this.articleName = articleName;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+}


### PR DESCRIPTION
The user can now control the mapping on `@BeanMapping` level. Especially when there only a few source properties and the target object has a large number of properties this comes in handy.

In stead of manually entering all the `@Mapping( target = "?", ignore=true ), this is now the default behaviour for this one method.

Note that this is different than disabling warnings (unmapped target policy). This leaves still implicit mappings to take care of.

See #1392 for more details.
