### PR TITLE
#1558 Annotations `ElementType.TYPE_USE` not handled correctly 

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -11,7 +11,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
@@ -46,6 +45,7 @@ import org.mapstruct.ap.internal.util.Extractor;
 import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.JavaStreamConstants;
 import org.mapstruct.ap.internal.util.Message;
+import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.RoundContext;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
@@ -242,8 +242,9 @@ public class TypeFactory {
             else if (componentTypeMirror.getKind().isPrimitive()) {
                 // When the component type is primitive and is annotated with ElementType.TYPE_USE then
                 // the typeMirror#toString returns (@CustomAnnotation :: byte) for the javac compiler
-                name = componentTypeMirror.getKind().name().toLowerCase( Locale.ROOT ) + builder.toString();
+                name = NativeTypes.getName( componentTypeMirror.getKind() ) + builder.toString();
                 packageName = null;
+                // for primitive types only name (e.g. byte, short..) required as qualified name
                 qualifiedName = name;
                 isImported = false;
             }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -242,7 +242,7 @@ public class TypeFactory {
             else if (componentTypeMirror.getKind().isPrimitive()) {
                 // When the component type is primitive and is annotated with ElementType.TYPE_USE then
                 // the typeMirror#toString returns (@CustomAnnotation :: byte) for the javac compiler
-                name = componentTypeMirror.getKind().name().toLowerCase( Locale.ROOT) + builder.toString();
+                name = componentTypeMirror.getKind().name().toLowerCase( Locale.ROOT ) + builder.toString();
                 packageName = null;
                 qualifiedName = name;
                 isImported = false;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -11,6 +11,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
@@ -237,6 +238,14 @@ public class TypeFactory {
                 packageName = elementUtils.getPackageOf( componentTypeElement ).getQualifiedName().toString();
                 qualifiedName = componentTypeElement.getQualifiedName().toString() + arraySuffix;
                 isImported = isImported( name, qualifiedName );
+            }
+            else if (componentTypeMirror.getKind().isPrimitive()) {
+                // When the component type is primitive and is annotated with ElementType.TYPE_USE then
+                // the typeMirror#toString returns (@CustomAnnotation :: byte) for the javac compiler
+                name = componentTypeMirror.getKind().name().toLowerCase( Locale.ROOT) + builder.toString();
+                packageName = null;
+                qualifiedName = name;
+                isImported = false;
             }
             else {
                 name = mirror.toString();

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/NativeTypes.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/NativeTypes.java
@@ -8,11 +8,13 @@ package org.mapstruct.ap.internal.util;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
+import javax.lang.model.type.TypeKind;
 
 /**
  * Provides functionality around the Java primitive data types and their wrapper types. They are considered native.
@@ -24,6 +26,7 @@ public class NativeTypes {
     private static final Map<Class<?>, Class<?>> WRAPPER_TO_PRIMITIVE_TYPES;
     private static final Map<Class<?>, Class<?>> PRIMITIVE_TO_WRAPPER_TYPES;
     private static final Set<Class<?>> NUMBER_TYPES = new HashSet<Class<?>>();
+    private static final Map<TypeKind, String> TYPE_KIND_NAME = new EnumMap<TypeKind, String>( TypeKind.class );
     private static final Map<String, LiteralAnalyzer> ANALYZERS;
 
     private static final Pattern PTRN_HEX = Pattern.compile( "^0[x|X].*" );
@@ -446,6 +449,15 @@ public class NativeTypes {
 
         ANALYZERS = Collections.unmodifiableMap( tmp2 );
 
+        TYPE_KIND_NAME.put( TypeKind.BOOLEAN, "boolean" );
+        TYPE_KIND_NAME.put( TypeKind.BYTE, "byte" );
+        TYPE_KIND_NAME.put( TypeKind.SHORT, "short" );
+        TYPE_KIND_NAME.put( TypeKind.INT, "int" );
+        TYPE_KIND_NAME.put( TypeKind.LONG, "long" );
+        TYPE_KIND_NAME.put( TypeKind.CHAR, "char" );
+        TYPE_KIND_NAME.put( TypeKind.FLOAT, "float" );
+        TYPE_KIND_NAME.put( TypeKind.DOUBLE, "double" );
+
     }
 
     public static Class<?> getWrapperType(Class<?> clazz) {
@@ -492,5 +504,17 @@ public class NativeTypes {
             result = analyzer.getLiteral();
         }
         return result;
+    }
+
+    /**
+     * The name that should be used for the {@code typeKind}.
+     * Should be used in order to get the name of a primitive type
+     *
+     * @param typeKind the type kind
+     *
+     * @return the name that should be used for the {@code typeKind}
+     */
+    public static String getName(TypeKind typeKind) {
+        return TYPE_KIND_NAME.get( typeKind );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Car.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Car.java
@@ -6,7 +6,22 @@
 package org.mapstruct.ap.test.bugs._1558.java8;
 
 public class Car {
-    byte[] data;
+    private boolean[] booleanData;
+    private byte[] data;
+    private short[] shortData;
+    private int[] intData;
+    private long[] longData;
+    private char[] charData;
+    private float[] floatData;
+    private double[] doubleData;
+
+    public boolean[] getBooleanData() {
+        return booleanData;
+    }
+
+    public void setBooleanData(boolean[] booleanData) {
+        this.booleanData = booleanData;
+    }
 
     public byte[] getData() {
         return data;
@@ -14,5 +29,53 @@ public class Car {
 
     public void setData(byte[] data) {
         this.data = data;
+    }
+
+    public short[] getShortData() {
+        return shortData;
+    }
+
+    public void setShortData(short[] shortData) {
+        this.shortData = shortData;
+    }
+
+    public int[] getIntData() {
+        return intData;
+    }
+
+    public void setIntData(int[] intData) {
+        this.intData = intData;
+    }
+
+    public long[] getLongData() {
+        return longData;
+    }
+
+    public void setLongData(long[] longData) {
+        this.longData = longData;
+    }
+
+    public char[] getCharData() {
+        return charData;
+    }
+
+    public void setCharData(char[] charData) {
+        this.charData = charData;
+    }
+
+    public float[] getFloatData() {
+        return floatData;
+    }
+
+    public void setFloatData(float[] floatData) {
+        this.floatData = floatData;
+    }
+
+    public double[] getDoubleData() {
+        return doubleData;
+    }
+
+    public void setDoubleData(double[] doubleData) {
+        this.doubleData = doubleData;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Car.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Car.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1558.java8;
+
+public class Car {
+    byte[] data;
+
+    public byte[] getData() {
+        return data;
+    }
+
+    public void setData(byte[] data) {
+        this.data = data;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Car2.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Car2.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1558.java8;
+
+public class Car2 {
+    private byte[] data;
+
+    @NotNull
+    public byte[] getData() {
+        return data;
+    }
+
+    public void setData(byte[] data) {
+        this.data = data;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Car2.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Car2.java
@@ -6,7 +6,23 @@
 package org.mapstruct.ap.test.bugs._1558.java8;
 
 public class Car2 {
+    private boolean[] booleanData;
     private byte[] data;
+    private short[] shortData;
+    private int[] intData;
+    private long[] longData;
+    private char[] charData;
+    private float[] floatData;
+    private double[] doubleData;
+
+    @NotNull
+    public boolean[] getBooleanData() {
+        return booleanData;
+    }
+
+    public void setBooleanData(boolean[] booleanData) {
+        this.booleanData = booleanData;
+    }
 
     @NotNull
     public byte[] getData() {
@@ -15,5 +31,59 @@ public class Car2 {
 
     public void setData(byte[] data) {
         this.data = data;
+    }
+
+    @NotNull
+    public short[] getShortData() {
+        return shortData;
+    }
+
+    public void setShortData(short[] shortData) {
+        this.shortData = shortData;
+    }
+
+    @NotNull
+    public int[] getIntData() {
+        return intData;
+    }
+
+    public void setIntData(int[] intData) {
+        this.intData = intData;
+    }
+
+    @NotNull
+    public long[] getLongData() {
+        return longData;
+    }
+
+    public void setLongData(long[] longData) {
+        this.longData = longData;
+    }
+
+    @NotNull
+    public char[] getCharData() {
+        return charData;
+    }
+
+    public void setCharData(char[] charData) {
+        this.charData = charData;
+    }
+
+    @NotNull
+    public float[] getFloatData() {
+        return floatData;
+    }
+
+    public void setFloatData(float[] floatData) {
+        this.floatData = floatData;
+    }
+
+    @NotNull
+    public double[] getDoubleData() {
+        return doubleData;
+    }
+
+    public void setDoubleData(double[] doubleData) {
+        this.doubleData = doubleData;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/CarMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/CarMapper.java
@@ -11,7 +11,7 @@ import org.mapstruct.factory.Mappers;
 @Mapper
 public interface CarMapper {
 
-    public static final CarMapper INSTANCE = Mappers.getMapper( CarMapper.class );
+    CarMapper INSTANCE = Mappers.getMapper( CarMapper.class );
 
     Car toCar(Car2 car2);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/CarMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/CarMapper.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1558.java8;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface CarMapper {
+
+    public static final CarMapper INSTANCE = Mappers.getMapper( CarMapper.class );
+
+    Car toCar(Car2 car2);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Issue1558Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Issue1558Test.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1558.java8;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.testutil.runner.Compiler;
+import org.mapstruct.ap.testutil.runner.WithSingleCompiler;
+
+/**
+ * @author Sjaak Derksen
+ */
+@WithClasses({
+    NotNull.class,
+    CarMapper.class,
+    Car.class,
+    Car2.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1558")
+@WithSingleCompiler( Compiler.JDK )
+public class Issue1558Test {
+
+    @Test
+    public void testShouldCompile() {
+        Car2 car = new Car2();
+        Car target = CarMapper.INSTANCE.toCar( car );
+
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Issue1558Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/Issue1558Test.java
@@ -10,8 +10,6 @@ import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
-import org.mapstruct.ap.testutil.runner.Compiler;
-import org.mapstruct.ap.testutil.runner.WithSingleCompiler;
 
 /**
  * @author Sjaak Derksen
@@ -24,7 +22,6 @@ import org.mapstruct.ap.testutil.runner.WithSingleCompiler;
 })
 @RunWith(AnnotationProcessorTestRunner.class)
 @IssueKey("1558")
-@WithSingleCompiler( Compiler.JDK )
 public class Issue1558Test {
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/NotNull.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/NotNull.java
@@ -7,41 +7,16 @@ package org.mapstruct.ap.test.bugs._1558.java8;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
-import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-
 @Target({
     ElementType.METHOD,
-    ElementType.FIELD,
-    ElementType.ANNOTATION_TYPE,
-    ElementType.CONSTRUCTOR,
-    ElementType.PARAMETER,
     ElementType.TYPE_USE
 })
 @Retention(RetentionPolicy.RUNTIME)
-@Repeatable(NotNull.List.class)
 @Documented
 public @interface NotNull {
-
-    String message() default "{javax.validation.constraints.NotNull.message}";
-
-    Class<?>[] groups() default {};
-
-    @Target({
-        ElementType.METHOD,
-        ElementType.FIELD,
-        ElementType.ANNOTATION_TYPE,
-        ElementType.CONSTRUCTOR,
-        ElementType.PARAMETER,
-        ElementType.TYPE_USE
-    })
-    @Retention(RetentionPolicy.RUNTIME)
-    @Documented
-    public @interface List {
-        NotNull[] value();
-    }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/NotNull.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1558/java8/NotNull.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1558.java8;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+@Target({
+    ElementType.METHOD,
+    ElementType.FIELD,
+    ElementType.ANNOTATION_TYPE,
+    ElementType.CONSTRUCTOR,
+    ElementType.PARAMETER,
+    ElementType.TYPE_USE
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Repeatable(NotNull.List.class)
+@Documented
+public @interface NotNull {
+
+    String message() default "{javax.validation.constraints.NotNull.message}";
+
+    Class<?>[] groups() default {};
+
+    @Target({
+        ElementType.METHOD,
+        ElementType.FIELD,
+        ElementType.ANNOTATION_TYPE,
+        ElementType.CONSTRUCTOR,
+        ElementType.PARAMETER,
+        ElementType.TYPE_USE
+    })
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    public @interface List {
+        NotNull[] value();
+    }
+
+}


### PR DESCRIPTION
There's something strange ongoing in JDK (not in Eclipse) when there's an annotation on a method. The return type seems to be influenced by this annotation. A reproducer is added. The reproduce is a java 8 reproducer, but that's probably not necessary. I created a copy of the `@NotNull` locally. That works as well as far is reproducing is concerned.

Feel free to continue on this one and get to the bottom. 

Fixes #1558 