### PR TITLE
Fix typo and code error in documentation

### DIFF
--- a/documentation/src/main/asciidoc/mapping-streams.asciidoc
+++ b/documentation/src/main/asciidoc/mapping-streams.asciidoc
@@ -41,7 +41,7 @@ public Set<String> integerStreamToStringSet(Stream<Integer> integers) {
         return null;
     }
 
-    return integers.stream().map( integer -> String.valueOf( integer ) )
+    return integers.map( integer -> String.valueOf( integer ) )
         .collect( Collectors.toCollection( HashSet<String>::new ) );
 }
 
@@ -51,7 +51,7 @@ public List<CarDto> carsToCarDtos(Stream<Car> cars) {
         return null;
     }
 
-    return integers.stream().map( car -> carToCarDto( car ) )
+    return cars.map( car -> carToCarDto( car ) )
         .collect( Collectors.toCollection( ArrayList<CarDto>::new ) );
 }
 ----

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -666,7 +666,7 @@ project on GitHub.
 MapStruct also supports mapping of immutable types via builders.
 When performing a mapping MapStruct checks if there is a builder for the type being mapped.
 This is done via the `BuilderProvider` SPI.
-If a Builder exists for a certain type, than that builder will be used for the mappings.
+If a Builder exists for a certain type, then that builder will be used for the mappings.
 
 The default implementation of the `BuilderProvider` assumes the following:
 


### PR DESCRIPTION
fix typo in documentation "Using builders"

fix generated code example in stream mapping