### PR TITLE
 #1425 Update builtin templates and add package name to all classes

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInMethod.java
@@ -18,14 +18,11 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.first;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
 import javax.lang.model.element.ExecutableElement;
 
 import org.mapstruct.ap.internal.conversion.SimpleConversion;
@@ -38,6 +35,8 @@ import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.ParameterProvidedMethods;
 import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Strings;
+
+import static org.mapstruct.ap.internal.util.Collections.first;
 
 /**
  * Represents a "built-in" mapping method which will be added as private method to the generated mapper. Built-in

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/CalendarToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/CalendarToXmlGregorianCalendar.java
@@ -18,14 +18,7 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Calendar;
-import java.util.GregorianCalendar;
-import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -39,24 +32,10 @@ public class CalendarToXmlGregorianCalendar extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public CalendarToXmlGregorianCalendar(TypeFactory typeFactory) {
         this.parameter = new Parameter( "cal ", typeFactory.getType( Calendar.class ) );
         this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
-        this.importTypes = asSet(
-            returnType,
-            parameter.getType(),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( GregorianCalendar.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
-        );
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/CalendarToZonedDateTime.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/CalendarToZonedDateTime.java
@@ -18,11 +18,8 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.time.ZonedDateTime;
 import java.util.Calendar;
-import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
@@ -38,12 +35,10 @@ public class CalendarToZonedDateTime extends BuiltInMethod {
 
     private final Type returnType;
     private final Parameter parameter;
-    private final Set<Type> importedTypes;
 
     CalendarToZonedDateTime(TypeFactory typeFactory) {
         this.returnType = typeFactory.getType( JavaTimeConstants.ZONED_DATE_TIME_FQN );
         this.parameter = new Parameter( "cal", typeFactory.getType( Calendar.class ) );
-        this.importedTypes = asSet( returnType, parameter.getType() );
     }
 
     @Override
@@ -54,10 +49,5 @@ public class CalendarToZonedDateTime extends BuiltInMethod {
     @Override
     public Type getReturnType() {
         return returnType;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importedTypes;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/DateToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/DateToXmlGregorianCalendar.java
@@ -18,14 +18,7 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Date;
-import java.util.GregorianCalendar;
-import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -39,24 +32,10 @@ public class DateToXmlGregorianCalendar extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public DateToXmlGregorianCalendar(TypeFactory typeFactory) {
         this.parameter = new Parameter( "date", typeFactory.getType( Date.class ) );
         this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
-        this.importTypes = asSet(
-            returnType,
-            parameter.getType(),
-            typeFactory.getType( GregorianCalendar.class ),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
-        );
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.java
@@ -18,10 +18,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
-import java.util.Set;
-
 import javax.xml.bind.JAXBElement;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -35,12 +31,10 @@ public class JaxbElemToValue extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public JaxbElemToValue(TypeFactory typeFactory) {
         this.parameter = new Parameter( "element", typeFactory.getType( JAXBElement.class ) );
         this.returnType = typeFactory.getType( Object.class );
-        this.importTypes = asSet( parameter.getType() );
     }
 
     @Override
@@ -60,10 +54,5 @@ public class JaxbElemToValue extends BuiltInMethod {
     @Override
     public Type getReturnType() {
         return returnType;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaDateTimeToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaDateTimeToXmlGregorianCalendar.java
@@ -18,12 +18,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
-import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -38,7 +32,6 @@ public class JodaDateTimeToXmlGregorianCalendar extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public JodaDateTimeToXmlGregorianCalendar(TypeFactory typeFactory) {
         this.parameter = new Parameter(
@@ -46,18 +39,6 @@ public class JodaDateTimeToXmlGregorianCalendar extends BuiltInMethod {
             typeFactory.getType( JodaTimeConstants.DATE_TIME_FQN )
         );
         this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
-        this.importTypes = asSet(
-            returnType,
-            parameter.getType(),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
-        );
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.java
@@ -18,13 +18,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
-import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -39,7 +32,6 @@ public class JodaLocalDateTimeToXmlGregorianCalendar extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public JodaLocalDateTimeToXmlGregorianCalendar(TypeFactory typeFactory) {
         this.parameter = new Parameter(
@@ -47,19 +39,6 @@ public class JodaLocalDateTimeToXmlGregorianCalendar extends BuiltInMethod {
             typeFactory.getType( JodaTimeConstants.LOCAL_DATE_TIME_FQN )
         );
         this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
-        this.importTypes = asSet(
-            returnType,
-            parameter.getType(),
-            typeFactory.getType( DatatypeConstants.class ),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
-        );
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.java
@@ -18,13 +18,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
-import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -39,7 +32,6 @@ public class JodaLocalDateToXmlGregorianCalendar extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public JodaLocalDateToXmlGregorianCalendar(TypeFactory typeFactory) {
         this.parameter = new Parameter(
@@ -47,19 +39,6 @@ public class JodaLocalDateToXmlGregorianCalendar extends BuiltInMethod {
             typeFactory.getType( JodaTimeConstants.LOCAL_DATE_FQN )
         );
         this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
-        this.importTypes = asSet(
-            returnType,
-            parameter.getType(),
-            typeFactory.getType( DatatypeConstants.class ),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
-        );
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.java
@@ -18,13 +18,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
-import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -39,7 +32,6 @@ public class JodaLocalTimeToXmlGregorianCalendar extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public JodaLocalTimeToXmlGregorianCalendar(TypeFactory typeFactory) {
         this.parameter = new Parameter(
@@ -47,19 +39,6 @@ public class JodaLocalTimeToXmlGregorianCalendar extends BuiltInMethod {
             typeFactory.getType( JodaTimeConstants.LOCAL_TIME_FQN )
         );
         this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
-        this.importTypes = asSet(
-            returnType,
-            parameter.getType(),
-            typeFactory.getType( DatatypeConstants.class ),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
-        );
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.java
@@ -18,14 +18,7 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.time.LocalDate;
-import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -39,18 +32,10 @@ public class LocalDateToXmlGregorianCalendar extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public LocalDateToXmlGregorianCalendar(TypeFactory typeFactory) {
         this.parameter = new Parameter( "localDate", typeFactory.getType( LocalDate.class ) );
         this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-        this.importTypes = asSet(
-                returnType,
-                parameter.getType(),
-                typeFactory.getType( DatatypeFactory.class ),
-                typeFactory.getType( DatatypeConfigurationException.class ),
-                typeFactory.getType( DatatypeConstants.class )
-        );
     }
 
     @Override
@@ -61,10 +46,5 @@ public class LocalDateToXmlGregorianCalendar extends BuiltInMethod {
     @Override
     public Type getReturnType() {
         return returnType;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/StringToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/StringToXmlGregorianCalendar.java
@@ -18,16 +18,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.GregorianCalendar;
-import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
@@ -42,25 +32,10 @@ public class StringToXmlGregorianCalendar extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public StringToXmlGregorianCalendar(TypeFactory typeFactory) {
         this.parameter = new Parameter( "date", typeFactory.getType( String.class ) );
         this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-        this.importTypes = asSet(
-            returnType,
-            typeFactory.getType( GregorianCalendar.class ),
-            typeFactory.getType( SimpleDateFormat.class ),
-            typeFactory.getType( DateFormat.class ),
-            typeFactory.getType( ParseException.class ),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
-        );
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToCalendar.java
@@ -18,11 +18,7 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Calendar;
-import java.util.Set;
-
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -36,12 +32,10 @@ public class XmlGregorianCalendarToCalendar extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public XmlGregorianCalendarToCalendar(TypeFactory typeFactory) {
         this.parameter = new Parameter( "xcal", typeFactory.getType( XMLGregorianCalendar.class ) );
         this.returnType = typeFactory.getType( Calendar.class );
-        this.importTypes = asSet( returnType, parameter.getType() );
     }
 
     @Override
@@ -52,10 +46,5 @@ public class XmlGregorianCalendarToCalendar extends BuiltInMethod {
     @Override
     public Type getReturnType() {
         return returnType;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.java
@@ -18,11 +18,7 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Date;
-import java.util.Set;
-
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -36,12 +32,10 @@ public class XmlGregorianCalendarToDate extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public XmlGregorianCalendarToDate(TypeFactory typeFactory) {
         this.parameter = new Parameter( "xcal", typeFactory.getType( XMLGregorianCalendar.class ) );
         this.returnType = typeFactory.getType( Date.class );
-        this.importTypes = asSet( returnType, parameter.getType() );
     }
 
     @Override
@@ -52,10 +46,5 @@ public class XmlGregorianCalendarToDate extends BuiltInMethod {
     @Override
     public Type getReturnType() {
         return returnType;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaDateTime.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaDateTime.java
@@ -18,10 +18,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
-import java.util.Set;
-import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -36,16 +32,10 @@ public class XmlGregorianCalendarToJodaDateTime extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public XmlGregorianCalendarToJodaDateTime(TypeFactory typeFactory) {
         this.parameter = new Parameter( "xcal", typeFactory.getType( XMLGregorianCalendar.class ) );
         this.returnType = typeFactory.getType( JodaTimeConstants.DATE_TIME_FQN );
-        this.importTypes = asSet(
-            typeFactory.getType( DatatypeConstants.class ),
-            typeFactory.getType( JodaTimeConstants.DATE_TIME_ZONE_FQN ),
-            returnType,
-            parameter.getType() );
     }
 
     @Override
@@ -56,10 +46,5 @@ public class XmlGregorianCalendarToJodaDateTime extends BuiltInMethod {
     @Override
     public Type getReturnType() {
         return returnType;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.java
@@ -18,10 +18,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
-import java.util.Set;
-import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -36,15 +32,10 @@ public class XmlGregorianCalendarToJodaLocalDate extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public XmlGregorianCalendarToJodaLocalDate(TypeFactory typeFactory) {
         this.parameter = new Parameter( "xcal", typeFactory.getType( XMLGregorianCalendar.class ) );
         this.returnType = typeFactory.getType( JodaTimeConstants.LOCAL_DATE_FQN );
-        this.importTypes = asSet(
-            typeFactory.getType( DatatypeConstants.class ),
-            returnType,
-            parameter.getType() );
     }
 
     @Override
@@ -55,10 +46,5 @@ public class XmlGregorianCalendarToJodaLocalDate extends BuiltInMethod {
     @Override
     public Type getReturnType() {
         return returnType;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.java
@@ -18,10 +18,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
-import java.util.Set;
-import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -36,15 +32,10 @@ public class XmlGregorianCalendarToJodaLocalDateTime extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public XmlGregorianCalendarToJodaLocalDateTime(TypeFactory typeFactory) {
         this.parameter = new Parameter( "xcal", typeFactory.getType( XMLGregorianCalendar.class ) );
         this.returnType = typeFactory.getType( JodaTimeConstants.LOCAL_DATE_TIME_FQN );
-        this.importTypes = asSet(
-            typeFactory.getType( DatatypeConstants.class ),
-            returnType,
-            parameter.getType() );
     }
 
     @Override
@@ -55,10 +46,5 @@ public class XmlGregorianCalendarToJodaLocalDateTime extends BuiltInMethod {
     @Override
     public Type getReturnType() {
         return returnType;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.java
@@ -18,10 +18,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
-import java.util.Set;
-import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -36,15 +32,10 @@ public class XmlGregorianCalendarToJodaLocalTime extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public XmlGregorianCalendarToJodaLocalTime(TypeFactory typeFactory) {
         this.parameter = new Parameter( "xcal", typeFactory.getType( XMLGregorianCalendar.class ) );
         this.returnType = typeFactory.getType( JodaTimeConstants.LOCAL_TIME_FQN );
-        this.importTypes = asSet(
-            typeFactory.getType( DatatypeConstants.class ),
-            returnType,
-            parameter.getType() );
     }
 
     @Override
@@ -55,10 +46,5 @@ public class XmlGregorianCalendarToJodaLocalTime extends BuiltInMethod {
     @Override
     public Type getReturnType() {
         return returnType;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.java
@@ -18,12 +18,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.Set;
-
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
@@ -38,21 +32,10 @@ public class XmlGregorianCalendarToString extends BuiltInMethod {
 
     private final Parameter parameter;
     private final Type returnType;
-    private final Set<Type> importTypes;
 
     public XmlGregorianCalendarToString(TypeFactory typeFactory) {
         this.parameter = new Parameter( "xcal", typeFactory.getType( XMLGregorianCalendar.class ) );
         this.returnType = typeFactory.getType( String.class );
-        this.importTypes = asSet(
-            parameter.getType(),
-            typeFactory.getType( Date.class ),
-            typeFactory.getType( SimpleDateFormat.class )
-        );
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToCalendar.java
@@ -18,12 +18,8 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.time.ZonedDateTime;
 import java.util.Calendar;
-import java.util.Set;
-import java.util.TimeZone;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
@@ -38,12 +34,10 @@ import org.mapstruct.ap.internal.util.JavaTimeConstants;
 public class ZonedDateTimeToCalendar extends BuiltInMethod {
     private final Type returnType;
     private final Parameter parameter;
-    private final Set<Type> importedTypes;
 
     ZonedDateTimeToCalendar(TypeFactory typeFactory) {
         this.returnType = typeFactory.getType( Calendar.class );
         this.parameter = new Parameter( "dateTime", typeFactory.getType( JavaTimeConstants.ZONED_DATE_TIME_FQN ) );
-        this.importedTypes = asSet( returnType, parameter.getType(), typeFactory.getType( TimeZone.class ) );
     }
 
     @Override
@@ -54,10 +48,5 @@ public class ZonedDateTimeToCalendar extends BuiltInMethod {
     @Override
     public Type getReturnType() {
         return returnType;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importedTypes;
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToXmlGregorianCalendar.ftl
@@ -19,17 +19,17 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( Calendar cal ) {
+private static javax.xml.datatype.XMLGregorianCalendar ${name}( java.util.Calendar cal ) {
     if ( cal == null ) {
         return null;
     }
 
     try {
-        GregorianCalendar gcal = new GregorianCalendar();
+        java.util.GregorianCalendar gcal = new java.util.GregorianCalendar();
         gcal.setTimeInMillis( cal.getTimeInMillis() );
-        return DatatypeFactory.newInstance().newXMLGregorianCalendar( gcal );
+        return javax.xml.datatype.DatatypeFactory.newInstance().newXMLGregorianCalendar( gcal );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( javax.xml.datatype.DatatypeConfigurationException ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToZonedDateTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToZonedDateTime.ftl
@@ -19,10 +19,10 @@
      limitations under the License.
 
 -->
-private ZonedDateTime ${name}(Calendar cal) {
+private static java.time.ZonedDateTime ${name}(java.util.Calendar cal) {
     if ( cal == null ) {
         return null;
     }
 
-    return ZonedDateTime.ofInstant( cal.toInstant(), cal.getTimeZone().toZoneId() );
+    return java.time.ZonedDateTime.ofInstant( cal.toInstant(), cal.getTimeZone().toZoneId() );
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/DateToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/DateToXmlGregorianCalendar.ftl
@@ -19,17 +19,17 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( Date date ) {
+private static javax.xml.datatype.XMLGregorianCalendar ${name}( java.util.Date date ) {
     if ( date == null ) {
         return null;
     }
 
     try {
-        GregorianCalendar c = new GregorianCalendar();
+        java.util.GregorianCalendar c = new java.util.GregorianCalendar();
         c.setTime( date );
-        return DatatypeFactory.newInstance().newXMLGregorianCalendar( c );
+        return javax.xml.datatype.DatatypeFactory.newInstance().newXMLGregorianCalendar( c );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( javax.xml.datatype.DatatypeConfigurationException ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private <T> T ${name}( JAXBElement<T> element ) {
+private static <T> T ${name}( javax.xml.bind.JAXBElement<T> element ) {
     if ( element == null ) {
         return null;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaDateTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaDateTimeToXmlGregorianCalendar.ftl
@@ -19,13 +19,13 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( DateTime dt ) {
+private static javax.xml.datatype.XMLGregorianCalendar ${name}( org.joda.time.DateTime dt ) {
     if ( dt == null ) {
         return null;
     }
 
     try {
-        return DatatypeFactory.newInstance().newXMLGregorianCalendar(
+        return javax.xml.datatype.DatatypeFactory.newInstance().newXMLGregorianCalendar(
             dt.getYear(),
             dt.getMonthOfYear(),
             dt.getDayOfMonth(),
@@ -35,7 +35,7 @@ private XMLGregorianCalendar ${name}( DateTime dt ) {
             dt.getMillisOfSecond(),
             dt.getZone().getOffset( null ) / 60000 );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( javax.xml.datatype.DatatypeConfigurationException ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.ftl
@@ -19,13 +19,13 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( LocalDateTime dt ) {
+private static javax.xml.datatype.XMLGregorianCalendar ${name}( org.joda.time.LocalDateTime dt ) {
     if ( dt == null ) {
         return null;
     }
 
     try {
-        return DatatypeFactory.newInstance().newXMLGregorianCalendar(
+        return javax.xml.datatype.DatatypeFactory.newInstance().newXMLGregorianCalendar(
             dt.getYear(),
             dt.getMonthOfYear(),
             dt.getDayOfMonth(),
@@ -33,9 +33,9 @@ private XMLGregorianCalendar ${name}( LocalDateTime dt ) {
             dt.getMinuteOfHour(),
             dt.getSecondOfMinute(),
             dt.getMillisOfSecond(),
-            DatatypeConstants.FIELD_UNDEFINED );
+            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( javax.xml.datatype.DatatypeConfigurationException ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.ftl
@@ -19,19 +19,19 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( LocalDate dt ) {
+private static javax.xml.datatype.XMLGregorianCalendar ${name}( org.joda.time.LocalDate dt ) {
     if ( dt == null ) {
         return null;
     }
 
     try {
-        return DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
+        return javax.xml.datatype.DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
             dt.getYear(),
             dt.getMonthOfYear(),
             dt.getDayOfMonth(),
-            DatatypeConstants.FIELD_UNDEFINED );
+            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( javax.xml.datatype.DatatypeConfigurationException ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.ftl
@@ -19,20 +19,20 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( LocalTime dt ) {
+private static javax.xml.datatype.XMLGregorianCalendar ${name}( org.joda.time.LocalTime dt ) {
     if ( dt == null ) {
         return null;
     }
 
     try {
-        return DatatypeFactory.newInstance().newXMLGregorianCalendarTime(
+        return javax.xml.datatype.DatatypeFactory.newInstance().newXMLGregorianCalendarTime(
             dt.getHourOfDay(),
             dt.getMinuteOfHour(),
             dt.getSecondOfMinute(),
             dt.getMillisOfSecond(),
-            DatatypeConstants.FIELD_UNDEFINED );
+            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( javax.xml.datatype.DatatypeConfigurationException ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.ftl
@@ -19,20 +19,20 @@
      limitations under the License.
 
 -->
-private static XMLGregorianCalendar ${name}( java.time.LocalDate localDate ) {
+private static javax.xml.datatype.XMLGregorianCalendar ${name}( java.time.LocalDate localDate ) {
     if ( localDate == null ) {
         return null;
     }
 
     try {
-        return DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
+        return javax.xml.datatype.DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
             localDate.getYear(),
             localDate.getMonthValue(),
             localDate.getDayOfMonth(),
-            DatatypeConstants.FIELD_UNDEFINED
+            javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
         );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( javax.xml.datatype.DatatypeConfigurationException ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/StringToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/StringToXmlGregorianCalendar.ftl
@@ -19,26 +19,26 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( String date, String dateFormat ) {
+private static javax.xml.datatype.XMLGregorianCalendar ${name}( String date, String dateFormat ) {
     if ( date == null ) {
         return null;
     }
 
     try {
         if ( dateFormat != null ) {
-            DateFormat df = new SimpleDateFormat( dateFormat );
-            GregorianCalendar c = new GregorianCalendar();
+            java.text.DateFormat df = new java.text.SimpleDateFormat( dateFormat );
+            java.util.GregorianCalendar c = new java.util.GregorianCalendar();
             c.setTime( df.parse( date ) );
-            return DatatypeFactory.newInstance().newXMLGregorianCalendar( c );
+            return javax.xml.datatype.DatatypeFactory.newInstance().newXMLGregorianCalendar( c );
         }
         else {
-            return DatatypeFactory.newInstance().newXMLGregorianCalendar( date );
+            return javax.xml.datatype.DatatypeFactory.newInstance().newXMLGregorianCalendar( date );
         }
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( javax.xml.datatype.DatatypeConfigurationException ex ) {
         throw new RuntimeException( ex );
     }
-    catch ( ParseException ex ) {
+    catch ( java.text.ParseException ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToCalendar.ftl
@@ -19,12 +19,12 @@
      limitations under the License.
 
 -->
-private Calendar ${name}( XMLGregorianCalendar xcal ) {
+private static java.util.Calendar ${name}( javax.xml.datatype.XMLGregorianCalendar xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    Calendar cal = Calendar.getInstance();
+    java.util.Calendar cal = java.util.Calendar.getInstance();
     cal.setTimeInMillis( xcal.toGregorianCalendar().getTimeInMillis() );
     return cal;
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private static Date ${name}( XMLGregorianCalendar xcal ) {
+private static java.util.Date ${name}( javax.xml.datatype.XMLGregorianCalendar xcal ) {
     if ( xcal == null ) {
         return null;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaDateTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaDateTime.ftl
@@ -19,33 +19,33 @@
      limitations under the License.
 
 -->
-private static DateTime ${name}( XMLGregorianCalendar xcal ) {
+private static org.joda.time.DateTime ${name}( javax.xml.datatype.XMLGregorianCalendar xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    if ( xcal.getYear() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getMonth() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getDay() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getHour() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getMinute() != DatatypeConstants.FIELD_UNDEFINED
+    if ( xcal.getYear() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+        && xcal.getMonth() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+        && xcal.getDay() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+        && xcal.getHour() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+        && xcal.getMinute() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
         ) {
-            if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getMillisecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getTimezone() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new DateTime( xcal.getYear(),
+            if ( xcal.getSecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+                && xcal.getMillisecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+                && xcal.getTimezone() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED ) {
+                return new org.joda.time.DateTime( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
                     xcal.getMinute(),
                     xcal.getSecond(),
                     xcal.getMillisecond(),
-                    DateTimeZone.forOffsetMillis( xcal.getTimezone() * 60000 )
+                    org.joda.time.DateTimeZone.forOffsetMillis( xcal.getTimezone() * 60000 )
                 );
             }
-            else if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getMillisecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new DateTime( xcal.getYear(),
+            else if ( xcal.getSecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+                && xcal.getMillisecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED ) {
+                return new org.joda.time.DateTime( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
@@ -54,19 +54,19 @@ private static DateTime ${name}( XMLGregorianCalendar xcal ) {
                     xcal.getMillisecond()
                 );
             }
-            else if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getTimezone() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new DateTime( xcal.getYear(),
+            else if ( xcal.getSecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+                && xcal.getTimezone() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED ) {
+                return new org.joda.time.DateTime( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
                     xcal.getMinute(),
                     xcal.getSecond(),
-                    DateTimeZone.forOffsetMillis( xcal.getTimezone() * 60000 )
+                    org.joda.time.DateTimeZone.forOffsetMillis( xcal.getTimezone() * 60000 )
                 );
             }
-            else if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new DateTime( xcal.getYear(),
+            else if ( xcal.getSecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED ) {
+                return new org.joda.time.DateTime( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
@@ -74,17 +74,17 @@ private static DateTime ${name}( XMLGregorianCalendar xcal ) {
                     xcal.getSecond()
                 );
             }
-            else if ( xcal.getTimezone() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new DateTime( xcal.getYear(),
+            else if ( xcal.getTimezone() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED ) {
+                return new org.joda.time.DateTime( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
                     xcal.getMinute(),
-                    DateTimeZone.forOffsetMillis( xcal.getTimezone() * 60000 )
+                    org.joda.time.DateTimeZone.forOffsetMillis( xcal.getTimezone() * 60000 )
             );
             }
             else {
-                return new DateTime( xcal.getYear(),
+                return new org.joda.time.DateTime( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.ftl
@@ -19,15 +19,15 @@
      limitations under the License.
 
 -->
-private static LocalDate ${name}( XMLGregorianCalendar xcal ) {
+private static org.joda.time.LocalDate ${name}( javax.xml.datatype.XMLGregorianCalendar xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    if ( xcal.getYear() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getMonth() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getDay() != DatatypeConstants.FIELD_UNDEFINED )  {
-            return new LocalDate( xcal.getYear(), xcal.getMonth(), xcal.getDay() );
+    if ( xcal.getYear() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+        && xcal.getMonth() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+        && xcal.getDay() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED )  {
+            return new org.joda.time.LocalDate( xcal.getYear(), xcal.getMonth(), xcal.getDay() );
     }
 
     return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.ftl
@@ -19,20 +19,20 @@
      limitations under the License.
 
 -->
-private static LocalDateTime ${name}( XMLGregorianCalendar xcal ) {
+private static org.joda.time.LocalDateTime ${name}( javax.xml.datatype.XMLGregorianCalendar xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    if ( xcal.getYear() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getMonth() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getDay() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getHour() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getMinute() != DatatypeConstants.FIELD_UNDEFINED
+    if ( xcal.getYear() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+        && xcal.getMonth() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+        && xcal.getDay() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+        && xcal.getHour() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+        && xcal.getMinute() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
         ) {
-            if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getMillisecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new LocalDateTime( xcal.getYear(),
+            if ( xcal.getSecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+                && xcal.getMillisecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED ) {
+                return new org.joda.time.LocalDateTime( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
@@ -41,8 +41,8 @@ private static LocalDateTime ${name}( XMLGregorianCalendar xcal ) {
                     xcal.getMillisecond()
                 );
             }
-            else if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new LocalDateTime( xcal.getYear(),
+            else if ( xcal.getSecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED ) {
+                return new org.joda.time.LocalDateTime( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
@@ -51,7 +51,7 @@ private static LocalDateTime ${name}( XMLGregorianCalendar xcal ) {
                 );
             }
             else {
-                return new LocalDateTime( xcal.getYear(),
+                return new org.joda.time.LocalDateTime( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.ftl
@@ -19,30 +19,30 @@
      limitations under the License.
 
 -->
-private static LocalTime ${name}( XMLGregorianCalendar xcal ) {
+private static org.joda.time.LocalTime ${name}( javax.xml.datatype.XMLGregorianCalendar xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    if ( xcal.getHour() != DatatypeConstants.FIELD_UNDEFINED
-         && xcal.getMinute() != DatatypeConstants.FIELD_UNDEFINED ) {
-            if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getMillisecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new LocalTime( xcal.getHour(),
+    if ( xcal.getHour() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+         && xcal.getMinute() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED ) {
+            if ( xcal.getSecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED
+                && xcal.getMillisecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED ) {
+                return new org.joda.time.LocalTime( xcal.getHour(),
                     xcal.getMinute(),
                     xcal.getSecond(),
                     xcal.getMillisecond()
                 );
             }
-            else if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new LocalTime(
+            else if ( xcal.getSecond() != javax.xml.datatype.DatatypeConstants.FIELD_UNDEFINED ) {
+                return new org.joda.time.LocalTime(
                     xcal.getHour(),
                     xcal.getMinute(),
                     xcal.getSecond()
                 );
             }
             else {
-                return new LocalTime( xcal.getHour(),
+                return new org.joda.time.LocalTime( xcal.getHour(),
                     xcal.getMinute()
             );
             }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToLocalDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToLocalDate.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private static java.time.LocalDate ${name}( XMLGregorianCalendar xcal ) {
+private static java.time.LocalDate ${name}( javax.xml.datatype.XMLGregorianCalendar xcal ) {
     if ( xcal == null ) {
         return null;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private String ${name}( XMLGregorianCalendar xcal, String dateFormat ) {
+private static String ${name}( javax.xml.datatype.XMLGregorianCalendar xcal, String dateFormat ) {
     if ( xcal == null ) {
         return null;
     }
@@ -28,8 +28,8 @@ private String ${name}( XMLGregorianCalendar xcal, String dateFormat ) {
         return xcal.toString();
     }
     else {
-        Date d = xcal.toGregorianCalendar().getTime();
-        SimpleDateFormat sdf = new SimpleDateFormat( dateFormat );
+        java.util.Date d = xcal.toGregorianCalendar().getTime();
+        java.text.SimpleDateFormat sdf = new java.text.SimpleDateFormat( dateFormat );
         return sdf.format( d );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToCalendar.ftl
@@ -19,12 +19,12 @@
      limitations under the License.
 
 -->
-private Calendar ${name}(ZonedDateTime dateTime) {
+private static java.util.Calendar ${name}(java.time.ZonedDateTime dateTime) {
     if ( dateTime == null ) {
        return null;
     }
 
-    Calendar instance = Calendar.getInstance( TimeZone.getTimeZone( dateTime.getZone() ) );
+    java.util.Calendar instance = java.util.Calendar.getInstance( java.util.TimeZone.getTimeZone( dateTime.getZone() ) );
     instance.setTimeInMillis( dateTime.toInstant().toEpochMilli() );
     return instance;
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Mapper.java
@@ -16,35 +16,24 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.internal.model.source.builtin;
+package org.mapstruct.ap.test.bugs._1425;
 
 import java.time.LocalDate;
-import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.mapstruct.ap.internal.model.common.Parameter;
-import org.mapstruct.ap.internal.model.common.Type;
-import org.mapstruct.ap.internal.model.common.TypeFactory;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
 
 /**
- * @author Gunnar Morling
+ * @author Christian Bandowski
  */
