### PR TITLE
Make hickory an optional dependency as well

### DIFF
--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -36,10 +36,14 @@
         <!-- Compile-only; Using "provided" scope as there is no such scope in Maven;
         these dependencies are not required at runtime, only for prism generation
         and tests -->
+        <!-- Using optional as well due to IntelliJ picking up the dependency
+         and running the hickory processor in projects using the mapstruct-processor.
+         This happens only when the processor is defined in the maven-compiler annotationProcessorPaths -->
         <dependency>
             <groupId>com.jolira</groupId>
             <artifactId>hickory</artifactId>
             <scope>provided</scope>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
Using optional because IntelliJ is picking up hickory as a transitive
dependency and runs the hickory processor in projects using mapstruct-processor.
This happens only when the processor is defined in the maven-compiler annotationProcessorPaths.
This is related to https://youtrack.jetbrains.com/issue/IDEA-200481.