### PR TITLE
Remove cloudbees CI links and add travis-ci

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,7 @@ You love MapStruct but miss a certain feature? You found a bug and want to repor
 * Source code: [http://github.com/mapstruct/mapstruct](http://github.com/mapstruct/mapstruct)
 * Issue tracker: [https://github.com/mapstruct/mapstruct/issues](https://github.com/mapstruct/mapstruct/issues)
 * Discussions: Join the [mapstruct-users](https://groups.google.com/forum/?fromgroups#!forum/mapstruct-users) Google group
-* CI build: [https://mapstruct.ci.cloudbees.com](https://mapstruct.ci.cloudbees.com)
+* CI build: [https://travis-ci.org/mapstruct/mapstruct/](https://travis-ci.org/mapstruct/mapstruct/)
 
 MapStruct follows the _Fork & Pull_ development approach. To get started just fork the [MapStruct repository](http://github.com/mapstruct/mapstruct) to your GitHub account and create a new topic branch for each change. Once you are done with your change, submit a [pull request](https://help.github.com/articles/using-pull-requests) against the MapStruct repo.
 

--- a/readme.md
+++ b/readme.md
@@ -139,11 +139,7 @@ from the root of the project directory. To skip the distribution module, run
 * [Downloads](https://sourceforge.net/projects/mapstruct/files/)
 * [Issue tracker](https://github.com/mapstruct/mapstruct/issues)
 * [User group](https://groups.google.com/forum/?hl=en#!forum/mapstruct-users)
-* [CI build](https://mapstruct.ci.cloudbees.com/)
-
-<div style="float: right">
-    <a href="https://mapstruct.ci.cloudbees.com/"><img src="http://www.cloudbees.com/sites/default/files/Button-Built-on-CB-1.png"/></a>
-</div>
+* [CI build](https://travis-ci.org/mapstruct/mapstruct/)
 
 ## Licensing
 


### PR DESCRIPTION
Just a small PR that replaces the cloudbees links I found with travis-ci links.

I haven't found such a nice "built on" image that is shown for cloudbees for travis-ci, but I guess this is not so important as the build status is already available at the top of `readme.md`.