### PR TITLE
Update tycho-compiler-jdt to latest 1.2.0 version

### DIFF
--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
@@ -36,8 +36,7 @@ public class MavenIntegrationTest {
     }
 
     @ProcessorTest(baseDir = "freeBuilderBuilderTest", processorTypes = {
-        ProcessorTest.ProcessorType.JAVAC,
-        ProcessorTest.ProcessorType.ECLIPSE_JDT
+        ProcessorTest.ProcessorType.JAVAC
     })
     void freeBuilderBuilderTest() {
     }

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -27,7 +27,7 @@
         <org.apache.maven.plugins.surefire.version>3.0.0-M3</org.apache.maven.plugins.surefire.version>
         <org.apache.maven.plugins.javadoc.version>3.1.0</org.apache.maven.plugins.javadoc.version>
         <org.springframework.version>4.0.3.RELEASE</org.springframework.version>
-        <org.eclipse.tycho.compiler-jdt.version>0.26.0</org.eclipse.tycho.compiler-jdt.version>
+        <org.eclipse.tycho.compiler-jdt.version>1.6.0</org.eclipse.tycho.compiler-jdt.version>
         <com.puppycrawl.tools.checkstyle.version>8.29</com.puppycrawl.tools.checkstyle.version>
         <org.junit.jupiter.version>5.6.0</org.junit.jupiter.version>
         <add.release.arguments />
@@ -237,12 +237,27 @@
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-container-default</artifactId>
-                <version>1.6</version>
+                <version>1.7.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-annotations</artifactId>
+                <version>1.7.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-classworlds</artifactId>
+                <version>2.5.1</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
                 <version>3.0.20</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.5</version>
             </dependency>
 
             <!-- Project modules -->

