### PR TITLE
#1435 add import to MapperConfig

### DIFF
--- a/core/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core/src/main/java/org/mapstruct/MapperConfig.java
@@ -45,6 +45,16 @@ public @interface MapperConfig {
     Class<?>[] uses() default { };
 
     /**
+     * Additional types for which an import statement is to be added to the generated mapper implementation class.
+     * This allows to refer to those types from within mapping expressions given via {@link Mapping#expression()},
+     * {@link Mapping#defaultExpression()} or using
+     * their simple name rather than their fully-qualified name.
+     *
+     * @return classes to add in the imports of the generated implementation.
+     */
+    Class<?>[] imports() default { };
+
+    /**
      * How unmapped properties of the source type of a mapping should be
      * reported.
      *

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct.ap.internal.util;
 
+import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -97,7 +98,12 @@ public class MapperConfiguration {
     }
 
     public List<TypeMirror> imports() {
-        return mapperPrism.imports();
+        List<TypeMirror> imports = new ArrayList<>();
+        imports.addAll( mapperPrism.imports() );
+        if ( mapperConfigPrism != null ) {
+            imports.addAll( mapperConfigPrism.imports() );
+        }
+        return imports;
     }
 
     public ReportingPolicyPrism unmappedTargetPolicy(Options options) {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1435/Config.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1435/Config.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1435;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingInheritanceStrategy;
+
+import java.util.Objects;
+
+@MapperConfig(mappingInheritanceStrategy = MappingInheritanceStrategy.AUTO_INHERIT_FROM_CONFIG, imports = Objects.class)
+public interface Config {
+    @Mapping(expression = "java( Objects.equals( source.getName(), \"Rainbow Dash\" ) )", target = "rainbowDash")
+    OutObject map(InObject source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1435/InObject.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1435/InObject.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1435;
+
+public class InObject {
+
+    private final String name;
+
+    public InObject(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1435/Issue1435Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1435/Issue1435Mapper.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1435;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(config = Config.class)
+public interface Issue1435Mapper {
+
+    Issue1435Mapper INSTANCE = Mappers.getMapper( Issue1435Mapper.class );
+
+    OutObject map(InObject source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1435/Issue1435Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1435/Issue1435Test.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1435;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1435")
+@WithClasses({
+    Config.class,
+    Issue1435Mapper.class,
+    InObject.class,
+    OutObject.class,
+})
+public class Issue1435Test {
+    @Test
+    public void mustNotSetListToNull() {
+        InObject source = new InObject( "Rainbow Dash" );
+
+        OutObject result = Issue1435Mapper.INSTANCE.map( source );
+
+        assertThat( result.isRainbowDash() ).isTrue();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1435/OutObject.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1435/OutObject.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1435;
+
+public class OutObject {
+
+    private boolean isRainbowDash;
+
+    public boolean isRainbowDash() {
+        return isRainbowDash;
+    }
+
+    public void setRainbowDash(boolean rainbowDash) {
+        isRainbowDash = rainbowDash;
+    }
+}


### PR DESCRIPTION
It adds import field to @MapperConfig annotation.

Fixes #1435 