### PR TITLE
#1383 Report error on the @Mapping annotation when using invalid values

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
@@ -110,35 +110,59 @@ public class Mapping {
         }
 
         if ( !mappingPrism.source().isEmpty() && mappingPrism.values.constant() != null ) {
-            messager.printMessage( element, Message.PROPERTYMAPPING_SOURCE_AND_CONSTANT_BOTH_DEFINED );
+            messager.printMessage(
+                    element,
+                    mappingPrism.mirror,
+                    Message.PROPERTYMAPPING_SOURCE_AND_CONSTANT_BOTH_DEFINED );
             return null;
         }
         else if ( !mappingPrism.source().isEmpty() && mappingPrism.values.expression() != null ) {
-            messager.printMessage( element, Message.PROPERTYMAPPING_SOURCE_AND_EXPRESSION_BOTH_DEFINED );
+            messager.printMessage(
+                    element,
+                    mappingPrism.mirror,
+                    Message.PROPERTYMAPPING_SOURCE_AND_EXPRESSION_BOTH_DEFINED );
             return null;
         }
         else if ( mappingPrism.values.expression() != null && mappingPrism.values.constant() != null ) {
-            messager.printMessage( element, Message.PROPERTYMAPPING_EXPRESSION_AND_CONSTANT_BOTH_DEFINED );
+            messager.printMessage(
+                    element,
+                    mappingPrism.mirror,
+                    Message.PROPERTYMAPPING_EXPRESSION_AND_CONSTANT_BOTH_DEFINED );
             return null;
         }
         else if ( mappingPrism.values.expression() != null && mappingPrism.values.defaultValue() != null ) {
-            messager.printMessage( element, Message.PROPERTYMAPPING_EXPRESSION_AND_DEFAULT_VALUE_BOTH_DEFINED );
+            messager.printMessage(
+                    element,
+                    mappingPrism.mirror,
+                    Message.PROPERTYMAPPING_EXPRESSION_AND_DEFAULT_VALUE_BOTH_DEFINED );
             return null;
         }
         else if ( mappingPrism.values.constant() != null && mappingPrism.values.defaultValue() != null ) {
-            messager.printMessage( element, Message.PROPERTYMAPPING_CONSTANT_AND_DEFAULT_VALUE_BOTH_DEFINED );
+            messager.printMessage(
+                    element,
+                    mappingPrism.mirror,
+                    Message.PROPERTYMAPPING_CONSTANT_AND_DEFAULT_VALUE_BOTH_DEFINED );
             return null;
         }
         else if ( mappingPrism.values.expression() != null && mappingPrism.values.defaultExpression() != null) {
-            messager.printMessage( element, Message.PROPERTYMAPPING_EXPRESSION_AND_DEFAULT_EXPRESSION_BOTH_DEFINED );
+            messager.printMessage(
+                    element,
+                    mappingPrism.mirror,
+                    Message.PROPERTYMAPPING_EXPRESSION_AND_DEFAULT_EXPRESSION_BOTH_DEFINED );
             return null;
         }
         else if ( mappingPrism.values.constant() != null && mappingPrism.values.defaultExpression() != null) {
-            messager.printMessage( element, Message.PROPERTYMAPPING_CONSTANT_AND_DEFAULT_EXPRESSION_BOTH_DEFINED );
+            messager.printMessage(
+                    element,
+                    mappingPrism.mirror,
+                    Message.PROPERTYMAPPING_CONSTANT_AND_DEFAULT_EXPRESSION_BOTH_DEFINED );
             return null;
         }
         else if ( mappingPrism.values.defaultValue() != null && mappingPrism.values.defaultExpression() != null) {
-            messager.printMessage( element, Message.PROPERTYMAPPING_DEFAULT_VALUE_AND_DEFAULT_EXPRESSION_BOTH_DEFINED );
+            messager.printMessage(
+                    element,
+                    mappingPrism.mirror,
+                    Message.PROPERTYMAPPING_DEFAULT_VALUE_AND_DEFAULT_EXPRESSION_BOTH_DEFINED );
             return null;
         }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/DefaultValueTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/defaultvalue/DefaultValueTest.java
