### PR TITLE
Renames MAPPER field to INSTANCE

### DIFF
--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -583,7 +583,7 @@ public class CustomerDto {
 @Mapper
 public interface CustomerMapper {
 
-    CustomerMapper MAPPER = Mappers.getMapper( CustomerMapper.class );
+    CustomerMapper INSTANCE = Mappers.getMapper( CustomerMapper.class );
 
     @Mapping(source = "customerName", target = "name")
     Customer toCustomer(CustomerDto customerDto);


### PR DESCRIPTION
According to the convention explained in chapter 4.1 the static field declared in the mapper interface should be named INSTANCE.

However, my proposal is to remove this line completely here as this example appears in chapter 3.5. I myself asked my why this mapper instance has to be declared. Same with the `@InheritInverseConfiguration` annotation. You use it here but it has not yet been introduced 
here, so I would revert this to a conventional mapping annotation.