### PR TITLE
#1657: Add Mappers.getMapperClass for getting the class of a Mapper

### DIFF
--- a/core/src/test/java/org/mapstruct/factory/MappersTest.java
+++ b/core/src/test/java/org/mapstruct/factory/MappersTest.java
@@ -25,18 +25,37 @@ public class MappersTest {
         assertThat( mapper ).isNotNull();
     }
 
+    @Test
+    public void shouldReturnImplementationClass() {
+
+        Class<? extends Foo> mapperClass = Mappers.getMapperClass( Foo.class );
+        assertThat( mapperClass ).isNotNull();
+        assertThat( mapperClass ).isNotExactlyInstanceOf( Foo.class );
+    }
+
     /**
      * Checks if an implementation of a nested mapper can be found. This is a special case since
      * it is named
      */
     @Test
-    public void findsNestedMapperImpl() throws Exception {
+    public void findsNestedMapperImpl() {
         assertThat( Mappers.getMapper( SomeClass.Foo.class ) ).isNotNull();
         assertThat( Mappers.getMapper( SomeClass.NestedClass.Foo.class ) ).isNotNull();
     }
 
     @Test
+    public void findsNestedMapperImplClass() {
+        assertThat( Mappers.getMapperClass( SomeClass.Foo.class ) ).isNotNull();
+        assertThat( Mappers.getMapperClass( SomeClass.NestedClass.Foo.class ) ).isNotNull();
+    }
+
+    @Test
     public void shouldReturnPackagePrivateImplementationInstance() {
         assertThat( Mappers.getMapper( PackagePrivateMapper.class ) ).isNotNull();
+    }
+
+    @Test
+    public void shouldReturnPackagePrivateImplementationClass() {
+        assertThat( Mappers.getMapperClass( PackagePrivateMapper.class ) ).isNotNull();
     }
 }


### PR DESCRIPTION
Added `Mappers#getMapperClass(Class<?>)`

I am unsure if it's fine to try loading the class with the `ServiceLoader` also in this case