### PR TITLE
#1384 Put AstModifyingAnnotationProcessor in a separate module for reuse by Lombok and the likes

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -28,6 +28,7 @@
         <org.springframework.version>4.0.3.RELEASE</org.springframework.version>
         <org.eclipse.tycho.compiler-jdt.version>0.26.0</org.eclipse.tycho.compiler-jdt.version>
         <com.puppycrawl.tools.checkstyle.version>7.2</com.puppycrawl.tools.checkstyle.version>
+        <org.aptintegration.tools.ast-modifying-spi.version>1.0.0-SNAPSHOT</org.aptintegration.tools.ast-modifying-spi.version>
         <add.release.arguments />
         <forkCount>1</forkCount>
         <assertj.version>3.7.0</assertj.version>
@@ -256,6 +257,11 @@
                 <groupId>org.apache.maven.shared</groupId>
                 <artifactId>maven-verifier</artifactId>
                 <version>1.5</version>
+            </dependency>
+            <dependency>
+                <groupId>org.aptintegration.tools</groupId>
+                <artifactId>ast-modifying-spi</artifactId>
+                <version>${org.aptintegration.tools.ast-modifying-spi.version}</version>
             </dependency>
 
             <!-- Not directly used but required for dependency convergence -->

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -116,6 +116,12 @@
             <artifactId>joda-time</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Integration with Lombok -->
+        <dependency>
+            <groupId>org.aptintegration.tools</groupId>
+            <artifactId>ast-modifying-spi</artifactId>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -39,6 +39,7 @@ import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
+import org.aptintegration.tools.spi.AstModifyingAnnotationProcessor;
 import org.mapstruct.ap.internal.util.AnnotationProcessingException;
 import org.mapstruct.ap.internal.util.Collections;
 import org.mapstruct.ap.internal.util.Extractor;
@@ -49,7 +50,6 @@ import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.RoundContext;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
-import org.mapstruct.ap.spi.AstModifyingAnnotationProcessor;
 import org.mapstruct.ap.spi.BuilderInfo;
 import org.mapstruct.ap.spi.MoreThanOneBuilderCreationMethodException;
 import org.mapstruct.ap.spi.TypeHierarchyErroneousException;

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/AnnotationProcessorContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/AnnotationProcessorContext.java
@@ -13,8 +13,8 @@ import java.util.ServiceLoader;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 
+import org.aptintegration.tools.spi.AstModifyingAnnotationProcessor;
 import org.mapstruct.ap.spi.AccessorNamingStrategy;
-import org.mapstruct.ap.spi.AstModifyingAnnotationProcessor;
 import org.mapstruct.ap.spi.BuilderProvider;
 import org.mapstruct.ap.spi.DefaultAccessorNamingStrategy;
 import org.mapstruct.ap.spi.DefaultBuilderProvider;
