### PR TITLE
Use constants instead of strings in ValueMapping javadoc

### DIFF
--- a/core-jdk8/src/main/java/org/mapstruct/ValueMapping.java
+++ b/core-jdk8/src/main/java/org/mapstruct/ValueMapping.java
@@ -65,9 +65,9 @@ import java.lang.annotation.Target;
  *
  * <pre>
  * <code>
- * &#64;ValueMapping( source = "&lt;NULL&gt;", target = "DEFAULT" ),
- * &#64;ValueMapping( source = "STANDARD", target = "&lt;NULL&gt;" ),
- * &#64;ValueMapping( source = "&lt;ANY_REMAINING&gt;", target = "SPECIAL" )
+ * &#64;ValueMapping( source = MappingConstants.NULL, target = "DEFAULT" ),
+ * &#64;ValueMapping( source = "STANDARD", target = MappingConstants.NULL ),
+ * &#64;ValueMapping( source = MappingConstants.ANY_REMAINING, target = "SPECIAL" )
  * ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
  * </code>
  * Mapping result:

--- a/core/src/main/java/org/mapstruct/ValueMapping.java
+++ b/core/src/main/java/org/mapstruct/ValueMapping.java
@@ -67,9 +67,9 @@ import java.lang.annotation.Target;
  * <pre>
  * <code>
  * &#64;ValueMappings({
- *    &#64;ValueMapping( source = "&lt;NULL&gt;", target = "DEFAULT" ),
- *    &#64;ValueMapping( source = "STANDARD", target = "&lt;NULL&gt;" ),
- *    &#64;ValueMapping( source = "&lt;ANY_REMAINING&gt;", target = "SPECIAL" )
+ *    &#64;ValueMapping( source = MappingConstants.NULL, target = "DEFAULT" ),
+ *    &#64;ValueMapping( source = "STANDARD", target = MappingConstants.NULL ),
+ *    &#64;ValueMapping( source = MappingConstants.ANY_REMAINING, target = "SPECIAL" )
  * })
  * ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
  * </code>


### PR DESCRIPTION
I noticed that the String values were used in `@ValueMapping` javadoc and as there are constants available I think it is always better to just use those.