-public class XmlGregorianCalendarToLocalDate extends BuiltInMethod {
+@Mapper
+public abstract class Issue1425Mapper {
 
-    private final Parameter parameter;
-    private final Type returnType;
+    public static final Issue1425Mapper INSTANCE = Mappers.getMapper( Issue1425Mapper.class );
 
-    public XmlGregorianCalendarToLocalDate(TypeFactory typeFactory) {
-        this.parameter = new Parameter( "xcal", typeFactory.getType( XMLGregorianCalendar.class ) );
-        this.returnType = typeFactory.getType( LocalDate.class );
-    }
+    public abstract Target map(Source source);
 
-    @Override
-    public Parameter getParameter() {
-        return parameter;
-    }
-
-    @Override
-    public Type getReturnType() {
-        return returnType;
+    LocalDate now() {
+        return LocalDate.now();
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Test.java
@@ -1,0 +1,57 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1425;
+
+import org.joda.time.LocalDate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Christian Bandowski
+ */
+@WithClasses({
+    Issue1425Mapper.class,
+    Source.class,
+    Target.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1425")
+public class Issue1425Test {
+
+    @Test
+    public void shouldGenerateValidCode() {
+
+    }
+
+    @Test
+    public void shouldTestMappingLocalDates() {
+        Source source = new Source();
+        source.setValue( LocalDate.parse( "2018-04-18" ) );
+
+        Target target = Issue1425Mapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getValue() ).isEqualTo( "2018-04-18" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Source.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1425;
+
+import org.joda.time.LocalDate;
+
+/**
+ * @author Christian Bandowski
+ */
+public class Source {
+
+    private LocalDate value;
+
+    public LocalDate getValue() {
+        return value;
+    }
+
+    public void setValue(LocalDate value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Target.java
@@ -16,35 +16,22 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.internal.model.source.builtin;
+package org.mapstruct.ap.test.bugs._1425;
 
 import java.time.LocalDate;
-import javax.xml.datatype.XMLGregorianCalendar;
-
-import org.mapstruct.ap.internal.model.common.Parameter;
-import org.mapstruct.ap.internal.model.common.Type;
-import org.mapstruct.ap.internal.model.common.TypeFactory;
 
 /**
- * @author Gunnar Morling
+ * @author Christian Bandowski
  */
-public class XmlGregorianCalendarToLocalDate extends BuiltInMethod {
+public class Target {
 
-    private final Parameter parameter;
-    private final Type returnType;
+    private LocalDate value;
 
-    public XmlGregorianCalendarToLocalDate(TypeFactory typeFactory) {
-        this.parameter = new Parameter( "xcal", typeFactory.getType( XMLGregorianCalendar.class ) );
-        this.returnType = typeFactory.getType( LocalDate.class );
+    public LocalDate getValue() {
+        return value;
     }
 
-    @Override
-    public Parameter getParameter() {
-        return parameter;
-    }
-
-    @Override
-    public Type getReturnType() {
-        return returnType;
+    public void setValue(LocalDate value) {
+        this.value = value;
     }
 }


### PR DESCRIPTION
Importing the classes, as it was before, makes troubles as soon as a
class with the same name in a different package is used. It is not
possible to have two imports for classes with the same simple-name and
thus it is safer to always include the package name and don't use
imports for the builtin templates

Hopefully I don't missed a package in the templates, but all tests were fine. So in case for every builtin template there is at least one testcase my changes should be okay. Otherwise there should be a compile issue which would break the test.