### PR TITLE
Rename Typo to FormattingMessenger

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractBaseBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractBaseBuilder.java
@@ -153,7 +153,7 @@ class AbstractBaseBuilder<B extends AbstractBaseBuilder<B>> {
      */
     void reportCannotCreateMapping(Method method, String sourceErrorMessagePart, Type sourceType, Type targetType,
         String targetPropertyName) {
-        ctx.getMessager().printMessage(
+        ctx.getMessenger().printMessage(
             method.getExecutable(),
             Message.PROPERTYMAPPING_MAPPING_NOT_FOUND,
             sourceErrorMessagePart,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -204,7 +204,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 if ( selectionParameters != null && selectionParameters.getResultType() != null ) {
                     resultType = ctx.getTypeFactory().getType( selectionParameters.getResultType() ).getEffectiveType();
                     if ( resultType.isAbstract() ) {
-                        ctx.getMessager().printMessage(
+                        ctx.getMessenger().printMessage(
                             method.getExecutable(),
                             beanMappingPrism.mirror,
                             Message.BEANMAPPING_ABSTRACT,
@@ -213,14 +213,14 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                         );
                     }
                     else if ( !resultType.isAssignableTo( method.getResultType() ) ) {
-                        ctx.getMessager().printMessage(
+                        ctx.getMessenger().printMessage(
                             method.getExecutable(),
                             beanMappingPrism.mirror,
                             Message.BEANMAPPING_NOT_ASSIGNABLE, resultType, method.getResultType()
                         );
                     }
                     else if ( !resultType.hasEmptyAccessibleContructor() ) {
-                        ctx.getMessager().printMessage(
+                        ctx.getMessenger().printMessage(
                             method.getExecutable(),
                             beanMappingPrism.mirror,
                             Message.GENERAL_NO_SUITABLE_CONSTRUCTOR,
@@ -229,7 +229,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                     }
                 }
                 else if ( !method.isUpdateMethod() && method.getReturnType().getEffectiveType().isAbstract() ) {
-                    ctx.getMessager().printMessage(
+                    ctx.getMessenger().printMessage(
                         method.getExecutable(),
                         Message.GENERAL_ABSTRACT_RETURN_TYPE,
                         method.getReturnType().getEffectiveType()
@@ -237,7 +237,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 }
                 else if ( !method.isUpdateMethod() &&
                     !method.getReturnType().getEffectiveType().hasEmptyAccessibleContructor() ) {
-                    ctx.getMessager().printMessage(
+                    ctx.getMessenger().printMessage(
                         method.getExecutable(),
                         Message.GENERAL_NO_SUITABLE_CONSTRUCTOR,
                         method.getReturnType().getEffectiveType()
@@ -356,7 +356,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                     cycles.add( Strings.join( cycle, " -> " ) );
                 }
 
-                ctx.getMessager().printMessage(
+                ctx.getMessenger().printMessage(
                     method.getExecutable(),
                     Message.BEANMAPPING_CYCLE_BETWEEN_PROPERTIES, Strings.join( cycles, ", " )
                 );
@@ -454,7 +454,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             // unknown properties given via dependsOn()?
             for ( String dependency : mapping.getDependsOn() ) {
                 if ( !targetProperties.contains( dependency ) ) {
-                    ctx.getMessager().printMessage(
+                    ctx.getMessenger().printMessage(
                         method.getExecutable(),
                         mapping.getMirror(),
                         mapping.getDependsOnAnnotationValue(),
@@ -616,7 +616,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
 
                         if ( propertyMapping != null && newPropertyMapping != null ) {
                             // TODO improve error message
-                            ctx.getMessager().printMessage(
+                            ctx.getMessenger().printMessage(
                                 method.getExecutable(),
                                 Message.BEANMAPPING_SEVERAL_POSSIBLE_SOURCES,
                                 targetPropertyName
@@ -724,7 +724,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 if ( forgedMethod.getHistory() == null ) {
                     Type sourceType = this.method.getParameters().get( 0 ).getType();
                     Type targetType = this.method.getReturnType();
-                    ctx.getMessager().printMessage(
+                    ctx.getMessenger().printMessage(
                         this.method.getExecutable(),
                         Message.PROPERTYMAPPING_FORGED_MAPPING_NOT_FOUND,
                         sourceType,
@@ -735,7 +735,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 }
                 else {
                     ForgedMethodHistory history = forgedMethod.getHistory();
-                    ctx.getMessager().printMessage(
+                    ctx.getMessenger().printMessage(
                         this.method.getExecutable(),
                         Message.PROPERTYMAPPING_MAPPING_NOT_FOUND,
                         history.createSourcePropertyErrorMessage(),
@@ -779,7 +779,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                     };
                 }
 
-                ctx.getMessager().printMessage(
+                ctx.getMessenger().printMessage(
                     method.getExecutable(),
                     msg,
                     args
@@ -808,7 +808,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                     )
                 };
 
-                ctx.getMessager().printMessage(
+                ctx.getMessenger().printMessage(
                     method.getExecutable(),
                     msg,
                     args

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
@@ -134,7 +134,7 @@ public class CollectionAssignmentBuilder {
 
                 // call to an update method
                 if ( targetReadAccessor == null ) {
-                    ctx.getMessager().printMessage(
+                    ctx.getMessenger().printMessage(
                         method.getExecutable(),
                         Message.PROPERTYMAPPING_NO_READ_ACCESSOR_FOR_TARGET_TYPE,
                         targetPropertyName
@@ -189,7 +189,7 @@ public class CollectionAssignmentBuilder {
         }
         else {
             if ( targetImmutable ) {
-                ctx.getMessager().printMessage(
+                ctx.getMessenger().printMessage(
                     method.getExecutable(),
                     Message.PROPERTYMAPPING_NO_WRITE_ACCESSOR_FOR_TARGET_TYPE,
                     targetPropertyName

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/EnumMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/EnumMappingMethod.java
@@ -92,7 +92,7 @@ public class EnumMappingMethod extends MappingMethod {
                     for ( Mapping mapping : mappedConstants ) {
                         targetConstants.add( mapping.getTargetName() );
                     }
-                    ctx.getMessager().printMessage( method.getExecutable(),
+                    ctx.getMessenger().printMessage( method.getExecutable(),
                         Message.ENUMMAPPING_MULTIPLE_SOURCES,
                         enumConstant,
                         Strings.join( targetConstants, ", " )
@@ -132,14 +132,14 @@ public class EnumMappingMethod extends MappingMethod {
                 for ( Mapping mappedConstant : mappedConstants ) {
 
                     if ( mappedConstant.getSourceName() == null ) {
-                        ctx.getMessager().printMessage( method.getExecutable(),
+                        ctx.getMessenger().printMessage( method.getExecutable(),
                             mappedConstant.getMirror(),
                             Message.ENUMMAPPING_UNDEFINED_SOURCE
                         );
                         foundIncorrectMapping = true;
                     }
                     else if ( !sourceEnumConstants.contains( mappedConstant.getSourceName() ) ) {
-                        ctx.getMessager().printMessage( method.getExecutable(),
+                        ctx.getMessenger().printMessage( method.getExecutable(),
                             mappedConstant.getMirror(),
                             mappedConstant.getSourceAnnotationValue(),
                             Message.ENUMMAPPING_NON_EXISTING_CONSTANT,
@@ -149,14 +149,14 @@ public class EnumMappingMethod extends MappingMethod {
                         foundIncorrectMapping = true;
                     }
                     if ( mappedConstant.getTargetName() == null ) {
-                        ctx.getMessager().printMessage( method.getExecutable(),
+                        ctx.getMessenger().printMessage( method.getExecutable(),
                             mappedConstant.getMirror(),
                             Message.ENUMMAPPING_UNDEFINED_TARGET
                         );
                         foundIncorrectMapping = true;
                     }
                     else if ( !targetEnumConstants.contains( mappedConstant.getTargetName() ) ) {
-                        ctx.getMessager().printMessage( method.getExecutable(),
+                        ctx.getMessenger().printMessage( method.getExecutable(),
                             mappedConstant.getMirror(),
                             mappedConstant.getTargetAnnotationValue(),
                             Message.ENUMMAPPING_NON_EXISTING_CONSTANT,
@@ -186,7 +186,7 @@ public class EnumMappingMethod extends MappingMethod {
             }
 
             if ( !unmappedSourceEnumConstants.isEmpty() ) {
-                ctx.getMessager().printMessage( method.getExecutable(),
+                ctx.getMessenger().printMessage( method.getExecutable(),
                     Message.ENUMMAPPING_UNMAPPED_SOURCES,
                     Strings.join( unmappedSourceEnumConstants, ", " )
                 );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
@@ -39,7 +39,7 @@ import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.SourceMethod;
 import org.mapstruct.ap.internal.option.Options;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Services;
 import org.mapstruct.ap.spi.MappingExclusionProvider;
 
@@ -113,7 +113,7 @@ public class MappingBuilderContext {
     private final TypeFactory typeFactory;
     private final Elements elementUtils;
     private final Types typeUtils;
-    private final FormattingMessager messager;
+    private final FormattingMessenger messenger;
     private final AccessorNamingUtils accessorNaming;
     private final Options options;
     private final TypeElement mapperTypeElement;
@@ -127,7 +127,7 @@ public class MappingBuilderContext {
     public MappingBuilderContext(TypeFactory typeFactory,
                           Elements elementUtils,
                           Types typeUtils,
-                          FormattingMessager messager,
+                          FormattingMessenger messenger,
                           AccessorNamingUtils accessorNaming,
                           Options options,
                           MappingResolver mappingResolver,
@@ -137,7 +137,7 @@ public class MappingBuilderContext {
         this.typeFactory = typeFactory;
         this.elementUtils = elementUtils;
         this.typeUtils = typeUtils;
-        this.messager = messager;
+        this.messenger = messenger;
         this.accessorNaming = accessorNaming;
         this.options = options;
         this.mappingResolver = mappingResolver;
@@ -183,8 +183,8 @@ public class MappingBuilderContext {
         return typeUtils;
     }
 
-    public FormattingMessager getMessager() {
-        return messager;
+    public FormattingMessenger getMessenger() {
+        return messenger;
     }
 
     public AccessorNamingUtils getAccessorNaming() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ObjectFactoryMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ObjectFactoryMethodResolver.java
@@ -80,7 +80,7 @@ public class ObjectFactoryMethodResolver {
         }
 
         if ( matchingFactoryMethods.size() > 1 ) {
-            ctx.getMessager().printMessage(
+            ctx.getMessenger().printMessage(
                 method.getExecutable(),
                 Message.GENERAL_AMBIGIOUS_FACTORY_METHOD,
                 targetType.getEffectiveType(),

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -423,7 +423,7 @@ public class PropertyMapping extends ModelElement {
 
             if ( rhs.isCallingUpdateMethod() ) {
                 if ( targetReadAccessor == null ) {
-                    ctx.getMessager().printMessage(
+                    ctx.getMessenger().printMessage(
                         method.getExecutable(),
                         Message.PROPERTYMAPPING_NO_READ_ACCESSOR_FOR_TARGET_TYPE,
                         targetPropertyName
@@ -805,7 +805,7 @@ public class PropertyMapping extends ModelElement {
                     // target accessor is setter, so decorate assignment as setter
                     if ( assignment.isCallingUpdateMethod() ) {
                         if ( targetReadAccessor == null ) {
-                            ctx.getMessager().printMessage(
+                            ctx.getMessenger().printMessage(
                                 method.getExecutable(),
                                 Message.CONSTANTMAPPING_NO_READ_ACCESSOR_FOR_TARGET_TYPE,
                                 targetPropertyName
@@ -836,7 +836,7 @@ public class PropertyMapping extends ModelElement {
                 }
             }
             else if ( errorMessageDetails == null ) {
-                ctx.getMessager().printMessage(
+                ctx.getMessenger().printMessage(
                     method.getExecutable(),
                     mirror,
                     Message.CONSTANTMAPPING_MAPPING_NOT_FOUND,
@@ -847,7 +847,7 @@ public class PropertyMapping extends ModelElement {
                 );
             }
             else {
-                ctx.getMessager().printMessage(
+                ctx.getMessenger().printMessage(
                     method.getExecutable(),
                     mirror,
                     Message.CONSTANTMAPPING_MAPPING_NOT_FOUND_WITH_DETAILS,
@@ -880,7 +880,7 @@ public class PropertyMapping extends ModelElement {
                 assignment = new EnumConstantWrapper( assignment, targetType );
             }
             else {
-                ctx.getMessager().printMessage(
+                ctx.getMessenger().printMessage(
                     method.getExecutable(),
                     Message.CONSTANTMAPPING_NON_EXISTING_CONSTANT,
                     constantExpression,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
@@ -174,7 +174,7 @@ public class ValueMappingMethod extends MappingMethod {
                     }
                     // all sources should now be matched, there's no default to fall back to, so if sources remain,
                     // we have an issue.
-                    ctx.getMessager().printMessage( method.getExecutable(),
+                    ctx.getMessenger().printMessage( method.getExecutable(),
                         Message.VALUE_MAPPING_UNMAPPED_SOURCES,
                         sourceErrorMessage,
                         targetErrorMessage,
@@ -206,7 +206,7 @@ public class ValueMappingMethod extends MappingMethod {
             for ( ValueMapping mappedConstant : trueValueMappings ) {
 
                 if ( !sourceEnumConstants.contains( mappedConstant.getSource() ) ) {
-                    ctx.getMessager().printMessage( method.getExecutable(),
+                    ctx.getMessenger().printMessage( method.getExecutable(),
                         mappedConstant.getMirror(),
                         mappedConstant.getSourceAnnotationValue(),
                         Message.VALUEMAPPING_NON_EXISTING_CONSTANT,
@@ -217,7 +217,7 @@ public class ValueMappingMethod extends MappingMethod {
                 }
                 if ( !MappingConstantsPrism.NULL.equals( mappedConstant.getTarget() )
                     && !targetEnumConstants.contains( mappedConstant.getTarget() ) ) {
-                    ctx.getMessager().printMessage( method.getExecutable(),
+                    ctx.getMessenger().printMessage( method.getExecutable(),
                         mappedConstant.getMirror(),
                         mappedConstant.getTargetAnnotationValue(),
                         Message.VALUEMAPPING_NON_EXISTING_CONSTANT,
@@ -230,7 +230,7 @@ public class ValueMappingMethod extends MappingMethod {
 
             if ( defaultTargetValue != null && !MappingConstantsPrism.NULL.equals( defaultTargetValue.getTarget() )
                 && !targetEnumConstants.contains( defaultTargetValue.getTarget() ) ) {
-                ctx.getMessager().printMessage( method.getExecutable(),
+                ctx.getMessenger().printMessage( method.getExecutable(),
                     defaultTargetValue.getMirror(),
                     defaultTargetValue.getTargetAnnotationValue(),
                     Message.VALUEMAPPING_NON_EXISTING_CONSTANT,
@@ -242,7 +242,7 @@ public class ValueMappingMethod extends MappingMethod {
 
             if ( nullTargetValue != null && MappingConstantsPrism.NULL.equals( nullTargetValue.getTarget() )
                 && !targetEnumConstants.contains( nullTargetValue.getTarget() ) ) {
-                ctx.getMessager().printMessage( method.getExecutable(),
+                ctx.getMessenger().printMessage( method.getExecutable(),
                     nullTargetValue.getMirror(),
                     nullTargetValue.getTargetAnnotationValue(),
                     Message.VALUEMAPPING_NON_EXISTING_CONSTANT,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/DateFormatValidationResult.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/DateFormatValidationResult.java
@@ -22,7 +22,7 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Message;
 
 /**
@@ -59,8 +59,8 @@ final class DateFormatValidationResult {
      * @param annotation the mirror of the annotation that had an error
      * @param value the value of the annotation that had an error
      */
-    public void printErrorMessage(FormattingMessager messager, Element element, AnnotationMirror annotation,
-        AnnotationValue value) {
+    public void printErrorMessage(FormattingMessenger messager, Element element, AnnotationMirror annotation,
+                                  AnnotationValue value) {
         messager.printMessage( element, annotation, value, validationInfo, validationInfoArgs );
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/DefaultConversionContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/DefaultConversionContext.java
@@ -18,7 +18,7 @@
  */
 package org.mapstruct.ap.internal.model.common;
 
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Strings;
 
 /**
@@ -28,7 +28,7 @@ import org.mapstruct.ap.internal.util.Strings;
  */
 public class DefaultConversionContext implements ConversionContext {
 
-    private final FormattingMessager messager;
+    private final FormattingMessenger messager;
     private final Type sourceType;
     private final Type targetType;
     private final FormattingParameters formattingParameters;
@@ -36,8 +36,8 @@ public class DefaultConversionContext implements ConversionContext {
     private final String numberFormat;
     private final TypeFactory typeFactory;
 
-    public DefaultConversionContext(TypeFactory typeFactory, FormattingMessager messager, Type sourceType,
-        Type targetType, FormattingParameters formattingParameters) {
+    public DefaultConversionContext(TypeFactory typeFactory, FormattingMessenger messager, Type sourceType,
+                                    Type targetType, FormattingParameters formattingParameters) {
         this.typeFactory = typeFactory;
         this.messager = messager;
         this.sourceType = sourceType;
@@ -87,7 +87,7 @@ public class DefaultConversionContext implements ConversionContext {
         return typeFactory;
     }
 
-    protected FormattingMessager getMessager() {
+    protected FormattingMessenger getMessager() {
         return messager;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
@@ -27,7 +27,7 @@ import javax.lang.model.util.Types;
 import org.mapstruct.ap.internal.prism.BeanMappingPrism;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
 import org.mapstruct.ap.internal.prism.ReportingPolicyPrism;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Message;
 
 /**
@@ -60,7 +60,7 @@ public class BeanMapping {
     }
 
     public static BeanMapping fromPrism(BeanMappingPrism beanMapping, ExecutableElement method,
-        FormattingMessager messager, Types typeUtils) {
+                                        FormattingMessenger messager, Types typeUtils) {
 
         if ( beanMapping == null ) {
             return null;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/IterableMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/IterableMapping.java
@@ -26,7 +26,7 @@ import javax.lang.model.util.Types;
 import org.mapstruct.ap.internal.model.common.FormattingParameters;
 import org.mapstruct.ap.internal.prism.IterableMappingPrism;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Message;
 
 /**
@@ -42,7 +42,7 @@ public class IterableMapping {
     private final NullValueMappingStrategyPrism nullValueMappingStrategy;
 
     public static IterableMapping fromPrism(IterableMappingPrism iterableMapping, ExecutableElement method,
-        FormattingMessager messager, Types typeUtils) {
+                                            FormattingMessenger messager, Types typeUtils) {
         if ( iterableMapping == null ) {
             return null;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapMapping.java
@@ -26,7 +26,7 @@ import javax.lang.model.util.Types;
 import org.mapstruct.ap.internal.model.common.FormattingParameters;
 import org.mapstruct.ap.internal.prism.MapMappingPrism;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Message;
 
 /**
@@ -44,7 +44,7 @@ public class MapMapping {
     private final NullValueMappingStrategyPrism nullValueMappingStrategy;
 
     public static MapMapping fromPrism(MapMappingPrism mapMapping, ExecutableElement method,
-        FormattingMessager messager, Types typeUtils) {
+                                       FormattingMessenger messager, Types typeUtils) {
         if ( mapMapping == null ) {
             return null;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/Mapping.java
@@ -40,7 +40,7 @@ import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.prism.MappingPrism;
 import org.mapstruct.ap.internal.prism.MappingsPrism;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 
@@ -74,7 +74,7 @@ public class Mapping {
     private TargetReference targetReference;
 
     public static Map<String, List<Mapping>> fromMappingsPrism(MappingsPrism mappingsAnnotation,
-        ExecutableElement method, FormattingMessager messager, Types typeUtils) {
+                                                               ExecutableElement method, FormattingMessenger messager, Types typeUtils) {
         Map<String, List<Mapping>> mappings = new HashMap<String, List<Mapping>>();
 
         for ( MappingPrism mappingPrism : mappingsAnnotation.value() ) {
@@ -98,7 +98,7 @@ public class Mapping {
     }
 
     public static Mapping fromMappingPrism(MappingPrism mappingPrism, ExecutableElement element,
-        FormattingMessager messager, Types typeUtils) {
+                                           FormattingMessenger messager, Types typeUtils) {
 
         if ( mappingPrism.target().isEmpty() ) {
             messager.printMessage(
@@ -292,7 +292,7 @@ public class Mapping {
     }
 
     private static String getExpression(MappingPrism mappingPrism, ExecutableElement element,
-                                        FormattingMessager messager) {
+                                        FormattingMessenger messager) {
         if ( mappingPrism.expression().isEmpty() ) {
             return null;
         }
@@ -311,7 +311,7 @@ public class Mapping {
     }
 
     private static String getDefaultExpression(MappingPrism mappingPrism, ExecutableElement element,
-                                        FormattingMessager messager) {
+                                        FormattingMessenger messager) {
         if ( mappingPrism.defaultExpression().isEmpty() ) {
             return null;
         }
@@ -334,7 +334,7 @@ public class Mapping {
             ( (DeclaredType) mirror ).asElement().getKind() == ElementKind.ENUM;
     }
 
-    public void init(SourceMethod method, FormattingMessager messager, TypeFactory typeFactory,
+    public void init(SourceMethod method, FormattingMessenger messager, TypeFactory typeFactory,
                      AccessorNamingUtils accessorNaming) {
         init( method, messager, typeFactory, accessorNaming, false, null );
     }
@@ -349,7 +349,7 @@ public class Mapping {
      * @param isReverse whether the init is for a reverse mapping
      * @param reverseSourceParameter the source parameter from the revers mapping
      */
-    private void init(SourceMethod method, FormattingMessager messager, TypeFactory typeFactory,
+    private void init(SourceMethod method, FormattingMessenger messager, TypeFactory typeFactory,
                       AccessorNamingUtils accessorNaming, boolean isReverse,
                       Parameter reverseSourceParameter) {
 
@@ -478,7 +478,7 @@ public class Mapping {
         return dependsOn;
     }
 
-    public Mapping reverse(SourceMethod method, FormattingMessager messager, TypeFactory typeFactory,
+    public Mapping reverse(SourceMethod method, FormattingMessenger messager, TypeFactory typeFactory,
                            AccessorNamingUtils accessorNaming) {
 
         // mapping can only be reversed if the source was not a constant nor an expression nor a nested property

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
@@ -34,7 +34,7 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 
 /**
@@ -224,7 +224,7 @@ public class MappingOptions {
      * @param accessorNaming the accessor naming utils
      */
     public void applyInheritedOptions(MappingOptions inherited, boolean isInverse, SourceMethod method,
-                                      FormattingMessager messager, TypeFactory typeFactory,
+                                      FormattingMessenger messager, TypeFactory typeFactory,
                                       AccessorNamingUtils accessorNaming) {
         if ( null != inherited ) {
             if ( getIterableMapping() == null ) {
@@ -299,7 +299,7 @@ public class MappingOptions {
         }
     }
 
-    public void applyIgnoreAll(MappingOptions inherited, SourceMethod method, FormattingMessager messager,
+    public void applyIgnoreAll(MappingOptions inherited, SourceMethod method, FormattingMessenger messager,
                                TypeFactory typeFactory, AccessorNamingUtils accessorNaming) {
         CollectionMappingStrategyPrism cms = method.getMapperConfiguration().getCollectionMappingStrategy();
         Type writeType = method.getResultType();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -38,7 +38,7 @@ import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.prism.ObjectFactoryPrism;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
 import org.mapstruct.ap.internal.util.Executables;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Strings;
 
@@ -101,7 +101,7 @@ public class SourceMethod implements Method {
         private Types typeUtils;
         private TypeFactory typeFactory = null;
         private AccessorNamingUtils accessorNaming = null;
-        private FormattingMessager messager = null;
+        private FormattingMessenger messager = null;
         private MapperConfiguration mapperConfig = null;
         private List<SourceMethod> prototypeMethods = Collections.emptyList();
         private List<ValueMapping> valueMappings;
@@ -172,7 +172,7 @@ public class SourceMethod implements Method {
             return this;
         }
 
-        public Builder setMessager(FormattingMessager messager) {
+        public Builder setMessager(FormattingMessenger messager) {
             this.messager = messager;
             return this;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
@@ -33,7 +33,7 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.util.Extractor;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
@@ -74,10 +74,10 @@ public class SourceReference {
 
         private Mapping mapping;
         private SourceMethod method;
-        private FormattingMessager messager;
+        private FormattingMessenger messager;
         private TypeFactory typeFactory;
 
-        public BuilderFromMapping messager(FormattingMessager messager) {
+        public BuilderFromMapping messager(FormattingMessenger messager) {
             this.messager = messager;
             return this;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
@@ -32,7 +32,7 @@ import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
 import org.mapstruct.ap.internal.util.Executables;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
@@ -73,7 +73,7 @@ public class TargetReference {
 
         private Mapping mapping;
         private SourceMethod method;
-        private FormattingMessager messager;
+        private FormattingMessenger messager;
         private TypeFactory typeFactory;
         private AccessorNamingUtils accessorNaming;
         private boolean isReverse;
@@ -101,7 +101,7 @@ public class TargetReference {
          */
         private MappingErrorMessage errorMessage;
 
-        public BuilderFromTargetMapping messager(FormattingMessager messager) {
+        public BuilderFromTargetMapping messager(FormattingMessenger messager) {
             this.messager = messager;
             return this;
         }
@@ -392,9 +392,9 @@ public class TargetReference {
     private abstract static class MappingErrorMessage {
         private final Mapping mapping;
         private final SourceMethod method;
-        private final FormattingMessager messager;
+        private final FormattingMessenger messager;
 
-        private MappingErrorMessage(Mapping mapping, SourceMethod method, FormattingMessager messager) {
+        private MappingErrorMessage(Mapping mapping, SourceMethod method, FormattingMessenger messager) {
             this.mapping = mapping;
             this.method = method;
             this.messager = messager;
@@ -416,7 +416,7 @@ public class TargetReference {
 
     private static class NoWriteAccessorErrorMessage extends MappingErrorMessage {
 
-        private NoWriteAccessorErrorMessage(Mapping mapping, SourceMethod method, FormattingMessager messager) {
+        private NoWriteAccessorErrorMessage(Mapping mapping, SourceMethod method, FormattingMessenger messager) {
             super( mapping, method, messager );
         }
 
@@ -432,7 +432,7 @@ public class TargetReference {
         private final int index;
         private final Type nextType;
 
-        private NoPropertyErrorMessage(Mapping mapping, SourceMethod method, FormattingMessager messager,
+        private NoPropertyErrorMessage(Mapping mapping, SourceMethod method, FormattingMessenger messager,
                                        String[] entryNames, int index, Type nextType) {
             super( mapping, method, messager );
             this.entryNames = entryNames;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ValueMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ValueMapping.java
@@ -27,7 +27,7 @@ import javax.lang.model.element.ExecutableElement;
 import org.mapstruct.ap.internal.prism.MappingConstantsPrism;
 import org.mapstruct.ap.internal.prism.ValueMappingPrism;
 import org.mapstruct.ap.internal.prism.ValueMappingsPrism;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Message;
 
 /**
@@ -44,7 +44,7 @@ public class ValueMapping {
     private final AnnotationValue targetAnnotationValue;
 
     public static void fromMappingsPrism(ValueMappingsPrism mappingsAnnotation, ExecutableElement method,
-        FormattingMessager messager, List<ValueMapping> mappings) {
+                                         FormattingMessenger messager, List<ValueMapping> mappings) {
 
         boolean anyFound = false;
         for ( ValueMappingPrism mappingPrism : mappingsAnnotation.value() ) {
@@ -81,7 +81,7 @@ public class ValueMapping {
     }
 
     public static ValueMapping fromMappingPrism(ValueMappingPrism mappingPrism, ExecutableElement element,
-                                           FormattingMessager messager) {
+                                           FormattingMessenger messager) {
 
         return new ValueMapping( mappingPrism.source(), mappingPrism.target(), mappingPrism.mirror,
             mappingPrism.values.source(), mappingPrism.values.target() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/DefaultModelElementProcessorContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/DefaultModelElementProcessorContext.java
@@ -32,7 +32,7 @@ import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.option.Options;
 import org.mapstruct.ap.internal.processor.ModelElementProcessor.ProcessorContext;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.RoundContext;
 import org.mapstruct.ap.internal.util.workarounds.TypesDecorator;
@@ -90,7 +90,7 @@ public class DefaultModelElementProcessorContext implements ProcessorContext {
     }
 
     @Override
-    public FormattingMessager getMessager() {
+    public FormattingMessenger getMessenger() {
         return messager;
     }
 
@@ -114,7 +114,7 @@ public class DefaultModelElementProcessorContext implements ProcessorContext {
         return messager.isErroneous();
     }
 
-    private static final class DelegatingMessager implements FormattingMessager {
+    private static final class DelegatingMessager implements FormattingMessenger {
 
         private final Messager delegate;
         private boolean isErroneous = false;

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -63,7 +63,7 @@ import org.mapstruct.ap.internal.prism.MappingInheritanceStrategyPrism;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
 import org.mapstruct.ap.internal.processor.creation.MappingResolverImpl;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
@@ -82,7 +82,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
 
     private Elements elementUtils;
     private Types typeUtils;
-    private FormattingMessager messager;
+    private FormattingMessenger messager;
     private Options options;
     private VersionInformation versionInformation;
     private TypeFactory typeFactory;
@@ -93,7 +93,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
     public Mapper process(ProcessorContext context, TypeElement mapperTypeElement, List<SourceMethod> sourceModel) {
         this.elementUtils = context.getElementUtils();
         this.typeUtils = context.getTypeUtils();
-        this.messager = context.getMessager();
+        this.messager = context.getMessenger();
         this.options = context.getOptions();
         this.versionInformation = context.getVersionInformation();
         this.typeFactory = context.getTypeFactory();

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -58,7 +58,7 @@ import org.mapstruct.ap.internal.prism.ValueMappingsPrism;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
 import org.mapstruct.ap.internal.util.AnnotationProcessingException;
 import org.mapstruct.ap.internal.util.Executables;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Message;
 
@@ -72,7 +72,7 @@ import org.mapstruct.ap.internal.util.Message;
  */
 public class MethodRetrievalProcessor implements ModelElementProcessor<Void, List<SourceMethod>> {
 
-    private FormattingMessager messager;
+    private FormattingMessenger messager;
     private TypeFactory typeFactory;
     private AccessorNamingUtils accessorNaming;
     private Types typeUtils;
@@ -80,7 +80,7 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
 
     @Override
     public List<SourceMethod> process(ProcessorContext context, TypeElement mapperTypeElement, Void sourceModel) {
-        this.messager = context.getMessager();
+        this.messager = context.getMessenger();
         this.typeFactory = context.getTypeFactory();
         this.accessorNaming = context.getAccessorNaming();
         this.typeUtils = context.getTypeUtils();

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/ModelElementProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/ModelElementProcessor.java
@@ -27,7 +27,7 @@ import javax.tools.Diagnostic.Kind;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.option.Options;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.version.VersionInformation;
 
 /**
@@ -60,7 +60,7 @@ public interface ModelElementProcessor<P, R> {
 
         TypeFactory getTypeFactory();
 
-        FormattingMessager getMessager();
+        FormattingMessenger getMessenger();
 
         AccessorNamingUtils getAccessorNaming();
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
@@ -58,7 +58,7 @@ import org.mapstruct.ap.internal.model.source.selector.MethodSelectors;
 import org.mapstruct.ap.internal.model.source.selector.SelectedMethod;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Collections;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 
@@ -71,7 +71,7 @@ import org.mapstruct.ap.internal.util.Strings;
  */
 public class MappingResolverImpl implements MappingResolver {
 
-    private final FormattingMessager messager;
+    private final FormattingMessenger messager;
     private final Types typeUtils;
     private final TypeFactory typeFactory;
 
@@ -88,7 +88,7 @@ public class MappingResolverImpl implements MappingResolver {
      */
     private final Set<VirtualMappingMethod> usedVirtualMappings = new HashSet<VirtualMappingMethod>();
 
-    public MappingResolverImpl(FormattingMessager messager, Elements elementUtils, Types typeUtils,
+    public MappingResolverImpl(FormattingMessenger messager, Elements elementUtils, Types typeUtils,
                                TypeFactory typeFactory, List<Method> sourceModel,
                                List<MapperReference> mapperReferences) {
         this.messager = messager;

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/AnnotationProcessingException.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/AnnotationProcessingException.java
@@ -25,7 +25,7 @@ import javax.lang.model.element.Element;
 /**
  * Indicates an error during annotation processing. Should only be thrown in non-recoverable situations such as errors
  * due to incomplete compilations etc. Expected errors to be propagated to the user of the annotation processor should
- * be raised using the {@link FormattingMessager} API instead.
+ * be raised using the {@link FormattingMessenger} API instead.
  *
  * @author Gunnar Morling
  */

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/FormattingMessenger.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/FormattingMessenger.java
@@ -28,7 +28,7 @@ import javax.lang.model.element.Element;
  *
  * @author Sjaak Derksen
  */
-public interface FormattingMessager {
+public interface FormattingMessenger {
 
     /**
      * Prints a message of the specified kind.

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
@@ -32,7 +32,7 @@ import javax.lang.model.type.TypeVisitor;
 import javax.tools.Diagnostic;
 
 import org.junit.Test;
-import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.FormattingMessenger;
 import org.mapstruct.ap.internal.util.JavaTimeConstants;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.testutil.IssueKey;
@@ -139,7 +139,7 @@ public class DefaultConversionContextTest {
                         false );
     }
 
-    private static class StatefulMessagerMock implements FormattingMessager {
+    private static class StatefulMessagerMock implements FormattingMessenger {
 
         private Diagnostic.Kind lastKindPrinted;
 


### PR DESCRIPTION
I found typo class name FormattingMessager. It is FormattingMessenger, isn't it?

I renamed class name and rename field,method argument param.

