### PR TITLE
Add support for initializing the AccessorNamingStrategy with Elements and Types and use Types for determining fluent setters

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -541,6 +541,14 @@
                         <parameter>
                             <oldVersionPattern>\d+\.\d+\.\d+\.Final</oldVersionPattern>
                             <breakBuildBasedOnSemanticVersioning>true</breakBuildBasedOnSemanticVersioning>
+                            <overrideCompatibilityChangeParameters>
+                                <overrideCompatibilityChangeParameter>
+                                    <compatibilityChange>METHOD_NEW_DEFAULT</compatibilityChange>
+                                    <binaryCompatible>true</binaryCompatible>
+                                    <sourceCompatible>false</sourceCompatible>
+                                    <semanticVersionLevel>MINOR</semanticVersionLevel>
+                                </overrideCompatibilityChangeParameter>
+                            </overrideCompatibilityChangeParameters>
                         </parameter>
                     </configuration>
                 </plugin>

--- a/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
@@ -114,7 +114,10 @@ public class MappingProcessor extends AbstractProcessor {
         super.init( processingEnv );
 
         options = createOptions();
-        annotationProcessorContext = new AnnotationProcessorContext( processingEnv.getElementUtils() );
+        annotationProcessorContext = new AnnotationProcessorContext(
+            processingEnv.getElementUtils(),
+            processingEnv.getTypeUtils()
+        );
     }
 
     private Options createOptions() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/AnnotationProcessorContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/AnnotationProcessorContext.java
@@ -10,7 +10,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
 
-import javax.lang.model.element.TypeElement;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
@@ -19,6 +18,7 @@ import org.mapstruct.ap.spi.AstModifyingAnnotationProcessor;
 import org.mapstruct.ap.spi.BuilderProvider;
 import org.mapstruct.ap.spi.DefaultAccessorNamingStrategy;
 import org.mapstruct.ap.spi.DefaultBuilderProvider;
+import org.mapstruct.ap.spi.FreeBuilderAccessorNamingStrategy;
 import org.mapstruct.ap.spi.ImmutablesAccessorNamingStrategy;
 import org.mapstruct.ap.spi.ImmutablesBuilderProvider;
 import org.mapstruct.ap.spi.MapStructProcessingEnvironment;
@@ -61,14 +61,17 @@ public class AnnotationProcessorContext implements MapStructProcessingEnvironmen
 
         AccessorNamingStrategy defaultAccessorNamingStrategy;
         BuilderProvider defaultBuilderProvider;
