### PR TITLE
Mark some Builder providers as Experimental

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/spi/FreeBuilderAccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/FreeBuilderAccessorNamingStrategy.java
@@ -7,6 +7,8 @@ package org.mapstruct.ap.spi;
 
 import javax.lang.model.element.ExecutableElement;
 
+import org.mapstruct.util.Experimental;
+
 /**
  * Accessor naming strategy for FreeBuilder.
  * FreeBuilder adds a lot of other methods that can be considered as fluent setters. Such as:
@@ -24,6 +26,7 @@ import javax.lang.model.element.ExecutableElement;
  *
  * @author Filip Hrisafov
  */
+@Experimental("The FreeBuilder accessor naming strategy might change in a subsequent release")
 public class FreeBuilderAccessorNamingStrategy extends DefaultAccessorNamingStrategy {
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/spi/ImmutablesAccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/ImmutablesAccessorNamingStrategy.java
@@ -7,6 +7,8 @@ package org.mapstruct.ap.spi;
 
 import javax.lang.model.element.ExecutableElement;
 
+import org.mapstruct.util.Experimental;
+
 /**
  * Accesor naming strategy for Immutables.
  * The generated Immutables also have a from that works as a copy. Our default strategy considers this method
@@ -14,6 +16,7 @@ import javax.lang.model.element.ExecutableElement;
  *
  * @author Filip Hrisafov
  */
+@Experimental("The Immutables accessor naming strategy might change in a subsequent release")
 public class ImmutablesAccessorNamingStrategy extends DefaultAccessorNamingStrategy {
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/spi/ImmutablesBuilderProvider.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/ImmutablesBuilderProvider.java
@@ -13,6 +13,8 @@ import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
 
+import org.mapstruct.util.Experimental;
+
 /**
  * Builder provider for Immutables. A custom provider is needed because Immutables creates an implementation of an
  * interface and that implementation has the builder. This implementation would try to find the type created by
@@ -21,6 +23,7 @@ import javax.lang.model.element.TypeElement;
  *
  * @author Filip Hrisafov
  */
+@Experimental("The Immutables builder provider might change in a subsequent release")
 public class ImmutablesBuilderProvider extends DefaultBuilderProvider {
 
     private static final Pattern JAVA_JAVAX_PACKAGE = Pattern.compile( "^javax?\\..*" );


### PR DESCRIPTION
Mark the Immutables BuilderProvider and AccessorNamingStrategy and the FreeBuilderAccessorNamingStrategy as Experimental.

Was not entirely sure whether we should do this or not.