### PR TITLE
#1460 Ensures the FQN will be used for SimpleConversion if required

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractJavaTimeToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractJavaTimeToStringConversion.java
@@ -52,10 +52,12 @@ public abstract class AbstractJavaTimeToStringConversion extends SimpleConversio
 
     private String dateTimeFormatter(ConversionContext conversionContext) {
         if ( !Strings.isEmpty( conversionContext.getDateFormat() ) ) {
-            return "DateTimeFormatter.ofPattern( \"" + conversionContext.getDateFormat() + "\" )";
+            return dateTimeFormatterType( conversionContext )
+                + ".ofPattern( \"" + conversionContext.getDateFormat()
+                + "\" )";
         }
         else {
-            return "DateTimeFormatter." + defaultFormatterSuffix();
+            return dateTimeFormatterType( conversionContext ) + "." + defaultFormatterSuffix();
         }
     }
 
@@ -64,7 +66,7 @@ public abstract class AbstractJavaTimeToStringConversion extends SimpleConversio
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
         // See http://docs.oracle.com/javase/tutorial/datetime/iso/format.html for how to parse Dates
-        return new StringBuilder().append( conversionContext.getTargetType().getFullyQualifiedName() )
+        return new StringBuilder().append( conversionContext.getTargetType().getReferenceName() )
                                   .append( ".parse( " )
                                   .append( parametersListForParsing( conversionContext ) )
                                   .append( " )" ).toString();
@@ -74,9 +76,8 @@ public abstract class AbstractJavaTimeToStringConversion extends SimpleConversio
         // See http://docs.oracle.com/javase/tutorial/datetime/iso/format.html for how to format Dates
         StringBuilder parameterBuilder = new StringBuilder( "<SOURCE>" );
         if ( !Strings.isEmpty( conversionContext.getDateFormat() ) ) {
-            parameterBuilder.append( ", DateTimeFormatter.ofPattern( \"" )
-                            .append( conversionContext.getDateFormat() )
-                            .append( "\" )" );
+            parameterBuilder.append( ", " );
+            parameterBuilder.append( dateTimeFormatter( conversionContext ) );
         }
         return parameterBuilder.toString();
     }
@@ -84,14 +85,25 @@ public abstract class AbstractJavaTimeToStringConversion extends SimpleConversio
     @Override
     protected Set<Type> getToConversionImportTypes(ConversionContext conversionContext) {
         return Collections.asSet(
-                        conversionContext.getTypeFactory().getType( JavaTimeConstants.DATE_TIME_FORMATTER_FQN )
+            conversionContext.getTypeFactory().getType( JavaTimeConstants.DATE_TIME_FORMATTER_FQN )
         );
     }
 
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
-        return Collections.asSet(
-                        conversionContext.getTypeFactory().getType( JavaTimeConstants.DATE_TIME_FORMATTER_FQN )
-        );
+        if ( !Strings.isEmpty( conversionContext.getDateFormat() ) ) {
+            return Collections.asSet(
+                conversionContext.getTargetType(),
+                conversionContext.getTypeFactory().getType( JavaTimeConstants.DATE_TIME_FORMATTER_FQN )
+            );
+        }
+
+        return Collections.asSet( conversionContext.getTargetType() );
+    }
+
+    protected String dateTimeFormatterType(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory()
+            .getType( JavaTimeConstants.DATE_TIME_FORMATTER_FQN )
+            .getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractJavaTimeToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractJavaTimeToStringConversion.java
@@ -52,12 +52,12 @@ public abstract class AbstractJavaTimeToStringConversion extends SimpleConversio
 
     private String dateTimeFormatter(ConversionContext conversionContext) {
         if ( !Strings.isEmpty( conversionContext.getDateFormat() ) ) {
-            return dateTimeFormatterType( conversionContext )
+            return ConversionUtils.dateTimeFormatter( conversionContext )
                 + ".ofPattern( \"" + conversionContext.getDateFormat()
                 + "\" )";
         }
         else {
-            return dateTimeFormatterType( conversionContext ) + "." + defaultFormatterSuffix();
+            return ConversionUtils.dateTimeFormatter( conversionContext ) + "." + defaultFormatterSuffix();
         }
     }
 
@@ -101,9 +101,4 @@ public abstract class AbstractJavaTimeToStringConversion extends SimpleConversio
         return Collections.asSet( conversionContext.getTargetType() );
     }
 
