### PR TITLE
#1456, apply source presence tracking recursively

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -563,6 +563,20 @@ public class PropertyMapping extends ModelElement {
                 if ( propertyEntry.getPresenceChecker() != null ) {
                     sourcePresenceChecker = sourceParam.getName()
                         + "." + propertyEntry.getPresenceChecker().getSimpleName() + "()";
+
+                    String variableName = sourceParam.getName() + "."
+                        + propertyEntry.getReadAccessor().getSimpleName() + "()";
+                    for (int i = 1; i < sourceReference.getPropertyEntries().size(); i++) {
+                        PropertyEntry entry = sourceReference.getPropertyEntries().get( i );
+                        if (entry.getPresenceChecker() != null && entry.getReadAccessor() != null) {
+                            sourcePresenceChecker += " && " + variableName + " != null && "
+                                + variableName + "." + entry.getPresenceChecker().getSimpleName() + "()";
+                            variableName = variableName + "." + entry.getReadAccessor().getSimpleName() + "()";
+                        }
+                        else {
+                            break;
+                        }
+                    }
                 }
             }
             return sourcePresenceChecker;

--- a/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/PresenceCheckNestedObjectsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/PresenceCheckNestedObjectsTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.source.presencecheck.spi;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Test for correct handling of source presence checks for nested objects.
+ *
+ * @author Cindy Wang
+ */
+@WithClasses({
+    SoccerTeamMapperNestedObjects.class,
+    SoccerTeamSource.class,
+    GoalKeeper.class,
+    SoccerTeamTargetWithPresenceCheck.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class PresenceCheckNestedObjectsTest {
+
+    @Test
+    public void testNestedWithSourcesAbsentOnNestingLevel() {
+
+        SoccerTeamSource soccerTeamSource = new SoccerTeamSource();
+        GoalKeeper goalKeeper = new GoalKeeper();
+        goalKeeper.setHasName( false );
+        soccerTeamSource.setGoalKeeper( goalKeeper );
+
+        SoccerTeamTargetWithPresenceCheck target = SoccerTeamMapperNestedObjects.INSTANCE.mapNested( soccerTeamSource );
+
+        assertThat( target.getGoalKeeperName() ).isNull();
+        assertFalse( target.hasGoalKeeperName() );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/SoccerTeamMapperNestedObjects.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/SoccerTeamMapperNestedObjects.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.source.presencecheck.spi;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Cindy Wang
+ */
+@Mapper
+public interface SoccerTeamMapperNestedObjects {
+    SoccerTeamMapperNestedObjects INSTANCE = Mappers.getMapper( SoccerTeamMapperNestedObjects.class );
+
+    @Mappings({
+        @Mapping(target = "players", ignore = true),
+        @Mapping(target = "goalKeeperName", source = "goalKeeper.name")
+    })
+    SoccerTeamTargetWithPresenceCheck mapNested( SoccerTeamSource in );
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/SoccerTeamTargetWithPresenceCheck.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/SoccerTeamTargetWithPresenceCheck.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.source.presencecheck.spi;
+
+import java.util.List;
+
+/**
+ * @author Cindy Wang
+ */
+public class SoccerTeamTargetWithPresenceCheck {
+
+    private List<String> players;
+    private String goalKeeperName;
+
+    private boolean hasPlayers = false;
+    private boolean hasGoalKeeperName = false;
+
+    public List<String> getPlayers() {
+        return players;
+    }
+
+    public String getGoalKeeperName() {
+        return goalKeeperName;
+    }
+
+    public void setGoalKeeperName(String goalKeeperName) {
+        this.goalKeeperName = goalKeeperName;
+        hasGoalKeeperName = true;
+    }
+
+    public boolean hasPlayers() {
+        return hasPlayers;
+    }
+
+    public boolean hasGoalKeeperName() {
+        return hasGoalKeeperName;
+    }
+}


### PR DESCRIPTION
When mapping nested objects with source presence tracking enabled, source presence tracking is only enabled for the top level objects. It should be expected that source presence tracking can be applied to all nested levels.