### PR TITLE
#1738: Use typeBound for the return type of the nested property mapping method and for the definition of the properties within the method

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.ftl
@@ -6,7 +6,7 @@
 
 -->
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.NestedPropertyMappingMethod" -->
-<#lt>private <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
+<#lt>private <@includeModel object=returnType.typeBound/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     if ( ${sourceParameter.name} == null ) {
         return ${returnType.null};
     }
@@ -16,7 +16,7 @@
         return ${returnType.null};
     }
     </#if>
-    <@includeModel object=entry.type/> ${entry.name} = <@localVarName index=entry_index/>.${entry.accessorName};
+    <@includeModel object=entry.type.typeBound/> ${entry.name} = <@localVarName index=entry_index/>.${entry.accessorName};
     <#if !entry.presenceCheckerName?? >
     <#if !entry.type.primitive>
     if ( ${entry.name} == null ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1738/Issue1738Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1738/Issue1738Mapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1738;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue1738Mapper {
+
+    Issue1738Mapper INSTANCE = Mappers.getMapper( Issue1738Mapper.class );
+
+    @Mapping(target = "value", source = "nested.value")
+    Target map(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1738/Issue1738Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1738/Issue1738Test.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1738;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1738")
+@WithClasses({
+    Issue1738Mapper.class,
+    Source.class,
+    Target.class
+})
+public class Issue1738Test {
+
+    @Test
+    public void shouldGenerateCorrectSourceNestedMapping() {
+        Source source = new Source();
+        Source.Nested<Number> nested = new Source.Nested<>();
+        source.setNested( nested );
+        nested.setValue( 100L );
+
+        Target target = Issue1738Mapper.INSTANCE.map( source );
+
+        assertThat( target.getValue() ).isEqualTo( 100L );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1738/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1738/Source.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1738;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Source {
+
+    private Nested<? extends Number> nested;
+
+    public Nested<? extends Number> getNested() {
+        return nested;
+    }
+
+    public void setNested(Nested<? extends Number> nested) {
+        this.nested = nested;
+    }
+
+    public static class Nested<T> {
+
+        private T value;
+
+        public T getValue() {
+            return value;
+        }
+
+        public void setValue(T value) {
+            this.value = value;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1738/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1738/Target.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1738;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Target {
+
+    private Number value;
+
+    public Number getValue() {
+        return value;
+    }
+
+    public void setValue(Number value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
Fixes #1738 