### PR TITLE
#1455, source presence tracking for collections

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.ftl
@@ -10,7 +10,7 @@
 <@lib.sourceLocalVarAssignment/>
 <@lib.handleExceptions>
   <@callTargetWriteAccessor/>
-  <#if !ext.defaultValueAssignment??>else {<#-- the opposite (defaultValueAssignment) case is handeld inside lib.handleLocalVarNullCheck -->
+  <#if !ext.defaultValueAssignment?? && !sourcePresenceCheckerReference??>else {<#-- the opposite (defaultValueAssignment) case is handeld inside lib.handleLocalVarNullCheck -->
     ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite><#if mapNullToDefault><@lib.initTargetObject/><#else>null</#if></@lib.handleWrite>;
   }
   </#if>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Issue913SetterMapperForCollectionsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Issue913SetterMapperForCollectionsTest.java
@@ -218,7 +218,7 @@ public class Issue913SetterMapperForCollectionsTest {
         Domain domain = DomainDtoWithPresenceCheckMapper.INSTANCE.create( dto );
 
         doControlAsserts( domain );
-        assertThat( domain.getStrings() ).isNull();
+        assertThat( domain.getStrings() ).isEmpty();
         assertThat( domain.getLongs() ).isNull();
     }
 
@@ -284,8 +284,8 @@ public class Issue913SetterMapperForCollectionsTest {
         Domain domain = DomainDtoWithNcvsAlwaysMapper.INSTANCE.create( dto );
 
         doControlAsserts( domain );
-        assertThat( domain.getStrings() ).isNull();
-        assertThat( domain.getLongs() ).isNull();
+        assertThat( domain.getStrings() ).isEmpty();
+        assertThat( domain.getLongs() ).isEmpty();
     }
 
     /**

--- a/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/PresenceCheckTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/PresenceCheckTest.java
@@ -6,6 +6,8 @@
 package org.mapstruct.ap.test.source.presencecheck.spi;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 
@@ -26,7 +28,9 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
     SoccerTeamMapper.class,
     SoccerTeamSource.class,
     GoalKeeper.class,
-    SoccerTeamTarget.class
+    SoccerTeamTarget.class,
+    TargetWithPresenceTracking.class,
+    SourceTargetWithPresenceTrackingMapper.class
 })
 @RunWith(AnnotationProcessorTestRunner.class)
 public class PresenceCheckTest {
@@ -198,5 +202,46 @@ public class PresenceCheckTest {
         SoccerTeamTarget target = SoccerTeamMapper.INSTANCE.mapNested( soccerTeamSource );
 
         assertThat( target.getGoalKeeperName() ).isNull();
+    }
+
+    @Test
+    public void testPresenceWithSourcesAbsent() {
+
+        Source source = new Source();
+
+        source.setHasSomePrimitiveDouble( false );
+        source.setHasSomeInteger( false );
+        source.setHasSomeList( false );
+        source.setHasSomeArray( false );
+
+        TargetWithPresenceTracking target = SourceTargetWithPresenceTrackingMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target.getSomePrimitiveDouble() ).isEqualTo( 0d );
+        assertThat( target.getSomeInteger() ).isNull();
+        assertThat( target.getSomeList() ).isNull();
+        assertThat( target.getSomeArray() ).isNull();
+
+        assertFalse( target.hasSomePrimitiveDouble() );
+        assertFalse( target.hasSomeInteger() );
+        assertFalse( target.hasSomeList() );
+        assertFalse( target.hasSomeArray() );
+    }
+
+    @Test
+    public void testPresenceWithSourcePresent() {
+        Source source = new Source();
+
+        source.setSomePrimitiveDouble( 5.0 );
+        source.setSomeInteger( 7 );
+        source.setSomeList( Arrays.asList( "first", "second" ) );
+        source.setSomeArray( new String[]{ "x", "y" } );
+
+        TargetWithPresenceTracking target = SourceTargetWithPresenceTrackingMapper.INSTANCE.sourceToTarget( source );
+
+        assertTrue( target.hasSomePrimitiveDouble() );
+        assertTrue( target.hasSomeInteger() );
+        assertTrue( target.hasSomeList() );
+        assertTrue( target.hasSomeArray() );
+
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/SourceTargetWithPresenceTrackingMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/SourceTargetWithPresenceTrackingMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.source.presencecheck.spi;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Cindy Wang
+ */
+@Mapper
+public abstract class SourceTargetWithPresenceTrackingMapper {
+
+    public static final SourceTargetWithPresenceTrackingMapper INSTANCE =
+        Mappers.getMapper( SourceTargetWithPresenceTrackingMapper.class );
+
+    abstract TargetWithPresenceTracking sourceToTarget(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/TargetWithPresenceTracking.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/TargetWithPresenceTracking.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.source.presencecheck.spi;
+
+import java.util.List;
+
+/**
+ * @author Cindy Wang
+ */
+public class TargetWithPresenceTracking {
+    private double somePrimitiveDouble;
+    private Integer someInteger;
+    private List<String> someList;
+    private String[] someArray;
+
+    private boolean hasSomePrimitiveDouble = false;
+    private boolean hasSomeInteger = false;
+    private boolean hasSomeList = false;
+    private boolean hasSomeArray = false;
+
+    public double getSomePrimitiveDouble() {
+        return somePrimitiveDouble;
+    }
+
+    public void setSomePrimitiveDouble(double someDouble) {
+        this.somePrimitiveDouble = someDouble;
+        hasSomePrimitiveDouble = true;
+    }
+
+    public Integer getSomeInteger() {
+        return someInteger;
+    }
+
+    public void setSomeInteger(Integer someInteger) {
+        this.someInteger = someInteger;
+        hasSomeInteger = true;
+    }
+
+    public List<String> getSomeList() {
+        return someList;
+    }
+
+    public void setSomeList(List<String> someList) {
+        this.someList = someList;
+        hasSomeList = true;
+    }
+
+    public String[] getSomeArray() {
+        return someArray;
+    }
+
+    public void setSomeArray(String[] someArray) {
+        this.someArray = someArray;
+        hasSomeArray = true;
+    }
+
+    public boolean hasSomePrimitiveDouble() {
+        return hasSomePrimitiveDouble;
+    }
+
+    public boolean hasSomeInteger() {
+        return hasSomeInteger;
+    }
+
+    public boolean hasSomeList() {
+        return hasSomeList;
+    }
+
+    public boolean hasSomeArray() {
+        return hasSomeArray;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
@@ -31,21 +31,12 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         if ( source.hasStringsInitialized() ) {
             domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
         }
-        else {
-            domain.setLongsInitialized( null );
-        }
         if ( source.hasStrings() ) {
             domain.setLongs( stringListToLongSet( source.getStrings() ) );
-        }
-        else {
-            domain.setLongs( null );
         }
         if ( source.hasStrings() ) {
             List<String> list = source.getStrings();
             domain.setStrings( new HashSet<String>( list ) );
-        }
-        else {
-            domain.setStrings( null );
         }
         if ( source.hasStringsWithDefault() ) {
             List<String> list1 = source.getStringsWithDefault();
@@ -57,9 +48,6 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         if ( source.hasStringsInitialized() ) {
             List<String> list2 = source.getStringsInitialized();
             domain.setStringsInitialized( new HashSet<String>( list2 ) );
-        }
-        else {
-            domain.setStringsInitialized( null );
         }
 
         return domain;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
@@ -34,9 +34,6 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
             List<String> list = source.getStrings();
             domain.setStrings( new HashSet<String>( list ) );
         }
-        else {
-            domain.setStrings( null );
-        }
         if ( source.hasStringsWithDefault() ) {
             List<String> list1 = source.getStringsWithDefault();
             domain.setStringsWithDefault( new ArrayList<String>( list1 ) );
@@ -47,9 +44,6 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         if ( source.hasStringsInitialized() ) {
             List<String> list2 = source.getStringsInitialized();
             domain.setStringsInitialized( new HashSet<String>( list2 ) );
-        }
-        else {
-            domain.setStringsInitialized( null );
         }
 
         return domain;


### PR DESCRIPTION
When mapping collections with source presence tracking enabled, currently the target field will always be set even though the source field is not present. The behavior of collections is different from other non-primitive types, including arrays.

It should be expected that if the source is not present, the corresponding target field should not be set.