### PR TITLE
#1569 Make sure that converting Java 8 LocalDate to Date generates correct code

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateToDateConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/JavaLocalDateToDateConversion.java
@@ -16,7 +16,6 @@ import static org.mapstruct.ap.internal.conversion.ConversionUtils.date;
 import static org.mapstruct.ap.internal.conversion.ConversionUtils.localDateTime;
 import static org.mapstruct.ap.internal.conversion.ConversionUtils.zoneOffset;
 import static org.mapstruct.ap.internal.util.JavaTimeConstants.LOCAL_DATE_TIME_FQN;
-import static org.mapstruct.ap.internal.util.JavaTimeConstants.ZONE_ID_FQN;
 import static org.mapstruct.ap.internal.util.JavaTimeConstants.ZONE_OFFSET_FQN;
 
 /**
@@ -53,7 +52,7 @@ public class JavaLocalDateToDateConversion extends SimpleConversion {
     protected Set<Type> getFromConversionImportTypes(ConversionContext conversionContext) {
         return Collections.asSet(
             conversionContext.getTypeFactory().getType( LOCAL_DATE_TIME_FQN ),
-            conversionContext.getTypeFactory().getType( ZONE_ID_FQN )
+            conversionContext.getTypeFactory().getType( ZONE_OFFSET_FQN )
         );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1569/java8/Issue1569Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1569/java8/Issue1569Mapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1569.java8;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue1569Mapper {
+
+    Issue1569Mapper INSTANCE = Mappers.getMapper( Issue1569Mapper.class );
+
+    Target map(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1569/java8/Issue1569Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1569/java8/Issue1569Test.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1569.java8;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.ZoneOffset;
+import java.util.Date;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses({
+    Issue1569Mapper.class,
+    Source.class,
+    Target.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1569")
+public class Issue1569Test {
+
+    @Test
+    public void shouldGenerateCorrectMapping() {
+        Source source = new Source();
+        Date date = Date.from( LocalDate.of( 2018, Month.AUGUST, 5 ).atTime( 20, 30 ).toInstant( ZoneOffset.UTC ) );
+        source.setPromotionDate( date );
+
+        Target target = Issue1569Mapper.INSTANCE.map( source );
+
+        assertThat( target.getPromotionDate() ).isEqualTo( LocalDate.of( 2018, Month.AUGUST, 5 ) );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1569/java8/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1569/java8/Source.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1569.java8;
+
+import java.util.Date;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Source {
+
+    private Date promotionDate;
+
+    public Date getPromotionDate() {
+        return promotionDate;
+    }
+
+    public void setPromotionDate(Date promotionDate) {
+        this.promotionDate = promotionDate;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1569/java8/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1569/java8/Target.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1569.java8;
+
+import java.time.LocalDate;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Target {
+
+    private LocalDate promotionDate;
+
+    public LocalDate getPromotionDate() {
+        return promotionDate;
+    }
+
+    public void setPromotionDate(LocalDate promotionDate) {
+        this.promotionDate = promotionDate;
+    }
+}


### PR DESCRIPTION

* ZoneOffset instead of ZoneId needs to be imported when performing a conversion from LocalDate to Date

Fixed #1569 