@@ -75,11 +75,21 @@ public class AnnotationProcessorContext {
     private static List<AstModifyingAnnotationProcessor> findAstModifyingAnnotationProcessors() {
         List<AstModifyingAnnotationProcessor> processors = new ArrayList<AstModifyingAnnotationProcessor>();
 
-        ServiceLoader<AstModifyingAnnotationProcessor> loader = ServiceLoader.load(
-                AstModifyingAnnotationProcessor.class, AnnotationProcessorContext.class.getClassLoader()
+        ServiceLoader<AstModifyingAnnotationProcessor> newLoader = ServiceLoader.load(
+            AstModifyingAnnotationProcessor.class, AnnotationProcessorContext.class.getClassLoader()
         );
 
-        for ( Iterator<AstModifyingAnnotationProcessor> it = loader.iterator(); it.hasNext(); ) {
+        for ( Iterator<AstModifyingAnnotationProcessor> it = newLoader.iterator(); it.hasNext(); ) {
+            processors.add( it.next() );
+        }
+
+        ServiceLoader<org.mapstruct.ap.spi.AstModifyingAnnotationProcessor> deprecatedLoader = ServiceLoader.load(
+            org.mapstruct.ap.spi.AstModifyingAnnotationProcessor.class,
+            AnnotationProcessorContext.class.getClassLoader()
+        );
+
+        for ( Iterator<org.mapstruct.ap.spi.AstModifyingAnnotationProcessor> it = deprecatedLoader.iterator();
+              it.hasNext(); ) {
             processors.add( it.next() );
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/RoundContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/RoundContext.java
@@ -10,7 +10,8 @@ import java.util.Set;
 
 import javax.lang.model.type.TypeMirror;
 
-import org.mapstruct.ap.spi.AstModifyingAnnotationProcessor;
+import org.aptintegration.tools.spi.AstModifyingAnnotationProcessor;
+
 
 /**
  * Keeps contextual data in the scope of one annotation processing round.

--- a/processor/src/main/java/org/mapstruct/ap/spi/AstModifyingAnnotationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/AstModifyingAnnotationProcessor.java
@@ -7,32 +7,13 @@ package org.mapstruct.ap.spi;
 
 import javax.lang.model.type.TypeMirror;
 
-import org.mapstruct.util.Experimental;
-
 /**
- * A contract to be implemented by other annotation processors which - against the design philosophy of JSR 269 - alter
- * the types under compilation.
- * <p>
- * This contract will be queried by MapStruct when examining types referenced by mappers to be generated, most notably
- * the source and target types of mapping methods. If at least one AST-modifying processor announces further changes to
- * such type, the generation of the affected mapper(s) will be deferred to a future round in the annnotation processing
- * cycle.
- * <p>
- * Implementations are discovered via the service loader, i.e. a JAR providing an AST-modifying processor needs to
- * declare its implementation in a file {@code META-INF/services/org.mapstruct.ap.spi.AstModifyingAnnotationProcessor}.
- *
- * @author Gunnar Morling
+ *  @deprecated Superseded by {@link org.aptintegration.tools.spi.AstModifyingAnnotationProcessor}
  */
-@Experimental( "This interface may change in future revisions" )
-public interface AstModifyingAnnotationProcessor {
+@Deprecated
+public interface AstModifyingAnnotationProcessor extends org.aptintegration.tools.spi.AstModifyingAnnotationProcessor {
 
-    /**
-     * Whether the specified type has been fully processed by this processor or not (i.e. this processor will amend the
-     * given type's structure after this invocation).
-     *
-     * @param type The type of interest
-     * @return {@code true} if this processor has fully processed the given type (or has no interest in processing this
-     * type altogether), {@code false} otherwise.
-     */
-    boolean isTypeComplete(TypeMirror type);
+    @Override
+    boolean isTypeComplete(TypeMirror var1);
 }
+

--- a/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AccountDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AccountDto.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.aptintegration;
+
+import java.math.BigDecimal;
+
+/**
+ * @author Sjaak Derksen
+ */
+public class AccountDto {
+
+    private BigDecimal amount;
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AccountEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AccountEntity.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.aptintegration;
+
+import java.math.BigDecimal;
+
+/**
+ * @author Sjaak Derksen
+ */
+public class AccountEntity {
+
+    private BigDecimal amount;
+
+    public BigDecimal getAmount() {
+        return amount;
+    }
+
+    public void setAmount(BigDecimal amount) {
+        this.amount = amount;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AccountMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AccountMapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.aptintegration;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Sjaak Derksen
+ */
+@Mapper
+public interface AccountMapper {
+
+    AccountMapper INSTANCE = Mappers.getMapper( AccountMapper.class );
+
+    AccountEntity map(AccountDto dto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AlwaysComplete.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AlwaysComplete.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.aptintegration;
+
+import javax.lang.model.type.TypeMirror;
+
+import org.aptintegration.tools.spi.AstModifyingAnnotationProcessor;
+
+/**
+ * @author Sjaak Derksen
+ */
+public class AlwaysComplete implements AstModifyingAnnotationProcessor {
+
+    @Override
+    public boolean isTypeComplete(TypeMirror var1) {
+        return true;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AlwaysCompleteDeprecated.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AlwaysCompleteDeprecated.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.aptintegration;
+
+import javax.lang.model.type.TypeMirror;
+
+import org.mapstruct.ap.spi.AstModifyingAnnotationProcessor;
+
+/**
+ * @author Sjaak Derksen
+ */
+public class AlwaysCompleteDeprecated implements AstModifyingAnnotationProcessor {
+
+    @Override
+    public boolean isTypeComplete(TypeMirror var1) {
+        return true;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AlwaysIncomplete.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AlwaysIncomplete.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.aptintegration;
+
+import javax.lang.model.type.TypeMirror;
+
+import org.aptintegration.tools.spi.AstModifyingAnnotationProcessor;
+
+
+/**
+ * @author Sjaak Derksen
+ */
+public class AlwaysIncomplete implements AstModifyingAnnotationProcessor {
+
+    @Override
+    public boolean isTypeComplete(TypeMirror var1) {
+        return false;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AlwaysIncompleteDeprecated.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AlwaysIncompleteDeprecated.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.aptintegration;
+
+import javax.lang.model.type.TypeMirror;
+
+import org.mapstruct.ap.spi.AstModifyingAnnotationProcessor;
+
+/**
+ * @author Sjaak Derksen
+ */
+public class AlwaysIncompleteDeprecated implements AstModifyingAnnotationProcessor {
+
+    @Override
+    public boolean isTypeComplete(TypeMirror var1) {
+        return false;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AptIntegrationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/aptintegration/AptIntegrationTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.aptintegration;
+
+import java.math.BigDecimal;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithServiceImplementation;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1384")
+@WithClasses({
+    AccountDto.class,
+    AccountEntity.class,
+    AccountMapper.class
+})
+/**
+ * @author Sjaak Derksen
+ */
+public class AptIntegrationTest {
+
+    @Test
+    public void testWithoutAstModifyingAnnotationProcessorSpi() {
+        testSucces();
+    }
+
+    @Test
+    @WithServiceImplementation(AlwaysComplete.class)
+    public void testAlwaysCompleteSpi() {
+        testSucces();
+    }
+
+    @Test
+    @WithServiceImplementation(AlwaysIncomplete.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.SUCCEEDED,
+        diagnostics = {}
+    )
+    public void testAlwaysIncompleteSpi() {
+    }
+
+    @Test
+    @WithServiceImplementation(AlwaysCompleteDeprecated.class)
+    public void testAlwaysCompleteDeprecatedSpi() {
+        testSucces();
+    }
+
+    @Test
+    @WithServiceImplementation(AlwaysIncompleteDeprecated.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.SUCCEEDED,
+        diagnostics = {}
+    )
+    public void testAlwaysIncompleteDeprecatedSpi() {
+    }
+
+    private void testSucces() {
+        AccountDto dto = new AccountDto();
+        dto.setAmount( new BigDecimal( "15.50" ) );
+
+        AccountEntity entity = AccountMapper.INSTANCE.map( dto );
+
+        assertThat( entity ).isNotNull();
+        assertThat( entity.getAmount() ).isNotNull();
+        assertThat( entity.getAmount() ).isEqualByComparingTo( new BigDecimal( "15.50" ) );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingStatement.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingStatement.java
@@ -137,6 +137,7 @@ abstract class CompilingStatement extends Statement {
         String[] whitelist =
             new String[] {
                 "processor" + File.separator + "target",  // the processor itself,
+                "mapstruct" + File.separator + "astmodifying-spi",
                 "freemarker",
                 "javax.inject",
                 "spring-context",


### PR DESCRIPTION
@filiphr @gunnarmorling ..trying ot isolate the `AstModifyingProcessor` into a separate maven module. Like requested in #1384 

Questions.
1. what kind of dependency scope should I use? Provided / Compile?
2. I only did the `AstModifyingProcessor`.. I reckon the remainder stays in the processor.
3. I'm struggling with the unit test. Do not understand why there's a difference between the annotations which seems to be on the class path directly in contrast to the new `astmodifying-spi'  module, which seems to be there only as maven dependency.. 
4. Is this what you think should be done?