@@ -138,7 +138,7 @@ public class DefaultValueTest {
             diagnostics = {
                     @Diagnostic( type = ErroneousMapper.class,
                             kind = javax.tools.Diagnostic.Kind.ERROR,
-                            line = 33,
+                            line = 31,
                             messageRegExp = "Constant and default value are both defined in @Mapping,"
                                     + " either define a defaultValue or a constant." ),
                     @Diagnostic(type = ErroneousMapper.class,
@@ -160,7 +160,7 @@ public class DefaultValueTest {
             diagnostics = {
                     @Diagnostic( type = ErroneousMapper2.class,
                             kind = javax.tools.Diagnostic.Kind.ERROR,
-                            line = 33,
+                            line = 31,
                             messageRegExp = "Expression and default value are both defined in @Mapping,"
                                     + " either define a defaultValue or an expression." ),
                     @Diagnostic(type = ErroneousMapper2.class,

--- a/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceConstantsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceConstantsTest.java
@@ -103,7 +103,7 @@ public class SourceConstantsTest {
         diagnostics = {
             @Diagnostic(type = ErroneousMapper1.class,
                 kind = Kind.ERROR,
-                line = 43,
+                line = 37,
                 messageRegExp = "Source and constant are both defined in @Mapping, either define a source or a "
                     + "constant"),
             @Diagnostic(type = ErroneousMapper1.class,
@@ -129,7 +129,7 @@ public class SourceConstantsTest {
         diagnostics = {
             @Diagnostic(type = ErroneousMapper3.class,
                 kind = Kind.ERROR,
-                line = 43,
+                line = 37,
                 messageRegExp =
                     "Expression and constant are both defined in @Mapping, either define an expression or a "
                         + "constant"),
@@ -156,7 +156,7 @@ public class SourceConstantsTest {
         diagnostics = {
             @Diagnostic(type = ErroneousMapper4.class,
                 kind = Kind.ERROR,
-                line = 43,
+                line = 37,
                 messageRegExp = "Source and expression are both defined in @Mapping, either define a source or an "
                     + "expression"),
             @Diagnostic(type = ErroneousMapper4.class,

--- a/processor/src/test/java/org/mapstruct/ap/test/source/defaultExpressions/java/JavaDefaultExpressionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/defaultExpressions/java/JavaDefaultExpressionTest.java
@@ -68,7 +68,7 @@ public class JavaDefaultExpressionTest {
         diagnostics = {
             @Diagnostic(type = ErroneousDefaultExpressionExpressionMapper.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
-                line = 39,
+                line = 35,
                 messageRegExp = "Expression and default expression are both defined in @Mapping,"
                     + " either define an expression or a default expression."
             ),
@@ -89,7 +89,7 @@ public class JavaDefaultExpressionTest {
         diagnostics = {
             @Diagnostic(type = ErroneousDefaultExpressionConstantMapper.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
-                line = 38,
+                line = 35,
                 messageRegExp = "Constant and default expression are both defined in @Mapping,"
                     + " either define a constant or a default expression."
             ),
@@ -110,7 +110,7 @@ public class JavaDefaultExpressionTest {
         diagnostics = {
             @Diagnostic(type = ErroneousDefaultExpressionDefaultValueMapper.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
-                line = 38,
+                line = 35,
                 messageRegExp = "Default value and default expression are both defined in @Mapping,"
                     + " either define a default value or a default expression."
             ),


### PR DESCRIPTION
This PR will change the line that is reported in an error message when an `@Mapping` annotation contains improper values. An example of this is:
```
@Mapper
public interface MyMapper {

    @Mapping( target = "id", expression = "java(String.valueOf( \"123\" )), constant = "1234") // error should be reported here
    Target map(Source source); // error report on this line
}
```

Before this PR, the error message would report an error on the Target. Now, the error message will report the line that the @Mapping annotation is on.