### PR TITLE
#1075 initial steps mapping from Map to object

### DIFF
--- a/core/src/main/java/org/mapstruct/AsBean.java
+++ b/core/src/main/java/org/mapstruct/AsBean.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Wraps the source / target object in a bean
+ *
+ * @author Sjaak Derksen
+ */
+@Target( ElementType.PARAMETER )
+@Retention(RetentionPolicy.CLASS)
+public @interface AsBean {
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/gem/GemGenerator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/gem/GemGenerator.java
@@ -9,6 +9,7 @@ import javax.xml.bind.annotation.XmlElementDecl;
 import javax.xml.bind.annotation.XmlElementRef;
 
 import org.mapstruct.AfterMapping;
+import org.mapstruct.AsBean;
 import org.mapstruct.BeanMapping;
 import org.mapstruct.BeforeMapping;
 import org.mapstruct.Builder;
@@ -61,6 +62,7 @@ import org.mapstruct.tools.gem.GemDefinition;
 @GemDefinition(ValueMappings.class)
 @GemDefinition(Context.class)
 @GemDefinition(Builder.class)
+@GemDefinition(AsBean.class)
 
 @GemDefinition(MappingControl.class)
 @GemDefinition(MappingControls.class)

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanToMap.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanToMap.java
@@ -1,0 +1,49 @@
+package org.mapstruct.ap.internal.model;
+
+import java.util.List;
+
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.util.Strings;
+
+public class BeanToMap {
+
+    private final List<MapEntry> mapEntries;
+    private final String className;
+
+
+    public BeanToMap(String className, List<MapEntry> types) {
+        this.className = className;
+        this.mapEntries = types;
+    }
+
+    public String getClassName() {
+        return className;
+    }
+
+    public List<MapEntry> getMapEntries() {
+        return mapEntries;
+    }
+
+    public String capitalize(String in) {
+        return Strings.capitalize( in );
+    }
+
+    public static class MapEntry {
+
+        private final String name;
+        private final Type type;
+
+        public MapEntry(String name, Type type) {
+            this.name = name;
+            this.type = type;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Type getType() {
+            return type;
+        }
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapAsBeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapAsBeanMappingMethod.java
@@ -1,4 +1,12 @@
 package org.mapstruct.ap.internal.model;
 
+import java.util.List;
+
+import org.mapstruct.ap.internal.model.common.Type;
+
 public class MapAsBeanMappingMethod {
+
+    public MapAsBeanMappingMethod( List<Type> targetType) {
+
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapAsBeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapAsBeanMappingMethod.java
@@ -1,0 +1,4 @@
+package org.mapstruct.ap.internal.model;
+
+public class MapAsBeanMappingMethod {
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -212,6 +212,31 @@ public class PropertyMapping extends ModelElement {
         }
 
         public PropertyMapping build() {
+            if ( sourceReference.getParameter().isAsBean() ) {
+                return buildAsBean();
+            }
+            else {
+                return buildStandard();
+            }
+        }
+
+        public PropertyMapping buildAsBean() {
+
+            Assignment assignment = getSourceRHS( sourceReference );
+
+            return new PropertyMapping(
+                targetPropertyName,
+                rightHandSide.getSourceParameterName(),
+                ValueProvider.of( targetReadAccessor ),
+                targetType,
+                assignment,
+                dependsOn,
+                getDefaultValueAssignment( assignment ),
+                targetWriteAccessorType == AccessorType.GETTER
+            );
+        }
+
+        public PropertyMapping buildStandard() {
 
             // handle source
             this.rightHandSide = getSourceRHS( sourceReference );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/SourceReference.java
@@ -7,6 +7,7 @@ package org.mapstruct.ap.internal.model.beanmapping;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -121,16 +122,24 @@ public class SourceReference extends AbstractReference {
             String[] segments = sourceNameTrimmed.split( "\\." );
 
             // start with an invalid source reference
-            SourceReference result = new SourceReference( null, new ArrayList<>(  ), false );
+            SourceReference result = new SourceReference( null, new ArrayList<>(), false );
             if ( method.getSourceParameters().size() > 1 ) {
                 Parameter parameter = fetchMatchingParameterFromFirstSegment( segments );
                 if ( parameter != null ) {
-                    result = buildFromMultipleSourceParameters( segments, parameter );
+                    if ( parameter.isAsBean() ) {
+                    }
+                    else {
+                        result = buildFromMultipleSourceParameters( segments, parameter );
+                    }
                 }
             }
             else {
                 Parameter parameter = method.getSourceParameters().get( 0 );
-                result = buildFromSingleSourceParameters( segments, parameter );
+                if ( parameter.isAsBean() ) {
+                }
+                else {
+                    result = buildFromSingleSourceParameters( segments, parameter );
+                }
             }
             return result;
 
@@ -205,6 +214,33 @@ public class SourceReference extends AbstractReference {
             }
 
             return new SourceReference( parameter, entries, foundEntryMatch );
+        }
+
+        /**
+         * When there is only one source parameters, the first segment name of the property may, or may not match
+         * the parameter name to avoid ambiguity
+         *
+         * consider: {@code Target map( Source1 source1 )}
+         * entries in an @Mapping#source can be "source1.propx" or just "propx" to be valid
+         *
+         * @param segments the segments of @Mapping#source
+         * @param parameter the one and only  parameter
+         * @return the source reference
+         */
+        private SourceReference buildFromAsBean(String[] segments, Parameter parameter) {
+
+            SourceReference result = new SourceReference( null, new ArrayList<>(), false );
+            if ( segments.length == 0 ) {
+                // TODO error cannot directly map from parameter
+            }
+            else if ( segments.length > 1 ) {
+                // TODO error cannot do nested parameter
+            }
+            else {
+                // TODO.. need to fix property entry
+                result = new SourceReference( parameter, new ArrayList<>( Collections.singleton( null ) ), true );
+            }
+            return result;
         }
 
         /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Parameter.java
@@ -12,6 +12,7 @@ import java.util.stream.Collectors;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.VariableElement;
 
+import org.mapstruct.ap.internal.gem.AsBeanGem;
 import org.mapstruct.ap.internal.gem.ContextGem;
 import org.mapstruct.ap.internal.gem.MappingTargetGem;
 import org.mapstruct.ap.internal.gem.TargetTypeGem;
@@ -31,6 +32,7 @@ public class Parameter extends ModelElement {
     private final boolean mappingTarget;
     private final boolean targetType;
     private final boolean mappingContext;
+    private final boolean asBean;
 
     private final boolean varArgs;
 
@@ -42,11 +44,12 @@ public class Parameter extends ModelElement {
         this.mappingTarget = MappingTargetGem.instanceOn( element ) != null;
         this.targetType = TargetTypeGem.instanceOn( element ) != null;
         this.mappingContext = ContextGem.instanceOn( element ) != null;
+        this.asBean = AsBeanGem.instanceOn( element ) != null;
         this.varArgs = varArgs;
     }
 
     private Parameter(String name, Type type, boolean mappingTarget, boolean targetType, boolean mappingContext,
-                      boolean varArgs) {
+                      boolean asBean, boolean varArgs) {
         this.element = null;
         this.name = name;
         this.originalName = name;
@@ -54,11 +57,12 @@ public class Parameter extends ModelElement {
         this.mappingTarget = mappingTarget;
         this.targetType = targetType;
         this.mappingContext = mappingContext;
+        this.asBean = asBean;
         this.varArgs = varArgs;
     }
 
     public Parameter(String name, Type type) {
-        this( name, type, false, false, false, false );
+        this( name, type, false, false, false, false, false );
     }
 
     public Element getElement() {
@@ -86,6 +90,7 @@ public class Parameter extends ModelElement {
         return ( mappingTarget ? "@MappingTarget " : "" )
             + ( targetType ? "@TargetType " : "" )
             + ( mappingContext ? "@Context " : "" )
+            + ( asBean ? "@AsBean " : "" )
             + type.toString() + " " + name;
     }
 
@@ -104,6 +109,10 @@ public class Parameter extends ModelElement {
 
     public boolean isVarArgs() {
         return varArgs;
+    }
+
+    public boolean isAsBean() {
+        return asBean;
     }
 
     @Override
@@ -144,6 +153,7 @@ public class Parameter extends ModelElement {
             "mappingTarget",
             parameterType,
             true,
+            false,
             false,
             false,
             false

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
@@ -238,10 +238,10 @@ public class MappingMethodOptions {
     }
 
     private boolean elementsAreContainedIn( String redefinedName, String inheritedName ) {
-        if ( redefinedName.startsWith( inheritedName ) ) {
+        if ( inheritedName != null && redefinedName.startsWith( inheritedName ) ) {
             // it is possible to redefine an exact matching source name, because the same source can be mapped to
             // multiple targets. It is not possible for target, but caught by the Set and equals methoded in
-            // MappingOptions
+            // MappingOptions. SourceName == null also could hint at redefinition
             if ( redefinedName.length() > inheritedName.length() ) {
                 // redefined.lenght() > inherited.length(), first following character should be separator
                 return '.' == redefinedName.charAt( inheritedName.length() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -65,6 +65,7 @@ public class SourceMethod implements Method {
     private Boolean isIterableMapping;
     private Boolean isMapMapping;
     private Boolean isStreamMapping;
+    private Boolean isMapAsBeanMapping;
     private final boolean hasObjectFactoryAnnotation;
 
     public static class Builder {
@@ -349,6 +350,14 @@ public class SourceMethod implements Method {
                 && getResultType().isMapType();
         }
         return isMapMapping;
+    }
+
+    public boolean isMapAsBeanMapping() {
+        if ( isMapAsBeanMapping != null ) {
+            isMapAsBeanMapping = getSourceParameters().stream().filter( Parameter::isAsBean ).findFirst().isPresent();
+            // TODO return type
+        }
+        return isMapAsBeanMapping;
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
@@ -10,8 +10,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Name;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
@@ -48,6 +51,7 @@ import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Collections;
 import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.Message;
+import org.mapstruct.ap.internal.util.MessageConstants;
 import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.Strings;
 
@@ -260,13 +264,7 @@ public class MappingResolverImpl implements MappingResolver {
             }
 
             if ( hasQualfiers() ) {
-                messager.printMessage(
-                        mappingMethod.getExecutable(),
-                        positionHint,
-                        Message.GENERAL_NO_QUALIFYING_METHOD,
-                        Strings.join( selectionCriteria.getQualifiers(), ", " ),
-                        Strings.join( selectionCriteria.getQualifiedByNames(), ", " )
-                );
+                printQualifierMessage( selectionCriteria );
             }
             else if ( allowMappingMethod() ) {
                 // only forge if we would allow mapping method
@@ -279,6 +277,46 @@ public class MappingResolverImpl implements MappingResolver {
 
         private boolean hasQualfiers() {
             return selectionCriteria != null && selectionCriteria.hasQualfiers();
+        }
+
+        private void printQualifierMessage(SelectionCriteria selectionCriteria ) {
+
+            List<String> annotations = selectionCriteria.getQualifiers().stream()
+                .filter( DeclaredType.class::isInstance )
+                .map( DeclaredType.class::cast )
+                .map( DeclaredType::asElement )
+                .map( Element::getSimpleName )
+                .map( Name::toString )
+                .map( a -> "@" + a )
+                .collect( Collectors.toList() );
+            List<String> names = selectionCriteria.getQualifiedByNames();
+
+            if ( !annotations.isEmpty() && !names.isEmpty() ) {
+                messager.printMessage(
+                    mappingMethod.getExecutable(),
+                    positionHint,
+                    Message.GENERAL_NO_QUALIFYING_METHOD_COMBINED,
+                    Strings.join( names, MessageConstants.AND ),
+                    Strings.join( annotations, MessageConstants.AND )
+                );
+            }
+            else if ( !annotations.isEmpty() ) {
+                messager.printMessage(
+                    mappingMethod.getExecutable(),
+                    positionHint,
+                    Message.GENERAL_NO_QUALIFYING_METHOD_ANNOTATION,
+                    Strings.join( annotations, MessageConstants.AND )
+                );
+            }
+            else  {
+                messager.printMessage(
+                    mappingMethod.getExecutable(),
+                    positionHint,
+                    Message.GENERAL_NO_QUALIFYING_METHOD_NAMED,
+                    Strings.join( names, MessageConstants.AND )
+                );
+            }
+
         }
 
         private boolean allowDirect( Type sourceType, Type targetType ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -7,6 +7,8 @@ package org.mapstruct.ap.internal.util;
 
 import javax.tools.Diagnostic;
 
+import static org.mapstruct.ap.internal.util.MessageConstants.FAQ_QUALIFIER_URL;
+
 /**
  * A message used in warnings/errors raised by the annotation processor.
  *
@@ -119,7 +121,9 @@ public enum Message {
     GENERAL_JODA_NOT_ON_CLASSPATH( "Cannot validate Joda dateformat, no Joda on classpath. Consider adding Joda to the annotation processorpath.", Diagnostic.Kind.WARNING ),
     GENERAL_NOT_ALL_FORGED_CREATED( "Internal Error in creation of Forged Methods, it was expected all Forged Methods to finished with creation, but %s did not" ),
     GENERAL_NO_SUITABLE_CONSTRUCTOR( "%s does not have an accessible constructor." ),
-    GENERAL_NO_QUALIFYING_METHOD( "No qualifying method found for qualifiers: %s and / or qualifying names: %s" ),
+    GENERAL_NO_QUALIFYING_METHOD_ANNOTATION( "Qualifier error. No method found annotated with: [ %s ]. See " + FAQ_QUALIFIER_URL + " for more info." ),
+    GENERAL_NO_QUALIFYING_METHOD_NAMED( "Qualifier error. No method found annotated with @Named#value: [ %s ]. See " + FAQ_QUALIFIER_URL + " for more info." ),
+    GENERAL_NO_QUALIFYING_METHOD_COMBINED( "Qualifier error. No method found annotated with @Named#value: [ %s ], annotated with [ %s ]. See " + FAQ_QUALIFIER_URL + " for more info." ),
 
     BUILDER_MORE_THAN_ONE_BUILDER_CREATION_METHOD( "More than one builder creation method for \"%s\". Found methods: \"%s\". Builder will not be used. Consider implementing a custom BuilderProvider SPI.", Diagnostic.Kind.WARNING ),
     BUILDER_NO_BUILD_METHOD_FOUND("No build method \"%s\" found in \"%s\" for \"%s\". Found methods: \"%s\".", Diagnostic.Kind.ERROR ),
@@ -161,6 +165,7 @@ public enum Message {
     VALUEMAPPING_NON_EXISTING_CONSTANT_FROM_SPI( "Constant %s doesn't exist in enum type %s. Constant was returned from EnumNamingStrategy: %s"),
     VALUEMAPPING_NON_EXISTING_CONSTANT( "Constant %s doesn't exist in enum type %s." );
     // CHECKSTYLE:ON
+
 
     private final String description;
     private final Diagnostic.Kind kind;

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/MessageConstants.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/MessageConstants.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.util;
+
+public final class MessageConstants {
+
+    public static final String AND = " and ";
+    public static final String FAQ_QUALIFIER_URL = "https://mapstruct.org/faq/#qualifier";
+
+    private MessageConstants() {
+    }
+}

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanToMap.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanToMap.ftl
@@ -1,0 +1,27 @@
+<#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.BeanToMap" -->
+private static class ${className} {
+
+    private final Map &lt;String, Object&gt; result;
+
+    private ${className} (Map< &lt;String, Object&gt; result) {
+        this.result = result;
+    }
+
+<#list mapEntries as mapEntry>
+    private void set${capitalize(mapEntry.name)}(<@includeModel object=mapEntry.type/> ${mapEntry.name} ){
+        result.put( "${mapEntry.name}", ${mapEntry.name} );
+    }
+
+    private <@includeModel object=mapEntry.type/> get${capitalize(mapEntry.name)}( ){
+        return (<@includeModel object=mapEntry.type/>) result.get( "${mapEntry.name}" );
+    }
+
+</#list>
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2101/Issue2101Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2101/Issue2101Test.java
@@ -64,4 +64,20 @@ public class Issue2101Test {
         assertThat( target.value3 ).isEqualTo( "test" );
 
     }
+
+    @Test
+    @WithClasses(Issue2102IgnoreAllButMapper.class)
+    public void shouldApplyIgnoreAllButTemplateOfMethod1() {
+
+        Issue2102IgnoreAllButMapper.Source source = new Issue2102IgnoreAllButMapper.Source();
+        source.value1 = "value1";
+        source.value2 = "value2";
+
+        Issue2102IgnoreAllButMapper.Target target = Issue2102IgnoreAllButMapper.INSTANCE.map1( source );
+        assertThat( target.value1 ).isEqualTo( "value1" );
+
+        target = Issue2102IgnoreAllButMapper.INSTANCE.map2( source );
+        assertThat( target.value1 ).isEqualTo( "value2" );
+
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2101/Issue2102IgnoreAllButMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2101/Issue2102IgnoreAllButMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2101;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue2102IgnoreAllButMapper {
+
+    Issue2102IgnoreAllButMapper INSTANCE = Mappers.getMapper( Issue2102IgnoreAllButMapper.class );
+
+    @BeanMapping( ignoreByDefault = true )
+    @Mapping(target = "value1") // but do map value1
+    Target map1(Source source);
+
+    @InheritConfiguration
+    @Mapping(target = "value1", source = "value2" )
+    Target map2(Source source);
+
+    //CHECKSTYLE:OFF
+    class Source {
+        public String value1;
+        public String value2;
+    }
+
+    class Target {
+        public String value1;
+    }
+    //CHECKSTYLE:ON
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/mapasbean/Map2BeanMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mapasbean/Map2BeanMapper.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.mapasbean;
+
+import java.util.Map;
+
+import org.mapstruct.AsBean;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Map2BeanMapper {
+
+    Map2BeanMapper INSTANCE = Mappers.getMapper( Map2BeanMapper.class );
+
+    // manned should be name based (source / target are assumed the same)
+    @Mapping( target = "propulsion", source = "propulsionType")
+    // string should be name based (source / target are assumed the same)
+    RocketDto map(@AsBean Map<String, Object> rocket );
+
+
+    class RocketDto{
+
+        private boolean manned;
+        private Propulsion propulsion;
+        private String fuel;
+
+        public boolean isManned() {
+            return manned;
+        }
+
+        public void setManned(boolean manned) {
+            this.manned = manned;
+        }
+
+        public Propulsion getPropulsion() {
+            return propulsion;
+        }
+
+        public void setPropulsion(Propulsion propulsion) {
+            this.propulsion = propulsion;
+        }
+
+        public String getFuel() {
+            return fuel;
+        }
+
+        public void setFuel(String fuel) {
+            this.fuel = fuel;
+        }
+    }
+
+    class Propulsion { }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/mapasbean/MapAsBeanTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mapasbean/MapAsBeanTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.mapasbean;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses( Map2BeanMapper.class )
+@IssueKey( "1075" )
+@RunWith(AnnotationProcessorTestRunner.class)
+public class MapAsBeanTest {
+
+
+    // TODO.. good name
+    @Test
+    public void test(){
+
+        Map2BeanMapper.Propulsion propulsion = new Map2BeanMapper.Propulsion();
+
+        Map<String, Object> source = new HashMap<>(  );
+        source.put( "manned", Boolean.TRUE );
+        source.put( "propulsion", propulsion );
+        source.put( "fuel", "solid" );
+
+        Map2BeanMapper.RocketDto rocket = Map2BeanMapper.INSTANCE.map( source );
+
+        assertThat( rocket ).isNotNull();
+        assertThat( rocket.isManned() ).isTrue();
+        assertThat( rocket.getPropulsion() ).isEqualTo( propulsion );
+        assertThat( rocket.getFuel() ).isEqualTo( "solid" );
+    }
+
+
+    // TODO.. multiarg, errors, etc.
+}
+
+

--- a/processor/src/test/java/org/mapstruct/ap/test/mapasbean/TemporaryDesiredMap2BeanMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mapasbean/TemporaryDesiredMap2BeanMapper.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.mapasbean;
+
+import java.util.Map;
+
+import org.mapstruct.AsBean;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface TemporaryDesiredMap2BeanMapper {
+
+    TemporaryDesiredMap2BeanMapper INSTANCE = Mappers.getMapper( TemporaryDesiredMap2BeanMapper.class );
+
+    // manned should be name based (source / target are assumed the same)
+    @Mapping( target = "propulsion", source = "propulsionType")
+    // string should be name based (source / target are assumed the same)
+    RocketDto map(@AsBean Map<String, Object> rocket);
+
+    // leads to builtin method (check whether present already) (here default, must be private)
+    default Rocket mapToRocket( Map<String, Object> rocket) {
+        return new Rocket( rocket );
+    }
+
+    // types should be deepestLevelTypes in SourceReferences
+    class RocketDto{
+
+        private boolean manned;
+        private Propulsion propulsion;
+        private String fuel;
+
+        public boolean isManned() {
+            return manned;
+        }
+
+        public void setManned(boolean manned) {
+            this.manned = manned;
+        }
+
+        public Propulsion getPropulsion() {
+            return propulsion;
+        }
+
+        public void setPropulsion(Propulsion propulsion) {
+            this.propulsion = propulsion;
+        }
+
+        public String getFuel() {
+            return fuel;
+        }
+
+        public void setFuel(String fuel) {
+            this.fuel = fuel;
+        }
+    }
+
+    class Propulsion { }
+
+    class Rocket {
+
+        private final Map<String, Object> result;
+
+        public Rocket(Map<String, Object> result) {
+            this.result = result;
+        }
+
+        // name should be camelized target
+        public void setPropulsion(Propulsion propulsion) {
+            // key should be target
+            result.put( "propulsion", propulsion );
+        }
+
+        // name should be camelized target
+        // what about primitive types? Wrap?
+        public void setManned(boolean manned) {
+            // key should be target
+            result.put( "manned", manned );
+        }
+
+        // name should be camelized target
+        public void setFuel(String fuel) {
+            // key should be target
+            result.put( "fuel", fuel );
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/QualifierTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/QualifierTest.java
@@ -103,8 +103,8 @@ public class QualifierTest {
                 kind = Kind.ERROR,
                 line = 28,
                 message =
-                    "No qualifying method found for qualifiers: org.mapstruct.ap.test.selection.qualifier.annotation" +
-                        ".NonQualifierAnnotated and / or qualifying names: "),
+                    "Qualifier error. No method found annotated with: [ @NonQualifierAnnotated ]. " +
+                        "See https://mapstruct.org/faq/#qualifier for more info."),
             @Diagnostic(
                 type = ErroneousMapper.class,
                 kind = Kind.ERROR,

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/ErroneousMessageByAnnotationAndNamedMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/ErroneousMessageByAnnotationAndNamedMapper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.selection.qualifier.errors;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Qualifier;
+
+@Mapper
+public interface ErroneousMessageByAnnotationAndNamedMapper {
+
+    @Mapping(target = "nested", source = "value", qualifiedBy = {
+        SelectMe1.class,
+        SelectMe2.class
+    }, qualifiedByName = { "selectMe1", "selectMe2" })
+    Target map(Source source);
+
+    default Nested map(String in) {
+        return null;
+    }
+
+    // CHECKSTYLE:OFF
+    class Source {
+        public String value;
+    }
+
+    class Target {
+        public Nested nested;
+    }
+
+    class Nested {
+        public String value;
+    }
+    // CHECKSTYLE ON
+
+    @Qualifier
+    @java.lang.annotation.Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.CLASS)
+    public @interface SelectMe1 {
+    }
+
+    @Qualifier
+    @java.lang.annotation.Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.CLASS)
+    public @interface SelectMe2 {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/ErroneousMessageByAnnotationMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/ErroneousMessageByAnnotationMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.selection.qualifier.errors;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Qualifier;
+
+@Mapper
+public interface ErroneousMessageByAnnotationMapper {
+
+    @Mapping(target = "nested", source = "value", qualifiedBy = SelectMe.class)
+    Target map(Source source);
+
+    default Nested map(String in) {
+        return null;
+    }
+
+    // CHECKSTYLE:OFF
+    class Source {
+        public String value;
+    }
+
+    class Target {
+        public Nested nested;
+    }
+
+    class Nested {
+        public String value;
+    }
+    // CHECKSTYLE ON
+
+    @Qualifier
+    @java.lang.annotation.Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.CLASS)
+    public @interface SelectMe {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/ErroneousMessageByNamedMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/ErroneousMessageByNamedMapper.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.selection.qualifier.errors;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Qualifier;
+
+@Mapper
+public interface ErroneousMessageByNamedMapper {
+
+    @Mapping(target = "nested", source = "value", qualifiedByName = "SelectMe")
+    Target map(Source source);
+
+    default Nested map(String in) {
+        return null;
+    }
+
+    // CHECKSTYLE:OFF
+    class Source {
+        public String value;
+    }
+
+    class Target {
+        public Nested nested;
+    }
+
+    class Nested {
+        public String value;
+    }
+    // CHECKSTYLE ON
+
+    @Qualifier
+    @java.lang.annotation.Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.CLASS)
+    public @interface SelectMe {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/QualfierMessageTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/QualfierMessageTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.selection.qualifier.errors;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static javax.tools.Diagnostic.Kind.ERROR;
+
+@IssueKey("2135")
+@RunWith(AnnotationProcessorTestRunner.class)
+public class QualfierMessageTest {
+
+    @Test
+    @WithClasses(ErroneousMessageByAnnotationMapper.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(
+                type = ErroneousMessageByAnnotationMapper.class,
+                kind = ERROR,
+                line = 19,
+                message = "Qualifier error. No method found annotated with: [ @SelectMe ]. " +
+                    "See https://mapstruct.org/faq/#qualifier for more info."),
+            @Diagnostic(
+                type = ErroneousMessageByAnnotationMapper.class,
+                kind = ERROR,
+                line = 19,
+                messageRegExp = "Can't map property.*")
+
+        }
+    )
+    public void testNoQualifyingMethodByAnnotationFound() {
+    }
+
+    @Test
+    @WithClasses(ErroneousMessageByNamedMapper.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(
+                type = ErroneousMessageByNamedMapper.class,
+                kind = ERROR,
+                line = 19,
+                message = "Qualifier error. No method found annotated with @Named#value: [ SelectMe ]. " +
+                    "See https://mapstruct.org/faq/#qualifier for more info."),
+            @Diagnostic(
+                type = ErroneousMessageByNamedMapper.class,
+                kind = ERROR,
+                line = 19,
+                messageRegExp = "Can't map property.*")
+
+        }
+    )
+    public void testNoQualifyingMethodByNamedFound() {
+    }
+
+    @Test
+    @WithClasses(ErroneousMessageByAnnotationAndNamedMapper.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(
+                type = ErroneousMessageByAnnotationAndNamedMapper.class,
+                kind = ERROR,
+                line = 19,
+                message =
+                    "Qualifier error. No method found annotated with @Named#value: [ selectMe1 and selectMe2 ], " +
+                        "annotated with [ @SelectMe1 and @SelectMe2 ]. " +
+                        "See https://mapstruct.org/faq/#qualifier for more info."),
+            @Diagnostic(
+                type = ErroneousMessageByAnnotationAndNamedMapper.class,
+                kind = ERROR,
+                line = 19,
+                messageRegExp = "Can't map property.*")
+
+        }
+    )
+    public void testNoQualifyingMethodByAnnotationAndNamedFound() {
+    }
+}


### PR DESCRIPTION
Outline:
* Make a copy `BeanMappingMethod` including backing template: call it: `BeanMapMappingMethod`
* Select this method on `java.util.Map` to `Bean` and vice versa.
* Start from that point onwards to refactor the method.

Bean to Map, Map to Bean should be a first class citizen (initially we thought about wrapping the bean and using an annotation). The PR below can be scrapped. 

Some findings:
Note 1: Can't do nesting on source side. From a source side perspective we have no clue which types are in a Map
Note 2: Can't handle a map as a parameter (direct mapping)
Note 3: We should not allow Map to Map

TODO
- [x]: refactoring source reference
- []: copy and adapt `BeanMappingMethod`
- []: a lot of unit testing (multiple source parameters, error conditions).
- []: How to handle a special PropertyEntry? We can only determine the Type when we have the target in our hand
- []: error handling