### PR TITLE
#1698 Skip "java.lang.Object" as intermediate result in 2 step mappings

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
@@ -342,6 +342,12 @@ public class MappingResolverImpl implements MappingResolver {
             // sourceMethod or builtIn that fits the signature B to C. Only then there is a match. If we have a match
             // a nested method call can be called. so C = methodY( methodX (A) )
             for ( Method methodYCandidate : methodYCandidates ) {
+                if ( Object.class.getName()
+                    .equals( methodYCandidate.getSourceParameters().get( 0 ).getType().getName() ) ) {
+                    //  java.lang.Object as intermediate result
+                    continue;
+                }
+
                 methodRefY =
                     resolveViaMethod( methodYCandidate.getSourceParameters().get( 0 ).getType(), targetType, true );
 
@@ -381,6 +387,12 @@ public class MappingResolverImpl implements MappingResolver {
             Assignment methodRefY = null;
 
             for ( Method methodYCandidate : methodYCandidates ) {
+                if ( Object.class.getName()
+                    .equals( methodYCandidate.getSourceParameters().get( 0 ).getType().getName() ) ) {
+                    //  java.lang.Object as intermediate result
+                    continue;
+                }
+
                 methodRefY =
                     resolveViaMethod( methodYCandidate.getSourceParameters().get( 0 ).getType(), targetType, true );
 
@@ -420,7 +432,9 @@ public class MappingResolverImpl implements MappingResolver {
 
             // search the other way around
             for ( Method methodXCandidate : methodXCandidates ) {
-                if ( methodXCandidate.getMappingTargetParameter() != null ) {
+                if ( methodXCandidate.isUpdateMethod() ||
+                    Object.class.getName().equals( methodXCandidate.getReturnType().getFullyQualifiedName() ) ) {
+                    // skip update methods || java.lang.Object as intermediate result
                     continue;
                 }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1698/Erroneous1698Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1698/Erroneous1698Mapper.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1698;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Erroneous1698Mapper {
+
+    Erroneous1698Mapper INSTANCE = Mappers.getMapper( Erroneous1698Mapper.class );
+
+    Target map(Source source);
+
+    @Mapping(target = "value", source = "source")
+    Cat mapToCat(String source);
+
+    @Mapping(target = "value", source = "source")
+    Dog mapToDog(String source);
+
+    class Source {
+
+        private String cat;
+        private String dog;
+        private String rabbit;
+
+        public String getCat() {
+            return cat;
+        }
+
+        public void setCat(String cat) {
+            this.cat = cat;
+        }
+
+        public String getDog() {
+            return dog;
+        }
+
+        public void setDog(String dog) {
+            this.dog = dog;
+        }
+
+        public String getRabbit() {
+            return rabbit;
+        }
+
+        public void setRabbit(String rabbit) {
+            this.rabbit = rabbit;
+        }
+    }
+
+    class Target {
+
+        private Cat cat;
+        private Dog dog;
+        private Rabbit rabbit;
+
+        public Cat getCat() {
+            return cat;
+        }
+
+        public void setCat(Cat cat) {
+            this.cat = cat;
+        }
+
+        public Dog getDog() {
+            return dog;
+        }
+
+        public void setDog(Dog dog) {
+            this.dog = dog;
+        }
+
+        public Rabbit getRabbit() {
+            return rabbit;
+        }
+
+        public void setRabbit(Rabbit rabbit) {
+            this.rabbit = rabbit;
+        }
+    }
+
+    class Animal {
+
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    class Cat extends Animal {
+
+    }
+
+    class Dog extends Animal {
+
+    }
+
+    class Rabbit extends Animal {
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1698/Issue1698Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1698/Issue1698Test.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1698;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1698")
+@WithClasses(Erroneous1698Mapper.class)
+public class Issue1698Test {
+
+    @Test
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = Erroneous1698Mapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                messageRegExp = "Can't map property.*")
+        })
+
+    public void testErrorMessage() {
+    }
+}


### PR DESCRIPTION
When mapping A to C via B,  A -> B -> C the 2 step mechanism tries B. Some builtin methods have `java.lang.Object` as intermediate result (user methods might have the same). Most notably: `T map(JAXBElement<T> source)` in which the result `T` is in essence an `java.lang.Object`.

This results in the strange error messages. 
