### PR TITLE
#1359 Collection target should be considered as immutable if there is no read accessor

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
@@ -125,7 +125,7 @@ public class CollectionAssignmentBuilder {
         Assignment result = assignment;
 
         CollectionMappingStrategyPrism cms = method.getMapperConfiguration().getCollectionMappingStrategy();
-        boolean targetImmutable = cms == CollectionMappingStrategyPrism.TARGET_IMMUTABLE;
+        boolean targetImmutable = cms == CollectionMappingStrategyPrism.TARGET_IMMUTABLE || targetReadAccessor == null;
 
         if ( targetAccessorType == PropertyMapping.TargetWriteAccessorType.SETTER ||
             targetAccessorType == PropertyMapping.TargetWriteAccessorType.FIELD ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1359/Issue1359Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1359/Issue1359Mapper.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1359;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue1359Mapper {
+
+    Issue1359Mapper INSTANCE = Mappers.getMapper( Issue1359Mapper.class );
+
+    void map(@MappingTarget Target target, Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1359/Issue1359Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1359/Issue1359Test.java
@@ -1,0 +1,59 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1359;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.atIndex;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses( {
+    Issue1359Mapper.class,
+    Source.class,
+    Target.class
+} )
+@RunWith( AnnotationProcessorTestRunner.class )
+@IssueKey( "1359" )
+public class Issue1359Test {
+
+    @Test
+    public void shouldCompile() {
+
+        Target target = new Target();
+        assertThat( target ).extracting( "properties" ).contains( null, atIndex( 0 ) );
+
+        Set<String> properties = new HashSet<String>();
+        properties.add( "first" );
+        Source source = new Source( properties );
+        Issue1359Mapper.INSTANCE.map( target, source );
+
+        assertThat( target ).extracting( "properties" ).contains( properties, atIndex( 0 ) );
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1359/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1359/Source.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1359;
+
+import java.util.Set;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Source {
+
+    private Set<String> properties;
+
+    public Source(Set<String> properties) {
+        this.properties = properties;
+    }
+
+    public Set<String> getProperties() {
+        return properties;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1359/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1359/Target.java
@@ -1,0 +1,33 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1359;
+
+import java.util.Set;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Target {
+
+    private Set<String> properties;
+
+    public void setProperties(Set<String> properties) {
+        this.properties = properties;
+    }
+}


### PR DESCRIPTION
Fixes #1359.

We need to consider a collection target as immutable if there is no read accessor for it