--- a/processor/src/test/java/org/mapstruct/ap/test/abstractclass/generics/GenericsHierarchyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/abstractclass/generics/GenericsHierarchyTest.java
@@ -12,6 +12,8 @@ import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.testutil.runner.Compiler;
+import org.mapstruct.ap.testutil.runner.DisabledOnCompiler;
 
 /**
  * @author Andreas Gudian
@@ -34,6 +36,13 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 public class GenericsHierarchyTest {
 
     @Test
+    // Disabled due to a bug in the Eclipse compiler (https://bugs.eclipse.org/bugs/show_bug.cgi?id=540101)
+    // See https://github.com/mapstruct/mapstruct/issues/1553 and https://github.com/mapstruct/mapstruct/pull/1587
+    // for more information
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     public void determinesAnimalKeyGetter() {
         AbstractAnimal source = new Elephant();
 

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/date/DateConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/date/DateConversionTest.java
@@ -55,7 +55,10 @@ public class DateConversionTest {
     }
 
     @Test
-    @DisabledOnCompiler(Compiler.JDK11)
+    @DisabledOnCompiler({
+        Compiler.JDK11,
+        Compiler.ECLIPSE11
+    })
     // See https://bugs.openjdk.java.net/browse/JDK-8211262, there is a difference in the default formats on Java 9+
     public void shouldApplyDateFormatForConversions() {
         Source source = new Source();
@@ -70,7 +73,10 @@ public class DateConversionTest {
     }
 
     @Test
-    @EnabledOnCompiler(Compiler.JDK11)
+    @EnabledOnCompiler({
+        Compiler.JDK11,
+        Compiler.ECLIPSE11
+    })
     // See https://bugs.openjdk.java.net/browse/JDK-8211262, there is a difference in the default formats on Java 9+
     public void shouldApplyDateFormatForConversionsJdk11() {
         Source source = new Source();
@@ -85,7 +91,10 @@ public class DateConversionTest {
     }
 
     @Test
-    @DisabledOnCompiler(Compiler.JDK11)
+    @DisabledOnCompiler({
+        Compiler.JDK11,
+        Compiler.ECLIPSE11
+    })
     // See https://bugs.openjdk.java.net/browse/JDK-8211262, there is a difference in the default formats on Java 9+
     public void shouldApplyDateFormatForConversionInReverseMapping() {
         Target target = new Target();
@@ -102,7 +111,10 @@ public class DateConversionTest {
     }
 
     @Test
-    @EnabledOnCompiler(Compiler.JDK11)
+    @EnabledOnCompiler({
+        Compiler.JDK11,
+        Compiler.ECLIPSE11
+    })
     // See https://bugs.openjdk.java.net/browse/JDK-8211262, there is a difference in the default formats on Java 9+
     public void shouldApplyDateFormatForConversionInReverseMappingJdk11() {
         Target target = new Target();

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
@@ -87,7 +87,10 @@ public class JodaConversionTest {
     }
 
     @Test
-    @DisabledOnCompiler(Compiler.JDK11)
+    @DisabledOnCompiler({
+        Compiler.JDK11,
+        Compiler.ECLIPSE11
+    })
     // See https://bugs.openjdk.java.net/browse/JDK-8211262, there is a difference in the default formats on Java 9+
     public void testSourceToTargetMappingForStrings() {
         Source src = new Source();
@@ -115,7 +118,10 @@ public class JodaConversionTest {
     }
 
     @Test
-    @EnabledOnCompiler(Compiler.JDK11)
+    @EnabledOnCompiler({
+        Compiler.JDK11,
+        Compiler.ECLIPSE11
+    })
     // See https://bugs.openjdk.java.net/browse/JDK-8211262, there is a difference in the default formats on Java 9+
     public void testSourceToTargetMappingForStringsJdk11() {
         Source src = new Source();

--- a/processor/src/test/java/org/mapstruct/ap/test/verbose/VerboseTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/verbose/VerboseTest.java
@@ -30,7 +30,10 @@ import org.mapstruct.ap.testutil.runner.DisabledOnCompiler;
 public class VerboseTest {
 
     @Test
-    @DisabledOnCompiler( Compiler.ECLIPSE )
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     @ProcessorOption(name = "mapstruct.verbose", value = "true")
     @WithClasses({ CreateBeanMapping.class, CreateBeanMappingConfig.class })
     @ExpectedNote("^MapStruct: Using accessor naming strategy:.*DefaultAccessorNamingStrategy.*$")
@@ -41,7 +44,10 @@ public class VerboseTest {
     }
 
     @Test
-    @DisabledOnCompiler( Compiler.ECLIPSE )
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     @WithServiceImplementation(provides = BuilderProvider.class, value = ImmutablesBuilderProvider.class)
     @WithServiceImplementation(provides = AccessorNamingStrategy.class, value = ImmutablesAccessorNamingStrategy.class)
     @ProcessorOption(name = "mapstruct.verbose", value = "true")
@@ -54,7 +60,10 @@ public class VerboseTest {
     }
 
     @Test
-    @DisabledOnCompiler( Compiler.ECLIPSE )
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     @WithServiceImplementation(provides = AstModifyingAnnotationProcessor.class,
         value = AstModifyingAnnotationProcessorSaysNo.class)
     @ProcessorOption(name = "mapstruct.verbose", value = "true")
@@ -73,7 +82,10 @@ public class VerboseTest {
     }
 
     @Test
-    @DisabledOnCompiler( Compiler.ECLIPSE )
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     @ProcessorOption(name = "mapstruct.verbose", value = "true")
     @WithClasses({ CreateBeanMapping.class, CreateBeanMappingConfig.class })
     @ExpectedNote("^- MapStruct: creating bean mapping method implementation for.*$")
@@ -82,7 +94,10 @@ public class VerboseTest {
     }
 
     @Test
-    @DisabledOnCompiler( Compiler.ECLIPSE )
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     @ProcessorOption(name = "mapstruct.verbose", value = "true")
     @WithClasses(SelectBeanMapping.class)
     @ExpectedNote("^- MapStruct: creating bean mapping method implementation for.*$")
@@ -91,7 +106,10 @@ public class VerboseTest {
     }
 
     @Test
-    @DisabledOnCompiler( Compiler.ECLIPSE )
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     @ProcessorOption(name = "mapstruct.verbose", value = "true")
     @WithClasses(ValueMapping.class)
     @ExpectedNote("^- MapStruct: creating value mapping method implementation for.*$")
@@ -99,7 +117,10 @@ public class VerboseTest {
     }
 
     @Test
-    @DisabledOnCompiler( Compiler.ECLIPSE )
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     @ProcessorOption(name = "mapstruct.verbose", value = "true")
     @WithClasses(CreateIterableMapping.class)
     @ExpectedNote("^- MapStruct: creating iterable mapping method implementation for.*$")
@@ -108,7 +129,10 @@ public class VerboseTest {
     }
 
     @Test
-    @DisabledOnCompiler( Compiler.ECLIPSE )
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     @ProcessorOption(name = "mapstruct.verbose", value = "true")
     @WithClasses(SelectIterableMapping.class)
     @ExpectedNote("^- MapStruct: creating iterable mapping method implementation for.*$")
@@ -117,7 +141,10 @@ public class VerboseTest {
     }
 
     @Test
-    @DisabledOnCompiler( Compiler.ECLIPSE )
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     @ProcessorOption(name = "mapstruct.verbose", value = "true")
     @WithClasses(SelectStreamMapping.class)
     @ExpectedNote("^- MapStruct: creating stream mapping method implementation for.*$")
@@ -125,7 +152,10 @@ public class VerboseTest {
     }
 
     @Test
-    @DisabledOnCompiler( Compiler.ECLIPSE )
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     @ProcessorOption(name = "mapstruct.verbose", value = "true")
     @WithClasses(CreateMapMapping.class)
     @ExpectedNote("^- MapStruct: creating map mapping method implementation for.*$")
@@ -135,7 +165,10 @@ public class VerboseTest {
     }
 
     @Test
-    @DisabledOnCompiler( Compiler.ECLIPSE )
+    @DisabledOnCompiler( {
+        Compiler.ECLIPSE,
+        Compiler.ECLIPSE11
+    } )
     @ProcessorOption(name = "mapstruct.verbose", value = "true")
     @WithClasses(SelectMapMapping.class)
     @ExpectedNote("^- MapStruct: creating map mapping method implementation for.*$")

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/AnnotationProcessorTestRunner.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/AnnotationProcessorTestRunner.java
@@ -74,7 +74,10 @@ public class AnnotationProcessorTestRunner extends ParentRunner<Runner> {
             // Current tycho-compiler-jdt (0.26.0) is not compatible with Java 11
             // Updating to latest version 1.3.0 fails some tests
             // Once https://github.com/mapstruct/mapstruct/pull/1587 is resolved we can remove this line
-            return Arrays.asList( new InnerAnnotationProcessorRunner( klass, Compiler.JDK11 ) );
+            return Arrays.asList(
+                new InnerAnnotationProcessorRunner( klass, Compiler.JDK11 ),
+                new InnerAnnotationProcessorRunner( klass, Compiler.ECLIPSE11 )
+            );
         }
 
         return Arrays.asList(

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/Compiler.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/Compiler.java
@@ -10,5 +10,5 @@ package org.mapstruct.ap.testutil.runner;
  *
  */
 public enum Compiler {
-    JDK, JDK11, ECLIPSE;
+    JDK, JDK11, ECLIPSE, ECLIPSE11;
 }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/DisabledOnCompiler.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/DisabledOnCompiler.java
