### PR TITLE
#1551 Use javax.annotation.processing.Generated if it is available

### DIFF
--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -283,8 +283,8 @@ If the `@Generated` annotation is not available, MapStruct will detect this situ
 
 [NOTE]
 =====
-In Java 9 `java.annotation.processing.Generated` was added, which is considered as a general purpose annotation for any code generators
-and is part of the `java.compiler` module. Support for it is planned within https://github.com/mapstruct/mapstruct/issues/1551[#1551]
+In Java 9 `java.annotation.processing.Generated` was added (part of the `java.compiler` module),
+if this annotation is available then it will be used.
 =====
 
 [[defining-mapper]]

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -74,12 +74,18 @@ public abstract class GeneratedType extends ModelElement {
         this.versionInformation = versionInformation;
         this.accessibility = accessibility;
 
-        this.generatedTypeAvailable = typeFactory.isTypeAvailable( "javax.annotation.Generated" );
-        if ( generatedTypeAvailable ) {
+        if ( versionInformation.isSourceVersionAtLeast9() &&
+            typeFactory.isTypeAvailable( "javax.annotation.processing.Generated" ) ) {
+            this.generatedType = typeFactory.getType( "javax.annotation.processing.Generated" );
+            this.generatedTypeAvailable = true;
+        }
+        else if ( typeFactory.isTypeAvailable( "javax.annotation.Generated" ) ) {
             this.generatedType = typeFactory.getType( "javax.annotation.Generated" );
+            this.generatedTypeAvailable = true;
         }
         else {
             this.generatedType = null;
+            this.generatedTypeAvailable = false;
         }
 
         this.constructor = constructor;

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/DefaultVersionInformation.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/DefaultVersionInformation.java
@@ -11,6 +11,7 @@ import java.net.URL;
 import java.util.jar.Manifest;
 
 import javax.annotation.processing.ProcessingEnvironment;
+import javax.lang.model.SourceVersion;
 
 import org.mapstruct.ap.internal.version.VersionInformation;
 
@@ -37,15 +38,19 @@ public class DefaultVersionInformation implements VersionInformation {
     private final String runtimeVersion;
     private final String runtimeVendor;
     private final String compiler;
+    private final boolean sourceVersionAtLeast9;
     private final boolean eclipseJDT;
     private final boolean javac;
 
-    DefaultVersionInformation(String runtimeVersion, String runtimeVendor, String compiler) {
+    DefaultVersionInformation(String runtimeVersion, String runtimeVendor, String compiler,
+        SourceVersion sourceVersion) {
         this.runtimeVersion = runtimeVersion;
         this.runtimeVendor = runtimeVendor;
         this.compiler = compiler;
         this.eclipseJDT = compiler.startsWith( COMPILER_NAME_ECLIPSE_JDT );
         this.javac = compiler.startsWith( COMPILER_NAME_JAVAC );
+        // If the difference between the source version and RELEASE_6 is more that 2 than we are at least on 9
+        this.sourceVersionAtLeast9 = sourceVersion.compareTo( SourceVersion.RELEASE_6 ) > 2;
     }
 
     @Override
@@ -69,6 +74,11 @@ public class DefaultVersionInformation implements VersionInformation {
     }
 
     @Override
+    public boolean isSourceVersionAtLeast9() {
+        return sourceVersionAtLeast9;
+    }
+
+    @Override
     public boolean isEclipseJDTCompiler() {
         return eclipseJDT;
     }
@@ -84,7 +94,12 @@ public class DefaultVersionInformation implements VersionInformation {
 
         String compiler = getCompiler( processingEnv );
 
-        return new DefaultVersionInformation( runtimeVersion, runtimeVendor, compiler );
+        return new DefaultVersionInformation(
+            runtimeVersion,
+            runtimeVendor,
+            compiler,
+            processingEnv.getSourceVersion()
+        );
     }
 
     private static String getCompiler(ProcessingEnvironment processingEnv) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/version/VersionInformation.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/version/VersionInformation.java
@@ -19,6 +19,8 @@ public interface VersionInformation {
 
     String getCompiler();
 
+    boolean isSourceVersionAtLeast9();
+
     boolean isEclipseJDTCompiler();
 
     boolean isJavacCompiler();


### PR DESCRIPTION
The annotation would be used only if the source version is at least RELEASE_9.

Fixes #1551.

There are no tests because we still don't have tests running on Java 9. Once #1309 is implemented we should add tests for this.

I tested this with the examples and it works properly. When Java 10 is used but the source version is lower than 9 then `javax.annotation.Generated` would be used. Otherwise `javax.annotation.processing.Generated` would be used