-    protected String dateTimeFormatterType(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory()
-            .getType( JavaTimeConstants.DATE_TIME_FORMATTER_FQN )
-            .getReferenceName();
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractJodaTypeToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractJodaTypeToStringConversion.java
@@ -27,6 +27,8 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.JodaTimeConstants;
 
 import static org.mapstruct.ap.internal.util.Collections.asSet;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.dateTimeFormat;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.locale;
 
 /**
  * Base class for conversions between Joda-Time types and String.
@@ -111,14 +113,6 @@ public abstract class AbstractJodaTypeToStringConversion extends SimpleConversio
             + ".patternForStyle( \"" + formatStyle() + "\", "
             + locale( conversionContext )
             + ".getDefault() )";
-    }
-
-    private String dateTimeFormat(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( JodaTimeConstants.DATE_TIME_FORMAT_FQN ).getReferenceName();
-    }
-
-    private String locale(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( Locale.class ).getReferenceName();
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractJodaTypeToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractJodaTypeToStringConversion.java
@@ -18,8 +18,6 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Set;
@@ -27,6 +25,8 @@ import java.util.Set;
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.JodaTimeConstants;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * Base class for conversions between Joda-Time types and String.
@@ -78,7 +78,7 @@ public abstract class AbstractJodaTypeToStringConversion extends SimpleConversio
     }
 
     private String conversionString(ConversionContext conversionContext, String method) {
-        StringBuilder conversionString = new StringBuilder( "DateTimeFormat" );
+        StringBuilder conversionString = new StringBuilder( dateTimeFormat( conversionContext ) );
         conversionString.append( dateFormatPattern( conversionContext ) );
         conversionString.append( "." );
         conversionString.append( method );
@@ -92,7 +92,7 @@ public abstract class AbstractJodaTypeToStringConversion extends SimpleConversio
 
         String dateFormat = conversionContext.getDateFormat();
         if ( dateFormat == null ) {
-            conversionString.append( defaultDateFormatPattern() );
+            conversionString.append( defaultDateFormatPattern( conversionContext ) );
 
         }
         else {
@@ -105,8 +105,20 @@ public abstract class AbstractJodaTypeToStringConversion extends SimpleConversio
         return conversionString.toString();
     }
 
-    private String defaultDateFormatPattern() {
-        return " DateTimeFormat.patternForStyle( \"" + formatStyle() + "\", Locale.getDefault() )";
+    private String defaultDateFormatPattern(ConversionContext conversionContext) {
+        return " "
+            + dateTimeFormat( conversionContext )
+            + ".patternForStyle( \"" + formatStyle() + "\", "
+            + locale( conversionContext )
+            + ".getDefault() )";
+    }
+
+    private String dateTimeFormat(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( JodaTimeConstants.DATE_TIME_FORMAT_FQN ).getReferenceName();
+    }
+
+    private String locale(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( Locale.class ).getReferenceName();
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractNumberToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractNumberToStringConversion.java
@@ -40,7 +40,6 @@ public abstract class AbstractNumberToStringConversion extends SimpleConversion 
     private final boolean sourceTypeNumberSubclass;
 
     public AbstractNumberToStringConversion(boolean sourceTypeNumberSubclass) {
-
         this.sourceTypeNumberSubclass = sourceTypeNumberSubclass;
     }
 
@@ -76,9 +75,5 @@ public abstract class AbstractNumberToStringConversion extends SimpleConversion 
         else {
             return super.getFromConversionExceptionTypes( conversionContext );
         }
-    }
-
-    protected String decimalFormat(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( DecimalFormat.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractNumberToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/AbstractNumberToStringConversion.java
@@ -78,4 +78,7 @@ public abstract class AbstractNumberToStringConversion extends SimpleConversion 
         }
     }
 
+    protected String decimalFormat(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( DecimalFormat.class ).getReferenceName();
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToBigIntegerConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToBigIntegerConversion.java
@@ -26,6 +26,7 @@ import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 
 import static org.mapstruct.ap.internal.util.Collections.asSet;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.bigDecimal;
 
 /**
  * Conversion between {@link BigDecimal} and {@link BigInteger}.
@@ -49,9 +50,5 @@ public class BigDecimalToBigIntegerConversion extends SimpleConversion {
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTypeFactory().getType( BigDecimal.class ) );
-    }
-
-    private String bigDecimal(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( BigDecimal.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToBigIntegerConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToBigIntegerConversion.java
@@ -18,14 +18,14 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * Conversion between {@link BigDecimal} and {@link BigInteger}.
@@ -41,11 +41,17 @@ public class BigDecimalToBigIntegerConversion extends SimpleConversion {
 
     @Override
     public String getFromExpression(ConversionContext conversionContext) {
-        return "new BigDecimal( <SOURCE> )";
+        return "new "
+            + bigDecimal( conversionContext )
+            + "( <SOURCE> )";
     }
 
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTypeFactory().getType( BigDecimal.class ) );
+    }
+
+    private String bigDecimal(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( BigDecimal.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToPrimitiveConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToPrimitiveConversion.java
@@ -18,13 +18,14 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.math.BigDecimal;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.bigDecimal;
 
 /**
  * Conversion between {@link BigDecimal} and native number types.
@@ -56,9 +57,5 @@ public class BigDecimalToPrimitiveConversion extends SimpleConversion {
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTypeFactory().getType( BigDecimal.class ) );
-    }
-
-    private String bigDecimal(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( BigDecimal.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToPrimitiveConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToPrimitiveConversion.java
@@ -50,11 +50,15 @@ public class BigDecimalToPrimitiveConversion extends SimpleConversion {
 
     @Override
     public String getFromExpression(ConversionContext conversionContext) {
-        return "BigDecimal.valueOf( <SOURCE> )";
+        return bigDecimal( conversionContext ) + ".valueOf( <SOURCE> )";
     }
 
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTypeFactory().getType( BigDecimal.class ) );
+    }
+
+    private String bigDecimal(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( BigDecimal.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToStringConversion.java
@@ -18,8 +18,6 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +26,8 @@ import java.util.Set;
 import org.mapstruct.ap.internal.model.HelperMethod;
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * Conversion between {@link BigDecimal} and {@link String}.
@@ -57,13 +57,13 @@ public class BigDecimalToStringConversion extends AbstractNumberToStringConversi
     public String getFromExpression(ConversionContext conversionContext) {
         if ( requiresDecimalFormat( conversionContext ) ) {
             StringBuilder sb = new StringBuilder();
-            sb.append( "(BigDecimal) " );
+            sb.append( "(" + bigDecimal( conversionContext ) + ") " );
             appendDecimalFormatter( sb, conversionContext );
             sb.append( ".parse( <SOURCE> )" );
             return sb.toString();
         }
         else {
-           return "new BigDecimal( <SOURCE> )";
+            return "new " + bigDecimal( conversionContext ) + "( <SOURCE> )";
         }
     }
 
@@ -92,4 +92,7 @@ public class BigDecimalToStringConversion extends AbstractNumberToStringConversi
         sb.append( " )" );
     }
 
+    private String bigDecimal(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( BigDecimal.class ).getReferenceName();
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToStringConversion.java
@@ -28,6 +28,7 @@ import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 
 import static org.mapstruct.ap.internal.util.Collections.asSet;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.bigDecimal;
 
 /**
  * Conversion between {@link BigDecimal} and {@link String}.
@@ -90,9 +91,5 @@ public class BigDecimalToStringConversion extends AbstractNumberToStringConversi
         }
 
         sb.append( " )" );
-    }
-
-    private String bigDecimal(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( BigDecimal.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToWrapperConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToWrapperConversion.java
@@ -18,14 +18,15 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.math.BigDecimal;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.NativeTypes;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.bigDecimal;
 
 /**
  * Conversion between {@link BigDecimal} and wrappers of native number types.
@@ -57,9 +58,5 @@ public class BigDecimalToWrapperConversion extends SimpleConversion {
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTypeFactory().getType( BigDecimal.class ) );
-    }
-
-    private String bigDecimal(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( BigDecimal.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToWrapperConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigDecimalToWrapperConversion.java
@@ -51,11 +51,15 @@ public class BigDecimalToWrapperConversion extends SimpleConversion {
 
     @Override
     public String getFromExpression(ConversionContext conversionContext) {
-        return "BigDecimal.valueOf( <SOURCE> )";
+        return bigDecimal( conversionContext ) + ".valueOf( <SOURCE> )";
     }
 
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTypeFactory().getType( BigDecimal.class ) );
+    }
+
+    private String bigDecimal(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( BigDecimal.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToPrimitiveConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToPrimitiveConversion.java
@@ -54,11 +54,15 @@ public class BigIntegerToPrimitiveConversion extends SimpleConversion {
         if ( targetType == float.class || targetType == double.class ) {
             castString = "(long) ";
         }
-        return "BigInteger.valueOf( " + castString + "<SOURCE> )";
+        return bigInteger( conversionContext ) + ".valueOf( " + castString + "<SOURCE> )";
     }
 
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTypeFactory().getType( BigInteger.class ) );
+    }
+
+    private String bigInteger(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( BigInteger.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToPrimitiveConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToPrimitiveConversion.java
@@ -18,13 +18,14 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.math.BigInteger;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.bigInteger;
 
 /**
  * Conversion between {@link BigInteger} and native number types.
@@ -60,9 +61,5 @@ public class BigIntegerToPrimitiveConversion extends SimpleConversion {
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTypeFactory().getType( BigInteger.class ) );
-    }
-
-    private String bigInteger(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( BigInteger.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToStringConversion.java
@@ -18,8 +18,7 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
@@ -28,6 +27,8 @@ import java.util.Set;
 import org.mapstruct.ap.internal.model.HelperMethod;
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * Conversion between {@link BigInteger} and {@link String}.
@@ -57,22 +58,21 @@ public class BigIntegerToStringConversion extends AbstractNumberToStringConversi
     public String getFromExpression(ConversionContext conversionContext) {
         if ( requiresDecimalFormat( conversionContext ) ) {
             StringBuilder sb = new StringBuilder();
-            sb.append( "( (BigDecimal) " );
+            sb.append( "( (" + bigDecimal( conversionContext ) + ") " );
             appendDecimalFormatter( sb, conversionContext );
             sb.append( ".parse( <SOURCE> )" );
             sb.append( " ).toBigInteger()" );
             return sb.toString();
         }
         else {
-            return "new BigInteger( <SOURCE> )";
+            return "new " + bigInteger( conversionContext ) + "( <SOURCE> )";
         }
     }
 
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         if ( requiresDecimalFormat( conversionContext ) ) {
-            // no imports are required when decimal format is used.
-            return super.getFromConversionImportTypes( conversionContext );
+            return asSet( conversionContext.getTypeFactory().getType( BigDecimal.class ) );
         }
         else {
             return asSet( conversionContext.getTypeFactory().getType( BigInteger.class ) );
@@ -97,5 +97,13 @@ public class BigIntegerToStringConversion extends AbstractNumberToStringConversi
         }
 
         sb.append( " )" );
+    }
+
+    private String bigInteger(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( BigInteger.class ).getReferenceName();
+    }
+
+    private String bigDecimal(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( BigDecimal.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToStringConversion.java
@@ -29,6 +29,8 @@ import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 
 import static org.mapstruct.ap.internal.util.Collections.asSet;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.bigDecimal;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.bigInteger;
 
 /**
  * Conversion between {@link BigInteger} and {@link String}.
@@ -97,13 +99,5 @@ public class BigIntegerToStringConversion extends AbstractNumberToStringConversi
         }
 
         sb.append( " )" );
-    }
-
-    private String bigInteger(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( BigInteger.class ).getReferenceName();
-    }
-
-    private String bigDecimal(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( BigDecimal.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToWrapperConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToWrapperConversion.java
@@ -18,14 +18,14 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.math.BigInteger;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.NativeTypes;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * Conversion between {@link BigInteger} and wrappers of native number types.
@@ -56,11 +56,15 @@ public class BigIntegerToWrapperConversion extends SimpleConversion {
             toLongValueStr = ".longValue()";
         }
 
-        return "BigInteger.valueOf( <SOURCE>" + toLongValueStr + " )";
+        return bigInteger( conversionContext ) + ".valueOf( <SOURCE>" + toLongValueStr + " )";
     }
 
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTypeFactory().getType( BigInteger.class ) );
+    }
+
+    private String bigInteger(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( BigInteger.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToWrapperConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/BigIntegerToWrapperConversion.java
@@ -26,6 +26,7 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.NativeTypes;
 
 import static org.mapstruct.ap.internal.util.Collections.asSet;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.bigInteger;
 
 /**
  * Conversion between {@link BigInteger} and wrappers of native number types.
@@ -62,9 +63,5 @@ public class BigIntegerToWrapperConversion extends SimpleConversion {
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTypeFactory().getType( BigInteger.class ) );
-    }
-
-    private String bigInteger(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( BigInteger.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/ConversionUtils.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/ConversionUtils.java
@@ -1,0 +1,243 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.internal.conversion;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.text.DecimalFormat;
+import java.text.SimpleDateFormat;
+import java.util.Currency;
+import java.util.Locale;
+
+import org.mapstruct.ap.internal.model.common.ConversionContext;
+import org.mapstruct.ap.internal.util.JavaTimeConstants;
+import org.mapstruct.ap.internal.util.JodaTimeConstants;
+
+/**
+ * Methods mainly used in {@link org.mapstruct.ap.internal.conversion.SimpleConversion SimpleConversion} classes, e. g.
+ * to get the correct String representation of various types that could be used in generated sources.
+ *
+ * @author Christian Bandowski
+ */
+public final class ConversionUtils {
+    private ConversionUtils() {
+    }
+
+    /**
+     * Name for the given {@code canonicalName}.
+     *
+     * @param conversionContext Conversion context
+     * @param canonicalName Canonical name of the type
+     *
+     * @return Name or fully-qualified name.
+     */
+    private static String typeReferenceName(ConversionContext conversionContext, String canonicalName) {
+        return conversionContext.getTypeFactory().getType( canonicalName ).getReferenceName();
+    }
+
+    /**
+     * Name for the given {@code canonicalName}.
+     *
+     * @param conversionContext Conversion context
+     * @param type Type
+     *
+     * @return Name or fully-qualified name.
+     */
+    private static String typeReferenceName(ConversionContext conversionContext, Class<?> type) {
+        return conversionContext.getTypeFactory().getType( type ).getReferenceName();
+    }
+
+    /**
+     * Name for {@link java.math.BigDecimal}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String bigDecimal(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, BigDecimal.class );
+    }
+
+    /**
+     * Name for {@link java.math.BigInteger}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String bigInteger(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, BigInteger.class );
+    }
+
+    /**
+     * Name for {@link java.util.Locale}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String locale(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, Locale.class );
+    }
+
+    /**
+     * Name for {@link java.util.Currency}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String currency(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, Currency.class );
+    }
+
+    /**
+     * Name for {@link java.sql.Date}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String sqlDate(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, java.sql.Date.class );
+    }
+
+    /**
+     * Name for {@link java.sql.Time}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String time(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, Time.class );
+    }
+
+    /**
+     * Name for {@link java.sql.Timestamp}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String timestamp(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, Timestamp.class );
+    }
+
+    /**
+     * Name for {@link java.text.DecimalFormat}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String decimalFormat(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, DecimalFormat.class );
+    }
+
+    /**
+     * Name for {@link java.text.SimpleDateFormat}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String simpleDateFormat(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, SimpleDateFormat.class );
+    }
+
+    /**
+     * Name for {@link java.util.Date}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String date(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, java.util.Date.class );
+    }
+
+    /**
+     * Name for {@link java.time.ZoneOffset}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String zoneOffset(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, JavaTimeConstants.ZONE_OFFSET_FQN );
+    }
+
+    /**
+     * Name for {@link java.time.ZoneId}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String zoneId(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, JavaTimeConstants.ZONE_ID_FQN );
+    }
+
+    /**
+     * Name for {@link java.time.LocalDateTime}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String localDateTime(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, JavaTimeConstants.LOCAL_DATE_TIME_FQN );
+    }
+
+    /**
+     * Name for {@link java.time.ZonedDateTime}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String zonedDateTime(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, JavaTimeConstants.ZONED_DATE_TIME_FQN );
+    }
+
+    /**
+     * Name for {@link java.time.format.DateTimeFormatter}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String dateTimeFormatter(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, JavaTimeConstants.DATE_TIME_FORMATTER_FQN );
+    }
+
+    /**
+     * Name for {@code org.joda.time.format.DateTimeFormat}.
+     *
+     * @param conversionContext Conversion context
+     *
+     * @return Name or fully-qualified name.
+     */
+    public static String dateTimeFormat(ConversionContext conversionContext) {
+        return typeReferenceName( conversionContext, JodaTimeConstants.DATE_TIME_FORMAT_FQN );
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/CurrencyToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/CurrencyToStringConversion.java
@@ -18,12 +18,12 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
+import java.util.Currency;
+import java.util.Set;
+
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Collections;
-
-import java.util.Currency;
-import java.util.Set;
 
 /**
  * @author Darren Rambaud
@@ -36,11 +36,15 @@ public class CurrencyToStringConversion extends SimpleConversion {
 
     @Override
     protected String getFromExpression(final ConversionContext conversionContext) {
-        return "Currency.getInstance( <SOURCE> )";
+        return currency( conversionContext ) + ".getInstance( <SOURCE> )";
     }
 
     @Override
     protected Set<Type> getFromConversionImportTypes(final ConversionContext conversionContext) {
         return Collections.asSet( conversionContext.getTypeFactory().getType( Currency.class ) );
+    }
+
+    private String currency(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( Currency.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/CurrencyToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/CurrencyToStringConversion.java
@@ -25,6 +25,8 @@ import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Collections;
 
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.currency;
+
 /**
  * @author Darren Rambaud
  */
@@ -42,9 +44,5 @@ public class CurrencyToStringConversion extends SimpleConversion {
     @Override
     protected Set<Type> getFromConversionImportTypes(final ConversionContext conversionContext) {
         return Collections.asSet( conversionContext.getTypeFactory().getType( Currency.class ) );
-    }
-
-    private String currency(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( Currency.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlDateConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlDateConversion.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.sqlDate;
+
 /**
  * Conversion between {@link java.util.Date} and {@link java.sql.Date}.
  *
@@ -34,7 +36,7 @@ public class DateToSqlDateConversion extends SimpleConversion {
 
     @Override
     protected String getToExpression(ConversionContext conversionContext) {
-        return "new " + date( conversionContext ) + "( <SOURCE>.getTime() )";
+        return "new " + sqlDate( conversionContext ) + "( <SOURCE>.getTime() )";
     }
 
     @Override
@@ -45,9 +47,5 @@ public class DateToSqlDateConversion extends SimpleConversion {
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
         return "<SOURCE>";
-    }
-
-    private String date(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( Date.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlDateConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlDateConversion.java
@@ -18,7 +18,12 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
+import java.sql.Date;
+import java.util.Collections;
+import java.util.Set;
+
 import org.mapstruct.ap.internal.model.common.ConversionContext;
+import org.mapstruct.ap.internal.model.common.Type;
 
 /**
  * Conversion between {@link java.util.Date} and {@link java.sql.Date}.
@@ -29,11 +34,20 @@ public class DateToSqlDateConversion extends SimpleConversion {
 
     @Override
     protected String getToExpression(ConversionContext conversionContext) {
-        return "new java.sql.Date( <SOURCE>.getTime() )";
+        return "new " + date( conversionContext ) + "( <SOURCE>.getTime() )";
+    }
+
+    @Override
+    protected Set<Type> getToConversionImportTypes(ConversionContext conversionContext) {
+        return Collections.singleton( conversionContext.getTypeFactory().getType( Date.class ) );
     }
 
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
         return "<SOURCE>";
+    }
+
+    private String date(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( Date.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlTimeConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlTimeConversion.java
@@ -25,6 +25,8 @@ import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Collections;
 
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.time;
+
 /**
  * Conversion between {@link java.util.Date} and {@link java.sql.Time}.
  *
@@ -45,9 +47,5 @@ public class DateToSqlTimeConversion extends SimpleConversion {
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
         return "<SOURCE>";
-    }
-
-    private String time(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( Time.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlTimeConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlTimeConversion.java
@@ -34,7 +34,7 @@ public class DateToSqlTimeConversion extends SimpleConversion {
 
     @Override
     protected String getToExpression(ConversionContext conversionContext) {
-        return "new Time( <SOURCE>.getTime() )";
+        return "new " + time( conversionContext ) + "( <SOURCE>.getTime() )";
     }
 
     @Override
@@ -45,5 +45,9 @@ public class DateToSqlTimeConversion extends SimpleConversion {
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
         return "<SOURCE>";
+    }
+
+    private String time(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( Time.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlTimestampConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlTimestampConversion.java
@@ -34,7 +34,7 @@ public class DateToSqlTimestampConversion extends SimpleConversion {
 
     @Override
     protected String getToExpression(ConversionContext conversionContext) {
-        return "new Timestamp( <SOURCE>.getTime() )";
+        return "new " + timestamp( conversionContext ) + "( <SOURCE>.getTime() )";
     }
 
     @Override
@@ -45,5 +45,9 @@ public class DateToSqlTimestampConversion extends SimpleConversion {
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
         return "<SOURCE>";
+    }
+
+    private String timestamp(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( Timestamp.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlTimestampConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToSqlTimestampConversion.java
@@ -25,6 +25,8 @@ import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Collections;
 
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.timestamp;
+
 /**
  * Conversion between {@link java.util.Date} and {@link java.sql.Timestamp}.
  *
@@ -45,9 +47,5 @@ public class DateToSqlTimestampConversion extends SimpleConversion {
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
         return "<SOURCE>";
-    }
-
-    private String timestamp(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( Timestamp.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToStringConversion.java
@@ -18,9 +18,6 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import static java.util.Arrays.asList;
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
@@ -32,6 +29,9 @@ import org.mapstruct.ap.internal.model.TypeConversion;
 import org.mapstruct.ap.internal.model.common.Assignment;
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
+
+import static java.util.Arrays.asList;
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * Conversion between {@link String} and {@link Date}.
@@ -62,7 +62,9 @@ public class DateToStringConversion implements ConversionProvider {
     }
 
     private String getConversionExpression(ConversionContext conversionContext, String method) {
-        StringBuilder conversionString = new StringBuilder( "new SimpleDateFormat(" );
+        StringBuilder conversionString = new StringBuilder( "new " );
+        conversionString.append( simpleDateFormat( conversionContext ) );
+        conversionString.append( '(' );
 
         if ( conversionContext.getDateFormat() != null ) {
             conversionString.append( " \"" );
@@ -75,5 +77,9 @@ public class DateToStringConversion implements ConversionProvider {
         conversionString.append( "( <SOURCE> )" );
 
         return conversionString.toString();
+    }
+
+    private String simpleDateFormat(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( SimpleDateFormat.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/DateToStringConversion.java
@@ -32,6 +32,7 @@ import org.mapstruct.ap.internal.model.common.Type;
 
 import static java.util.Arrays.asList;
 import static org.mapstruct.ap.internal.util.Collections.asSet;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.simpleDateFormat;
 
 /**
  * Conversion between {@link String} and {@link Date}.
@@ -77,9 +78,5 @@ public class DateToStringConversion implements ConversionProvider {
         conversionString.append( "( <SOURCE> )" );
 
         return conversionString.toString();
-    }
-
-    private String simpleDateFormat(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( SimpleDateFormat.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/EnumStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/EnumStringConversion.java
@@ -18,12 +18,12 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * Conversion between {@link String} and {@link Enum} types.
@@ -39,11 +39,20 @@ public class EnumStringConversion extends SimpleConversion {
 
     @Override
     public String getFromExpression(ConversionContext conversionContext) {
-        return "Enum.valueOf( " + conversionContext.getTargetType().getName() + ".class, <SOURCE> )";
+        return enumType( conversionContext )
+            + ".valueOf( " + conversionContext.getTargetType().getReferenceName()
+            + ".class, <SOURCE> )";
     }
 
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
-        return asSet( conversionContext.getTargetType() );
+        return asSet(
+            conversionContext.getTypeFactory().getType( Enum.class ),
+            conversionContext.getTargetType()
+        );
+    }
+
+    private String enumType(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( Enum.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/EnumStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/EnumStringConversion.java
@@ -39,20 +39,14 @@ public class EnumStringConversion extends SimpleConversion {
 
     @Override
     public String getFromExpression(ConversionContext conversionContext) {
-        return enumType( conversionContext )
-            + ".valueOf( " + conversionContext.getTargetType().getReferenceName()
+        return "Enum.valueOf( " + conversionContext.getTargetType().getReferenceName()
             + ".class, <SOURCE> )";
     }
 
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet(
-            conversionContext.getTypeFactory().getType( Enum.class ),
             conversionContext.getTargetType()
         );
-    }
-
-    private String enumType(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( Enum.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateTimeToDateConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateTimeToDateConversion.java
@@ -18,7 +18,15 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Set;
+
 import org.mapstruct.ap.internal.model.common.ConversionContext;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.util.Collections;
 
 /**
  * SimpleConversion for mapping {@link java.time.LocalDateTime} to
@@ -28,11 +36,49 @@ public class JavaLocalDateTimeToDateConversion extends SimpleConversion {
 
     @Override
     protected String getToExpression(ConversionContext conversionContext) {
-        return "java.util.Date.from( <SOURCE>.toInstant( java.time.ZoneOffset.UTC ) )";
+        return date( conversionContext )
+            + ".from( <SOURCE>.toInstant( "
+            + zoneOffset( conversionContext )
+            + ".UTC ) )";
+    }
+
+    @Override
+    protected Set<Type> getToConversionImportTypes(ConversionContext conversionContext) {
+        return Collections.asSet(
+            conversionContext.getTypeFactory().getType( Date.class ),
+            conversionContext.getTypeFactory().getType( ZoneOffset.class )
+        );
     }
 
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
-        return "java.time.LocalDateTime.ofInstant( <SOURCE>.toInstant(), java.time.ZoneId.of( \"UTC\" ) )";
+        return localDateTime( conversionContext )
+            + ".ofInstant( <SOURCE>.toInstant(), "
+            + zoneId( conversionContext )
+            + ".of( \"UTC\" ) )";
+    }
+
+    @Override
+    protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
+        return Collections.asSet(
+            conversionContext.getTypeFactory().getType( LocalDateTime.class ),
+            conversionContext.getTypeFactory().getType( ZoneId.class )
+        );
+    }
+
+    private String date(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( Date.class ).getReferenceName();
+    }
+
+    private String zoneOffset(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( ZoneOffset.class ).getReferenceName();
+    }
+
+    private String zoneId(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( ZoneId.class ).getReferenceName();
+    }
+
+    private String localDateTime(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( LocalDateTime.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateTimeToDateConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateTimeToDateConversion.java
@@ -18,15 +18,20 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Collections;
+
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.date;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.localDateTime;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.zoneId;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.zoneOffset;
+import static org.mapstruct.ap.internal.util.JavaTimeConstants.LOCAL_DATE_TIME_FQN;
+import static org.mapstruct.ap.internal.util.JavaTimeConstants.ZONE_ID_FQN;
+import static org.mapstruct.ap.internal.util.JavaTimeConstants.ZONE_OFFSET_FQN;
 
 /**
  * SimpleConversion for mapping {@link java.time.LocalDateTime} to
@@ -46,7 +51,7 @@ public class JavaLocalDateTimeToDateConversion extends SimpleConversion {
     protected Set<Type> getToConversionImportTypes(ConversionContext conversionContext) {
         return Collections.asSet(
             conversionContext.getTypeFactory().getType( Date.class ),
-            conversionContext.getTypeFactory().getType( ZoneOffset.class )
+            conversionContext.getTypeFactory().getType( ZONE_OFFSET_FQN )
         );
     }
 
@@ -61,24 +66,8 @@ public class JavaLocalDateTimeToDateConversion extends SimpleConversion {
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return Collections.asSet(
-            conversionContext.getTypeFactory().getType( LocalDateTime.class ),
-            conversionContext.getTypeFactory().getType( ZoneId.class )
+            conversionContext.getTypeFactory().getType( LOCAL_DATE_TIME_FQN ),
+            conversionContext.getTypeFactory().getType( ZONE_ID_FQN )
         );
-    }
-
-    private String date(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( Date.class ).getReferenceName();
-    }
-
-    private String zoneOffset(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( ZoneOffset.class ).getReferenceName();
-    }
-
-    private String zoneId(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( ZoneId.class ).getReferenceName();
-    }
-
-    private String localDateTime(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( LocalDateTime.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateToDateConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateToDateConversion.java
@@ -18,15 +18,19 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZoneOffset;
 import java.util.Date;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Collections;
+
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.date;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.localDateTime;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.zoneOffset;
+import static org.mapstruct.ap.internal.util.JavaTimeConstants.LOCAL_DATE_TIME_FQN;
+import static org.mapstruct.ap.internal.util.JavaTimeConstants.ZONE_ID_FQN;
+import static org.mapstruct.ap.internal.util.JavaTimeConstants.ZONE_OFFSET_FQN;
 
 /**
  * SimpleConversion for mapping {@link java.time.LocalDate} to
@@ -46,7 +50,7 @@ public class JavaLocalDateToDateConversion extends SimpleConversion {
     protected Set<Type> getToConversionImportTypes(ConversionContext conversionContext) {
         return Collections.asSet(
             conversionContext.getTypeFactory().getType( Date.class ),
-            conversionContext.getTypeFactory().getType( ZoneOffset.class )
+            conversionContext.getTypeFactory().getType( ZONE_OFFSET_FQN )
         );
     }
 
@@ -61,20 +65,8 @@ public class JavaLocalDateToDateConversion extends SimpleConversion {
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return Collections.asSet(
-            conversionContext.getTypeFactory().getType( LocalDateTime.class ),
-            conversionContext.getTypeFactory().getType( ZoneId.class )
+            conversionContext.getTypeFactory().getType( LOCAL_DATE_TIME_FQN ),
+            conversionContext.getTypeFactory().getType( ZONE_ID_FQN )
         );
-    }
-
-    private String date(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( Date.class ).getReferenceName();
-    }
-
-    private String zoneOffset(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( ZoneOffset.class ).getReferenceName();
-    }
-
-    private String localDateTime(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( LocalDateTime.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateToDateConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateToDateConversion.java
@@ -18,7 +18,15 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.Date;
+import java.util.Set;
+
 import org.mapstruct.ap.internal.model.common.ConversionContext;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.util.Collections;
 
 /**
  * SimpleConversion for mapping {@link java.time.LocalDate} to
@@ -28,12 +36,45 @@ public class JavaLocalDateToDateConversion extends SimpleConversion {
 
     @Override
     protected String getToExpression(ConversionContext conversionContext) {
-        return "java.util.Date.from( <SOURCE>.atStartOfDay( java.time.ZoneOffset.UTC ).toInstant() )";
+        return date( conversionContext )
+            + ".from( <SOURCE>.atStartOfDay( "
+            + zoneOffset( conversionContext )
+            + ".UTC ).toInstant() )";
+    }
 
+    @Override
+    protected Set<Type> getToConversionImportTypes(ConversionContext conversionContext) {
+        return Collections.asSet(
+            conversionContext.getTypeFactory().getType( Date.class ),
+            conversionContext.getTypeFactory().getType( ZoneOffset.class )
+        );
     }
 
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
-        return "java.time.LocalDateTime.ofInstant( <SOURCE>.toInstant(), java.time.ZoneOffset.UTC ).toLocalDate()";
+        return localDateTime( conversionContext )
+            + ".ofInstant( <SOURCE>.toInstant(), "
+            + zoneOffset( conversionContext )
+            + ".UTC ).toLocalDate()";
+    }
+
+    @Override
+    protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
+        return Collections.asSet(
+            conversionContext.getTypeFactory().getType( LocalDateTime.class ),
+            conversionContext.getTypeFactory().getType( ZoneId.class )
+        );
+    }
+
+    private String date(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( Date.class ).getReferenceName();
+    }
+
+    private String zoneOffset(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( ZoneOffset.class ).getReferenceName();
+    }
+
+    private String localDateTime(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( LocalDateTime.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaZonedDateTimeToDateConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaZonedDateTimeToDateConversion.java
@@ -18,7 +18,14 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import java.util.Set;
+
 import org.mapstruct.ap.internal.model.common.ConversionContext;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.util.Collections;
 
 /**
  * SimpleConversion for mapping {@link java.time.ZonedDateTime} to
@@ -29,11 +36,41 @@ public class JavaZonedDateTimeToDateConversion extends SimpleConversion {
 
     @Override
     protected String getToExpression(ConversionContext conversionContext) {
-        return "java.util.Date.from( <SOURCE>.toInstant() )";
+        return date( conversionContext ) + ".from( <SOURCE>.toInstant() )";
+    }
+
+    @Override
+    protected Set<Type> getToConversionImportTypes(ConversionContext conversionContext) {
+        return Collections.asSet(
+            conversionContext.getTypeFactory().getType( Date.class )
+        );
     }
 
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
-        return "java.time.ZonedDateTime.ofInstant( <SOURCE>.toInstant(), java.time.ZoneId.systemDefault() )";
+        return zonedDateTime( conversionContext )
+            + ".ofInstant( <SOURCE>.toInstant(), "
+            + zoneId( conversionContext )
+            + ".systemDefault() )";
+    }
+
+    @Override
+    protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
+        return Collections.asSet(
+            conversionContext.getTypeFactory().getType( ZonedDateTime.class ),
+            conversionContext.getTypeFactory().getType( ZoneId.class )
+        );
+    }
+
+    private String date(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( Date.class ).getReferenceName();
+    }
+
+    private String zonedDateTime(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( ZonedDateTime.class ).getReferenceName();
+    }
+
+    private String zoneId(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( ZoneId.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaZonedDateTimeToDateConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaZonedDateTimeToDateConversion.java
@@ -18,14 +18,18 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Collections;
+
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.date;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.zoneId;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.zonedDateTime;
+import static org.mapstruct.ap.internal.util.JavaTimeConstants.ZONED_DATE_TIME_FQN;
+import static org.mapstruct.ap.internal.util.JavaTimeConstants.ZONE_ID_FQN;
 
 /**
  * SimpleConversion for mapping {@link java.time.ZonedDateTime} to
@@ -57,20 +61,8 @@ public class JavaZonedDateTimeToDateConversion extends SimpleConversion {
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return Collections.asSet(
-            conversionContext.getTypeFactory().getType( ZonedDateTime.class ),
-            conversionContext.getTypeFactory().getType( ZoneId.class )
+            conversionContext.getTypeFactory().getType( ZONED_DATE_TIME_FQN ),
+            conversionContext.getTypeFactory().getType( ZONE_ID_FQN )
         );
-    }
-
-    private String date(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( Date.class ).getReferenceName();
-    }
-
-    private String zonedDateTime(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( ZonedDateTime.class ).getReferenceName();
-    }
-
-    private String zoneId(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( ZoneId.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/JodaDateTimeToCalendarConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/JodaDateTimeToCalendarConversion.java
@@ -26,6 +26,7 @@ import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
 
 import static org.mapstruct.ap.internal.util.Collections.asSet;
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.locale;
 
 /**
  * Conversion between {@code DateTime} and {@link Calendar}.
@@ -52,9 +53,5 @@ public class JodaDateTimeToCalendarConversion extends SimpleConversion {
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTargetType() );
-    }
-
-    private String locale(ConversionContext conversionContext) {
-        return conversionContext.getTypeFactory().getType( Locale.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/JodaDateTimeToCalendarConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/JodaDateTimeToCalendarConversion.java
@@ -18,14 +18,14 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Type;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * Conversion between {@code DateTime} and {@link Calendar}.
@@ -36,7 +36,7 @@ public class JodaDateTimeToCalendarConversion extends SimpleConversion {
 
     @Override
     protected String getToExpression(ConversionContext conversionContext) {
-        return "<SOURCE>.toCalendar( Locale.getDefault() )";
+        return "<SOURCE>.toCalendar( " + locale( conversionContext ) + ".getDefault() )";
     }
 
     @Override
@@ -46,11 +46,15 @@ public class JodaDateTimeToCalendarConversion extends SimpleConversion {
 
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
-        return "new " + conversionContext.getTargetType().getName() + "( <SOURCE> )";
+        return "new " + conversionContext.getTargetType().getReferenceName() + "( <SOURCE> )";
     }
 
     @Override
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return asSet( conversionContext.getTargetType() );
+    }
+
+    private String locale(ConversionContext conversionContext) {
+        return conversionContext.getTypeFactory().getType( Locale.class ).getReferenceName();
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/JodaTimeToDateConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/JodaTimeToDateConversion.java
@@ -45,7 +45,7 @@ public class JodaTimeToDateConversion extends SimpleConversion {
 
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
-        return "new " + conversionContext.getTargetType().getName() + "( <SOURCE> )";
+        return "new " + conversionContext.getTargetType().getReferenceName() + "( <SOURCE> )";
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/PrimitiveToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/PrimitiveToStringConversion.java
@@ -18,7 +18,12 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
+import java.text.DecimalFormat;
+import java.util.Collections;
+import java.util.Set;
+
 import org.mapstruct.ap.internal.model.common.ConversionContext;
+import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.Strings;
 
@@ -57,6 +62,17 @@ public class PrimitiveToStringConversion extends AbstractNumberToStringConversio
     }
 
     @Override
+    public Set<Type> getToConversionImportTypes(ConversionContext conversionContext) {
+        if ( requiresDecimalFormat( conversionContext ) ) {
+            return Collections.singleton(
+                conversionContext.getTypeFactory().getType( DecimalFormat.class )
+            );
+        }
+
+        return Collections.emptySet();
+    }
+
+    @Override
     public String getFromExpression(ConversionContext conversionContext) {
         if ( requiresDecimalFormat( conversionContext ) ) {
             StringBuilder sb = new StringBuilder();
@@ -72,8 +88,22 @@ public class PrimitiveToStringConversion extends AbstractNumberToStringConversio
         }
     }
 
+    @Override
+    protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
+        if ( requiresDecimalFormat( conversionContext ) ) {
+            return Collections.singleton(
+                conversionContext.getTypeFactory().getType( DecimalFormat.class )
+            );
+        }
+
+        return Collections.emptySet();
+    }
+
     private void appendDecimalFormatter(StringBuilder sb, ConversionContext conversionContext) {
-        sb.append( "new DecimalFormat( " );
+        sb.append( "new " );
+        sb.append( decimalFormat( conversionContext ) );
+        sb.append( "( " );
+
         if ( conversionContext.getNumberFormat() != null ) {
             sb.append( "\"" );
             sb.append( conversionContext.getNumberFormat() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/PrimitiveToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/PrimitiveToStringConversion.java
@@ -27,6 +27,8 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.Strings;
 
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.decimalFormat;
+
 /**
  * Conversion between primitive types such as {@code byte} or {@code long} and
  * {@link String}.

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/WrapperToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/WrapperToStringConversion.java
@@ -27,6 +27,8 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.Strings;
 
+import static org.mapstruct.ap.internal.conversion.ConversionUtils.decimalFormat;
+
 /**
  * Conversion between wrapper types such as {@link Integer} and {@link String}.
  *

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/WrapperToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/WrapperToStringConversion.java
@@ -18,7 +18,12 @@
  */
 package org.mapstruct.ap.internal.conversion;
 
+import java.text.DecimalFormat;
+import java.util.Collections;
+import java.util.Set;
+
 import org.mapstruct.ap.internal.model.common.ConversionContext;
+import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.Strings;
 
@@ -56,6 +61,17 @@ public class WrapperToStringConversion extends AbstractNumberToStringConversion 
     }
 
     @Override
+    public Set<Type> getToConversionImportTypes(ConversionContext conversionContext) {
+        if ( requiresDecimalFormat( conversionContext ) ) {
+            return Collections.singleton(
+                conversionContext.getTypeFactory().getType( DecimalFormat.class )
+            );
+        }
+
+        return Collections.emptySet();
+    }
+
+    @Override
     public String getFromExpression(ConversionContext conversionContext) {
         if ( requiresDecimalFormat( conversionContext ) ) {
             StringBuilder sb = new StringBuilder();
@@ -71,8 +87,22 @@ public class WrapperToStringConversion extends AbstractNumberToStringConversion 
         }
     }
 
+    @Override
+    protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
+        if ( requiresDecimalFormat( conversionContext ) ) {
+            return Collections.singleton(
+                conversionContext.getTypeFactory().getType( DecimalFormat.class )
+            );
+        }
+
+        return Collections.emptySet();
+    }
+
     private void appendDecimalFormatter(StringBuilder sb, ConversionContext conversionContext) {
-        sb.append( "new DecimalFormat( " );
+        sb.append( "new " );
+        sb.append( decimalFormat( conversionContext ) );
+        sb.append( "( " );
+
         if ( conversionContext.getNumberFormat() != null ) {
             sb.append( "\"" );
             sb.append( conversionContext.getNumberFormat() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -26,7 +26,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
@@ -175,6 +174,15 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     public String getName() {
         return name;
+    }
+
+    /**
+     * String that could be used in generated code to reference to this {@link Type}.
+     *
+     * @return Just the name if this {@link Type} will be imported, otherwise the fully-qualified name.
+     */
+    public String getReferenceName() {
+        return isImported ? name : qualifiedName;
     }
 
     public List<Type> getTypeParameters() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/JavaTimeConstants.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/JavaTimeConstants.java
@@ -24,9 +24,13 @@ package org.mapstruct.ap.internal.util;
 public final class JavaTimeConstants {
 
     public static final String ZONED_DATE_TIME_FQN = "java.time.ZonedDateTime";
+    public static final String ZONE_OFFSET_FQN = "java.time.ZoneOffset";
+    public static final String ZONE_ID_FQN = "java.time.ZoneId";
+
     public static final String LOCAL_DATE_TIME_FQN = "java.time.LocalDateTime";
     public static final String LOCAL_DATE_FQN = "java.time.LocalDate";
     public static final String LOCAL_TIME_FQN = "java.time.LocalTime";
+
     public static final String DATE_TIME_FORMATTER_FQN = "java.time.format.DateTimeFormatter";
 
     private JavaTimeConstants() {

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/common/Type.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/common/Type.ftl
@@ -26,6 +26,6 @@
     <#elseif wildCardSuperBound>
         ? super <@includeModel object=typeBound />
     <#else>
-        <#if imported>${name}<#else>${fullyQualifiedName}</#if></#if><#if (!ext.raw?? && typeParameters?size > 0) ><<#list typeParameters as typeParameter><@includeModel object=typeParameter /><#if typeParameter_has_next>, </#if></#list>>
+        ${referenceName}</#if><#if (!ext.raw?? && typeParameters?size > 0) ><<#list typeParameters as typeParameter><@includeModel object=typeParameter /><#if typeParameter_has_next>, </#if></#list>>
     </#if>
 </@compress>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Issue1460Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Issue1460Mapper.java
@@ -1,0 +1,58 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1460;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Christian Bandowski
+ */
+@Mapper
+public abstract class Issue1460Mapper {
+
+    public static final Issue1460Mapper INSTANCE = Mappers.getMapper( Issue1460Mapper.class );
+
+    public abstract Target map(Source source);
+
+    public abstract String forceUsageOfIssue1460Enum(Issue1460Enum source);
+
+    public abstract String forceUsageOfEnum(Enum source);
+
+    public abstract String forceUsageOfLocale(Locale source);
+
+    public abstract String forceUsageOfLocalDate(LocalDate source);
+
+    public abstract String forceUsageOfDateTime(DateTime source);
+
+    public static class Issue1460Enum {
+    }
+
+    public static class Enum {
+    }
+
+    public static class Locale {
+    }
+
+    public static class LocalDate {
+    }
+
+    public static class DateTime {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Issue1460Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Issue1460Test.java
@@ -1,0 +1,70 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1460;
+
+import java.time.LocalDate;
+import java.util.Date;
+import java.util.Locale;
+
+import org.joda.time.DateTime;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Christian Bandowski
+ */
+@WithClasses({
+    Issue1460Mapper.class,
+    Source.class,
+    Target.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1460")
+public class Issue1460Test {
+
+    @Test
+    public void shouldTestMappingLocalDates() {
+        long dateInMs = 1524693600000L;
+        String dateAsString = "2018-04-26";
+        String dateTimeAsString = dateAsString + "T00:00:00+00:00";
+
+        Source source = new Source();
+        source.setStringToEnum( "OK" );
+        source.setDateToJodaDateTime( new Date( dateInMs ) );
+        source.setJodaDateTimeToCalendar( DateTime.parse( dateTimeAsString ) );
+        source.setStringToJavaLocalDate( dateAsString );
+
+        Target target = Issue1460Mapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getStringToEnum() ).isEqualTo( Target.Issue1460Enum.OK );
+        assertThat( target.getDateToJodaDateTime() ).isEqualTo(
+            new DateTime( new Date( dateInMs ) )
+        );
+        assertThat( target.getJodaDateTimeToCalendar().getTimeInMillis() ).isEqualTo(
+            DateTime.parse( dateTimeAsString ).toCalendar( Locale.getDefault() ).getTimeInMillis()
+        );
+        assertThat( target.getStringToJavaLocalDate() ).isEqualTo( LocalDate.parse( dateAsString ) );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Source.java
@@ -1,0 +1,62 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1460;
+
+import java.util.Date;
+
+import org.joda.time.DateTime;
+
+public class Source {
+    private String stringToEnum;
+    private DateTime jodaDateTimeToCalendar;
+    private String stringToJavaLocalDate;
+    private Date dateToJodaDateTime;
+
+    public String getStringToEnum() {
+        return stringToEnum;
+    }
+
+    public void setStringToEnum(String stringToEnum) {
+        this.stringToEnum = stringToEnum;
+    }
+
+    public DateTime getJodaDateTimeToCalendar() {
+        return jodaDateTimeToCalendar;
+    }
+
+    public void setJodaDateTimeToCalendar(DateTime jodaDateTimeToCalendar) {
+        this.jodaDateTimeToCalendar = jodaDateTimeToCalendar;
+    }
+
+    public String getStringToJavaLocalDate() {
+        return stringToJavaLocalDate;
+    }
+
+    public void setStringToJavaLocalDate(String stringToJavaLocalDate) {
+        this.stringToJavaLocalDate = stringToJavaLocalDate;
+    }
+
+    public Date getDateToJodaDateTime() {
+        return dateToJodaDateTime;
+    }
+
+    public void setDateToJodaDateTime(Date dateToJodaDateTime) {
+        this.dateToJodaDateTime = dateToJodaDateTime;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Target.java
@@ -18,7 +18,6 @@
  */
 package org.mapstruct.ap.test.bugs._1460;
 
-import java.time.LocalDate;
 import java.util.Calendar;
 
 import org.joda.time.DateTime;
@@ -30,7 +29,6 @@ public class Target {
 
     private Issue1460Enum stringToEnum;
     private Calendar jodaDateTimeToCalendar;
-    private LocalDate stringToJavaLocalDate;
     private DateTime dateToJodaDateTime;
 
     public Issue1460Enum getStringToEnum() {
@@ -47,14 +45,6 @@ public class Target {
 
     public void setJodaDateTimeToCalendar(Calendar jodaDateTimeToCalendar) {
         this.jodaDateTimeToCalendar = jodaDateTimeToCalendar;
-    }
-
-    public LocalDate getStringToJavaLocalDate() {
-        return stringToJavaLocalDate;
-    }
-
-    public void setStringToJavaLocalDate(LocalDate stringToJavaLocalDate) {
-        this.stringToJavaLocalDate = stringToJavaLocalDate;
     }
 
     public DateTime getDateToJodaDateTime() {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Target.java
@@ -1,0 +1,67 @@
+/**
+ *  Copyright 2012-2017 Gunnar Morling (http://www.gunnarmorling.de/)
+ *  and/or other contributors as indicated by the @authors tag. See the
+ *  copyright.txt file in the distribution for a full listing of all
+ *  contributors.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+package org.mapstruct.ap.test.bugs._1460;
+
+import java.time.LocalDate;
+import java.util.Calendar;
+
+import org.joda.time.DateTime;
+
+public class Target {
+    public enum Issue1460Enum {
+        OK, KO;
+    }
+
+    private Issue1460Enum stringToEnum;
+    private Calendar jodaDateTimeToCalendar;
+    private LocalDate stringToJavaLocalDate;
+    private DateTime dateToJodaDateTime;
+
+    public Issue1460Enum getStringToEnum() {
+        return stringToEnum;
+    }
+
+    public void setStringToEnum(Issue1460Enum stringToEnum) {
+        this.stringToEnum = stringToEnum;
+    }
+
+    public Calendar getJodaDateTimeToCalendar() {
+        return jodaDateTimeToCalendar;
+    }
+
+    public void setJodaDateTimeToCalendar(Calendar jodaDateTimeToCalendar) {
+        this.jodaDateTimeToCalendar = jodaDateTimeToCalendar;
+    }
+
+    public LocalDate getStringToJavaLocalDate() {
+        return stringToJavaLocalDate;
+    }
+
+    public void setStringToJavaLocalDate(LocalDate stringToJavaLocalDate) {
+        this.stringToJavaLocalDate = stringToJavaLocalDate;
+    }
+
+    public DateTime getDateToJodaDateTime() {
+        return dateToJodaDateTime;
+    }
+
+    public void setDateToJodaDateTime(DateTime dateToJodaDateTime) {
+        this.dateToJodaDateTime = dateToJodaDateTime;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/java8/Issue1460JavaTimeMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/java8/Issue1460JavaTimeMapper.java
@@ -16,7 +16,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.bugs._1460;
+package org.mapstruct.ap.test.bugs._1460.java8;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
@@ -25,29 +25,14 @@ import org.mapstruct.factory.Mappers;
  * @author Christian Bandowski
  */
 @Mapper
-public abstract class Issue1460Mapper {
+public abstract class Issue1460JavaTimeMapper {
 
-    public static final Issue1460Mapper INSTANCE = Mappers.getMapper( Issue1460Mapper.class );
+    public static final Issue1460JavaTimeMapper INSTANCE = Mappers.getMapper( Issue1460JavaTimeMapper.class );
 
     public abstract Target map(Source source);
 
-    public abstract String forceUsageOfIssue1460Enum(Issue1460Enum source);
-
-    public abstract String forceUsageOfLocale(Locale source);
-
     public abstract String forceUsageOfLocalDate(LocalDate source);
 
-    public abstract String forceUsageOfDateTime(DateTime source);
-
-    public static class Issue1460Enum {
-    }
-
-    public static class Locale {
-    }
-
     public static class LocalDate {
-    }
-
-    public static class DateTime {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/java8/Issue1460JavaTimeTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/java8/Issue1460JavaTimeTest.java
@@ -16,12 +16,10 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.bugs._1460;
+package org.mapstruct.ap.test.bugs._1460.java8;
 
-import java.util.Date;
-import java.util.Locale;
+import java.time.LocalDate;
 
-import org.joda.time.DateTime;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
@@ -34,34 +32,24 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Christian Bandowski
  */
 @WithClasses({
-    Issue1460Mapper.class,
+    Issue1460JavaTimeMapper.class,
     Source.class,
     Target.class
 })
 @RunWith(AnnotationProcessorTestRunner.class)
 @IssueKey("1460")
-public class Issue1460Test {
+public class Issue1460JavaTimeTest {
 
     @Test
     public void shouldTestMappingLocalDates() {
-        long dateInMs = 1524693600000L;
         String dateAsString = "2018-04-26";
-        String dateTimeAsString = dateAsString + "T00:00:00+00:00";
 
         Source source = new Source();
-        source.setStringToEnum( "OK" );
-        source.setDateToJodaDateTime( new Date( dateInMs ) );
-        source.setJodaDateTimeToCalendar( DateTime.parse( dateTimeAsString ) );
+        source.setStringToJavaLocalDate( dateAsString );
 
-        Target target = Issue1460Mapper.INSTANCE.map( source );
+        Target target = Issue1460JavaTimeMapper.INSTANCE.map( source );
 
         assertThat( target ).isNotNull();
-        assertThat( target.getStringToEnum() ).isEqualTo( Target.Issue1460Enum.OK );
-        assertThat( target.getDateToJodaDateTime() ).isEqualTo(
-            new DateTime( new Date( dateInMs ) )
-        );
-        assertThat( target.getJodaDateTimeToCalendar().getTimeInMillis() ).isEqualTo(
-            DateTime.parse( dateTimeAsString ).toCalendar( Locale.getDefault() ).getTimeInMillis()
-        );
+        assertThat( target.getStringToJavaLocalDate() ).isEqualTo( LocalDate.parse( dateAsString ) );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/java8/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/java8/Source.java
@@ -16,38 +16,17 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.bugs._1460;
-
-import java.util.Date;
-
-import org.joda.time.DateTime;
+package org.mapstruct.ap.test.bugs._1460.java8;
 
 public class Source {
-    private String stringToEnum;
-    private DateTime jodaDateTimeToCalendar;
-    private Date dateToJodaDateTime;
+    private String stringToJavaLocalDate;
 
-    public String getStringToEnum() {
-        return stringToEnum;
+    public String getStringToJavaLocalDate() {
+        return stringToJavaLocalDate;
     }
 
-    public void setStringToEnum(String stringToEnum) {
-        this.stringToEnum = stringToEnum;
+    public void setStringToJavaLocalDate(String stringToJavaLocalDate) {
+        this.stringToJavaLocalDate = stringToJavaLocalDate;
     }
 
-    public DateTime getJodaDateTimeToCalendar() {
-        return jodaDateTimeToCalendar;
-    }
-
-    public void setJodaDateTimeToCalendar(DateTime jodaDateTimeToCalendar) {
-        this.jodaDateTimeToCalendar = jodaDateTimeToCalendar;
-    }
-
-    public Date getDateToJodaDateTime() {
-        return dateToJodaDateTime;
-    }
-
-    public void setDateToJodaDateTime(Date dateToJodaDateTime) {
-        this.dateToJodaDateTime = dateToJodaDateTime;
-    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/java8/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/java8/Target.java
@@ -16,38 +16,19 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-package org.mapstruct.ap.test.bugs._1460;
+package org.mapstruct.ap.test.bugs._1460.java8;
 
-import org.mapstruct.Mapper;
-import org.mapstruct.factory.Mappers;
+import java.time.LocalDate;
 
-/**
- * @author Christian Bandowski
- */
-@Mapper
-public abstract class Issue1460Mapper {
+public class Target {
+    private LocalDate stringToJavaLocalDate;
 
-    public static final Issue1460Mapper INSTANCE = Mappers.getMapper( Issue1460Mapper.class );
-
-    public abstract Target map(Source source);
-
-    public abstract String forceUsageOfIssue1460Enum(Issue1460Enum source);
-
-    public abstract String forceUsageOfLocale(Locale source);
-
-    public abstract String forceUsageOfLocalDate(LocalDate source);
-
-    public abstract String forceUsageOfDateTime(DateTime source);
-
-    public static class Issue1460Enum {
+    public LocalDate getStringToJavaLocalDate() {
+        return stringToJavaLocalDate;
     }
 
-    public static class Locale {
+    public void setStringToJavaLocalDate(LocalDate stringToJavaLocalDate) {
+        this.stringToJavaLocalDate = stringToJavaLocalDate;
     }
 
-    public static class LocalDate {
-    }
-
-    public static class DateTime {
-    }
 }


### PR DESCRIPTION
* Added getReferenceName() to Type which returns simple or fully-qualified-name
* Use getReferenceName() in all SimpleConversions
* Added testcase that is not working without these changes

The issue itself occurs as soon as there is the same class name used for the classes in the `SimpleConversions` and in the mapper (e. g. an own `LocalDate` class and a `LocalDate` conversion). 
I added a testcase that shows this for a few types., but I changed a lot more `SimpleConversions` and checked my changes multiple times. 
Please also take a look..  hopefully I haven't missed things like a `(` or an import. These were the issues I noticed after I added the changes, but in case all conversions are covered by at least one test everything should still work.

I am also not very happy with the name `getReferenceName()`, maybe you've got a better idea. But what it returns is the name that could be used to reference to this type .. so maybe it's okay.

Looking forward to your feedback!

Best regards,
Christian

PS: I directly used the java8 time classes in some conversions. Don't know if this is legit, maybe I need to change this to using the FQN as a `String` instead of the `Class`. But if this is the case I expect that Travis complains this.. 

Fixes #1460