### PR TITLE
Remove use of prerequisites from parent pom.xml

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -91,10 +91,6 @@
         </mailingList>
     </mailingLists>
 
-    <prerequisites>
-        <maven>3.0.3</maven>
-    </prerequisites>
-
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION

According to https://maven.apache.org/pom.html#Prerequisites, prerequisites are only checked with Maven 2.
The maven-enforcer-plugin could be used for this check. However, Considering that Maven 2 is not really used I think that we don't really need such check in our build
