### PR TITLE
#1675 Making mapstruct-processor compileable with OpenJDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,24 @@
 language: java
-jdk:
-  - oraclejdk8
 install: true
 script: mvn clean install -DprocessorIntegrationTest.toolchainsFile=etc/toolchains-travis-jenkins.xml -B -V
 after_success:
   - mvn jacoco:report && bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 
+matrix:
+  include:
+    - jdk: oraclejdk8
+    - jdk: openjdk11
+      # Only run the processor and its dependencies
+      # The integration tests are using the maven toolchain and that is not yet ready for Java 11
+      # There is an issue with the documentation so skip it
+      script: mvn -B -V clean install -pl processor -am
+      # Only run the processor and its dependencies
+      # The integration tests are using the maven toolchain and that is not yet ready for Java EA
+      # There is an issue with the documentation so skip it
+    - jdk: openjdk-ea
+      script: mvn -B -V clean install -pl processor -am
+    allow_failures:
+      - jdk: openjdk-ea
 deploy:
   provider: script
   script: "test ${TRAVIS_TEST_RESULT} -eq 0 && mvn -s etc/travis-settings.xml -DskipTests=true deploy"

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -86,4 +86,21 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>jdk-11-or-newer</id>
+            <activation>
+                <jdk>[11</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <version>2.3.1</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -304,4 +304,20 @@
         </plugins>
     </build>
 
+    <profiles>
+        <profile>
+            <id>jdk-11-or-newer</id>
+            <activation>
+                <jdk>[11</jdk>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <version>2.3.1</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/StaticParseToStringConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/StaticParseToStringConversion.java
@@ -12,9 +12,9 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Collections;
 
 /**
- * Handles conversion between a target type <tt>T</tt> and {@link String},
+ * Handles conversion between a target type {@code T} and {@link String},
  * where {@code T#parse(String)} and {@code T#toString} are inverse operations.
- * The {@link ConversionContext#getTargetType()} is used as the from target type <tt>T</tt>.
+ * The {@link ConversionContext#getTargetType()} is used as the from target type {@code T}.
  */
 public class StaticParseToStringConversion extends SimpleConversion {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/abstractclass/AbstractClassTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/abstractclass/AbstractClassTest.java
@@ -28,7 +28,8 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
     Identifiable.class,
     HasId.class,
     AlsoHasId.class,
-    Measurable.class
+    Measurable.class,
+    Holder.class
 })
 @RunWith(AnnotationProcessorTestRunner.class)
 public class AbstractClassTest {

--- a/processor/src/test/java/org/mapstruct/ap/test/abstractclass/AbstractReferencedMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/abstractclass/AbstractReferencedMapper.java
@@ -5,12 +5,11 @@
  */
 package org.mapstruct.ap.test.abstractclass;
 
-import javax.xml.ws.Holder;
-
 /**
  * @author Andreas Gudian
  */
 public abstract class AbstractReferencedMapper implements ReferencedMapperInterface {
+
     @Override
     public int holderToInt(Holder<String> holder) {
         return 41;

--- a/processor/src/test/java/org/mapstruct/ap/test/abstractclass/Holder.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/abstractclass/Holder.java
@@ -6,9 +6,10 @@
 package org.mapstruct.ap.test.abstractclass;
 
 /**
- * @author Andreas Gudian
+ * @author Gunnar Morling
  */
-public interface ReferencedMapperInterface {
+public class Holder<T> {
 
-    int holderToInt(Holder<String> holder);
+    public Holder(String string) {
+   }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/abstractclass/ReferencedMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/abstractclass/ReferencedMapper.java
@@ -5,12 +5,11 @@
  */
 package org.mapstruct.ap.test.abstractclass;
 
-import javax.xml.ws.Holder;
-
 /**
  * @author Andreas Gudian
  */
 public class ReferencedMapper extends AbstractReferencedMapper {
+
     @Override
     public int holderToInt(Holder<String> holder) {
         return 42;

--- a/processor/src/test/java/org/mapstruct/ap/test/abstractclass/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/abstractclass/Source.java
@@ -7,8 +7,6 @@ package org.mapstruct.ap.test.abstractclass;
 
 import java.util.Calendar;
 
-import javax.xml.ws.Holder;
-
 public class Source extends AbstractDto implements HasId, AlsoHasId {
 
     //CHECKSTYLE:OFF

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1170/AdderTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1170/AdderTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 
+import org.assertj.core.api.ListAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.test.bugs._1170._target.Target;
@@ -44,8 +45,8 @@ public class AdderTest {
         assertThat( target ).isNotNull();
         assertThat( target.getWithoutWildcards() ).containsExactly( 2L );
         assertThat( target.getWildcardInSources() ).containsExactly( 2L );
-        assertThat( target.getWildcardInTargets() ).containsExactly( 2L );
-        assertThat( target.getWildcardInBoths() ).containsExactly( 2L );
+        ( (ListAssert<Long>) assertThat( target.getWildcardInTargets() ) ).containsExactly( 2L );
+        ( (ListAssert<Long>) assertThat( target.getWildcardInBoths() ) ).containsExactly( 2L );
         assertThat( target.getWildcardAdderToSetters() ).containsExactly( 2L );
     }
 
@@ -63,10 +64,9 @@ public class AdderTest {
 
         assertThat( source ).isNotNull();
         assertThat( source.getWithoutWildcards() ).containsExactly( "mouse" );
-        assertThat( source.getWildcardInSources() ).containsExactly( "mouse" );
+        ( (ListAssert<String>) assertThat( source.getWildcardInSources() ) ).containsExactly( "mouse" );
         assertThat( source.getWildcardInTargets() ).containsExactly( "mouse" );
-        assertThat( source.getWildcardInBoths() ).containsExactly( "mouse" );
-        assertThat( source.getWildcardAdderToSetters() ).containsExactly( "mouse" );
+        ( (ListAssert<String>) assertThat( source.getWildcardInBoths() ) ).containsExactly( "mouse" );
+        ( (ListAssert<String>) assertThat( source.getWildcardAdderToSetters() ) ).containsExactly( "mouse" );
     }
-
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableWithBoundedElementTypeTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableWithBoundedElementTypeTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Arrays;
 
+import org.assertj.core.api.IterableAssert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
@@ -42,7 +43,8 @@ public class IterableWithBoundedElementTypeTest {
         source.setValues( Arrays.asList( "42", "47" ) );
         IterableContainer result = MapperWithForgedIterableMapping.INSTANCE.toContainerWithIterable( source );
 
-        assertThat( result.getValues() ).contains( Integer.valueOf( 42 ), Integer.valueOf( 47 ) );
+        ( (IterableAssert<Integer>) assertThat( result.getValues() ) )
+                .contains( Integer.valueOf( 42 ), Integer.valueOf( 47 ) );
     }
 
     @Test
@@ -52,6 +54,7 @@ public class IterableWithBoundedElementTypeTest {
         source.setValues( Arrays.asList( "42", "47" ) );
         IterableContainer result = MapperWithCustomListMapping.INSTANCE.toContainerWithIterable( source );
 
-        assertThat( result.getValues() ).contains( Integer.valueOf( 66 ), Integer.valueOf( 71 ) );
+        ( (IterableAssert<Integer>) assertThat( result.getValues() ) )
+                .contains( Integer.valueOf( 66 ), Integer.valueOf( 71 ) );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/date/DateConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/date/DateConversionTest.java
@@ -22,6 +22,9 @@ import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.testutil.runner.Compiler;
+import org.mapstruct.ap.testutil.runner.DisabledOnCompiler;
+import org.mapstruct.ap.testutil.runner.EnabledOnCompiler;
 
 /**
  * Tests application of format strings for conversions between strings and dates.
@@ -43,6 +46,8 @@ public class DateConversionTest {
     }
 
     @Test
+    @DisabledOnCompiler(Compiler.JDK11)
+    // See https://bugs.openjdk.java.net/browse/JDK-8211262, there is a difference in the default formats on Java 9+
     public void shouldApplyDateFormatForConversions() {
         Source source = new Source();
         source.setDate( new GregorianCalendar( 2013, 6, 6 ).getTime() );
@@ -56,10 +61,42 @@ public class DateConversionTest {
     }
 
     @Test
+    @EnabledOnCompiler(Compiler.JDK11)
+    // See https://bugs.openjdk.java.net/browse/JDK-8211262, there is a difference in the default formats on Java 9+
+    public void shouldApplyDateFormatForConversionsJdk11() {
+        Source source = new Source();
+        source.setDate( new GregorianCalendar( 2013, 6, 6 ).getTime() );
+        source.setAnotherDate( new GregorianCalendar( 2013, 1, 14 ).getTime() );
+
+        Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getDate() ).isEqualTo( "06.07.2013" );
+        assertThat( target.getAnotherDate() ).isEqualTo( "14.02.13, 00:00" );
+    }
+
+    @Test
+    @DisabledOnCompiler(Compiler.JDK11)
+    // See https://bugs.openjdk.java.net/browse/JDK-8211262, there is a difference in the default formats on Java 9+
     public void shouldApplyDateFormatForConversionInReverseMapping() {
         Target target = new Target();
         target.setDate( "06.07.2013" );
         target.setAnotherDate( "14.02.13 8:30" );
+
+        Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getDate() ).isEqualTo( new GregorianCalendar( 2013, 6, 6 ).getTime() );
+        assertThat( source.getAnotherDate() ).isEqualTo( new GregorianCalendar( 2013, 1, 14, 8, 30 ).getTime() );
+    }
+
+    @Test
+    @EnabledOnCompiler(Compiler.JDK11)
+    // See https://bugs.openjdk.java.net/browse/JDK-8211262, there is a difference in the default formats on Java 9+
+    public void shouldApplyDateFormatForConversionInReverseMappingJdk11() {
+        Target target = new Target();
+        target.setDate( "06.07.2013" );
+        target.setAnotherDate( "14.02.13, 8:30" );
 
         Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
 

--- a/processor/src/test/java/org/mapstruct/ap/testutil/assertions/JavaFileAssert.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/assertions/JavaFileAssert.java
@@ -38,6 +38,8 @@ public class JavaFileAssert extends FileAssert {
         "\"\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\+\\d{4}\",";
     private static final String GENERATED_COMMENTS_REGEX = "\\s+comments = \"version: , compiler: .*, environment: " +
         ".*\"";
+    private static final String IMPORT_GENERATED_ANNOTATION_REGEX = "import javax\\.annotation\\.(processing\\.)?" +
+        "Generated;";
 
     private Diff diff = new Diff();
 
@@ -135,7 +137,8 @@ public class JavaFileAssert extends FileAssert {
         else if ( delta.getType() == Delta.TYPE.CHANGE ) {
             List<String> lines = delta.getOriginal().getLines();
             if ( lines.size() == 1 ) {
-                return lines.get( 0 ).matches( GENERATED_DATE_REGEX );
+                return lines.get( 0 ).matches( GENERATED_DATE_REGEX ) ||
+                    lines.get( 0 ).matches( IMPORT_GENERATED_ANNOTATION_REGEX );
             }
             else if ( lines.size() == 2 ) {
                 return lines.get( 0 ).matches( GENERATED_DATE_REGEX ) &&

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/AnnotationProcessorTestRunner.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/AnnotationProcessorTestRunner.java
@@ -37,6 +37,19 @@ import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
  * @author Andreas Gudian
  */
 public class AnnotationProcessorTestRunner extends ParentRunner<Runner> {
+
+    private static final boolean IS_AT_LEAST_JAVA_9 = isIsAtLeastJava9();
+
+    private static boolean isIsAtLeastJava9() {
+        try {
+            Runtime.class.getMethod( "version" );
+            return true;
+        }
+        catch ( NoSuchMethodException e ) {
+            return false;
+        }
+    }
+
     private final List<Runner> runners;
 
     /**
@@ -56,6 +69,12 @@ public class AnnotationProcessorTestRunner extends ParentRunner<Runner> {
 
         if (singleCompiler != null) {
             return Arrays.<Runner> asList( new InnerAnnotationProcessorRunner( klass, singleCompiler.value() ) );
+        }
+        else if ( IS_AT_LEAST_JAVA_9 ) {
+            // Current tycho-compiler-jdt (0.26.0) is not compatible with Java 11
+            // Updating to latest version 1.3.0 fails some tests
+            // Once https://github.com/mapstruct/mapstruct/pull/1587 is resolved we can remove this line
+            return Arrays.asList( new InnerAnnotationProcessorRunner( klass, Compiler.JDK11 ) );
         }
 
         return Arrays.<Runner> asList(

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/Compiler.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/Compiler.java
@@ -10,5 +10,5 @@ package org.mapstruct.ap.testutil.runner;
  *
  */
 public enum Compiler {
-    JDK, ECLIPSE;
+    JDK, JDK11, ECLIPSE;
 }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingStatement.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingStatement.java
@@ -128,6 +128,7 @@ abstract class CompilingStatement extends Statement {
                 "javax.inject",
                 "spring-beans",
                 "spring-context",
+                "jaxb-api",
                 "joda-time" };
 
         return filterBootClassPath( whitelist );

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/DisabledOnCompiler.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/DisabledOnCompiler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil.runner;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This should be used with care.
+ * This is similar to the JUnit 5 DisabledOnJre (once we have JUnit 5 we can replace this one)
+ *
+ * @author Filip Hrisafov
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DisabledOnCompiler {
+    /**
+     * @return The compiler to use.
+     */
+    Compiler value();
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/EnabledOnCompiler.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/EnabledOnCompiler.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil.runner;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * This should be used with care.
+ * This is similar to the JUnit 5 EnabledOnJre (once we have JUnit 5 we can replace this one)
+ *
+ * @author Filip Hrisafov
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface EnabledOnCompiler {
+    /**
+     * @return The compiler to use.
+     */
+    Compiler value();
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/InnerAnnotationProcessorRunner.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/InnerAnnotationProcessorRunner.java
@@ -61,6 +61,25 @@ class InnerAnnotationProcessorRunner extends BlockJUnit4ClassRunner {
     }
 
     @Override
+    protected boolean isIgnored(FrameworkMethod child) {
+        return super.isIgnored( child ) || isIgnoredForCompiler( child );
+    }
+
+    protected boolean isIgnoredForCompiler(FrameworkMethod child) {
+        EnabledOnCompiler enabledOnCompiler = child.getAnnotation( EnabledOnCompiler.class );
+        if ( enabledOnCompiler != null ) {
+            return enabledOnCompiler.value() != compiler;
+        }
+
+        DisabledOnCompiler disabledOnCompiler = child.getAnnotation( DisabledOnCompiler.class );
+        if ( disabledOnCompiler != null ) {
+            return disabledOnCompiler.value() == compiler;
+        }
+
+        return false;
+    }
+
+    @Override
     protected TestClass createTestClass(final Class<?> testClass) {
         replacableTestClass = new ReplacableTestClass( testClass );
         return replacableTestClass;
@@ -97,6 +116,9 @@ class InnerAnnotationProcessorRunner extends BlockJUnit4ClassRunner {
     private CompilingStatement createCompilingStatement(FrameworkMethod method) {
         if ( compiler == Compiler.JDK ) {
             return new JdkCompilingStatement( method, compilationCache );
+        }
+        else if ( compiler == Compiler.JDK11 ) {
+            return new Jdk11CompilingStatement( method, compilationCache );
         }
         else {
             return new EclipseCompilingStatement( method, compilationCache );

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/Jdk11CompilingStatement.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/Jdk11CompilingStatement.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil.runner;
+
+import java.util.List;
+
+import org.junit.runners.model.FrameworkMethod;
+import org.mapstruct.ap.testutil.compilation.model.DiagnosticDescriptor;
+
+/**
+ * Statement that uses the JDK compiler to compile.
+ *
+ * @author Filip Hrisafov
+ */
+class Jdk11CompilingStatement extends JdkCompilingStatement {
+
+    Jdk11CompilingStatement(FrameworkMethod method, CompilationCache compilationCache) {
+        super( method, compilationCache );
+    }
+
+
+    /**
+     * The JDK 11 compiler reports all ERROR diagnostics properly. Also when there are multiple per line.
+     */
+    @Override
+    protected List<DiagnosticDescriptor> filterExpectedDiagnostics(List<DiagnosticDescriptor> expectedDiagnostics) {
+        return expectedDiagnostics;
+    }
+
+    @Override
+    protected String getPathSuffix() {
+        return "_jdk";
+    }
+}


### PR DESCRIPTION
@filiphr This makes _mapstruct-processor_ compile for me with OpenJDK 11. But tests fail as the test runner seems not to find any classes from the JDK (stuff like `Integer` etc.). Have you encountered this, too?

Fixes #1675 