### PR TITLE
[#1457] Stricter matching for lifecycle methods / non-unique parameters

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleMethodResolver.java
@@ -91,7 +91,7 @@ public final class LifecycleMethodResolver {
             MappingBuilderContext ctx, Set<String> existingVariableNames) {
 
         MethodSelectors selectors =
-            new MethodSelectors( ctx.getTypeUtils(), ctx.getElementUtils(), ctx.getTypeFactory() );
+            new MethodSelectors( ctx.getTypeUtils(), ctx.getElementUtils(), ctx.getTypeFactory(), ctx.getMessager() );
 
         Type targetType = method.getResultType();
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ObjectFactoryMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ObjectFactoryMethodResolver.java
@@ -5,11 +5,8 @@
  */
 package org.mapstruct.ap.internal.model;
 
-import static org.mapstruct.ap.internal.util.Collections.first;
-
 import java.util.ArrayList;
 import java.util.List;
-
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 
@@ -25,6 +22,8 @@ import org.mapstruct.ap.internal.model.source.selector.SelectedMethod;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
+
+import static org.mapstruct.ap.internal.util.Collections.first;
 
 /**
  *
@@ -52,7 +51,7 @@ public class ObjectFactoryMethodResolver {
                                                     MappingBuilderContext ctx) {
 
         MethodSelectors selectors =
-            new MethodSelectors( ctx.getTypeUtils(), ctx.getElementUtils(), ctx.getTypeFactory() );
+            new MethodSelectors( ctx.getTypeUtils(), ctx.getElementUtils(), ctx.getTypeFactory(), ctx.getMessager() );
 
         List<SelectedMethod<SourceMethod>> matchingFactoryMethods =
             selectors.getMatchingMethods(

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/MethodSelectors.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/MethodSelectors.java
@@ -8,13 +8,13 @@ package org.mapstruct.ap.internal.model.source.selector;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.model.source.Method;
+import org.mapstruct.ap.internal.util.FormattingMessager;
 
 /**
  * Applies all known {@link MethodSelector}s in order.
@@ -25,10 +25,11 @@ public class MethodSelectors {
 
     private final List<MethodSelector> selectors;
 
-    public MethodSelectors(Types typeUtils, Elements elementUtils, TypeFactory typeFactory) {
+    public MethodSelectors(Types typeUtils, Elements elementUtils, TypeFactory typeFactory,
+                           FormattingMessager messager) {
         selectors = Arrays.asList(
             new MethodFamilySelector(),
-            new TypeSelector( typeFactory ),
+            new TypeSelector( typeFactory, messager ),
             new QualifierSelector( typeUtils, elementUtils ),
             new TargetTypeSelector( typeUtils, elementUtils ),
             new XmlElementDeclSelector( typeUtils ),

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/TypeSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/TypeSelector.java
@@ -6,10 +6,8 @@
 package org.mapstruct.ap.internal.model.source.selector;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.mapstruct.ap.internal.model.common.Parameter;

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
@@ -90,7 +90,7 @@ public class MappingResolverImpl implements MappingResolver {
 
         this.conversions = new Conversions( elementUtils, typeFactory );
         this.builtInMethods = new BuiltInMappingMethods( typeFactory );
-        this.methodSelectors = new MethodSelectors( typeUtils, elementUtils, typeFactory );
+        this.methodSelectors = new MethodSelectors( typeUtils, elementUtils, typeFactory, messager );
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -98,6 +98,8 @@ public enum Message {
     ENUMMAPPING_UNMAPPED_SOURCES( "The following constants from the source enum have no corresponding constant in the target enum and must be be mapped via adding additional mappings: %s." ),
     ENUMMAPPING_DEPRECATED( "Mapping of Enums via @Mapping is going to be removed in future versions of MapStruct. Please use @ValueMapping instead!", Diagnostic.Kind.WARNING ),
 
+    LIFECYCLEMETHOD_AMBIGUOUS_PARAMETERS( "Lifecycle method has multiple matching parameters (e. g. same type), in this case please ensure to name the parameters in the lifecycle and mapping method identical. This lifecycle method will not be used for the mapping method '%s'.", Diagnostic.Kind.WARNING),
+
     DECORATOR_NO_SUBTYPE( "Specified decorator type is no subtype of the annotated mapper type." ),
     DECORATOR_CONSTRUCTOR( "Specified decorator type has no default constructor nor a constructor with a single parameter accepting the decorated mapper type." ),
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/BookMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/BookMapper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1457;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class BookMapper {
+
+    public static final BookMapper INSTANCE = Mappers.getMapper( BookMapper.class );
+
+    public abstract TargetBook mapBook(SourceBook sourceBook, String authorFirstName, String authorLastName);
+
+    @AfterMapping
+    protected void fillAuthor(@MappingTarget TargetBook targetBook, String authorFirstName, String authorLastName) {
+        targetBook.setAuthorFirstName( authorFirstName );
+        targetBook.setAuthorLastName( authorLastName );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/BookMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/BookMapper.java
@@ -7,7 +7,6 @@ package org.mapstruct.ap.test.bugs._1457;
 
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
-import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 import org.mapstruct.factory.Mappers;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/BookMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/BookMapper.java
@@ -8,9 +8,10 @@ package org.mapstruct.ap.test.bugs._1457;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
-@Mapper
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public abstract class BookMapper {
 
     public static final BookMapper INSTANCE = Mappers.getMapper( BookMapper.class );
@@ -21,6 +22,26 @@ public abstract class BookMapper {
     protected void fillAuthor(@MappingTarget TargetBook targetBook, String authorFirstName, String authorLastName) {
         targetBook.setAuthorFirstName( authorFirstName );
         targetBook.setAuthorLastName( authorLastName );
+    }
+
+    @AfterMapping
+    protected void withoutAuthorNames(@MappingTarget TargetBook targetBook) {
+        targetBook.setAfterMappingWithoutAuthorName( true );
+    }
+
+    @AfterMapping
+    protected void withOnlyFirstName(@MappingTarget TargetBook targetBook, String authorFirstName) {
+        targetBook.setAfterMappingWithOnlyFirstName( authorFirstName );
+    }
+
+    @AfterMapping
+    protected void withOnlyLastName(@MappingTarget TargetBook targetBook, String authorLastName) {
+        targetBook.setAfterMappingWithOnlyLastName( authorLastName );
+    }
+
+    @AfterMapping
+    protected void withDifferentVariableName(@MappingTarget TargetBook targetBook, String author) {
+        targetBook.setAfterMappingWithDifferentVariableName( true );
     }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/DifferentOrderingBookMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/DifferentOrderingBookMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1457;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class DifferentOrderingBookMapper {
+
+    public static final DifferentOrderingBookMapper INSTANCE = Mappers.getMapper( DifferentOrderingBookMapper.class );
+
+    public abstract TargetBook mapBook(SourceBook sourceBook, String authorFirstName, String authorLastName);
+
+    @AfterMapping
+    protected void fillAuthor(String authorLastName, String authorFirstName, @MappingTarget TargetBook targetBook) {
+        targetBook.setAuthorLastName( authorLastName );
+        targetBook.setAuthorFirstName( authorFirstName );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/ErroneousBookMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/ErroneousBookMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1457;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class ErroneousBookMapper {
+
+    public static final ErroneousBookMapper INSTANCE = Mappers.getMapper( ErroneousBookMapper.class );
+
+    public abstract TargetBook mapBook(SourceBook sourceBook, String authorFirstName, String authorLastName);
+
+    @AfterMapping
+    protected void fillAuthor(@MappingTarget TargetBook targetBook, String authorFirstN, String authorLastN) {
+        targetBook.setAuthorFirstName( authorFirstN );
+        targetBook.setAuthorLastName( authorLastN );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/ErroneousBookMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/ErroneousBookMapper.java
@@ -8,9 +8,10 @@ package org.mapstruct.ap.test.bugs._1457;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingTarget;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
-@Mapper
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public abstract class ErroneousBookMapper {
 
     public static final ErroneousBookMapper INSTANCE = Mappers.getMapper( ErroneousBookMapper.class );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/Issue1457Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/Issue1457Test.java
@@ -6,7 +6,6 @@
 package org.mapstruct.ap.test.bugs._1457;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
@@ -40,7 +39,6 @@ public class Issue1457Test {
         authorLastName = "Adams";
     }
 
-
     @Test
     @WithClasses({
         BookMapper.class
@@ -48,7 +46,7 @@ public class Issue1457Test {
     public void testMapperWithMatchingParameterNames() {
         TargetBook targetBook = BookMapper.INSTANCE.mapBook( sourceBook, authorFirstName, authorLastName );
 
-        assertTargetBookMatchesSourceBook(targetBook);
+        assertTargetBookMatchesSourceBook( targetBook );
     }
 
     @Test
@@ -56,9 +54,13 @@ public class Issue1457Test {
         DifferentOrderingBookMapper.class
     })
     public void testMapperWithMatchingParameterNamesAndDifferentOrdering() {
-        TargetBook targetBook = DifferentOrderingBookMapper.INSTANCE.mapBook( sourceBook, authorFirstName, authorLastName );
+        TargetBook targetBook = DifferentOrderingBookMapper.INSTANCE.mapBook(
+            sourceBook,
+            authorFirstName,
+            authorLastName
+        );
 
-        assertTargetBookMatchesSourceBook(targetBook);
+        assertTargetBookMatchesSourceBook( targetBook );
     }
 
     private void assertTargetBookMatchesSourceBook(TargetBook targetBook) {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/Issue1457Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/Issue1457Test.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1457;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses({
+    SourceBook.class,
+    TargetBook.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("1457")
+public class Issue1457Test {
+
+    private SourceBook sourceBook;
+    private String authorFirstName;
+    private String authorLastName;
+
+    @Before
+    public void setup() {
+        sourceBook = new SourceBook();
+        sourceBook.setIsbn( "3453146972" );
+        sourceBook.setTitle( "Per Anhalter durch die Galaxis" );
+
+        authorFirstName = "Douglas";
+        authorLastName = "Adams";
+    }
+
+
+    @Test
+    @WithClasses({
+        BookMapper.class
+    })
+    public void testMapperWithMatchingParameterNames() {
+        TargetBook targetBook = BookMapper.INSTANCE.mapBook( sourceBook, authorFirstName, authorLastName );
+
+        assertTargetBookMatchesSourceBook(targetBook);
+    }
+
+    @Test
+    @WithClasses({
+        DifferentOrderingBookMapper.class
+    })
+    public void testMapperWithMatchingParameterNamesAndDifferentOrdering() {
+        TargetBook targetBook = DifferentOrderingBookMapper.INSTANCE.mapBook( sourceBook, authorFirstName, authorLastName );
+
+        assertTargetBookMatchesSourceBook(targetBook);
+    }
+
+    private void assertTargetBookMatchesSourceBook(TargetBook targetBook) {
+        assertThat( sourceBook.getIsbn() ).isEqualTo( targetBook.getIsbn() );
+        assertThat( sourceBook.getTitle() ).isEqualTo( targetBook.getTitle() );
+        assertThat( authorFirstName ).isEqualTo( targetBook.getAuthorFirstName() );
+        assertThat( authorLastName ).isEqualTo( targetBook.getAuthorLastName() );
+    }
+
+    @Test
+    @WithClasses({
+        ErroneousBookMapper.class
+    })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.SUCCEEDED,
+        diagnostics = @Diagnostic(
+            messageRegExp =
+                "Lifecycle method has multiple matching parameters \\(e\\. g\\. same type\\), in this case " +
+                    "please ensure to name the parameters in the lifecycle and mapping method identical\\. This " +
+                    "lifecycle method will not be used for the mapping method '.*\\.TargetBook mapBook\\(" +
+                    ".*\\.SourceBook sourceBook, .*\\.String authorFirstName, .*\\.String authorLastName\\)'\\.",
+            kind = javax.tools.Diagnostic.Kind.WARNING,
+            line = 21
+        )
+    )
+    public void testMapperWithoutMatchingParameterNames() {
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/Issue1457Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/Issue1457Test.java
@@ -43,10 +43,27 @@ public class Issue1457Test {
     @WithClasses({
         BookMapper.class
     })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.SUCCEEDED,
+        diagnostics = @Diagnostic(
+            messageRegExp =
+                "Lifecycle method has multiple matching parameters \\(e\\. g\\. same type\\), in this case " +
+                    "please ensure to name the parameters in the lifecycle and mapping method identical\\. This " +
+                    "lifecycle method will not be used for the mapping method '.*\\.TargetBook mapBook\\(" +
+                    ".*\\.SourceBook sourceBook, .*\\.String authorFirstName, .*\\.String authorLastName\\)'\\.",
+            kind = javax.tools.Diagnostic.Kind.WARNING,
+            line = 43
+        )
+    )
     public void testMapperWithMatchingParameterNames() {
         TargetBook targetBook = BookMapper.INSTANCE.mapBook( sourceBook, authorFirstName, authorLastName );
 
         assertTargetBookMatchesSourceBook( targetBook );
+
+        assertThat( targetBook.isAfterMappingWithoutAuthorName() ).isTrue();
+        assertThat( targetBook.getAfterMappingWithOnlyFirstName() ).isEqualTo( authorFirstName );
+        assertThat( targetBook.getAfterMappingWithOnlyLastName() ).isEqualTo( authorLastName );
+        assertThat( targetBook.isAfterMappingWithDifferentVariableName() ).isFalse();
     }
 
     @Test
@@ -55,6 +72,20 @@ public class Issue1457Test {
     })
     public void testMapperWithMatchingParameterNamesAndDifferentOrdering() {
         TargetBook targetBook = DifferentOrderingBookMapper.INSTANCE.mapBook(
+            sourceBook,
+            authorFirstName,
+            authorLastName
+        );
+
+        assertTargetBookMatchesSourceBook( targetBook );
+    }
+
+    @Test
+    @WithClasses({
+        ObjectFactoryBookMapper.class
+    })
+    public void testMapperWithObjectFactory() {
+        TargetBook targetBook = ObjectFactoryBookMapper.INSTANCE.mapBook(
             sourceBook,
             authorFirstName,
             authorLastName
@@ -83,7 +114,7 @@ public class Issue1457Test {
                     "lifecycle method will not be used for the mapping method '.*\\.TargetBook mapBook\\(" +
                     ".*\\.SourceBook sourceBook, .*\\.String authorFirstName, .*\\.String authorLastName\\)'\\.",
             kind = javax.tools.Diagnostic.Kind.WARNING,
-            line = 21
+            line = 22
         )
     )
     public void testMapperWithoutMatchingParameterNames() {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/ObjectFactoryBookMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/ObjectFactoryBookMapper.java
@@ -5,23 +5,25 @@
  */
 package org.mapstruct.ap.test.bugs._1457;
 
-import org.mapstruct.AfterMapping;
 import org.mapstruct.Mapper;
-import org.mapstruct.MappingTarget;
+import org.mapstruct.ObjectFactory;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 @Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public abstract class DifferentOrderingBookMapper {
+public abstract class ObjectFactoryBookMapper {
 
-    public static final DifferentOrderingBookMapper INSTANCE = Mappers.getMapper( DifferentOrderingBookMapper.class );
+    public static final ObjectFactoryBookMapper INSTANCE = Mappers.getMapper( ObjectFactoryBookMapper.class );
 
     public abstract TargetBook mapBook(SourceBook sourceBook, String authorFirstName, String authorLastName);
 
-    @AfterMapping
-    protected void fillAuthor(String authorLastName, String authorFirstName, @MappingTarget TargetBook targetBook) {
-        targetBook.setAuthorLastName( authorLastName );
+    @ObjectFactory
+    protected TargetBook createTargetBook(String authorFirstName, String authorLastName) {
+        TargetBook targetBook = new TargetBook();
         targetBook.setAuthorFirstName( authorFirstName );
+        targetBook.setAuthorLastName( authorLastName );
+
+        return targetBook;
     }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/SourceBook.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/SourceBook.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1457;
+
+public class SourceBook {
+    private String isbn;
+    private String title;
+
+    public String getIsbn() {
+        return isbn;
+    }
+
+    public void setIsbn(String isbn) {
+        this.isbn = isbn;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/TargetBook.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/TargetBook.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1457;
+
+public class TargetBook {
+
+    private String isbn;
+    private String title;
+    private String authorFirstName;
+    private String authorLastName;
+
+    public String getIsbn() {
+        return isbn;
+    }
+
+    public void setIsbn(String isbn) {
+        this.isbn = isbn;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public String getAuthorFirstName() {
+        return authorFirstName;
+    }
+
+    public void setAuthorFirstName(String authorFirstName) {
+        this.authorFirstName = authorFirstName;
+    }
+
+    public String getAuthorLastName() {
+        return authorLastName;
+    }
+
+    public void setAuthorLastName(String authorLastName) {
+        this.authorLastName = authorLastName;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/TargetBook.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1457/TargetBook.java
@@ -12,6 +12,11 @@ public class TargetBook {
     private String authorFirstName;
     private String authorLastName;
 
+    private boolean afterMappingWithoutAuthorName;
+    private String afterMappingWithOnlyFirstName;
+    private String afterMappingWithOnlyLastName;
+    private boolean afterMappingWithDifferentVariableName;
+
     public String getIsbn() {
         return isbn;
     }
@@ -42,5 +47,37 @@ public class TargetBook {
 
     public void setAuthorLastName(String authorLastName) {
         this.authorLastName = authorLastName;
+    }
+
+    public boolean isAfterMappingWithoutAuthorName() {
+        return afterMappingWithoutAuthorName;
+    }
+
+    public void setAfterMappingWithoutAuthorName(boolean afterMappingWithoutAuthorName) {
+        this.afterMappingWithoutAuthorName = afterMappingWithoutAuthorName;
+    }
+
+    public String getAfterMappingWithOnlyFirstName() {
+        return afterMappingWithOnlyFirstName;
+    }
+
+    public void setAfterMappingWithOnlyFirstName(String afterMappingWithOnlyFirstName) {
+        this.afterMappingWithOnlyFirstName = afterMappingWithOnlyFirstName;
+    }
+
+    public String getAfterMappingWithOnlyLastName() {
+        return afterMappingWithOnlyLastName;
+    }
+
+    public void setAfterMappingWithOnlyLastName(String afterMappingWithOnlyLastName) {
+        this.afterMappingWithOnlyLastName = afterMappingWithOnlyLastName;
+    }
+
+    public boolean isAfterMappingWithDifferentVariableName() {
+        return afterMappingWithDifferentVariableName;
+    }
+
+    public void setAfterMappingWithDifferentVariableName(boolean afterMappingWithDifferentVariableName) {
+        this.afterMappingWithDifferentVariableName = afterMappingWithDifferentVariableName;
     }
 }


### PR DESCRIPTION
In case a lifecycle method has multiple matching parameters (e. g. same type)
all parameter names must match exactly with the ones from the mapping method,
otherwise the lifecycle method will not be used and a warning will be shown.

As soon as the warning is displayed the lifecycle method will *not* be used, this might be a breaking change, but if the method will be used there is a high chance that it will be used in a wrong way (invalid parameter ordering, see #1457). The warning is not coming up for any of our tests.

I would prefer that only the names of the ambiguous parameters must match, but imho this would lead to bigger and really complex changes (see discussion in the ticket). As this here should already fix the issue and provide a possible solution (rename all parameters) it should be better to have it in mapstruct than waiting for a (more or less) complete rework of the "find-matching-method" algorithm.
