### PR TITLE
#1532 adding a final field for DatatypeFactory constructor initialized.

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
@@ -37,7 +37,7 @@ public abstract class AbstractMappingMethodBuilder<B extends AbstractMappingMeth
         }
 
         String name = getName( sourceType, targetType );
-        name = Strings.getSaveVariableName( name, ctx.getNamesOfMappingsToGenerate() );
+        name = Strings.getSafeVariableName( name, ctx.getNamesOfMappingsToGenerate() );
         ForgedMethodHistory history = null;
         if ( method instanceof ForgedMethod ) {
             history = ( (ForgedMethod) method ).getHistory();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AnnotatedConstructor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AnnotatedConstructor.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct.ap.internal.model;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -19,17 +20,52 @@ import org.mapstruct.ap.internal.model.common.Type;
  */
 public class AnnotatedConstructor extends ModelElement implements Constructor {
 
-    private final String name;
+    private String name;
     private final List<AnnotationMapperReference> mapperReferences;
     private final List<Annotation> annotations;
-    private final boolean publicEmptyConstructor;
+    private final NoArgumentConstructor noArgumentConstructor;
+    private final Set<SupportingConstructorFragment> fragments;
 
-    public AnnotatedConstructor(String name, List<AnnotationMapperReference> mapperReferences,
-                                List<Annotation> annotations, boolean publicEmptyConstructor) {
+    public static AnnotatedConstructor forComponentModels(String name,
+                                                          List<AnnotationMapperReference> mapperReferences,
+                                                          List<Annotation> annotations,
+                                                          Constructor constructor,
+                                                          boolean includeNoArgConstructor) {
+
+        NoArgumentConstructor noArgumentConstructor = null;
+        if ( constructor instanceof NoArgumentConstructor ) {
+            noArgumentConstructor = (NoArgumentConstructor) constructor;
+        }
+        NoArgumentConstructor noArgConstructorToInBecluded = null;
+        Set<SupportingConstructorFragment> fragmentsToBeIncluded = Collections.emptySet();
+        if ( includeNoArgConstructor ) {
+            if ( noArgumentConstructor != null ) {
+                noArgConstructorToInBecluded = noArgumentConstructor;
+            }
+            else {
+                noArgConstructorToInBecluded = new NoArgumentConstructor( name, fragmentsToBeIncluded );
+            }
+        }
+        else if ( noArgumentConstructor != null ) {
+            fragmentsToBeIncluded = noArgumentConstructor.getFragments();
+        }
+        return new AnnotatedConstructor(
+            name,
+            mapperReferences,
+            annotations,
+            noArgConstructorToInBecluded,
+            fragmentsToBeIncluded
+        );
+    }
+
+    private AnnotatedConstructor(String name, List<AnnotationMapperReference> mapperReferences,
+                                 List<Annotation> annotations, NoArgumentConstructor noArgumentConstructor,
+                                 Set<SupportingConstructorFragment> fragments) {
         this.name = name;
         this.mapperReferences = mapperReferences;
         this.annotations = annotations;
-        this.publicEmptyConstructor = publicEmptyConstructor;
+        this.noArgumentConstructor = noArgumentConstructor;
+        this.fragments = fragments;
     }
 
     @Override
@@ -60,7 +96,11 @@ public class AnnotatedConstructor extends ModelElement implements Constructor {
         return annotations;
     }
 
-    public boolean isPublicEmptyConstructor() {
-        return publicEmptyConstructor;
+    public NoArgumentConstructor getNoArgumentConstructor() {
+        return noArgumentConstructor;
+    }
+
+    public Set<SupportingConstructorFragment> getFragments() {
+        return fragments;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
@@ -41,8 +41,8 @@ public abstract class ContainerMappingMethod extends NormalTypeMappingMethod {
         this.elementAssignment = parameterAssignment;
         this.loopVariableName = loopVariableName;
         this.selectionParameters = selectionParameters;
-        this.index1Name = Strings.getSaveVariableName( "i", existingVariables );
-        this.index2Name = Strings.getSaveVariableName( "j", existingVariables );
+        this.index1Name = Strings.getSafeVariableName( "i", existingVariables );
+        this.index2Name = Strings.getSafeVariableName( "j", existingVariables );
     }
 
     public Parameter getSourceParameter() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
@@ -73,7 +73,7 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
         Type targetElementType = getElementType( resultType );
 
         String loopVariableName =
-            Strings.getSaveVariableName( sourceElementType.getName(), method.getParameterNames() );
+            Strings.getSafeVariableName( sourceElementType.getName(), method.getParameterNames() );
 
         SourceRHS sourceRHS = new SourceRHS(
             loopVariableName,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Decorator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Decorator.java
@@ -133,7 +133,7 @@ public class Decorator extends GeneratedType {
     @SuppressWarnings( "checkstyle:parameternumber" )
     private Decorator(TypeFactory typeFactory, String packageName, String name, Type decoratorType,
                       String interfacePackage, String interfaceName, List<MappingMethod> methods,
-                      List<? extends Field> fields, Options options, VersionInformation versionInformation,
+                      List<Field> fields, Options options, VersionInformation versionInformation,
                       Accessibility accessibility, SortedSet<Type> extraImports,
                       DecoratorConstructor decoratorConstructor) {
         super(

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/DefaultMapperReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/DefaultMapperReference.java
@@ -37,7 +37,7 @@ public class DefaultMapperReference extends MapperReference {
             importTypes.add( typeFactory.getType( "org.mapstruct.factory.Mappers" ) );
         }
 
-        String variableName = Strings.getSaveVariableName(
+        String variableName = Strings.getSafeVariableName(
             type.getName(),
             otherMapperReferences
         );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Field.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Field.java
@@ -5,7 +5,9 @@
  */
 package org.mapstruct.ap.internal.model;
 
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ModelElement;
@@ -113,6 +115,14 @@ public class Field extends ModelElement {
         final Field other = (Field) obj;
         return !( (this.variableName == null) ?
             (other.variableName != null) : !this.variableName.equals( other.variableName ) );
+    }
+
+    public static List<String> getFieldNames(Set<Field> fields) {
+        List<String> names = new ArrayList<String>( fields.size() );
+        for ( Field field : fields ) {
+            names.add( field.getVariableName() );
+        }
+        return names;
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -44,7 +44,7 @@ public abstract class GeneratedType extends ModelElement {
     private final boolean suppressGeneratorVersionComment;
     private final VersionInformation versionInformation;
     private final Accessibility accessibility;
-    private List<? extends Field> fields;
+    private List<Field> fields;
     private Constructor constructor;
 
     /**
@@ -56,7 +56,7 @@ public abstract class GeneratedType extends ModelElement {
     // CHECKSTYLE:OFF
     protected GeneratedType(TypeFactory typeFactory, String packageName, String name, String superClassName,
                             String interfacePackage, String interfaceName, List<MappingMethod> methods,
-                            List<? extends Field> fields, Options options, VersionInformation versionInformation,
+                            List<Field> fields, Options options, VersionInformation versionInformation,
                             Accessibility accessibility, SortedSet<Type> extraImportedTypes, Constructor constructor) {
         this.packageName = packageName;
         this.name = name;
@@ -123,11 +123,11 @@ public abstract class GeneratedType extends ModelElement {
         return methods;
     }
 
-    public List<? extends Field> getFields() {
+    public List<Field> getFields() {
         return fields;
     }
 
-    public void setFields(List<? extends Field> fields) {
+    public void setFields(List<Field> fields) {
         this.fields = fields;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleCallbackMethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleCallbackMethodReference.java
@@ -42,7 +42,7 @@ public class LifecycleCallbackMethodReference extends MethodReference {
         this.methodResultType = containingMethod.getResultType();
 
         if ( hasReturnType() ) {
-            this.targetVariableName = Strings.getSaveVariableName( "target", existingVariableNames );
+            this.targetVariableName = Strings.getSafeVariableName( "target", existingVariableNames );
             existingVariableNames.add( this.targetVariableName );
         }
         else {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -266,21 +266,21 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
     }
 
     public String getKeyVariableName() {
-        return Strings.getSaveVariableName(
+        return Strings.getSafeVariableName(
             "key",
             getParameterNames()
         );
     }
 
     public String getValueVariableName() {
-        return Strings.getSaveVariableName(
+        return Strings.getSafeVariableName(
             "value",
             getParameterNames()
         );
     }
 
     public String getEntryVariableName() {
-        return Strings.getSaveVariableName(
+        return Strings.getSafeVariableName(
             "entry",
             getParameterNames()
         );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
@@ -37,7 +37,7 @@ import org.mapstruct.ap.spi.MappingExclusionProvider;
  * <ul>
  * <li>Input for the building process, such as the source model (mapping methods found) and mapper references.</li>
  * <li>Required factory, utility, reporting methods for building the mappings.</li>
- * <li>Means to harbor results produced by the builders, such as forged- and virtual mapping methods that should be
+ * <li>Means to harbor results produced by the builders, such as forged- and supported mapping methods that should be
  * generated in a later stage.</li>
  * </ul>
  *
@@ -94,7 +94,7 @@ public class MappingBuilderContext {
                                        SelectionParameters selectionParameters, SourceRHS sourceRHS,
                                        boolean preferUpdateMethods);
 
-        Set<VirtualMappingMethod> getUsedVirtualMappings();
+        Set<SupportingMappingMethod> getUsedSupportedMappings();
     }
 
     private final TypeFactory typeFactory;
@@ -209,8 +209,8 @@ public class MappingBuilderContext {
         return existingMappingMethod;
     }
 
-    public Set<VirtualMappingMethod> getUsedVirtualMappings() {
-        return mappingResolver.getUsedVirtualMappings();
+    public Set<SupportingMappingMethod> getUsedSupportedMappings() {
+        return mappingResolver.getUsedSupportedMappings();
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
@@ -5,7 +5,7 @@
  */
 package org.mapstruct.ap.internal.model;
 
-import static org.mapstruct.ap.internal.util.Strings.getSaveVariableName;
+import static org.mapstruct.ap.internal.util.Strings.getSafeVariableName;
 import static org.mapstruct.ap.internal.util.Strings.join;
 
 import java.util.ArrayList;
@@ -91,12 +91,12 @@ public abstract class MappingMethod extends ModelElement {
             return targetParameter.getName();
         }
         else if ( getResultType().isArrayType() ) {
-            String name = getSaveVariableName( getResultType().getComponentType().getName() + "Tmp", existingVarNames );
+            String name = getSafeVariableName( getResultType().getComponentType().getName() + "Tmp", existingVarNames );
             existingVarNames.add( name );
             return name;
         }
         else {
-            String name = getSaveVariableName( getResultType().getName(), existingVarNames );
+            String name = getSafeVariableName( getResultType().getName(), existingVarNames );
             existingVarNames.add( name );
             return name;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
@@ -58,7 +58,7 @@ public class NestedPropertyMappingMethod extends MappingMethod {
             final List<Type> thrownTypes = new ArrayList<Type>();
             List<SafePropertyEntry> safePropertyEntries = new ArrayList<SafePropertyEntry>();
             for ( PropertyEntry propertyEntry : propertyEntries ) {
-                String safeName = Strings.getSaveVariableName( propertyEntry.getName(), existingVariableNames );
+                String safeName = Strings.getSafeVariableName( propertyEntry.getName(), existingVariableNames );
                 safePropertyEntries.add( new SafePropertyEntry( propertyEntry, safeName ) );
                 existingVariableNames.add( safeName );
                 thrownTypes.addAll( ctx.getTypeFactory().getThrownTypes(

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NoArgumentConstructor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NoArgumentConstructor.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.ModelElement;
+import org.mapstruct.ap.internal.model.common.Type;
+
+/**
+ * Represents a constructor that is used for constructor injection.
+ *
+ * @author Sjaak Derksen
+ */
+public class NoArgumentConstructor extends ModelElement implements Constructor {
+
+    private final String name;
+    private final Set<SupportingConstructorFragment> fragments;
+
+    public NoArgumentConstructor(String name, Set<SupportingConstructorFragment> fragments) {
+        this.name = name;
+        this.fragments = fragments;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public Set<SupportingConstructorFragment> getFragments() {
+        return fragments;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -511,7 +511,7 @@ public class PropertyMapping extends ModelElement {
 
                 // forge a method from the parameter type to the last entry type.
                 String forgedName = Strings.joinAndCamelize( sourceReference.getElementNames() );
-                forgedName = Strings.getSaveVariableName( forgedName, ctx.getNamesOfMappingsToGenerate() );
+                forgedName = Strings.getSafeVariableName( forgedName, ctx.getNamesOfMappingsToGenerate() );
                 ForgedMethod methodRef = new ForgedMethod(
                     forgedName,
                     sourceReference.getParameter().getType(),
@@ -601,7 +601,7 @@ public class PropertyMapping extends ModelElement {
         private ForgedMethod prepareForgedMethod(Type sourceType, Type targetType, SourceRHS source,
                                                  ExecutableElement element, String suffix) {
             String name = getName( sourceType, targetType );
-            name = Strings.getSaveVariableName( name, ctx.getNamesOfMappingsToGenerate() );
+            name = Strings.getSafeVariableName( name, ctx.getNamesOfMappingsToGenerate() );
 
             // copy mapper configuration from the source method, its the same mapper
             MapperConfiguration config = method.getMapperConfiguration();
@@ -647,7 +647,7 @@ public class PropertyMapping extends ModelElement {
             }
 
             String name = getName( sourceType, targetType );
-            name = Strings.getSaveVariableName( name, ctx.getNamesOfMappingsToGenerate() );
+            name = Strings.getSafeVariableName( name, ctx.getNamesOfMappingsToGenerate() );
 
             List<Parameter> parameters = new ArrayList<Parameter>( method.getContextParameters() );
             Type returnType;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/SupportingConstructorFragment.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/SupportingConstructorFragment.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.ModelElement;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.source.builtin.BuiltInConstructorFragment;
+
+/**
+ * A mapper instance field, initialized as null
+ *
+ * @author Sjaak Derksen
+ */
+public class SupportingConstructorFragment extends ModelElement {
+
+    private final String templateName;
+    private final SupportingMappingMethod definingMethod;
+
+    public SupportingConstructorFragment(SupportingMappingMethod definingMethod,
+                                         BuiltInConstructorFragment constructorFragment) {
+        this.templateName = getTemplateNameForClass( constructorFragment.getClass() );
+        this.definingMethod = definingMethod;
+    }
+
+    @Override
+    public String getTemplateName() {
+        return templateName;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return Collections.emptySet();
+    }
+
+    public SupportingMappingMethod getDefiningMethod() {
+        return definingMethod;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( templateName == null ) ? 0 : templateName.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        SupportingConstructorFragment other = (SupportingConstructorFragment) obj;
+        if ( templateName == null ) {
+            if ( other.templateName != null ) {
+                return false;
+            }
+        }
+        else if ( !templateName.equals( other.templateName ) ) {
+            return false;
+        }
+        return true;
+    }
+
+    public static void addAllFragmentsIn(Set<SupportingMappingMethod> supportingMappingMethods,
+                                         Set<SupportingConstructorFragment> targets) {
+        for ( SupportingMappingMethod supportingMappingMethod : supportingMappingMethods ) {
+            SupportingConstructorFragment fragment = supportingMappingMethod.getSupportingConstructorFragment();
+            if ( fragment != null ) {
+                targets.add( supportingMappingMethod.getSupportingConstructorFragment() );
+            }
+        }
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/SupportingField.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/SupportingField.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.source.builtin.BuiltInFieldReference;
+
+/**
+ * supports the
+ *
+ * @author Sjaak Derksen
+ */
+public class SupportingField extends Field {
+
+    private final String templateName;
+    private final SupportingMappingMethod definingMethod;
+
+    public SupportingField(SupportingMappingMethod definingMethod, BuiltInFieldReference fieldReference, String name) {
+        super( fieldReference.getType(), name, true );
+        this.templateName = getTemplateNameForClass( fieldReference.getClass() );
+        this.definingMethod = definingMethod;
+    }
+
+    @Override
+    public String getTemplateName() {
+        return templateName;
+    }
+
+    public SupportingMappingMethod getDefiningMethod() {
+        return definingMethod;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( templateName == null ) ? 0 : templateName.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        SupportingField other = (SupportingField) obj;
+        if ( templateName == null ) {
+            if ( other.templateName != null ) {
+                return false;
+            }
+        }
+        else if ( !templateName.equals( other.templateName ) ) {
+            return false;
+        }
+        return true;
+    }
+
+    public static void addAllFieldsIn(Set<SupportingMappingMethod> supportingMappingMethods, Set<Field> targets) {
+        for ( SupportingMappingMethod supportingMappingMethod : supportingMappingMethods ) {
+            Field field = supportingMappingMethod.getSupportingField();
+            if ( field != null ) {
+                targets.add( supportingMappingMethod.getSupportingField() );
+            }
+        }
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/SourceRHS.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/SourceRHS.java
@@ -69,7 +69,7 @@ public class SourceRHS extends ModelElement implements Assignment {
 
     @Override
     public String createLocalVarName(String desiredName) {
-        String result = Strings.getSaveVariableName( desiredName, existingVariableNames );
+        String result = Strings.getSafeVariableName( desiredName, existingVariableNames );
         existingVariableNames.add( result );
         return result;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
@@ -87,7 +87,7 @@ public class ForgedMethod implements Method {
                         ParameterProvidedMethods parameterProvidedMethods, ForgedMethodHistory history,
                         MappingOptions mappingOptions, boolean forgedNameBased) {
         String sourceParamName = Strings.decapitalize( sourceType.getName() );
-        String sourceParamSafeName = Strings.getSaveVariableName( sourceParamName );
+        String sourceParamSafeName = Strings.getSafeVariableName( sourceParamName );
 
         this.parameters = new ArrayList<Parameter>( 1 + additionalParameters.size() );
         Parameter sourceParameter = new Parameter( sourceParamSafeName, sourceType );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/AbstractToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/AbstractToXmlGregorianCalendar.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model.source.builtin;
+
+import java.util.Set;
+import javax.xml.datatype.DatatypeConfigurationException;
+import javax.xml.datatype.DatatypeFactory;
+import javax.xml.datatype.XMLGregorianCalendar;
+
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.common.TypeFactory;
+import org.mapstruct.ap.internal.util.Strings;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+
+/**
+ * @author Sjaak Derksen
+ */
+public abstract class AbstractToXmlGregorianCalendar extends BuiltInMethod {
+
+    private final Type returnType;
+    private final Set<Type> importTypes;
+    private final Type dataTypeFactoryType;
+
+    public AbstractToXmlGregorianCalendar(TypeFactory typeFactory) {
+        this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
+        this.dataTypeFactoryType = typeFactory.getType( DatatypeFactory.class );
+        this.importTypes = asSet(
+            returnType,
+            dataTypeFactoryType,
+            typeFactory.getType( DatatypeConfigurationException.class )
+        );
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return importTypes;
+    }
+
+    @Override
+    public Type getReturnType() {
+        return returnType;
+    }
+
+    @Override
+    public BuiltInFieldReference getFieldReference() {
+        return new FinalField( dataTypeFactoryType, Strings.decapitalize( DatatypeFactory.class.getSimpleName() ) );
+    }
+
+    @Override
+    public BuiltInConstructorFragment getConstructorFragment() {
+        return new NewDatatypeFactoryConstructorFragment( );
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInConstructorFragment.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInConstructorFragment.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model.source.builtin;
+
+/**
+ * ConstructorFragments are 'code snippets' added to the constructor to initialize fields used by {@link BuiltInMethod}
+ */
+public interface BuiltInConstructorFragment {
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInFieldReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInFieldReference.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model.source.builtin;
+
+import org.mapstruct.ap.internal.model.common.Type;
+
+/**
+ * reference used by BuiltInMethod to create an additional field in the mapper.
+ */
+public interface BuiltInFieldReference {
+
+    /**
+     *
+     * @return variable name of the field
+     */
+    String getVariableName();
+
+    /**
+     *
+     * @return type of the field
+     */
+    Type getType();
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/BuiltInMethod.java
@@ -5,14 +5,11 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.first;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
 import javax.lang.model.element.ExecutableElement;
 
 import org.mapstruct.ap.internal.conversion.SimpleConversion;
@@ -25,6 +22,8 @@ import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.ParameterProvidedMethods;
 import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Strings;
+
+import static org.mapstruct.ap.internal.util.Collections.first;
 
 /**
  * Represents a "built-in" mapping method which will be added as private method to the generated mapper. Built-in
@@ -275,4 +274,13 @@ public abstract class BuiltInMethod implements Method {
     public MappingOptions getMappingOptions() {
         return MappingOptions.empty();
     }
+
+    public BuiltInFieldReference getFieldReference() {
+        return null;
+    }
+
+    public BuiltInConstructorFragment getConstructorFragment() {
+        return null;
+    }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/CalendarToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/CalendarToXmlGregorianCalendar.java
@@ -5,45 +5,38 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+
 /**
  * @author Sjaak Derksen
  */
-public class CalendarToXmlGregorianCalendar extends BuiltInMethod {
+public class CalendarToXmlGregorianCalendar extends AbstractToXmlGregorianCalendar {
 
     private final Parameter parameter;
-    private final Type returnType;
     private final Set<Type> importTypes;
 
     public CalendarToXmlGregorianCalendar(TypeFactory typeFactory) {
+        super( typeFactory );
         this.parameter = new Parameter( "cal ", typeFactory.getType( Calendar.class ) );
-        this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
         this.importTypes = asSet(
-            returnType,
             parameter.getType(),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( GregorianCalendar.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
+            typeFactory.getType( GregorianCalendar.class )
         );
     }
 
     @Override
     public Set<Type> getImportTypes() {
-        return importTypes;
+        Set<Type> result = super.getImportTypes();
+        result.addAll( this.importTypes );
+        return result;
     }
 
     @Override
@@ -51,8 +44,4 @@ public class CalendarToXmlGregorianCalendar extends BuiltInMethod {
         return parameter;
     }
 
-    @Override
-    public Type getReturnType() {
-        return returnType;
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/CalendarToZonedDateTime.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/CalendarToZonedDateTime.java
@@ -5,8 +5,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Set;
@@ -15,6 +13,8 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.util.JavaTimeConstants;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * {@link BuiltInMethod} for mapping between {@link Calendar} and {@link ZonedDateTime}.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/DateToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/DateToXmlGregorianCalendar.java
@@ -5,45 +5,38 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+
 /**
  * @author Sjaak Derksen
  */
-public class DateToXmlGregorianCalendar extends BuiltInMethod {
+public class DateToXmlGregorianCalendar extends AbstractToXmlGregorianCalendar {
 
     private final Parameter parameter;
-    private final Type returnType;
     private final Set<Type> importTypes;
 
     public DateToXmlGregorianCalendar(TypeFactory typeFactory) {
+        super( typeFactory );
         this.parameter = new Parameter( "date", typeFactory.getType( Date.class ) );
-        this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
         this.importTypes = asSet(
-            returnType,
             parameter.getType(),
-            typeFactory.getType( GregorianCalendar.class ),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
+            typeFactory.getType( GregorianCalendar.class )
         );
     }
 
     @Override
     public Set<Type> getImportTypes() {
-        return importTypes;
+        Set<Type> result = super.getImportTypes();
+        result.addAll( this.importTypes );
+        return result;
     }
 
     @Override
@@ -51,8 +44,4 @@ public class DateToXmlGregorianCalendar extends BuiltInMethod {
         return parameter;
     }
 
-    @Override
-    public Type getReturnType() {
-        return returnType;
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/FinalField.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/FinalField.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model.source.builtin;
+
+import org.mapstruct.ap.internal.model.common.Type;
+
+/**
+ * A mapper instance field, initialized as null
+ *
+ * @author Sjaak Derksen
+ */
+public class FinalField implements BuiltInFieldReference {
+
+    private final Type type;
+    private String variableName;
+
+    public FinalField(Type type, String variableName) {
+        this.type = type;
+        this.variableName = variableName;
+    }
+
+    @Override
+    public String getVariableName() {
+        return variableName;
+    }
+
+    @Override
+    public Type getType() {
+        return type;
+    }
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.java
@@ -5,15 +5,14 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Set;
-
 import javax.xml.bind.JAXBElement;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * @author Sjaak Derksen

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaDateTimeToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaDateTimeToXmlGregorianCalendar.java
@@ -5,13 +5,7 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
@@ -21,30 +15,20 @@ import org.mapstruct.ap.internal.util.JodaTimeConstants;
 /**
  * @author Sjaak Derksen
  */
-public class JodaDateTimeToXmlGregorianCalendar extends BuiltInMethod {
+public class JodaDateTimeToXmlGregorianCalendar extends AbstractToXmlGregorianCalendar {
 
     private final Parameter parameter;
-    private final Type returnType;
-    private final Set<Type> importTypes;
 
     public JodaDateTimeToXmlGregorianCalendar(TypeFactory typeFactory) {
-        this.parameter = new Parameter(
-            "dt",
-            typeFactory.getType( JodaTimeConstants.DATE_TIME_FQN )
-        );
-        this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
-        this.importTypes = asSet(
-            returnType,
-            parameter.getType(),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
-        );
+        super( typeFactory );
+        this.parameter = new Parameter("dt", typeFactory.getType( JodaTimeConstants.DATE_TIME_FQN ) );
     }
 
     @Override
     public Set<Type> getImportTypes() {
-        return importTypes;
+        Set<Type> result = super.getImportTypes();
+        result.add( parameter.getType() );
+        return result;
     }
 
     @Override
@@ -52,8 +36,4 @@ public class JodaDateTimeToXmlGregorianCalendar extends BuiltInMethod {
         return parameter;
     }
 
-    @Override
-    public Type getReturnType() {
-        return returnType;
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.java
@@ -5,48 +5,38 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.util.JodaTimeConstants;
 
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+
 /**
  * @author Sjaak Derksen
  */
-public class JodaLocalDateTimeToXmlGregorianCalendar extends BuiltInMethod {
+public class JodaLocalDateTimeToXmlGregorianCalendar extends AbstractToXmlGregorianCalendar {
 
     private final Parameter parameter;
-    private final Type returnType;
     private final Set<Type> importTypes;
 
     public JodaLocalDateTimeToXmlGregorianCalendar(TypeFactory typeFactory) {
-        this.parameter = new Parameter(
-            "dt",
-            typeFactory.getType( JodaTimeConstants.LOCAL_DATE_TIME_FQN )
-        );
-        this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
+        super( typeFactory );
+        this.parameter = new Parameter( "dt", typeFactory.getType( JodaTimeConstants.LOCAL_DATE_TIME_FQN ) );
         this.importTypes = asSet(
-            returnType,
             parameter.getType(),
-            typeFactory.getType( DatatypeConstants.class ),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
+            typeFactory.getType( DatatypeConstants.class )
         );
     }
 
     @Override
     public Set<Type> getImportTypes() {
-        return importTypes;
+        Set<Type> result = super.getImportTypes();
+        result.addAll( importTypes );
+        return result;
     }
 
     @Override
@@ -54,8 +44,4 @@ public class JodaLocalDateTimeToXmlGregorianCalendar extends BuiltInMethod {
         return parameter;
     }
 
-    @Override
-    public Type getReturnType() {
-        return returnType;
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.java
@@ -5,48 +5,38 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.util.JodaTimeConstants;
 
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+
 /**
  * @author Sjaak Derksen
  */
-public class JodaLocalDateToXmlGregorianCalendar extends BuiltInMethod {
+public class JodaLocalDateToXmlGregorianCalendar extends AbstractToXmlGregorianCalendar {
 
     private final Parameter parameter;
-    private final Type returnType;
     private final Set<Type> importTypes;
 
     public JodaLocalDateToXmlGregorianCalendar(TypeFactory typeFactory) {
-        this.parameter = new Parameter(
-            "dt",
-            typeFactory.getType( JodaTimeConstants.LOCAL_DATE_FQN )
-        );
-        this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
+        super( typeFactory );
+        this.parameter = new Parameter( "dt", typeFactory.getType( JodaTimeConstants.LOCAL_DATE_FQN ) );
         this.importTypes = asSet(
-            returnType,
             parameter.getType(),
-            typeFactory.getType( DatatypeConstants.class ),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
+            typeFactory.getType( DatatypeConstants.class )
         );
     }
 
     @Override
     public Set<Type> getImportTypes() {
-        return importTypes;
+        Set<Type> result = super.getImportTypes();
+        result.addAll( importTypes );
+        return result;
     }
 
     @Override
@@ -54,8 +44,4 @@ public class JodaLocalDateToXmlGregorianCalendar extends BuiltInMethod {
         return parameter;
     }
 
-    @Override
-    public Type getReturnType() {
-        return returnType;
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.java
@@ -5,48 +5,38 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.util.JodaTimeConstants;
 
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+
 /**
  * @author Sjaak Derksen
  */
-public class JodaLocalTimeToXmlGregorianCalendar extends BuiltInMethod {
+public class JodaLocalTimeToXmlGregorianCalendar extends AbstractToXmlGregorianCalendar {
 
     private final Parameter parameter;
-    private final Type returnType;
     private final Set<Type> importTypes;
 
     public JodaLocalTimeToXmlGregorianCalendar(TypeFactory typeFactory) {
-        this.parameter = new Parameter(
-            "dt",
-            typeFactory.getType( JodaTimeConstants.LOCAL_TIME_FQN )
-        );
-        this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
-
+        super( typeFactory );
+        this.parameter = new Parameter( "dt", typeFactory.getType( JodaTimeConstants.LOCAL_TIME_FQN ) );
         this.importTypes = asSet(
-            returnType,
             parameter.getType(),
-            typeFactory.getType( DatatypeConstants.class ),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
+            typeFactory.getType( DatatypeConstants.class )
         );
     }
 
     @Override
     public Set<Type> getImportTypes() {
-        return importTypes;
+        Set<Type> result = super.getImportTypes();
+        result.addAll( importTypes );
+        return result;
     }
 
     @Override
@@ -54,8 +44,4 @@ public class JodaLocalTimeToXmlGregorianCalendar extends BuiltInMethod {
         return parameter;
     }
 
-    @Override
-    public Type getReturnType() {
-        return returnType;
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.java
@@ -5,39 +5,38 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.time.LocalDate;
 import java.util.Set;
-
-import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+
 /**
  * @author Gunnar Morling
  */
-public class LocalDateToXmlGregorianCalendar extends BuiltInMethod {
+public class LocalDateToXmlGregorianCalendar extends AbstractToXmlGregorianCalendar {
 
     private final Parameter parameter;
-    private final Type returnType;
     private final Set<Type> importTypes;
 
     public LocalDateToXmlGregorianCalendar(TypeFactory typeFactory) {
+        super( typeFactory );
         this.parameter = new Parameter( "localDate", typeFactory.getType( LocalDate.class ) );
-        this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
         this.importTypes = asSet(
-                returnType,
                 parameter.getType(),
-                typeFactory.getType( DatatypeFactory.class ),
-                typeFactory.getType( DatatypeConfigurationException.class ),
                 typeFactory.getType( DatatypeConstants.class )
         );
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        Set<Type> result = super.getImportTypes();
+        result.addAll( importTypes );
+        return result;
     }
 
     @Override
@@ -45,13 +44,4 @@ public class LocalDateToXmlGregorianCalendar extends BuiltInMethod {
         return parameter;
     }
 
-    @Override
-    public Type getReturnType() {
-        return returnType;
-    }
-
-    @Override
-    public Set<Type> getImportTypes() {
-        return importTypes;
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/NewDatatypeFactoryConstructorFragment.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/NewDatatypeFactoryConstructorFragment.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model.source.builtin;
+
+public class NewDatatypeFactoryConstructorFragment implements BuiltInConstructorFragment {
+
+    public NewDatatypeFactoryConstructorFragment() {
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/StringToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/StringToXmlGregorianCalendar.java
@@ -5,59 +5,48 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.GregorianCalendar;
 import java.util.Set;
 
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
-
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+
 /**
  * @author Sjaak Derksen
  */
-public class StringToXmlGregorianCalendar extends BuiltInMethod {
+public class StringToXmlGregorianCalendar extends AbstractToXmlGregorianCalendar {
 
     private final Parameter parameter;
-    private final Type returnType;
     private final Set<Type> importTypes;
 
     public StringToXmlGregorianCalendar(TypeFactory typeFactory) {
+        super( typeFactory );
         this.parameter = new Parameter( "date", typeFactory.getType( String.class ) );
-        this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
         this.importTypes = asSet(
-            returnType,
             typeFactory.getType( GregorianCalendar.class ),
             typeFactory.getType( SimpleDateFormat.class ),
             typeFactory.getType( DateFormat.class ),
-            typeFactory.getType( ParseException.class ),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
+            typeFactory.getType( ParseException.class )
         );
     }
 
     @Override
     public Set<Type> getImportTypes() {
-        return importTypes;
+        Set<Type> result = super.getImportTypes();
+        result.addAll( importTypes );
+        return result;
     }
 
     @Override
     public Parameter getParameter() {
         return parameter;
-    }
-
-    @Override
-    public Type getReturnType() {
-        return returnType;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToCalendar.java
@@ -5,16 +5,15 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Calendar;
 import java.util.Set;
-
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * @author Sjaak Derksen

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.java
@@ -5,16 +5,15 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Date;
 import java.util.Set;
-
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * @author Sjaak Derksen

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaDateTime.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaDateTime.java
@@ -5,8 +5,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Set;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -15,6 +13,8 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.util.JodaTimeConstants;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * @author Sjaak Derksen

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.java
@@ -5,8 +5,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Set;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -15,6 +13,8 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.util.JodaTimeConstants;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * @author Sjaak Derksen

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.java
@@ -5,8 +5,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Set;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -15,6 +13,8 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.util.JodaTimeConstants;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * @author Sjaak Derksen

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.java
@@ -5,8 +5,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.util.Set;
 import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.XMLGregorianCalendar;
@@ -15,6 +13,8 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.util.JodaTimeConstants;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * @author Sjaak Derksen

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToLocalDate.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToLocalDate.java
@@ -5,16 +5,15 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.time.LocalDate;
 import java.util.Set;
-
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * @author Gunnar Morling

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.java
@@ -5,18 +5,17 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Set;
-
 import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * @author Sjaak Derksen

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToCalendar.java
@@ -5,8 +5,6 @@
  */
 package org.mapstruct.ap.internal.model.source.builtin;
 
-import static org.mapstruct.ap.internal.util.Collections.asSet;
-
 import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.Set;
@@ -16,6 +14,8 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.util.JavaTimeConstants;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
 
 /**
  * {@link BuiltInMethod} for mapping between {@link Calendar} and {@link ZonedDateTime}.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToXmlGregorianCalendar.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToXmlGregorianCalendar.java
@@ -8,9 +8,6 @@ package org.mapstruct.ap.internal.model.source.builtin;
 import java.time.ZonedDateTime;
 import java.util.GregorianCalendar;
 import java.util.Set;
-import javax.xml.datatype.DatatypeConfigurationException;
-import javax.xml.datatype.DatatypeFactory;
-import javax.xml.datatype.XMLGregorianCalendar;
 
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
@@ -21,28 +18,26 @@ import static org.mapstruct.ap.internal.util.Collections.asSet;
 /**
  * @author Christian Bandowski
  */
-public class ZonedDateTimeToXmlGregorianCalendar extends BuiltInMethod {
+public class ZonedDateTimeToXmlGregorianCalendar extends AbstractToXmlGregorianCalendar {
 
     private final Parameter parameter;
-    private final Type returnType;
     private final Set<Type> importTypes;
 
     public ZonedDateTimeToXmlGregorianCalendar(TypeFactory typeFactory) {
+        super( typeFactory );
         this.parameter = new Parameter( "zdt ", typeFactory.getType( ZonedDateTime.class ) );
-        this.returnType = typeFactory.getType( XMLGregorianCalendar.class );
 
         this.importTypes = asSet(
-            returnType,
             parameter.getType(),
-            typeFactory.getType( DatatypeFactory.class ),
-            typeFactory.getType( GregorianCalendar.class ),
-            typeFactory.getType( DatatypeConfigurationException.class )
+            typeFactory.getType( GregorianCalendar.class )
         );
     }
 
     @Override
     public Set<Type> getImportTypes() {
-        return importTypes;
+        Set<Type> result = super.getImportTypes();
+        result.addAll( importTypes );
+        return result;
     }
 
     @Override
@@ -50,8 +45,4 @@ public class ZonedDateTimeToXmlGregorianCalendar extends BuiltInMethod {
         return parameter;
     }
 
-    @Override
-    public Type getReturnType() {
-        return returnType;
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Strings.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Strings.java
@@ -127,8 +127,8 @@ public class Strings {
         return string == null || string.isEmpty();
     }
 
-    public static String getSaveVariableName(String name, String... existingVariableNames) {
-        return getSaveVariableName( name, Arrays.asList( existingVariableNames ) );
+    public static String getSafeVariableName(String name, String... existingVariableNames) {
+        return getSafeVariableName( name, Arrays.asList( existingVariableNames ) );
     }
 
     /**
@@ -141,7 +141,7 @@ public class Strings {
      * @return a variable name based on the given original name, not conflicting with any of the given other names or
      * any Java keyword; starting with a lower-case letter
      */
-    public static String getSaveVariableName(String name, Collection<String> existingVariableNames) {
+    public static String getSafeVariableName(String name, Collection<String> existingVariableNames) {
         name = decapitalize( sanitizeIdentifierName( name ) );
         name = joinAndCamelize( extractParts( name ) );
 

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/AnnotatedConstructor.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/AnnotatedConstructor.ftl
@@ -1,20 +1,24 @@
-<#--
+ <#--
 
     Copyright MapStruct Authors.
 
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
-<#if publicEmptyConstructor>
-public ${name}() {
-}
+ <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.AnnotatedConstructor" -->
+ <#if noArgumentConstructor??>
+     <@includeModel object=noArgumentConstructor/>
 </#if>
 
 <#list annotations as annotation>
     <#nt><@includeModel object=annotation/>
 </#list>
 public ${name}(<#list mapperReferences as mapperReference><#list mapperReference.annotations as annotation><@includeModel object=annotation/> </#list><@includeModel object=mapperReference.type/> ${mapperReference.variableName}<#if mapperReference_has_next>, </#if></#list>) {
+    <#if noArgumentConstructor?? && !noArgumentConstructor.fragments.empty>this();</#if>
     <#list mapperReferences as mapperReference>
         this.${mapperReference.variableName} = ${mapperReference.variableName};
+    </#list>
+     <#list fragments as fragment>
+         <#nt><@includeModel object=fragment/>
     </#list>
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/Annotation.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/Annotation.ftl
@@ -5,4 +5,5 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.Annotation" -->
 @<@includeModel object=type/><#if (properties?size > 0) >(<#list properties as property>${property}<#if property_has_next>, </#if></#list>)</#if>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/AnnotationMapperReference.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/AnnotationMapperReference.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.AnnotationMapperReference" -->
 <#if includeAnnotationsOnField>
     <#list annotations as annotation>
         <#nt><@includeModel object=annotation/>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.BeanMappingMethod" -->
 <#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     <#assign targetType = resultType />

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/DecoratorConstructor.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/DecoratorConstructor.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.DecoratorConstructor" -->
 public ${name}() {
     this( new ${delegateName}() );
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/DefaultMapperReference.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/DefaultMapperReference.ftl
@@ -5,4 +5,5 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.DefaultMapperReference" -->
 private final <@includeModel object=type/> ${variableName} = <#if annotatedMapper>Mappers.getMapper( <@includeModel object=type/>.class );<#else>new <@includeModel object=type/>();</#if>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/DelegatingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/DelegatingMethod.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.DelegatingMethod" -->
 @Override
 public <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>) <@throws/> {
     <#if returnType.name != "void">return </#if>delegate.${name}( <#list parameters as param>${param.name}<#if param_has_next>, </#if></#list> );

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/EnumMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/EnumMappingMethod.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.EnumMappingMethod" -->
 @Override
 public <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>) {
     <#list beforeMappingReferencesWithoutMappingTarget as callback>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/Field.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/Field.ftl
@@ -5,4 +5,5 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.Field" -->
 private final <@includeModel object=type/> ${variableName};

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/GeneratedType.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/GeneratedType.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.GeneratedType" -->
 <#if hasPackageName()>
 package ${packageName};
 </#if>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableCreation.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableCreation.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.IterableCreation" -->
 <@compress single_line=true>
     <#if factoryMethod??>
         <@includeModel object=factoryMethod targetType=resultType/>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.IterableMappingMethod" -->
 <#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     <#list beforeMappingReferencesWithoutMappingTarget as callback>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/LifecycleCallbackMethodReference.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/LifecycleCallbackMethodReference.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.LifecycleCallbackMethodReference" -->
 <@compress single_line=true>
     <#if hasReturnType()>
         <@includeModel object=methodResultType /> ${targetVariableName} =

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.MapMappingMethod" -->
 <#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType /> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     <#list beforeMappingReferencesWithoutMappingTarget as callback>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MethodReference.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MethodReference.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.MethodReference" -->
 <@compress single_line=true>
     <#-- method is either internal to the mapper class, or external (via uses) declaringMapper!=null -->
     <#if declaringMapper??>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.NestedPropertyMappingMethod" -->
 <#lt>private <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     if ( ${sourceParameter.name} == null ) {
         return ${returnType.null};

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/NoArgumentConstructor.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/NoArgumentConstructor.ftl
@@ -1,0 +1,13 @@
+ <#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+ <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.NoArgumentConstructor" -->
+public ${name}() {
+ <#list fragments as fragment>
+     <#nt><@includeModel object=fragment/>
+ </#list>
+ }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/PropertyMapping.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/PropertyMapping.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.PropertyMapping" -->
 <@includeModel object=assignment
                targetBeanName=ext.targetBeanName
                existingInstanceMapping=ext.existingInstanceMapping

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ServicesEntry.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ServicesEntry.ftl
@@ -5,4 +5,5 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.ServicesEntry" -->
 ${implementationPackage}.${implementationName}

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.StreamMappingMethod" -->
 <#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     <#--TODO does it even make sense to do a callback if the result is a Stream, as they are immutable-->

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/TypeConversion.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/TypeConversion.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.TypeConversion" -->
 <@compress single_line=true>
 ${openExpression}<@_assignment/>${closeExpression}
 <#macro _assignment>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.ValueMappingMethod" -->
 <#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>) {
     <#list beforeMappingReferencesWithoutMappingTarget as callback>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/AdderWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/AdderWrapper.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.AdderWrapper" -->
 <#import "../macro/CommonMacros.ftl" as lib>
 <@lib.handleExceptions>
   if ( ${sourceReference} != null ) {

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ArrayCopyWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ArrayCopyWrapper.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.ArrayCopyWrapper" -->
 <#import "../macro/CommonMacros.ftl" as lib>
 <@lib.handleExceptions>
     <@lib.sourceLocalVarAssignment/>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/EnumConstantWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/EnumConstantWrapper.ftl
@@ -5,4 +5,5 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.EnumConstantWrapper" -->
 ${ext.targetType.name}.${assignment}

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.ExistingInstanceSetterWrapperForCollectionsAndMaps" -->
 <#import "../macro/CommonMacros.ftl" as lib>
 <@lib.sourceLocalVarAssignment/>
 <@lib.handleExceptions>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.GetterWrapperForCollectionsAndMaps" -->
 <#import "../macro/CommonMacros.ftl" as lib>
 <@lib.sourceLocalVarAssignment/>
 if ( ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing /> != null ) {

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.Java8FunctionWrapper" -->
 <#assign sourceVarName><#if assignment.sourceLocalVarName?? >${assignment.sourceLocalVarName}<#else>${assignment.sourceReference}</#if></#assign>
 <#if (thrownTypes?size == 0) >
     <#compress>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/LocalVarWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/LocalVarWrapper.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.LocalVarWrapper" -->
 <#if (thrownTypes?size == 0) >
     <#if !ext.isTargetDefined?? ><@includeModel object=ext.targetType/></#if> ${ext.targetWriteAccessorName} = <@_assignment/>;
 <#else>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapper.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.SetterWrapper" -->
 <#import "../macro/CommonMacros.ftl" as lib>
 <@lib.handleExceptions>
     <@lib.sourceLocalVarAssignment/>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMaps.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.SetterWrapperForCollectionsAndMaps" -->
 <#import "../macro/CommonMacros.ftl" as lib>
 <@lib.sourceLocalVarAssignment/>
 <@lib.handleExceptions>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.SetterWrapperForCollectionsAndMapsWithNullCheck" -->
 <#import "../macro/CommonMacros.ftl" as lib>
 <@lib.sourceLocalVarAssignment/>
 <@lib.handleExceptions>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/UpdateWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/UpdateWrapper.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.UpdateWrapper" -->
 <#import '../macro/CommonMacros.ftl' as lib >
 <@lib.handleExceptions>
   <#if includeSourceNullCheck>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/common/Parameter.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/common/Parameter.ftl
@@ -5,4 +5,5 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.common.Parameter" -->
 <@includeModel object=type asVarArgs=varArgs/> ${name}

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/common/SourceRHS.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/common/SourceRHS.ftl
@@ -5,4 +5,5 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.common.SourceRHS" -->
 <#if sourceLocalVarName??>${sourceLocalVarName}<#else>${sourceReference}</#if>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/common/Type.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/common/Type.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.common.Type" -->
 <@compress single_line=true>
     <#if wildCardExtendsBound>
         ? extends <@includeModel object=typeBound />

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToXmlGregorianCalendar.ftl
@@ -5,17 +5,13 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("Calendar")/> cal ) {
     if ( cal == null ) {
         return null;
     }
 
-    try {
-        <@includeModel object=findType("GregorianCalendar")/> gcal = new <@includeModel object=findType("GregorianCalendar")/>( cal.getTimeZone() );
-        gcal.setTimeInMillis( cal.getTimeInMillis() );
-        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar( gcal );
-    }
-    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
-        throw new RuntimeException( ex );
-    }
+    <@includeModel object=findType("GregorianCalendar")/> gcal = new <@includeModel object=findType("GregorianCalendar")/>( cal.getTimeZone() );
+    gcal.setTimeInMillis( cal.getTimeInMillis() );
+    return ${supportingField.variableName}.newXMLGregorianCalendar( gcal );
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToZonedDateTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/CalendarToZonedDateTime.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <@includeModel object=findType("ZonedDateTime")/> ${name}(<@includeModel object=findType("Calendar")/> cal) {
     if ( cal == null ) {
         return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/DateToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/DateToXmlGregorianCalendar.ftl
@@ -5,17 +5,13 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("Date")/> date ) {
     if ( date == null ) {
         return null;
     }
 
-    try {
-        <@includeModel object=findType("GregorianCalendar")/> c = new <@includeModel object=findType("GregorianCalendar")/>();
-        c.setTime( date );
-        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar( c );
-    }
-    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
-        throw new RuntimeException( ex );
-    }
+    <@includeModel object=findType("GregorianCalendar")/> c = new <@includeModel object=findType("GregorianCalendar")/>();
+    c.setTime( date );
+    return ${supportingField.variableName}.newXMLGregorianCalendar( c );
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/FinalField.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/FinalField.ftl
@@ -1,0 +1,9 @@
+<#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingField" -->
+private final <@includeModel object=type/> ${variableName};

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JaxbElemToValue.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <T> T ${name}( <@includeModel object=findType("JAXBElement") raw=true/><T> element ) {
     if ( element == null ) {
         return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaDateTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaDateTimeToXmlGregorianCalendar.ftl
@@ -5,23 +5,18 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("DateTime")/> dt ) {
     if ( dt == null ) {
         return null;
     }
-
-    try {
-        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar(
-            dt.getYear(),
-            dt.getMonthOfYear(),
-            dt.getDayOfMonth(),
-            dt.getHourOfDay(),
-            dt.getMinuteOfHour(),
-            dt.getSecondOfMinute(),
-            dt.getMillisOfSecond(),
-            dt.getZone().getOffset( null ) / 60000 );
-    }
-    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
-        throw new RuntimeException( ex );
-    }
+    return ${supportingField.variableName}.newXMLGregorianCalendar(
+        dt.getYear(),
+        dt.getMonthOfYear(),
+        dt.getDayOfMonth(),
+        dt.getHourOfDay(),
+        dt.getMinuteOfHour(),
+        dt.getSecondOfMinute(),
+        dt.getMillisOfSecond(),
+        dt.getZone().getOffset( null ) / 60000 );
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateTimeToXmlGregorianCalendar.ftl
@@ -5,23 +5,19 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("org.joda.time.LocalDateTime")/> dt ) {
     if ( dt == null ) {
         return null;
     }
 
-    try {
-        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar(
-            dt.getYear(),
-            dt.getMonthOfYear(),
-            dt.getDayOfMonth(),
-            dt.getHourOfDay(),
-            dt.getMinuteOfHour(),
-            dt.getSecondOfMinute(),
-            dt.getMillisOfSecond(),
-            <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED );
-    }
-    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
-        throw new RuntimeException( ex );
-    }
+    return  ${supportingField.variableName}.newXMLGregorianCalendar(
+        dt.getYear(),
+        dt.getMonthOfYear(),
+        dt.getDayOfMonth(),
+        dt.getHourOfDay(),
+        dt.getMinuteOfHour(),
+        dt.getSecondOfMinute(),
+        dt.getMillisOfSecond(),
+        <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED );
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalDateToXmlGregorianCalendar.ftl
@@ -5,19 +5,15 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("org.joda.time.LocalDate")/> dt ) {
     if ( dt == null ) {
         return null;
     }
 
-    try {
-        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendarDate(
-            dt.getYear(),
-            dt.getMonthOfYear(),
-            dt.getDayOfMonth(),
-            <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED );
-    }
-    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
-        throw new RuntimeException( ex );
-    }
+    return ${supportingField.variableName}.newXMLGregorianCalendarDate(
+        dt.getYear(),
+        dt.getMonthOfYear(),
+        dt.getDayOfMonth(),
+        <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED );
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/JodaLocalTimeToXmlGregorianCalendar.ftl
@@ -5,20 +5,17 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("org.joda.time.LocalTime")/> dt ) {
     if ( dt == null ) {
         return null;
     }
 
-    try {
-        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendarTime(
-            dt.getHourOfDay(),
-            dt.getMinuteOfHour(),
-            dt.getSecondOfMinute(),
-            dt.getMillisOfSecond(),
-            <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED );
-    }
-    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
-        throw new RuntimeException( ex );
-    }
+    return ${supportingField.variableName}.newXMLGregorianCalendarTime(
+        dt.getHourOfDay(),
+        dt.getMinuteOfHour(),
+        dt.getSecondOfMinute(),
+        dt.getMillisOfSecond(),
+        <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED );
+
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/LocalDateToXmlGregorianCalendar.ftl
@@ -5,20 +5,15 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
-private static <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("java.time.LocalDate")/> localDate ) {
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
+private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("java.time.LocalDate")/> localDate ) {
     if ( localDate == null ) {
         return null;
     }
 
-    try {
-        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendarDate(
-            localDate.getYear(),
-            localDate.getMonthValue(),
-            localDate.getDayOfMonth(),
-            <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED
-        );
-    }
-    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
-        throw new RuntimeException( ex );
-    }
+    return ${supportingField.variableName}.newXMLGregorianCalendarDate(
+        localDate.getYear(),
+        localDate.getMonthValue(),
+        localDate.getDayOfMonth(),
+        <@includeModel object=findType("DatatypeConstants")/>.FIELD_UNDEFINED );
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/NewDatatypeFactoryConstructorFragment.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/NewDatatypeFactoryConstructorFragment.ftl
@@ -1,0 +1,14 @@
+<#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingConstructorFragment" -->
+try {
+     ${definingMethod.supportingField.variableName} = <@includeModel object=definingMethod.supportingField.type/>.newInstance();
+}
+catch ( <@includeModel object=definingMethod.findType("DatatypeConfigurationException")/> ex ) {
+    throw new RuntimeException( ex );
+}

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/StringToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/StringToXmlGregorianCalendar.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( String date, String dateFormat ) {
     if ( date == null ) {
         return null;
@@ -15,14 +16,11 @@ private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( String
             <@includeModel object=findType("DateFormat")/> df = new <@includeModel object=findType("SimpleDateFormat")/>( dateFormat );
             <@includeModel object=findType("GregorianCalendar")/> c = new <@includeModel object=findType("GregorianCalendar")/>();
             c.setTime( df.parse( date ) );
-            return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar( c );
+            return ${supportingField.variableName}.newXMLGregorianCalendar( c );
         }
         else {
-            return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar( date );
+            return ${supportingField.variableName}.newXMLGregorianCalendar( date );
         }
-    }
-    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
-        throw new RuntimeException( ex );
     }
     catch ( <@includeModel object=findType("ParseException")/> ex ) {
         throw new RuntimeException( ex );

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToCalendar.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <@includeModel object=findType("Calendar")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToDate.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private static <@includeModel object=findType("java.util.Date")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaDateTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaDateTime.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private static <@includeModel object=findType("DateTime")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDate.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private static <@includeModel object=findType("org.joda.time.LocalDate")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalDateTime.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private static <@includeModel object=findType("org.joda.time.LocalDateTime")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToJodaLocalTime.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private static <@includeModel object=findType("org.joda.time.LocalTime")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToLocalDate.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToLocalDate.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private static <@includeModel object=findType("java.time.LocalDate")/> ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal ) {
     if ( xcal == null ) {
         return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/XmlGregorianCalendarToString.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private String ${name}( <@includeModel object=findType("XMLGregorianCalendar")/> xcal, String dateFormat ) {
     if ( xcal == null ) {
         return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToCalendar.ftl
@@ -5,6 +5,7 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <@includeModel object=findType("Calendar")/> ${name}(<@includeModel object=findType("ZonedDateTime")/> dateTime) {
     if ( dateTime == null ) {
        return null;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToXmlGregorianCalendar.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/source/builtin/ZonedDateTimeToXmlGregorianCalendar.ftl
@@ -5,15 +5,11 @@
     Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
 -->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.SupportingMappingMethod" -->
 private <@includeModel object=findType("XMLGregorianCalendar")/> ${name}( <@includeModel object=findType("ZonedDateTime")/> zdt ) {
     if ( zdt == null ) {
         return null;
     }
 
-    try {
-        return <@includeModel object=findType("DatatypeFactory")/>.newInstance().newXMLGregorianCalendar( <@includeModel object=findType("GregorianCalendar")/>.from( zdt ) );
-    }
-    catch ( <@includeModel object=findType("DatatypeConfigurationException")/> ex ) {
-        throw new RuntimeException( ex );
-    }
+    return ${supportingField.variableName}.newXMLGregorianCalendar( <@includeModel object=findType("GregorianCalendar")/>.from( zdt ) );
 }

--- a/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
@@ -76,27 +76,27 @@ public class StringsTest {
 
     @Test
     public void testGetSaveVariableNameWithArrayExistingVariables() throws Exception {
-        assertThat( Strings.getSaveVariableName( "int[]" ) ).isEqualTo( "intArray" );
-        assertThat( Strings.getSaveVariableName( "Extends" ) ).isEqualTo( "extends1" );
-        assertThat( Strings.getSaveVariableName( "class" ) ).isEqualTo( "class1" );
-        assertThat( Strings.getSaveVariableName( "Class" ) ).isEqualTo( "class1" );
-        assertThat( Strings.getSaveVariableName( "Case" ) ).isEqualTo( "case1" );
-        assertThat( Strings.getSaveVariableName( "Synchronized" ) ).isEqualTo( "synchronized1" );
-        assertThat( Strings.getSaveVariableName( "prop", "prop", "prop_" ) ).isEqualTo( "prop1" );
+        assertThat( Strings.getSafeVariableName( "int[]" ) ).isEqualTo( "intArray" );
+        assertThat( Strings.getSafeVariableName( "Extends" ) ).isEqualTo( "extends1" );
+        assertThat( Strings.getSafeVariableName( "class" ) ).isEqualTo( "class1" );
+        assertThat( Strings.getSafeVariableName( "Class" ) ).isEqualTo( "class1" );
+        assertThat( Strings.getSafeVariableName( "Case" ) ).isEqualTo( "case1" );
+        assertThat( Strings.getSafeVariableName( "Synchronized" ) ).isEqualTo( "synchronized1" );
+        assertThat( Strings.getSafeVariableName( "prop", "prop", "prop_" ) ).isEqualTo( "prop1" );
     }
 
     @Test
     public void testGetSaveVariableNameVariablesEndingOnNumberVariables() throws Exception {
-        assertThat( Strings.getSaveVariableName( "prop1", "prop1" ) ).isEqualTo( "prop1_1" );
-        assertThat( Strings.getSaveVariableName( "prop1", "prop1", "prop1_1" ) ).isEqualTo( "prop1_2" );
+        assertThat( Strings.getSafeVariableName( "prop1", "prop1" ) ).isEqualTo( "prop1_1" );
+        assertThat( Strings.getSafeVariableName( "prop1", "prop1", "prop1_1" ) ).isEqualTo( "prop1_2" );
     }
 
     @Test
     public void testGetSaveVariableNameWithCollection() throws Exception {
-        assertThat( Strings.getSaveVariableName( "int[]", new ArrayList<String>() ) ).isEqualTo( "intArray" );
-        assertThat( Strings.getSaveVariableName( "Extends", new ArrayList<String>() ) ).isEqualTo( "extends1" );
-        assertThat( Strings.getSaveVariableName( "prop", Arrays.asList( "prop", "prop1" ) ) ).isEqualTo( "prop2" );
-        assertThat( Strings.getSaveVariableName( "prop.font", Arrays.asList( "propFont", "propFont_" ) ) )
+        assertThat( Strings.getSafeVariableName( "int[]", new ArrayList<String>() ) ).isEqualTo( "intArray" );
+        assertThat( Strings.getSafeVariableName( "Extends", new ArrayList<String>() ) ).isEqualTo( "extends1" );
+        assertThat( Strings.getSafeVariableName( "prop", Arrays.asList( "prop", "prop1" ) ) ).isEqualTo( "prop2" );
+        assertThat( Strings.getSafeVariableName( "prop.font", Arrays.asList( "propFont", "propFont_" ) ) )
             .isEqualTo( "propFont1" );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/DatatypeFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/DatatypeFactoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builtin;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.builtin.bean.CalendarProperty;
+import org.mapstruct.ap.test.builtin.bean.DatatypeFactory;
+import org.mapstruct.ap.test.builtin.bean.DateProperty;
+import org.mapstruct.ap.test.builtin.bean.XmlGregorianCalendarFactorizedProperty;
+import org.mapstruct.ap.test.builtin.mapper.ToXmlGregCalMapper;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses( {
+    DatatypeFactory.class,
+    XmlGregorianCalendarFactorizedProperty.class,
+    ToXmlGregCalMapper.class,
+    CalendarProperty.class,
+    DateProperty.class
+
+} )
+@RunWith(AnnotationProcessorTestRunner.class)
+public class DatatypeFactoryTest {
+
+    @Test
+    public void testNoConflictsWithOwnDatatypeFactory() throws ParseException {
+
+        DateProperty source1 = new DateProperty();
+        source1.setProp( createDate( "31-08-1982 10:20:56" ) );
+
+        CalendarProperty source2 = new CalendarProperty();
+        source2.setProp( createCalendar( "02.03.1999" ) );
+
+        XmlGregorianCalendarFactorizedProperty target1 = ToXmlGregCalMapper.INSTANCE.map( source1 );
+        assertThat( target1 ).isNotNull();
+        assertThat( target1.getProp() ).isNotNull();
+        assertThat( target1.getProp().toString() ).isEqualTo( "1982-08-31T10:20:56.000+02:00" );
+
+        XmlGregorianCalendarFactorizedProperty target2 = ToXmlGregCalMapper.INSTANCE.map( source2 );
+        assertThat( target2 ).isNotNull();
+        assertThat( target2.getProp() ).isNotNull();
+        assertThat( target2.getProp().toString() ).isEqualTo( "1999-03-02T00:00:00.000+01:00" );
+
+    }
+
+    private Date createDate(String date) throws ParseException {
+        SimpleDateFormat sdf = new SimpleDateFormat( "dd-M-yyyy hh:mm:ss" );
+        return sdf.parse( date );
+    }
+
+    private Calendar createCalendar(String cal) throws ParseException {
+        SimpleDateFormat sdf = new SimpleDateFormat( "dd.MM.yyyy" );
+        GregorianCalendar gcal = new GregorianCalendar();
+        gcal.setTime( sdf.parse( cal ) );
+        return gcal;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/bean/DatatypeFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/bean/DatatypeFactory.java
@@ -1,0 +1,13 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builtin.bean;
+
+public class DatatypeFactory {
+
+    public XmlGregorianCalendarFactorizedProperty create()  {
+        return new XmlGregorianCalendarFactorizedProperty( "test" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/bean/XmlGregorianCalendarFactorizedProperty.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/bean/XmlGregorianCalendarFactorizedProperty.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builtin.bean;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+public class XmlGregorianCalendarFactorizedProperty {
+
+    private XMLGregorianCalendar prop;
+    private String control;
+
+    XmlGregorianCalendarFactorizedProperty( String in ) {
+        this.control = in;
+    }
+
+    public XMLGregorianCalendar getProp() {
+        return prop;
+    }
+
+    public void setProp( XMLGregorianCalendar prop ) {
+        this.prop = prop;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/mapper/ToXmlGregCalMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/mapper/ToXmlGregCalMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builtin.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.builtin.bean.CalendarProperty;
+import org.mapstruct.ap.test.builtin.bean.DatatypeFactory;
+import org.mapstruct.ap.test.builtin.bean.DateProperty;
+import org.mapstruct.ap.test.builtin.bean.XmlGregorianCalendarFactorizedProperty;
+import org.mapstruct.factory.Mappers;
+
+@Mapper( uses = DatatypeFactory.class )
+public interface ToXmlGregCalMapper {
+
+    ToXmlGregCalMapper INSTANCE = Mappers.getMapper( ToXmlGregCalMapper.class );
+
+    XmlGregorianCalendarFactorizedProperty map(CalendarProperty source);
+
+    XmlGregorianCalendarFactorizedProperty map(DateProperty source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/shared/CustomerRecordDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/shared/CustomerRecordDto.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.shared;
+
+import javax.xml.datatype.XMLGregorianCalendar;
+
+/**
+ * @author Sjaak Derksen
+ */
+public class CustomerRecordDto {
+
+    private XMLGregorianCalendar registrationDate;
+    private CustomerDto customer;
+
+    public XMLGregorianCalendar getRegistrationDate() {
+        return registrationDate;
+    }
+
+    public void setRegistrationDate(XMLGregorianCalendar registrationDate) {
+        this.registrationDate = registrationDate;
+    }
+
+    public CustomerDto getCustomer() {
+        return customer;
+    }
+
+    public void setCustomer(CustomerDto customer) {
+        this.customer = customer;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/shared/CustomerRecordEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/shared/CustomerRecordEntity.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.shared;
+
+import java.util.Date;
+
+/**
+ * @author Sjaak Derksen
+ */
+public class CustomerRecordEntity {
+
+    private Date registrationDate;
+    private CustomerEntity customer;
+
+    public Date getRegistrationDate() {
+        return registrationDate;
+    }
+
+    public void setRegistrationDate(Date registrationDate) {
+        this.registrationDate = registrationDate;
+    }
+
+    public CustomerEntity getCustomer() {
+        return customer;
+    }
+
+    public void setCustomer(CustomerEntity customer) {
+        this.customer = customer;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/constructor/CustomerRecordSpringConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/constructor/CustomerRecordSpringConstructorMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.spring.constructor;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerRecordDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerRecordEntity;
+
+/**
+ * @author Kevin Grüneberg
+ */
+@Mapper(componentModel = "spring",
+    uses = { CustomerSpringConstructorMapper.class, GenderSpringConstructorMapper.class },
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR,
+    disableSubMappingMethodsGeneration = true)
+public interface CustomerRecordSpringConstructorMapper {
+
+    CustomerRecordDto asTarget(CustomerRecordEntity customerRecordEntity);
+}


### PR DESCRIPTION
* Final field is constructor initialised
* VirtualMappingMethod is renamed to SupportingMappingMethod
* Solution is reusable.. Next to SupportingMappingMethod there are SupportingField and SupportingConstructorFragment
* Optimised solution (base class for all to -xmlCalendar builtins).
* Name clashes with object factory with coincidentally the same name avoided
* Extra test added on field duplication and avoiding name conflicts
* Fixed templates
* Fixed constructor based injection.