### PR TITLE
#1551 Use javax.annotation.processing.Generated if it is present

### DIFF
--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -283,8 +283,8 @@ If the `@Generated` annotation is not available, MapStruct will detect this situ
 
 [NOTE]
 =====
-In Java 9 `java.annotation.processing.Generated` was added, which is considered as a general purpose annotation for any code generators
-and is part of the `java.compiler` module. Support for it is planned within https://github.com/mapstruct/mapstruct/issues/1551[#1551]
+In Java 9 `java.annotation.processing.Generated` was added (part of the `java.compiler` module),
+if this annotation is available then it will be used.
 =====
 
 [[defining-mapper]]

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -74,12 +74,17 @@ public abstract class GeneratedType extends ModelElement {
         this.versionInformation = versionInformation;
         this.accessibility = accessibility;
 
-        this.generatedTypeAvailable = typeFactory.isTypeAvailable( "javax.annotation.Generated" );
-        if ( generatedTypeAvailable ) {
+        if ( typeFactory.isTypeAvailable( "javax.annotation.Generated" ) ) {
             this.generatedType = typeFactory.getType( "javax.annotation.Generated" );
+            this.generatedTypeAvailable = true;
+        }
+        else if (typeFactory.isTypeAvailable( "javax.annotation.processing.Generated" )) {
+            this.generatedType = typeFactory.getType( "javax.annotation.processing.Generated" );
+            this.generatedTypeAvailable = true;
         }
         else {
             this.generatedType = null;
+            this.generatedTypeAvailable = false;
         }
 
         this.constructor = constructor;


### PR DESCRIPTION
Fixes #1551 

There are no tests because we still don't have tests running on Java 9.  Once #1309 is implemented we should add tests for this.

I tested this with the examples and it works properly.