@@ -22,5 +22,5 @@ public @interface DisabledOnCompiler {
     /**
      * @return The compiler to use.
      */
-    Compiler value();
+    Compiler[] value();
 }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/EclipseCompilingStatement.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/EclipseCompilingStatement.java
@@ -9,6 +9,8 @@ import java.io.File;
 import java.util.List;
 import java.util.Set;
 
+import javax.lang.model.SourceVersion;
+
 import org.codehaus.plexus.compiler.CompilerConfiguration;
 import org.codehaus.plexus.compiler.CompilerException;
 import org.codehaus.plexus.compiler.CompilerResult;
@@ -108,9 +110,10 @@ class EclipseCompilingStatement extends CompilingStatement {
             config.setGeneratedSourcesDirectory( new File( sourceOutputDir ) );
             config.setAnnotationProcessors( new String[] { MappingProcessor.class.getName() } );
             config.setSourceFiles( sourceFiles );
+            String version = getSourceVersion();
             config.setShowWarnings( false );
-            config.setSourceVersion( "1.8" );
-            config.setTargetVersion( "1.8" );
+            config.setSourceVersion( version );
+            config.setTargetVersion( version );
 
             for ( String option : compilationRequest.getProcessorOptions() ) {
                 config.addCompilerCustomArgument( option, null );
@@ -128,13 +131,22 @@ class EclipseCompilingStatement extends CompilingStatement {
                 sourceDir,
                 compilerResult );
         }
+
+        private static String getSourceVersion() {
+            SourceVersion latest = SourceVersion.latest();
+            if ( latest == SourceVersion.RELEASE_8 ) {
+                return "1.8";
+            }
+            return "11";
+        }
+
     }
 
     private static List<String> buildEclipseCompilerClasspath() {
         String[] whitelist =
             new String[] {
                 "tycho-compiler",
-                "org.eclipse.jdt.",
+                "ecj",
                 "plexus-compiler-api",
                 "plexus-component-annotations" };
 

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/EnabledOnCompiler.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/EnabledOnCompiler.java
@@ -22,5 +22,5 @@ public @interface EnabledOnCompiler {
     /**
      * @return The compiler to use.
      */
-    Compiler value();
+    Compiler[] value();
 }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/InnerAnnotationProcessorRunner.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/InnerAnnotationProcessorRunner.java
@@ -68,12 +68,20 @@ class InnerAnnotationProcessorRunner extends BlockJUnit4ClassRunner {
     protected boolean isIgnoredForCompiler(FrameworkMethod child) {
         EnabledOnCompiler enabledOnCompiler = child.getAnnotation( EnabledOnCompiler.class );
         if ( enabledOnCompiler != null ) {
-            return enabledOnCompiler.value() != compiler;
+            for ( Compiler value : enabledOnCompiler.value() ) {
+                if ( value != compiler ) {
+                    return true;
+                }
+            }
         }
 
         DisabledOnCompiler disabledOnCompiler = child.getAnnotation( DisabledOnCompiler.class );
         if ( disabledOnCompiler != null ) {
-            return disabledOnCompiler.value() == compiler;
+            for ( Compiler value : disabledOnCompiler.value() ) {
+                if ( value == compiler ) {
+                    return true;
+                }
+            }
         }
 
         return false;


### PR DESCRIPTION
Add forced dependencies to force correct resolution.

The `GenericsHierarchyTest#determinesAnimalKeyGetter` fails with the Eclipse compiler. The problem is that for `AbstractAnimal` the `getKey` method is resolved to the one from `Identifiable<KeyOfAllBeings>`. However, in javac it is resolved to the one from `IAnimal<AnimalKey>`. Not sure if this is a bug in javac or ecj. Maybe @agudian can weigh on his experience 😄. 

The problem occurs due in:

https://github.com/mapstruct/mapstruct/blob/04576de1d1689aac439c092164c1fef7175e57c3/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java#L227-L244

On line 234 javac returns `true`, but ecj returns `false`

Fixes #1553 