### PR TITLE
#1454 add more tests for builder lifecycle methods

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/builder/lifecycle/BuilderLifecycleCallbacksTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/lifecycle/BuilderLifecycleCallbacksTest.java
@@ -58,10 +58,13 @@ public class BuilderLifecycleCallbacksTest {
 
         assertThat( context.getInvokedMethods() )
             .contains(
+                "beforeWithoutParameters",
                 "beforeWithBuilderTargetType",
                 "beforeWithBuilderTarget",
+                "afterWithoutParameters",
                 "afterWithBuilderTargetType",
-                "afterWithBuilderTarget"
+                "afterWithBuilderTarget",
+                "afterWithBuilderTargetReturningTarget"
             );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/lifecycle/MappingContext.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/lifecycle/MappingContext.java
@@ -34,6 +34,11 @@ public class MappingContext {
     private final List<String> invokedMethods = new ArrayList<String>();
 
     @BeforeMapping
+    public void beforeWithoutParameters() {
+        invokedMethods.add( "beforeWithoutParameters" );
+    }
+
+    @BeforeMapping
     public void beforeWithTargetType(OrderDto source, @TargetType Class<Order> orderClass) {
         invokedMethods.add( "beforeWithTargetType" );
     }
@@ -54,6 +59,11 @@ public class MappingContext {
     }
 
     @AfterMapping
+    public void afterWithoutParameters() {
+        invokedMethods.add( "afterWithoutParameters" );
+    }
+
+    @AfterMapping
     public void afterWithTargetType(OrderDto source, @TargetType Class<Order> orderClass) {
         invokedMethods.add( "afterWithTargetType" );
     }
@@ -71,6 +81,13 @@ public class MappingContext {
     @AfterMapping
     public void afterWithBuilderTarget(OrderDto source, @MappingTarget Order.Builder orderBuilder) {
         invokedMethods.add( "afterWithBuilderTarget" );
+    }
+
+    @AfterMapping
+    public Order afterWithBuilderTargetReturningTarget(@MappingTarget Order.Builder orderBuilder) {
+        invokedMethods.add( "afterWithBuilderTargetReturningTarget" );
+
+        return orderBuilder.create();
     }
 
     public List<String> getInvokedMethods() {


### PR DESCRIPTION
Added tests for following lifecycle methods mentioned in #1454

* `@BeforeMapping` with no parameters
* `@AfterMapping` with no parameters
* `@AfterMapping` with `@MappingTarget` `PersonBuilder` and returning `Person`

Last entry is not yet checked in #1454, but works

Generated code:

```java
Order target = context.afterWithBuilderTargetReturningTarget( order );
if ( target != null ) {
    return target;
}
```