### PR TITLE
#1425 Added findType to VirtualMappingMethod and use it in all builtin templates

### DIFF
--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationTest.java
@@ -70,6 +70,7 @@ public class FullFeatureCompilationTest {
                 case ORACLE_JAVA_6:
                     additionalExcludes.add( "org/mapstruct/ap/test/abstractclass/generics/*.java" );
                     additionalExcludes.add( "org/mapstruct/ap/test/bugs/_1170/*.java" );
+                    additionalExcludes.add( "org/mapstruct/ap/test/bugs/_1425/*.java" );
                 case ECLIPSE_JDT_JAVA_6:
                 case ORACLE_JAVA_7:
                 case ECLIPSE_JDT_JAVA_7:

--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationTest.java
@@ -70,10 +70,10 @@ public class FullFeatureCompilationTest {
                 case ORACLE_JAVA_6:
                     additionalExcludes.add( "org/mapstruct/ap/test/abstractclass/generics/*.java" );
                     additionalExcludes.add( "org/mapstruct/ap/test/bugs/_1170/*.java" );
-                    additionalExcludes.add( "org/mapstruct/ap/test/bugs/_1425/*.java" );
                 case ECLIPSE_JDT_JAVA_6:
                 case ORACLE_JAVA_7:
                 case ECLIPSE_JDT_JAVA_7:
+                    additionalExcludes.add( "org/mapstruct/ap/test/bugs/_1425/*.java" );
                     additionalExcludes.add( "**/java8*/**/*.java" );
                     break;
                 case ORACLE_JAVA_9:

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/VirtualMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/VirtualMappingMethod.java
@@ -56,6 +56,29 @@ public class VirtualMappingMethod extends MappingMethod {
         return importTypes;
     }
 
+    /**
+     * Finds a {@link Type} by a given name. The {@code name} will be compared to the fully-qualified and also simple
+     * names of the {@code importTypes}.
+     *
+     * @param name Fully-qualified or simple name of the type.
+     *
+     * @return Found type, never <code>null</code>.
+     *
+     * @throws IllegalArgumentException In case no {@link Type} was found for given name.
+     */
+    public Type findType(String name) {
+        for ( Type type : importTypes ) {
+            if ( type.getFullyQualifiedName().contentEquals( name ) ) {
+                return type;
+            }
+            if ( type.getName().contentEquals( name ) ) {
+                return type;
+            }
+        }
+
+        throw new IllegalArgumentException( "No type for given name '" + name + "' found in 'importTypes'." );
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToXmlGregorianCalendar.ftl
@@ -19,17 +19,17 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( Calendar cal ) {
+private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("Calendar")/> cal ) {
     if ( cal == null ) {
         return null;
     }
 
     try {
-        GregorianCalendar gcal = new GregorianCalendar();
+        <@includeModel object=findType("GregorianCalendar")/> gcal = new <@includeModel object=findType("GregorianCalendar")/>();
         gcal.setTimeInMillis( cal.getTimeInMillis() );
-        return DatatypeFactory.newInstance().newXMLGregorianCalendar( gcal );
+        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar( gcal );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToZonedDateTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToZonedDateTime.ftl
@@ -19,10 +19,10 @@
      limitations under the License.
 
 -->
-private ZonedDateTime ${name}(Calendar cal) {
+private <@includeModel object=findType("ZonedDateTime")/> ${name}(<@includeModel object=findType("Calendar")/> cal) {
     if ( cal == null ) {
         return null;
     }
 
-    return ZonedDateTime.ofInstant( cal.toInstant(), cal.getTimeZone().toZoneId() );
+    return <@includeModel object=findType("ZonedDateTime")/>.ofInstant( cal.toInstant(), cal.getTimeZone().toZoneId() );
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/DateToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/DateToXmlGregorianCalendar.ftl
@@ -19,17 +19,17 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( Date date ) {
+private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("Date")/> date ) {
     if ( date == null ) {
         return null;
     }
 
     try {
-        GregorianCalendar c = new GregorianCalendar();
+        <@includeModel object=findType("GregorianCalendar")/> c = new <@includeModel object=findType("GregorianCalendar")/>();
         c.setTime( date );
-        return DatatypeFactory.newInstance().newXMLGregorianCalendar( c );
+        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar( c );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.ftl
@@ -19,7 +19,10 @@
      limitations under the License.
 
 -->
-private <T> T ${name}( JAXBElement<T> element ) {
+<#assign jaxbElement = findType("JAXBElement")>
+<#assign typeElement = jaxbElement.typeParameters.get(0)>
+
+private <<@includeModel object=typeElement/>> <@includeModel object=typeElement/> ${name}( <@includeModel object=jaxbElement/> element ) {
     if ( element == null ) {
         return null;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.ftl
@@ -19,7 +19,6 @@
      limitations under the License.
 
 -->
-
 private <T> T ${name}( <@includeModel object=findType("JAXBElement") raw=true/><T> element ) {
     if ( element == null ) {
         return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.ftl
@@ -19,10 +19,8 @@
      limitations under the License.
 
 -->
-<#assign jaxbElement = findType("JAXBElement")>
-<#assign typeElement = jaxbElement.typeParameters.get(0)>
 
-private <<@includeModel object=typeElement/>> <@includeModel object=typeElement/> ${name}( <@includeModel object=jaxbElement/> element ) {
+private <T> T ${name}( <@includeModel object=findType("JAXBElement") raw=true/><T> element ) {
     if ( element == null ) {
         return null;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaDateTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaDateTimeToXmlGregorianCalendar.ftl
@@ -19,13 +19,13 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( DateTime dt ) {
+private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("DateTime")/> dt ) {
     if ( dt == null ) {
         return null;
     }
 
     try {
-        return DatatypeFactory.newInstance().newXMLGregorianCalendar(
+        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar(
             dt.getYear(),
             dt.getMonthOfYear(),
             dt.getDayOfMonth(),
@@ -35,7 +35,7 @@ private XMLGregorianCalendar ${name}( DateTime dt ) {
             dt.getMillisOfSecond(),
             dt.getZone().getOffset( null ) / 60000 );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("LocalDateTime")/> dt ) {
+private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("org.joda.time.LocalDateTime")/> dt ) {
     if ( dt == null ) {
         return null;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.ftl
@@ -19,13 +19,13 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( LocalDateTime dt ) {
+private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("LocalDateTime")/> dt ) {
     if ( dt == null ) {
         return null;
     }
 
     try {
-        return DatatypeFactory.newInstance().newXMLGregorianCalendar(
+        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar(
             dt.getYear(),
             dt.getMonthOfYear(),
             dt.getDayOfMonth(),
@@ -33,9 +33,9 @@ private XMLGregorianCalendar ${name}( LocalDateTime dt ) {
             dt.getMinuteOfHour(),
             dt.getSecondOfMinute(),
             dt.getMillisOfSecond(),
-            DatatypeConstants.FIELD_UNDEFINED );
+            <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.ftl
@@ -19,19 +19,19 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( LocalDate dt ) {
+private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("LocalDate")/> dt ) {
     if ( dt == null ) {
         return null;
     }
 
     try {
-        return DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
+        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendarDate(
             dt.getYear(),
             dt.getMonthOfYear(),
             dt.getDayOfMonth(),
-            DatatypeConstants.FIELD_UNDEFINED );
+            <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("LocalDate")/> dt ) {
+private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("org.joda.time.LocalDate")/> dt ) {
     if ( dt == null ) {
         return null;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("LocalTime")/> dt ) {
+private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("org.joda.time.LocalTime")/> dt ) {
     if ( dt == null ) {
         return null;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.ftl
@@ -19,20 +19,20 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( LocalTime dt ) {
+private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("LocalTime")/> dt ) {
     if ( dt == null ) {
         return null;
     }
 
     try {
-        return DatatypeFactory.newInstance().newXMLGregorianCalendarTime(
+        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendarTime(
             dt.getHourOfDay(),
             dt.getMinuteOfHour(),
             dt.getSecondOfMinute(),
             dt.getMillisOfSecond(),
-            DatatypeConstants.FIELD_UNDEFINED );
+            <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private static <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("LocalDate")/> localDate ) {
+private static <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("java.time.LocalDate")/> localDate ) {
     if ( localDate == null ) {
         return null;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.ftl
@@ -19,20 +19,20 @@
      limitations under the License.
 
 -->
-private static XMLGregorianCalendar ${name}( java.time.LocalDate localDate ) {
+private static <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("LocalDate")/> localDate ) {
     if ( localDate == null ) {
         return null;
     }
 
     try {
-        return DatatypeFactory.newInstance().newXMLGregorianCalendarDate(
+        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendarDate(
             localDate.getYear(),
             localDate.getMonthValue(),
             localDate.getDayOfMonth(),
-            DatatypeConstants.FIELD_UNDEFINED
+            <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
         );
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/StringToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/StringToXmlGregorianCalendar.ftl
@@ -19,26 +19,26 @@
      limitations under the License.
 
 -->
-private XMLGregorianCalendar ${name}( String date, String dateFormat ) {
+private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( String date, String dateFormat ) {
     if ( date == null ) {
         return null;
     }
 
     try {
         if ( dateFormat != null ) {
-            DateFormat df = new SimpleDateFormat( dateFormat );
-            GregorianCalendar c = new GregorianCalendar();
+            <@includeModel object=findType("DateFormat")/> df = new <@includeModel object=findType("SimpleDateFormat")/>( dateFormat );
+            <@includeModel object=findType("GregorianCalendar")/> c = new <@includeModel object=findType("GregorianCalendar")/>();
             c.setTime( df.parse( date ) );
-            return DatatypeFactory.newInstance().newXMLGregorianCalendar( c );
+            return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar( c );
         }
         else {
-            return DatatypeFactory.newInstance().newXMLGregorianCalendar( date );
+            return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar( date );
         }
     }
-    catch ( DatatypeConfigurationException ex ) {
+    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
         throw new RuntimeException( ex );
     }
-    catch ( ParseException ex ) {
+    catch ( <@includeModel object=findType("ParseException")/> ex ) {
         throw new RuntimeException( ex );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToCalendar.ftl
@@ -19,12 +19,12 @@
      limitations under the License.
 
 -->
-private Calendar ${name}( XMLGregorianCalendar xcal ) {
+private <@includeModel object=findType("Calendar")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    Calendar cal = Calendar.getInstance();
+    <@includeModel object=findType("Calendar")/> cal = <@includeModel object=findType("Calendar")/>.getInstance();
     cal.setTimeInMillis( xcal.toGregorianCalendar().getTimeInMillis() );
     return cal;
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private static Date ${name}( XMLGregorianCalendar xcal ) {
+private static <@includeModel object=findType("Date")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private static <@includeModel object=findType("Date")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
+private static <@includeModel object=findType("java.util.Date")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaDateTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaDateTime.ftl
@@ -19,33 +19,33 @@
      limitations under the License.
 
 -->
-private static DateTime ${name}( XMLGregorianCalendar xcal ) {
+private static <@includeModel object=findType("DateTime")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    if ( xcal.getYear() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getMonth() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getDay() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getHour() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getMinute() != DatatypeConstants.FIELD_UNDEFINED
+    if ( xcal.getYear() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+        && xcal.getMonth() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+        && xcal.getDay() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+        && xcal.getHour() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+        && xcal.getMinute() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
         ) {
-            if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getMillisecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getTimezone() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new DateTime( xcal.getYear(),
+            if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+                && xcal.getMillisecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+                && xcal.getTimezone() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
+                return new <@includeModel object=findType("DateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
                     xcal.getMinute(),
                     xcal.getSecond(),
                     xcal.getMillisecond(),
-                    DateTimeZone.forOffsetMillis( xcal.getTimezone() * 60000 )
+                    <@includeModel object=findType("DateTimeZone")/>.forOffsetMillis( xcal.getTimezone() * 60000 )
                 );
             }
-            else if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getMillisecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new DateTime( xcal.getYear(),
+            else if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+                && xcal.getMillisecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
+                return new <@includeModel object=findType("DateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
@@ -54,19 +54,19 @@ private static DateTime ${name}( XMLGregorianCalendar xcal ) {
                     xcal.getMillisecond()
                 );
             }
-            else if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getTimezone() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new DateTime( xcal.getYear(),
+            else if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+                && xcal.getTimezone() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
+                return new <@includeModel object=findType("DateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
                     xcal.getMinute(),
                     xcal.getSecond(),
-                    DateTimeZone.forOffsetMillis( xcal.getTimezone() * 60000 )
+                    <@includeModel object=findType("DateTimeZone")/>.forOffsetMillis( xcal.getTimezone() * 60000 )
                 );
             }
-            else if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new DateTime( xcal.getYear(),
+            else if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
+                return new <@includeModel object=findType("DateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
@@ -74,17 +74,17 @@ private static DateTime ${name}( XMLGregorianCalendar xcal ) {
                     xcal.getSecond()
                 );
             }
-            else if ( xcal.getTimezone() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new DateTime( xcal.getYear(),
+            else if ( xcal.getTimezone() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
+                return new <@includeModel object=findType("DateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
                     xcal.getMinute(),
-                    DateTimeZone.forOffsetMillis( xcal.getTimezone() * 60000 )
+                    <@includeModel object=findType("DateTimeZone")/>.forOffsetMillis( xcal.getTimezone() * 60000 )
             );
             }
             else {
-                return new DateTime( xcal.getYear(),
+                return new <@includeModel object=findType("DateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.ftl
@@ -19,15 +19,15 @@
      limitations under the License.
 
 -->
-private static LocalDate ${name}( XMLGregorianCalendar xcal ) {
+private static <@includeModel object=findType("LocalDate")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    if ( xcal.getYear() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getMonth() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getDay() != DatatypeConstants.FIELD_UNDEFINED )  {
-            return new LocalDate( xcal.getYear(), xcal.getMonth(), xcal.getDay() );
+    if ( xcal.getYear() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+        && xcal.getMonth() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+        && xcal.getDay() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED )  {
+            return new <@includeModel object=findType("LocalDate")/>( xcal.getYear(), xcal.getMonth(), xcal.getDay() );
     }
 
     return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private static <@includeModel object=findType("LocalDate")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
+private static <@includeModel object=findType("org.joda.time.LocalDate")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }
@@ -27,7 +27,7 @@ private static <@includeModel object=findType("LocalDate")/> ${name}( <@includeM
     if ( xcal.getYear() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
         && xcal.getMonth() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
         && xcal.getDay() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED )  {
-            return new <@includeModel object=findType("LocalDate")/>( xcal.getYear(), xcal.getMonth(), xcal.getDay() );
+            return new <@includeModel object=findType("org.joda.time.LocalDate")/>( xcal.getYear(), xcal.getMonth(), xcal.getDay() );
     }
 
     return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private static <@includeModel object=findType("LocalDateTime")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
+private static <@includeModel object=findType("org.joda.time.LocalDateTime")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }
@@ -32,7 +32,7 @@ private static <@includeModel object=findType("LocalDateTime")/> ${name}( <@incl
         ) {
             if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
                 && xcal.getMillisecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
-                return new <@includeModel object=findType("LocalDateTime")/>( xcal.getYear(),
+                return new <@includeModel object=findType("org.joda.time.LocalDateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
@@ -42,7 +42,7 @@ private static <@includeModel object=findType("LocalDateTime")/> ${name}( <@incl
                 );
             }
             else if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
-                return new <@includeModel object=findType("LocalDateTime")/>( xcal.getYear(),
+                return new <@includeModel object=findType("org.joda.time.LocalDateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
@@ -51,7 +51,7 @@ private static <@includeModel object=findType("LocalDateTime")/> ${name}( <@incl
                 );
             }
             else {
-                return new <@includeModel object=findType("LocalDateTime")/>( xcal.getYear(),
+                return new <@includeModel object=findType("org.joda.time.LocalDateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.ftl
@@ -19,20 +19,20 @@
      limitations under the License.
 
 -->
-private static LocalDateTime ${name}( XMLGregorianCalendar xcal ) {
+private static <@includeModel object=findType("LocalDateTime")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    if ( xcal.getYear() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getMonth() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getDay() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getHour() != DatatypeConstants.FIELD_UNDEFINED
-        && xcal.getMinute() != DatatypeConstants.FIELD_UNDEFINED
+    if ( xcal.getYear() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+        && xcal.getMonth() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+        && xcal.getDay() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+        && xcal.getHour() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+        && xcal.getMinute() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
         ) {
-            if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getMillisecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new LocalDateTime( xcal.getYear(),
+            if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+                && xcal.getMillisecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
+                return new <@includeModel object=findType("LocalDateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
@@ -41,8 +41,8 @@ private static LocalDateTime ${name}( XMLGregorianCalendar xcal ) {
                     xcal.getMillisecond()
                 );
             }
-            else if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new LocalDateTime( xcal.getYear(),
+            else if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
+                return new <@includeModel object=findType("LocalDateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),
@@ -51,7 +51,7 @@ private static LocalDateTime ${name}( XMLGregorianCalendar xcal ) {
                 );
             }
             else {
-                return new LocalDateTime( xcal.getYear(),
+                return new <@includeModel object=findType("LocalDateTime")/>( xcal.getYear(),
                     xcal.getMonth(),
                     xcal.getDay(),
                     xcal.getHour(),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.ftl
@@ -19,30 +19,30 @@
      limitations under the License.
 
 -->
-private static LocalTime ${name}( XMLGregorianCalendar xcal ) {
+private static <@includeModel object=findType("LocalTime")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    if ( xcal.getHour() != DatatypeConstants.FIELD_UNDEFINED
-         && xcal.getMinute() != DatatypeConstants.FIELD_UNDEFINED ) {
-            if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED
-                && xcal.getMillisecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new LocalTime( xcal.getHour(),
+    if ( xcal.getHour() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+         && xcal.getMinute() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
+            if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
+                && xcal.getMillisecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
+                return new <@includeModel object=findType("LocalTime")/>( xcal.getHour(),
                     xcal.getMinute(),
                     xcal.getSecond(),
                     xcal.getMillisecond()
                 );
             }
-            else if ( xcal.getSecond() != DatatypeConstants.FIELD_UNDEFINED ) {
-                return new LocalTime(
+            else if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
+                return new <@includeModel object=findType("LocalTime")/>(
                     xcal.getHour(),
                     xcal.getMinute(),
                     xcal.getSecond()
                 );
             }
             else {
-                return new LocalTime( xcal.getHour(),
+                return new <@includeModel object=findType("LocalTime")/>( xcal.getHour(),
                     xcal.getMinute()
             );
             }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private static <@includeModel object=findType("LocalTime")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
+private static <@includeModel object=findType("org.joda.time.LocalTime")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }
@@ -28,21 +28,21 @@ private static <@includeModel object=findType("LocalTime")/> ${name}( <@includeM
          && xcal.getMinute() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
             if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
                 && xcal.getMillisecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
-                return new <@includeModel object=findType("LocalTime")/>( xcal.getHour(),
+                return new <@includeModel object=findType("org.joda.time.LocalTime")/>( xcal.getHour(),
                     xcal.getMinute(),
                     xcal.getSecond(),
                     xcal.getMillisecond()
                 );
             }
             else if ( xcal.getSecond() != <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED ) {
-                return new <@includeModel object=findType("LocalTime")/>(
+                return new <@includeModel object=findType("org.joda.time.LocalTime")/>(
                     xcal.getHour(),
                     xcal.getMinute(),
                     xcal.getSecond()
                 );
             }
             else {
-                return new <@includeModel object=findType("LocalTime")/>( xcal.getHour(),
+                return new <@includeModel object=findType("org.joda.time.LocalTime")/>( xcal.getHour(),
                     xcal.getMinute()
             );
             }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToLocalDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToLocalDate.ftl
@@ -19,10 +19,10 @@
      limitations under the License.
 
 -->
-private static java.time.LocalDate ${name}( XMLGregorianCalendar xcal ) {
+private static <@includeModel object=findType("LocalDate")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    return java.time.LocalDate.of( xcal.getYear(), xcal.getMonth(), xcal.getDay() );
+    return <@includeModel object=findType("LocalDate")/>.of( xcal.getYear(), xcal.getMonth(), xcal.getDay() );
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToLocalDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToLocalDate.ftl
@@ -19,10 +19,10 @@
      limitations under the License.
 
 -->
-private static <@includeModel object=findType("LocalDate")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
+private static <@includeModel object=findType("java.time.LocalDate")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;
     }
 
-    return <@includeModel object=findType("LocalDate")/>.of( xcal.getYear(), xcal.getMonth(), xcal.getDay() );
+    return <@includeModel object=findType("java.time.LocalDate")/>.of( xcal.getYear(), xcal.getMonth(), xcal.getDay() );
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.ftl
@@ -19,7 +19,7 @@
      limitations under the License.
 
 -->
-private String ${name}( XMLGregorianCalendar xcal, String dateFormat ) {
+private String ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal, String dateFormat ) {
     if ( xcal == null ) {
         return null;
     }
@@ -28,8 +28,8 @@ private String ${name}( XMLGregorianCalendar xcal, String dateFormat ) {
         return xcal.toString();
     }
     else {
-        Date d = xcal.toGregorianCalendar().getTime();
-        SimpleDateFormat sdf = new SimpleDateFormat( dateFormat );
+        <@includeModel object=findType("Date")/> d = xcal.toGregorianCalendar().getTime();
+        <@includeModel object=findType("SimpleDateFormat")/> sdf = new <@includeModel object=findType("SimpleDateFormat")/>( dateFormat );
         return sdf.format( d );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.ftl
@@ -28,7 +28,7 @@ private String ${name}( <@includeModel object=findType("XMLGregorianCalendar")/>
         return xcal.toString();
     }
     else {
-        <@includeModel object=findType("Date")/> d = xcal.toGregorianCalendar().getTime();
+        <@includeModel object=findType("java.util.Date")/> d = xcal.toGregorianCalendar().getTime();
         <@includeModel object=findType("SimpleDateFormat")/> sdf = new <@includeModel object=findType("SimpleDateFormat")/>( dateFormat );
         return sdf.format( d );
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToCalendar.ftl
@@ -19,12 +19,12 @@
      limitations under the License.
 
 -->
-private Calendar ${name}(ZonedDateTime dateTime) {
+private <@includeModel object=findType("Calendar")/> ${name}(<@includeModel object=findType("ZonedDateTime")/> dateTime) {
     if ( dateTime == null ) {
        return null;
     }
 
-    Calendar instance = Calendar.getInstance( TimeZone.getTimeZone( dateTime.getZone() ) );
+    <@includeModel object=findType("Calendar")/> instance = <@includeModel object=findType("Calendar")/>.getInstance( TimeZone.getTimeZone( dateTime.getZone() ) );
     instance.setTimeInMillis( dateTime.toInstant().toEpochMilli() );
     return instance;
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Mapper.java
@@ -1,0 +1,39 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1425;
+
+import java.time.LocalDate;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Christian Bandowski
+ */
+@Mapper
+public abstract class Issue1425Mapper {
+
+    public static final Issue1425Mapper INSTANCE = Mappers.getMapper( Issue1425Mapper.class );
+
+    public abstract Target map(Source source);
+
+    LocalDate now() {
+        return LocalDate.now();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Test.java
@@ -40,11 +40,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class Issue1425Test {
 
     @Test
-    public void shouldGenerateValidCode() {
-
-    }
-
-    @Test
     public void shouldTestMappingLocalDates() {
         Source source = new Source();
         source.setValue( LocalDate.parse( "2018-04-18" ) );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Test.java
@@ -1,0 +1,57 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1425;
+
+import org.joda.time.LocalDate;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Christian Bandowski
+ */
+@WithClasses({
+    Issue1425Mapper.class,
+    Source.class,
+    Target.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1425")
+public class Issue1425Test {
+
+    @Test
+    public void shouldGenerateValidCode() {
+
+    }
+
+    @Test
+    public void shouldTestMappingLocalDates() {
+        Source source = new Source();
+        source.setValue( LocalDate.parse( "2018-04-18" ) );
+
+        Target target = Issue1425Mapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getValue() ).isEqualTo( "2018-04-18" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Source.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1425;
+
+import org.joda.time.LocalDate;
+
+/**
+ * @author Christian Bandowski
+ */
+public class Source {
+
+    private LocalDate value;
+
+    public LocalDate getValue() {
+        return value;
+    }
+
+    public void setValue(LocalDate value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Target.java
@@ -1,0 +1,37 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1425;
+
+import java.time.LocalDate;
+
+/**
+ * @author Christian Bandowski
+ */
+public class Target {
+
+    private LocalDate value;
+
+    public LocalDate getValue() {
+        return value;
+    }
+
+    public void setValue(LocalDate value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
_(new PR, discussion started in #1439)_

Together with the includeModel directive this will ensure that the type will be written to the file as a FQN if required, otherwise as a simple name.

The PR allows extending templates like this:
```java
<@includeModel name=findType("LocalDate")/>
```
or
```java
<@includeModel name=findType("org.joda.time.LocalDate")/>
```

The given fully-qualified/simple name must be available in the `importTypes` of the builtin method. Unlike it was proposed in #1439 I have not extended `BuiltinMethod` and `HelperMethod` to provide a `Map` with possible `Types` as the included `Types` must be returned in the `importTypes` property, otherwise the import statement will maybe not be added. So it should fail-fast in case someone tries to include a `Type` that might not be added to imports which would generate not compilable code.

There is just one thing I am not completly happy with. In case the `Type` has generic parameters those will be written to the template as well, therefore - to ensure the correct `Type` name will be used - the `JaxbElemToValue.ftl` template looks like this:

```java
<#assign jaxbElement = findType("JAXBElement")>
<#assign typeElement = jaxbElement.typeParameters.get(0)>

private <<@includeModel object=typeElement/>> <@includeModel object=typeElement/> ${name}( <@includeModel object=jaxbElement/> element ) {
```
A bit hard to read, but possible. Maybe someone has a good idea to enhance this to make it easier readible.