-        TypeElement immutableElement = elementUtils.getTypeElement( ImmutablesConstants.IMMUTABLE_FQN );
-        if ( immutableElement == null ) {
-            defaultAccessorNamingStrategy = new DefaultAccessorNamingStrategy();
+        if ( elementUtils.getTypeElement( ImmutablesConstants.IMMUTABLE_FQN ) != null ) {
+            defaultAccessorNamingStrategy = new ImmutablesAccessorNamingStrategy();
+            defaultBuilderProvider = new ImmutablesBuilderProvider();
+        }
+        else if ( elementUtils.getTypeElement( FreeBuilderConstants.FREE_BUILDER_FQN ) != null ) {
+            defaultAccessorNamingStrategy = new FreeBuilderAccessorNamingStrategy();
             defaultBuilderProvider = new DefaultBuilderProvider();
         }
         else {
-            defaultAccessorNamingStrategy = new ImmutablesAccessorNamingStrategy();
-            defaultBuilderProvider = new ImmutablesBuilderProvider();
+            defaultAccessorNamingStrategy = new DefaultAccessorNamingStrategy();
+            defaultBuilderProvider = new DefaultBuilderProvider();
         }
         this.accessorNamingStrategy = Services.get( AccessorNamingStrategy.class, defaultAccessorNamingStrategy );
         this.accessorNamingStrategy.init( this );

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/FreeBuilderConstants.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/FreeBuilderConstants.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.util;
+
+/**
+ * Helper for holding FreeBuilder FQN.
+ *
+ * @author Filip Hrisafov
+ */
+public class FreeBuilderConstants {
+
+    public static final String FREE_BUILDER_FQN = "org.inferred.freebuilder.FreeBuilder";
+
+    private FreeBuilderConstants() {
+
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/spi/AccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/AccessorNamingStrategy.java
@@ -16,6 +16,15 @@ import javax.lang.model.element.ExecutableElement;
 public interface AccessorNamingStrategy {
 
     /**
+     * Initializes the accessor naming strategy with the MapStruct processing environment.
+     *
+     * @param processingEnvironment environment for facilities
+     */
+    default void init(MapStructProcessingEnvironment processingEnvironment) {
+
+    }
+
+    /**
      * Returns the type of the given method.
      *
      * @param method to be analyzed.

--- a/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
@@ -12,8 +12,10 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
 import javax.lang.model.util.SimpleElementVisitor6;
 import javax.lang.model.util.SimpleTypeVisitor6;
+import javax.lang.model.util.Types;
 
 import org.mapstruct.ap.spi.util.IntrospectorUtils;
 
@@ -25,6 +27,15 @@ import org.mapstruct.ap.spi.util.IntrospectorUtils;
 public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
 
     private static final Pattern JAVA_JAVAX_PACKAGE = Pattern.compile( "^javax?\\..*" );
+
+    protected Elements elementUtils;
+    protected Types typeUtils;
+
+    @Override
+    public void init(MapStructProcessingEnvironment processingEnvironment) {
+        this.elementUtils = processingEnvironment.getElementUtils();
+        this.typeUtils = processingEnvironment.getTypeUtils();
+    }
 
     @Override
     public MethodType getMethodType(ExecutableElement method) {
@@ -90,8 +101,7 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
         return method.getParameters().size() == 1 &&
             !JAVA_JAVAX_PACKAGE.matcher( method.getEnclosingElement().asType().toString() ).matches() &&
             !isAdderWithUpperCase4thCharacter( method ) &&
-            //TODO The Types need to be compared with Types#isSameType(TypeMirror, TypeMirror)
-            method.getReturnType().toString().equals( method.getEnclosingElement().asType().toString() );
+            typeUtils.isAssignable( method.getReturnType(), method.getEnclosingElement().asType() );
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/spi/FreeBuilderAccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/FreeBuilderAccessorNamingStrategy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.spi;
+
+import javax.lang.model.element.ExecutableElement;
+
+/**
+ * Accessor naming strategy for FreeBuilder.
+ * FreeBuilder adds a lot of other methods that can be considered as fluent setters. Such as:
+ * <ul>
+ *     <li>{@code from(Target)}</li>
+ *     <li>{@code mapXXX(UnaryOperator)}</li>
+ *     <li>{@code mutateXXX(Consumer)}</li>
+ *     <li>{@code mergeFrom(Target)}</li>
+ *     <li>{@code mergeFrom(Target.Builder)}</li>
+ * </ul>
+ * <p>
+ * When the JavaBean convention is not used with FreeBuilder then the getters are non standard and MapStruct
+ * won't recognize them. Therefore one needs to use the JavaBean convention in which the fluent setters
+ * start with {@code set}.
+ *
+ * @author Filip Hrisafov
+ */
+public class FreeBuilderAccessorNamingStrategy extends DefaultAccessorNamingStrategy {
+
+    @Override
+    protected boolean isFluentSetter(ExecutableElement method) {
+        // When using FreeBuilder one needs to use the JavaBean convention, which means that all setters will start
+        // with set
+        return false;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/spi/MapStructProcessingEnvironment.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/MapStructProcessingEnvironment.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.spi;
+
+import javax.lang.model.util.Elements;
+import javax.lang.model.util.Types;
+
+/**
+ * MapStruct will provide the implementations of its SPIs with on object implementing this interface so they can use
+ * facilities provided by it. It is a subset of {@link javax.annotation.processing.ProcessingEnvironment
+ * ProcessingEnvironment}.
+ *
+ * @author Filip Hrisafov
+ * @see javax.annotation.processing.ProcessingEnvironment
+ */
+public interface MapStructProcessingEnvironment {
+
+    /**
+     * Returns an implementation of some utility methods for
+     * operating on elements
+     *
+     * @return element utilities
+     */
+    Elements getElementUtils();
+
+    /**
+     * Returns an implementation of some utility methods for
+     * operating on types.
+     *
+     * @return type utilities
+     */
+    Types getTypeUtils();
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1566/AbstractBuilder.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1566/AbstractBuilder.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1566;
+
+/**
+ * @author Filip Hrisafov
+ */
+public abstract class AbstractBuilder<T extends AbstractBuilder<T>> {
+    String id;
+
+    @SuppressWarnings("unchecked")
+    public T id(final String id) {
+        this.id = id;
+        return (T) this;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1566/Issue1566Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1566/Issue1566Mapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1566;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue1566Mapper {
+
+    Issue1566Mapper INSTANCE = Mappers.getMapper( Issue1566Mapper.class );
+
+    Target map(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1566/Issue1566Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1566/Issue1566Test.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1566;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses({
+    AbstractBuilder.class,
+    Issue1566Mapper.class,
+    Source.class,
+    Target.class
+})
+@IssueKey("1566")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue1566Test {
+
+    @Test
+    public void genericMapperIsCorrectlyUsed() {
+        Source source = new Source();
+        source.setId( "id-123" );
+        source.setName( "Source" );
+
+        Target target = Issue1566Mapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getId() ).isEqualTo( "id-123" );
+        assertThat( target.getName() ).isEqualTo( "Source" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1566/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1566/Source.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1566;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Source {
+
+    private String id;
+    private String name;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1566/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1566/Target.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1566;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Target {
+
+    private final String id;
+    private final String name;
+
+    private Target(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder extends AbstractBuilder<Builder> {
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Target build() {
+            return new Target( id, name );
+        }
+    }
+}


### PR DESCRIPTION
This fix for this actually depends on #1253. However, I am afraid that we might need to do something more involved like the [`MethodMatcher`](https://github.com/mapstruct/mapstruct/blob/master/processor/src/main/java/org/mapstruct/ap/internal/model/source/MethodMatcher.java). I am not 100% certain whether the `isAssignable` hint added would be enough. Maybe @agudian and @sjaakd can chime in on this as well.

Fixes #1566 
Fixes #1253 