### PR TITLE
1695 update gradle installation

### DIFF
--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -142,7 +142,7 @@ dependencies {
 ...
 ----
 ====
-Gradle (3.3 and older)
+.Gradle (3.3 and older)
 ====
 [source, groovy, linenums]
 [subs="verbatim,attributes"]

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -115,8 +115,7 @@ It will not work with older versions.
 
 Add the following to your Gradle build file in order to enable MapStruct:
 
-.Gradle configuration
-Gradle (3.4 and later)
+.Gradle configuration (3.4 and later)
 ====
 [source, groovy, linenums]
 [subs="verbatim,attributes"]

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -113,9 +113,10 @@ It will not work with older versions.
 
 === Gradle
 
-Add the following to your Gradle (5.1.1) build file in order to enable MapStruct:
+Add the following to your Gradle build file in order to enable MapStruct:
 
 .Gradle configuration
+Gradle (3.4 and later)
 ====
 [source, groovy, linenums]
 [subs="verbatim,attributes"]
@@ -134,8 +135,35 @@ apply plugin: 'net.ltgt.apt-eclipse'
 dependencies {
     ...
     implementation "org.mapstruct:mapstruct:${mapstructVersion}"
-
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+
+    // If you are using mapstruct in test code
+    testAnnotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+}
+...
+----
+====
+Gradle (3.3 and older)
+====
+[source, groovy, linenums]
+[subs="verbatim,attributes"]
+----
+...
+plugins {
+    ...
+    id 'net.ltgt.apt' version '0.20'
+}
+
+// You can integrate with your IDEs.
+// See more details: https://github.com/tbroyer/gradle-apt-plugin#usage-with-ides
+apply plugin: 'net.ltgt.apt-idea'
+apply plugin: 'net.ltgt.apt-eclipse'
+
+dependencies {
+    ...
+    compile "org.mapstruct:mapstruct:${mapstructVersion}"
+    annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
+
     // If you are using mapstruct in test code
     testAnnotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
 }

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -113,7 +113,7 @@ It will not work with older versions.
 
 === Gradle
 
-Add the following to your Gradle build file in order to enable MapStruct:
+Add the following to your Gradle (5.1.1) build file in order to enable MapStruct:
 
 .Gradle configuration
 ====
@@ -123,7 +123,7 @@ Add the following to your Gradle build file in order to enable MapStruct:
 ...
 plugins {
     ...
-    id 'net.ltgt.apt' version '0.15'
+    id 'net.ltgt.apt' version '0.20'
 }
 
 // You can integrate with your IDEs.
@@ -133,7 +133,7 @@ apply plugin: 'net.ltgt.apt-eclipse'
 
 dependencies {
     ...
-    compile "org.mapstruct:mapstruct:${mapstructVersion}"
+    implementation "org.mapstruct:mapstruct:${mapstructVersion}"
 
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapstructVersion}"
     // If you are using mapstruct in test code


### PR DESCRIPTION
based on the fact that the command "compile" was deprecated in Gradle I was changing that and updating the version of the net.ltgt.apt by the latest

Fixes #1695 