### PR TITLE
Box any primitives before attempting type comparison

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -23,6 +23,7 @@ import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.PrimitiveType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.WildcardType;
@@ -722,11 +723,20 @@ public class Type extends ModelElement implements Comparable<Type> {
                 continue;
             }
             VariableElement arg = executable.getParameters().get( 0 );
-            if ( typeUtils.isSameType( arg.asType(), typeArg ) ) {
+            if ( typeUtils.isSameType( boxed( arg.asType() ), boxed( typeArg ) ) ) {
                 candidateList.add( adder );
             }
         }
         return candidateList;
+    }
+
+    private TypeMirror boxed(TypeMirror possiblePrimitive) {
+        if ( possiblePrimitive.getKind().isPrimitive() ) {
+            return typeUtils.boxedClass( (PrimitiveType) possiblePrimitive ).asType();
+        }
+        else {
+            return possiblePrimitive;
+        }
     }
 
     /**

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1665/Issue1665Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1665/Issue1665Mapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1665;
+
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Arne Seime
+ */
+@Mapper(collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED)
+public interface Issue1665Mapper {
+
+    Issue1665Mapper INSTANCE = Mappers.getMapper( Issue1665Mapper.class );
+
+    Target map(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1665/Issue1665Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1665/Issue1665Test.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1665;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Arne Seime
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1665")
+@WithClasses({
+    Issue1665Mapper.class,
+    Source.class,
+    Target.class,
+})
+public class Issue1665Test {
+
+    @Test
+    public void shouldBoxIntPrimitive() {
+        Source source = new Source();
+        List<Integer> values = new ArrayList<>();
+        values.add( 10 );
+        source.setValue( values );
+
+        Target target = Issue1665Mapper.INSTANCE.map( source );
+
+        assertThat( target.getValue().size() ).isEqualTo( source.getValue().size() );
+        assertThat( target.getValue().get( 0 ) ).isEqualTo( source.getValue().get( 0 ) );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1665/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1665/Source.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1665;
+
+import java.util.List;
+
+/**
+ * @author Arne Seime
+ */
+public class Source {
+
+    private List<Integer> value;
+
+    public List<Integer> getValue() {
+        return value;
+    }
+
+    public void setValue(List<Integer> value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1665/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1665/Target.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1665;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author Arne Seime
+ */
+public class Target {
+
+    private List<Integer> value = new ArrayList<>();
+
+    public void addValue(int v) {
+        value.add( v );
+    }
+
+    public List<Integer> getValue() {
+        return value;
+    }
+}


### PR DESCRIPTION
Possible fix for #1665 . Could be that this problem is more widespread than for the ADDER_PREFERRED  collection style.