### PR TITLE
#1742 refactor accessors (make consistent) to have accessed type alwa…

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -50,7 +50,6 @@ import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
-import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
 
 /**
  * A {@link MappingMethod} implemented by a {@link Mapper} class which maps one bean type to another, optionally
@@ -590,7 +589,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                         Accessor sourceReadAccessor =
                             sourceParameter.getType().getPropertyReadAccessors().get( targetPropertyName );
 
-                        ExecutableElementAccessor sourcePresenceChecker =
+                        Accessor sourcePresenceChecker =
                             sourceParameter.getType().getPropertyPresenceCheckers().get( targetPropertyName );
 
                         if ( sourceReadAccessor != null ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
@@ -20,6 +20,7 @@ import org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism;
 import org.mapstruct.ap.internal.prism.NullValuePropertyMappingStrategyPrism;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 
 import static org.mapstruct.ap.internal.prism.NullValuePropertyMappingStrategyPrism.SET_TO_DEFAULT;
 import static org.mapstruct.ap.internal.prism.NullValuePropertyMappingStrategyPrism.SET_TO_NULL;
@@ -57,7 +58,7 @@ public class CollectionAssignmentBuilder {
     private Accessor targetReadAccessor;
     private Type targetType;
     private String targetPropertyName;
-    private PropertyMapping.TargetWriteAccessorType targetAccessorType;
+    private AccessorType targetAccessorType;
     private Assignment assignment;
     private SourceRHS sourceRHS;
     private NullValueCheckStrategyPrism nvcs;
@@ -88,7 +89,7 @@ public class CollectionAssignmentBuilder {
         return this;
     }
 
-    public CollectionAssignmentBuilder targetAccessorType(PropertyMapping.TargetWriteAccessorType targetAccessorType) {
+    public CollectionAssignmentBuilder targetAccessorType(AccessorType targetAccessorType) {
         this.targetAccessorType = targetAccessorType;
         return this;
     }
@@ -129,8 +130,7 @@ public class CollectionAssignmentBuilder {
         CollectionMappingStrategyPrism cms = method.getMapperConfiguration().getCollectionMappingStrategy();
         boolean targetImmutable = cms == CollectionMappingStrategyPrism.TARGET_IMMUTABLE || targetReadAccessor == null;
 
-        if ( targetAccessorType == PropertyMapping.TargetWriteAccessorType.SETTER ||
-            targetAccessorType == PropertyMapping.TargetWriteAccessorType.FIELD ) {
+        if ( targetAccessorType == AccessorType.SETTER || targetAccessorType == AccessorType.FIELD ) {
 
             if ( result.isCallingUpdateMethod() && !targetImmutable ) {
 
@@ -149,7 +149,7 @@ public class CollectionAssignmentBuilder {
                     result,
                     method.getThrownTypes(),
                     factoryMethod,
-                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType ),
+                    targetAccessorType == AccessorType.FIELD,
                     targetType,
                     true,
                     nvpms == SET_TO_NULL && !targetType.isPrimitive(),
@@ -165,7 +165,7 @@ public class CollectionAssignmentBuilder {
                     nvcs,
                     nvpms,
                     ctx.getTypeFactory(),
-                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+      targetAccessorType == AccessorType.FIELD
                 );
             }
             else if ( result.getType() == Assignment.AssignmentType.DIRECT ||
@@ -176,7 +176,7 @@ public class CollectionAssignmentBuilder {
                     method.getThrownTypes(),
                     targetType,
                     ctx.getTypeFactory(),
-                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+      targetAccessorType == AccessorType.FIELD
                 );
             }
             else {
@@ -185,7 +185,7 @@ public class CollectionAssignmentBuilder {
                     result,
                     method.getThrownTypes(),
                     targetType,
-                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+      targetAccessorType == AccessorType.FIELD
                 );
             }
         }
@@ -203,7 +203,7 @@ public class CollectionAssignmentBuilder {
                 result,
                 method.getThrownTypes(),
                 targetType,
-                PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+  targetAccessorType == AccessorType.FIELD
             );
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.type.DeclaredType;
 
 import org.mapstruct.ap.internal.model.assignment.AdderWrapper;
 import org.mapstruct.ap.internal.model.assignment.ArrayCopyWrapper;
@@ -40,14 +39,13 @@ import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
 import org.mapstruct.ap.internal.prism.NullValuePropertyMappingStrategyPrism;
-import org.mapstruct.ap.internal.util.AccessorNamingUtils;
-import org.mapstruct.ap.internal.util.Executables;
 import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.ValueProvider;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 
 import static org.mapstruct.ap.internal.model.common.Assignment.AssignmentType.DIRECT;
 import static org.mapstruct.ap.internal.prism.NullValuePropertyMappingStrategyPrism.SET_TO_DEFAULT;
@@ -73,37 +71,11 @@ public class PropertyMapping extends ModelElement {
     private final List<String> dependsOn;
     private final Assignment defaultValueAssignment;
 
-    public enum TargetWriteAccessorType {
-        FIELD,
-        GETTER,
-        SETTER,
-        ADDER;
-
-        public static TargetWriteAccessorType of(AccessorNamingUtils accessorNaming, Accessor accessor) {
-            if ( accessorNaming.isSetterMethod( accessor ) ) {
-                return TargetWriteAccessorType.SETTER;
-            }
-            else if ( accessorNaming.isAdderMethod( accessor ) ) {
-                return TargetWriteAccessorType.ADDER;
-            }
-            else if ( accessorNaming.isGetterMethod( accessor ) ) {
-                return TargetWriteAccessorType.GETTER;
-            }
-            else {
-                return TargetWriteAccessorType.FIELD;
-            }
-        }
-
-        public static boolean isFieldAssignment(TargetWriteAccessorType accessorType) {
-            return accessorType == FIELD;
-        }
-    }
-
     @SuppressWarnings("unchecked")
     private static class MappingBuilderBase<T extends MappingBuilderBase<T>> extends AbstractBaseBuilder<T> {
 
         protected Accessor targetWriteAccessor;
-        protected TargetWriteAccessorType targetWriteAccessorType;
+        protected AccessorType targetWriteAccessorType;
         protected Type targetType;
         protected Accessor targetReadAccessor;
         protected String targetPropertyName;
@@ -125,7 +97,7 @@ public class PropertyMapping extends ModelElement {
             this.targetReadAccessor = targetProp.getReadAccessor();
             this.targetWriteAccessor = targetProp.getWriteAccessor();
             this.targetType = targetProp.getType();
-            this.targetWriteAccessorType = TargetWriteAccessorType.of( ctx.getAccessorNaming(), targetWriteAccessor );
+            this.targetWriteAccessorType = targetWriteAccessor.getAccessorType();
             return (T) this;
         }
 
@@ -136,7 +108,7 @@ public class PropertyMapping extends ModelElement {
 
         public T targetWriteAccessor(Accessor targetWriteAccessor) {
             this.targetWriteAccessor = targetWriteAccessor;
-            this.targetWriteAccessorType = TargetWriteAccessorType.of( ctx.getAccessorNaming(), targetWriteAccessor );
+            this.targetWriteAccessorType = targetWriteAccessor.getAccessorType();
             this.targetType = determineTargetType();
 
             return (T) this;
@@ -148,25 +120,7 @@ public class PropertyMapping extends ModelElement {
         }
 
         private Type determineTargetType() {
-            // This is a bean mapping method, so we know the result is a declared type
-            Type mappingType = method.getResultType();
-            if ( !method.isUpdateMethod() ) {
-                mappingType = mappingType.getEffectiveType();
-            }
-            DeclaredType resultType = (DeclaredType) mappingType.getTypeMirror();
-
-            switch ( targetWriteAccessorType ) {
-                case ADDER:
-                case SETTER:
-                    return ctx.getTypeFactory()
-                        .getSingleParameter( resultType, targetWriteAccessor )
-                        .getType();
-                case GETTER:
-                case FIELD:
-                default:
-                    return ctx.getTypeFactory()
-                        .getReturnType( resultType, targetWriteAccessor );
-            }
+            return ctx.getTypeFactory().getType(  targetWriteAccessor.getAccessedType()  );
         }
 
         public T targetPropertyName(String targetPropertyName) {
@@ -190,7 +144,7 @@ public class PropertyMapping extends ModelElement {
         }
 
         protected boolean isFieldAssignment() {
-            return targetWriteAccessorType == TargetWriteAccessorType.FIELD;
+            return targetWriteAccessorType == AccessorType.FIELD;
         }
     }
 
@@ -300,11 +254,11 @@ public class PropertyMapping extends ModelElement {
             ctx.getMessager().note( 2, Message.PROPERTYMAPPING_MAPPING_NOTE, rightHandSide, targetWriteAccessor );
 
             rightHandSide.setUseElementAsSourceTypeForMatching(
-                targetWriteAccessorType == TargetWriteAccessorType.ADDER );
+                targetWriteAccessorType == AccessorType.ADDER );
 
             // all the tricky cases will be excluded for the time being.
             boolean preferUpdateMethods;
-            if ( targetWriteAccessorType == TargetWriteAccessorType.ADDER ) {
+            if ( targetWriteAccessorType == AccessorType.ADDER ) {
                 preferUpdateMethods = false;
             }
             else {
@@ -446,13 +400,12 @@ public class PropertyMapping extends ModelElement {
             return null;
         }
 
-        private Assignment assignToPlain(Type targetType, TargetWriteAccessorType targetAccessorType,
+        private Assignment assignToPlain(Type targetType, AccessorType targetAccessorType,
                                          Assignment rightHandSide) {
 
             Assignment result;
 
-            if ( targetAccessorType == TargetWriteAccessorType.SETTER ||
-                targetAccessorType == TargetWriteAccessorType.FIELD ) {
+            if ( targetAccessorType == AccessorType.SETTER || targetAccessorType == AccessorType.FIELD ) {
                 result = assignToPlainViaSetter( targetType, rightHandSide );
             }
             else {
@@ -530,7 +483,7 @@ public class PropertyMapping extends ModelElement {
             return result;
         }
 
-        private Assignment assignToCollection(Type targetType, TargetWriteAccessorType targetAccessorType,
+        private Assignment assignToCollection(Type targetType, AccessorType targetAccessorType,
                                             Assignment rhs) {
             return new CollectionAssignmentBuilder()
                 .mappingBuilderContext( ctx )
@@ -738,7 +691,7 @@ public class PropertyMapping extends ModelElement {
 
         private Assignment forgeMapping(SourceRHS sourceRHS) {
             Type sourceType;
-            if ( targetWriteAccessorType == TargetWriteAccessorType.ADDER ) {
+            if ( targetWriteAccessorType == AccessorType.ADDER ) {
                 sourceType = sourceRHS.getSourceTypeForMatching();
             }
             else {
@@ -764,7 +717,7 @@ public class PropertyMapping extends ModelElement {
             // because we are forging a Mapping for a method with multiple source parameters.
             // If the target type is enum, then we can't create an update method
             if ( !targetType.isEnumType() && ( method.isUpdateMethod() || forceUpdateMethod )
-                && targetWriteAccessorType != TargetWriteAccessorType.ADDER) {
+                && targetWriteAccessorType != AccessorType.ADDER) {
                 parameters.add( Parameter.forForgedMappingTarget( targetType ) );
                 returnType = ctx.getTypeFactory().createVoidType();
             }
@@ -899,8 +852,8 @@ public class PropertyMapping extends ModelElement {
 
             if ( assignment != null ) {
 
-                if ( ctx.getAccessorNaming().isSetterMethod( targetWriteAccessor ) ||
-                    Executables.isFieldAccessor( targetWriteAccessor ) ) {
+                if ( targetWriteAccessor.getAccessorType() == AccessorType.SETTER  ||
+                targetWriteAccessor.getAccessorType() == AccessorType.FIELD ) {
 
                     // target accessor is setter, so decorate assignment as setter
                     if ( assignment.isCallingUpdateMethod() ) {
@@ -1015,8 +968,8 @@ public class PropertyMapping extends ModelElement {
         public PropertyMapping build() {
             Assignment assignment = new SourceRHS( javaExpression, null, existingVariableNames, "" );
 
-            if ( ctx.getAccessorNaming().isSetterMethod( targetWriteAccessor ) ||
-                Executables.isFieldAccessor( targetWriteAccessor ) ) {
+            if ( targetWriteAccessor.getAccessorType() == AccessorType.SETTER  ||
+                            targetWriteAccessor.getAccessorType() == AccessorType.FIELD ) {
                 // setter, so wrap in setter
                 assignment = new SetterWrapper( assignment, method.getThrownTypes(), isFieldAssignment() );
             }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -49,6 +49,7 @@ import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.RoundContext;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 import org.mapstruct.ap.spi.AstModifyingAnnotationProcessor;
 import org.mapstruct.ap.spi.BuilderInfo;
 import org.mapstruct.ap.spi.MoreThanOneBuilderCreationMethodException;
@@ -354,10 +355,10 @@ public class TypeFactory {
     }
 
     public Parameter getSingleParameter(DeclaredType includingType, Accessor method) {
-        ExecutableElement executable = method.getExecutable();
-        if ( executable == null ) {
+        if ( method.getAccessorType() == AccessorType.FIELD ) {
             return null;
         }
+        ExecutableElement executable = (ExecutableElement) method.getElement();
         List<? extends VariableElement> parameters = executable.getParameters();
 
         if ( parameters.size() != 1 ) {
@@ -369,7 +370,7 @@ public class TypeFactory {
     }
 
     public List<Parameter> getParameters(DeclaredType includingType, Accessor accessor) {
-        ExecutableElement method = accessor.getExecutable();
+        ExecutableElement method = (ExecutableElement) accessor.getElement();
         TypeMirror methodType = getMethodType( includingType, accessor.getElement() );
         if ( method == null || methodType.getKind() != TypeKind.EXECUTABLE ) {
             return new ArrayList<>();
@@ -427,10 +428,10 @@ public class TypeFactory {
     }
 
     public List<Type> getThrownTypes(Accessor accessor) {
-        if (accessor.getExecutable() == null) {
+        if (accessor.getAccessorType() == AccessorType.FIELD) {
             return new ArrayList<>();
         }
-        return extractTypes( accessor.getExecutable().getThrownTypes() );
+        return extractTypes( ( (ExecutableElement) accessor.getElement() ).getThrownTypes() );
     }
 
     private List<Type> extractTypes(List<? extends TypeMirror> typeMirrors) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/PropertyEntry.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/PropertyEntry.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
-import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
 
 
 /**
@@ -22,7 +21,7 @@ public class PropertyEntry {
     private final String[] fullName;
     private final Accessor readAccessor;
     private final Accessor writeAccessor;
-    private final ExecutableElementAccessor presenceChecker;
+    private final Accessor presenceChecker;
     private final Type type;
 
     /**
@@ -34,7 +33,7 @@ public class PropertyEntry {
      * @param type
      */
     private PropertyEntry(String[] fullName, Accessor readAccessor, Accessor writeAccessor,
-                          ExecutableElementAccessor presenceChecker, Type type) {
+                          Accessor presenceChecker, Type type) {
         this.fullName = fullName;
         this.readAccessor = readAccessor;
         this.writeAccessor = writeAccessor;
@@ -66,7 +65,7 @@ public class PropertyEntry {
      * @return the property entry for given parameters.
      */
     public static PropertyEntry forSourceReference(String name, Accessor readAccessor,
-                                                   ExecutableElementAccessor presenceChecker, Type type) {
+                                                   Accessor presenceChecker, Type type) {
         return new PropertyEntry( new String[]{name}, readAccessor, null, presenceChecker, type );
     }
 
@@ -82,7 +81,7 @@ public class PropertyEntry {
         return writeAccessor;
     }
 
-    public ExecutableElementAccessor getPresenceChecker() {
+    public Accessor getPresenceChecker() {
         return presenceChecker;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
@@ -24,7 +24,6 @@ import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
-import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
 
 /**
  * This class describes the source side of a property mapping.
@@ -261,7 +260,7 @@ public class SourceReference {
             for ( String entryName : entryNames ) {
                 boolean matchFound = false;
                 Map<String, Accessor> sourceReadAccessors = newType.getPropertyReadAccessors();
-                Map<String, ExecutableElementAccessor> sourcePresenceCheckers = newType.getPropertyPresenceCheckers();
+                Map<String, Accessor> sourcePresenceCheckers = newType.getPropertyPresenceCheckers();
 
                 for ( Map.Entry<String, Accessor> getter : sourceReadAccessors.entrySet() ) {
                     if ( getter.getKey().equals( entryName ) ) {
@@ -297,7 +296,7 @@ public class SourceReference {
 
         private String name;
         private Accessor readAccessor;
-        private ExecutableElementAccessor presenceChecker;
+        private Accessor presenceChecker;
         private Type type;
         private Parameter sourceParameter;
 
@@ -311,7 +310,7 @@ public class SourceReference {
             return this;
         }
 
-        public BuilderFromProperty presenceChecker(ExecutableElementAccessor presenceChecker) {
+        public BuilderFromProperty presenceChecker(Accessor presenceChecker) {
             this.presenceChecker = presenceChecker;
             return this;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
@@ -18,11 +18,11 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
-import org.mapstruct.ap.internal.util.Executables;
 import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 
 /**
  * This class describes the target side of a property mapping.
@@ -198,8 +198,8 @@ public class TargetReference {
                     break;
                 }
 
-                if ( isLast || ( accessorNaming.isSetterMethod( targetWriteAccessor )
-                    || Executables.isFieldAccessor( targetWriteAccessor ) ) ) {
+                if ( isLast || ( targetWriteAccessor.getAccessorType() == AccessorType.SETTER  ||
+                                targetWriteAccessor.getAccessorType() == AccessorType.FIELD ) ) {
                     // only intermediate nested properties when they are a true setter or field accessor
                     // the last may be other readAccessor (setter / getter / adder).
 
@@ -228,8 +228,7 @@ public class TargetReference {
         private Type findNextType(Type initial, Accessor targetWriteAccessor, Accessor targetReadAccessor) {
             Type nextType;
             Accessor toUse = targetWriteAccessor != null ? targetWriteAccessor : targetReadAccessor;
-            if ( accessorNaming.isGetterMethod( toUse ) ||
-                Executables.isFieldAccessor( toUse ) ) {
+            if ( toUse.getAccessorType() == AccessorType.GETTER  || toUse.getAccessorType() == AccessorType.FIELD ) {
                 nextType = typeFactory.getReturnType(
                     (DeclaredType) typeBasedOnMethod( initial ).getTypeMirror(),
                     toUse

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
@@ -5,31 +5,25 @@
  */
 package org.mapstruct.ap.internal.util;
 
-import static javax.lang.model.util.ElementFilter.fieldsIn;
-import static javax.lang.model.util.ElementFilter.methodsIn;
-import static org.mapstruct.ap.internal.util.workarounds.SpecificCompilerWorkarounds.replaceTypeElementIfNecessary;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
-
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
-import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 
 import org.mapstruct.ap.internal.prism.AfterMappingPrism;
 import org.mapstruct.ap.internal.prism.BeforeMappingPrism;
-import org.mapstruct.ap.internal.util.accessor.Accessor;
-import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
-import org.mapstruct.ap.internal.util.accessor.VariableElementAccessor;
 import org.mapstruct.ap.spi.TypeHierarchyErroneousException;
+
+import static javax.lang.model.util.ElementFilter.methodsIn;
+import static org.mapstruct.ap.internal.util.Types.asTypeElement;
+import static org.mapstruct.ap.internal.util.Types.hasNonObjectSuperclass;
+import static org.mapstruct.ap.internal.util.workarounds.SpecificCompilerWorkarounds.replaceTypeElementIfNecessary;
 
 /**
  * Provides functionality around {@link ExecutableElement}s.
@@ -54,35 +48,6 @@ public class Executables {
     private Executables() {
     }
 
-    /**
-     * An {@link Accessor} is a field accessor, if it doesn't have an executable element, is public and it is not
-     * static.
-     *
-     * @param accessor the accessor to ber checked
-     *
-     * @return {@code true} if the {@code accessor} is for a {@code public} non {@code static} field.
-     */
-    public static boolean isFieldAccessor(Accessor accessor) {
-        ExecutableElement executable = accessor.getExecutable();
-        return executable == null && isPublic( accessor ) && isNotStatic( accessor );
-    }
-
-    static boolean isPublicNotStatic(Accessor accessor) {
-        return isPublic( accessor ) && isNotStatic( accessor );
-    }
-
-    static boolean isPublic(Accessor method) {
-        return method.getModifiers().contains( Modifier.PUBLIC );
-    }
-
-    private static boolean isNotStatic(Accessor accessor) {
-        return !accessor.getModifiers().contains( Modifier.STATIC );
-    }
-
-    public static boolean isFinal(Accessor accessor) {
-        return accessor != null && accessor.getModifiers().contains( Modifier.FINAL );
-    }
-
     public static boolean isDefaultMethod(ExecutableElement method) {
         try {
             return DEFAULT_METHOD != null && Boolean.TRUE.equals( DEFAULT_METHOD.invoke( method ) );
@@ -90,15 +55,6 @@ public class Executables {
         catch ( IllegalAccessException | InvocationTargetException e ) {
             return false;
         }
-    }
-
-    /**
-     * @param mirror the type positionHint
-     *
-     * @return the corresponding type element
-     */
-    private static TypeElement asTypeElement(TypeMirror mirror) {
-        return (TypeElement) ( (DeclaredType) mirror ).asElement();
     }
 
     /**
@@ -112,34 +68,14 @@ public class Executables {
      * @return the executable elements usable in the type
      */
     public static List<ExecutableElement> getAllEnclosedExecutableElements(Elements elementUtils, TypeElement element) {
-        List<ExecutableElement> executables = new ArrayList<>();
-        for ( Accessor accessor : getAllEnclosedAccessors( elementUtils, element ) ) {
-            if ( accessor.getExecutable() != null ) {
-                executables.add( accessor.getExecutable() );
-            }
-        }
-        return executables;
-    }
-
-    /**
-     * Finds all executable elements/variable elements within the given type element, including executable/variable
-     * elements defined in super classes and implemented interfaces and including the fields in the . Methods defined
-     * in {@link java.lang.Object} are ignored, as well as implementations of {@link java.lang.Object#equals(Object)}.
-     *
-     * @param elementUtils element helper
-     * @param element the element to inspect
-     *
-     * @return the executable elements usable in the type
-     */
-    public static List<Accessor> getAllEnclosedAccessors(Elements elementUtils, TypeElement element) {
-        List<Accessor> enclosedElements = new ArrayList<>();
+        List<ExecutableElement> enclosedElements = new ArrayList<>();
         element = replaceTypeElementIfNecessary( elementUtils, element );
         addEnclosedElementsInHierarchy( elementUtils, enclosedElements, element, element );
 
         return enclosedElements;
     }
 
-    private static void addEnclosedElementsInHierarchy(Elements elementUtils, List<Accessor> alreadyAdded,
+    private static void addEnclosedElementsInHierarchy(Elements elementUtils, List<ExecutableElement> alreadyAdded,
                                                        TypeElement element, TypeElement parentType) {
         if ( element != parentType ) { // otherwise the element was already checked for replacement
             element = replaceTypeElementIfNecessary( elementUtils, element );
@@ -150,23 +86,22 @@ public class Executables {
         }
 
         addNotYetOverridden( elementUtils, alreadyAdded, methodsIn( element.getEnclosedElements() ), parentType );
-        addFields( alreadyAdded, fieldsIn( element.getEnclosedElements() ) );
 
         if ( hasNonObjectSuperclass( element ) ) {
             addEnclosedElementsInHierarchy(
-                elementUtils,
-                alreadyAdded,
-                asTypeElement( element.getSuperclass() ),
-                parentType
+                            elementUtils,
+                            alreadyAdded,
+                            asTypeElement( element.getSuperclass() ),
+                            parentType
             );
         }
 
         for ( TypeMirror interfaceType : element.getInterfaces() ) {
             addEnclosedElementsInHierarchy(
-                elementUtils,
-                alreadyAdded,
-                asTypeElement( interfaceType ),
-                parentType
+                            elementUtils,
+                            alreadyAdded,
+                            asTypeElement( interfaceType ),
+                            parentType
             );
         }
 
@@ -178,28 +113,18 @@ public class Executables {
      * @param methodsToAdd methods to add to alreadyAdded, if they are not yet overridden by an element in the list
      * @param parentType the type for with elements are collected
      */
-    private static void addNotYetOverridden(Elements elementUtils, List<Accessor> alreadyCollected,
+    private static void addNotYetOverridden(Elements elementUtils, List<ExecutableElement> alreadyCollected,
                                             List<ExecutableElement> methodsToAdd, TypeElement parentType) {
-        List<Accessor> safeToAdd = new ArrayList<>( methodsToAdd.size() );
+        List<ExecutableElement> safeToAdd = new ArrayList<>( methodsToAdd.size() );
         for ( ExecutableElement toAdd : methodsToAdd ) {
             if ( isNotObjectEquals( toAdd )
-                && wasNotYetOverridden( elementUtils, alreadyCollected, toAdd, parentType ) ) {
-                safeToAdd.add( new ExecutableElementAccessor( toAdd ) );
+                            && wasNotYetOverridden( elementUtils, alreadyCollected, toAdd, parentType ) ) {
+                safeToAdd.add( toAdd );
             }
         }
 
         alreadyCollected.addAll( 0, safeToAdd );
     }
-
-    private static void addFields(List<Accessor> alreadyCollected, List<VariableElement> variablesToAdd) {
-        List<Accessor> safeToAdd = new ArrayList<>( variablesToAdd.size() );
-        for ( VariableElement toAdd : variablesToAdd ) {
-            safeToAdd.add( new VariableElementAccessor( toAdd ) );
-        }
-
-        alreadyCollected.addAll( 0, safeToAdd );
-    }
-
 
     /**
      * @param executable the executable to check
@@ -209,7 +134,7 @@ public class Executables {
      */
     private static boolean isNotObjectEquals(ExecutableElement executable) {
         if ( executable.getSimpleName().contentEquals( "equals" ) && executable.getParameters().size() == 1
-            && asTypeElement( executable.getParameters().get( 0 ).asType() ).getQualifiedName().contentEquals(
+                && asTypeElement( executable.getParameters().get( 0 ).asType() ).getQualifiedName().contentEquals(
             "java.lang.Object"
         ) ) {
             return false;
@@ -225,10 +150,10 @@ public class Executables {
      * @param parentType the type for which elements are collected
      * @return {@code true}, iff the given executable was not yet overridden by a method in the given list.
      */
-    private static boolean wasNotYetOverridden(Elements elementUtils, List<Accessor> alreadyCollected,
+    private static boolean wasNotYetOverridden(Elements elementUtils, List<ExecutableElement> alreadyCollected,
                                                ExecutableElement executable, TypeElement parentType) {
-        for ( ListIterator<Accessor> it = alreadyCollected.listIterator(); it.hasNext(); ) {
-            ExecutableElement executableInSubtype = it.next().getExecutable();
+        for ( ListIterator<ExecutableElement> it = alreadyCollected.listIterator(); it.hasNext(); ) {
+            ExecutableElement executableInSubtype = it.next();
             if ( executableInSubtype == null ) {
                 continue;
             }
@@ -243,20 +168,6 @@ public class Executables {
         }
 
         return true;
-    }
-
-    /**
-     * @param element the type element to check
-     *
-     * @return {@code true}, iff the type has a super-class that is not java.lang.Object
-     */
-    private static boolean hasNonObjectSuperclass(TypeElement element) {
-        if ( element.getSuperclass().getKind() == TypeKind.ERROR ) {
-            throw new TypeHierarchyErroneousException( element );
-        }
-
-        return element.getSuperclass().getKind() == TypeKind.DECLARED
-            && !asTypeElement( element.getSuperclass() ).getQualifiedName().toString().equals( "java.lang.Object" );
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Fields.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Fields.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.util.Elements;
+
+import org.mapstruct.ap.spi.TypeHierarchyErroneousException;
+
+import static javax.lang.model.util.ElementFilter.fieldsIn;
+import static org.mapstruct.ap.internal.util.Types.asTypeElement;
+import static org.mapstruct.ap.internal.util.Types.hasNonObjectSuperclass;
+import static org.mapstruct.ap.internal.util.workarounds.SpecificCompilerWorkarounds.replaceTypeElementIfNecessary;
+
+/**
+ * Provides functionality around {@link VariableElement}s.
+ *
+ * @author Sjaak Derksen
+ */
+public class Fields {
+
+    private Fields() {
+    }
+
+    public static boolean isFieldAccessor(VariableElement method) {
+        return isPublic( method ) && isNotStatic( method );
+    }
+
+    static boolean isPublic(VariableElement method) {
+        return method.getModifiers().contains( Modifier.PUBLIC );
+    }
+
+    private static boolean isNotStatic(VariableElement method) {
+        return !method.getModifiers().contains( Modifier.STATIC );
+    }
+
+    /**
+     * Finds all variable elements within the given type element, including variable
+     * elements defined in super classes and implemented interfaces and including the fields in the .
+     *
+     * @param elementUtils element helper
+     * @param element the element to inspect
+     *
+     * @return the executable elements usable in the type
+     */
+    public static List<VariableElement> getAllEnclosedFields(Elements elementUtils, TypeElement element) {
+        List<VariableElement> enclosedElements = new ArrayList<>();
+        element = replaceTypeElementIfNecessary( elementUtils, element );
+        addEnclosedElementsInHierarchy( elementUtils, enclosedElements, element, element );
+
+        return enclosedElements;
+    }
+
+    private static void addEnclosedElementsInHierarchy(Elements elementUtils, List<VariableElement> alreadyAdded,
+                                                       TypeElement element, TypeElement parentType) {
+        if ( element != parentType ) { // otherwise the element was already checked for replacement
+            element = replaceTypeElementIfNecessary( elementUtils, element );
+        }
+
+        if ( element.asType().getKind() == TypeKind.ERROR ) {
+            throw new TypeHierarchyErroneousException( element );
+        }
+
+        addFields( alreadyAdded, fieldsIn( element.getEnclosedElements() ) );
+
+
+        if ( hasNonObjectSuperclass( element ) ) {
+            addEnclosedElementsInHierarchy(
+                            elementUtils,
+                            alreadyAdded,
+                            asTypeElement( element.getSuperclass() ),
+                            parentType
+            );
+        }
+    }
+
+    private static void addFields(List<VariableElement> alreadyCollected, List<VariableElement> variablesToAdd) {
+        List<VariableElement> safeToAdd = new ArrayList<>( variablesToAdd.size() );
+        for ( VariableElement toAdd : variablesToAdd ) {
+            safeToAdd.add( toAdd );
+        }
+
+        alreadyCollected.addAll( 0, safeToAdd );
+    }
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Filters.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Filters.java
@@ -7,11 +7,23 @@ package org.mapstruct.ap.internal.util;
 
 import java.util.LinkedList;
 import java.util.List;
-
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
 
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
+import org.mapstruct.ap.internal.util.accessor.VariableElementAccessor;
+
+import static org.mapstruct.ap.internal.util.Collections.first;
+import static org.mapstruct.ap.internal.util.accessor.AccessorType.ADDER;
+import static org.mapstruct.ap.internal.util.accessor.AccessorType.GETTER;
+import static org.mapstruct.ap.internal.util.accessor.AccessorType.PRESENCE_CHECKER;
+import static org.mapstruct.ap.internal.util.accessor.AccessorType.SETTER;
 
 /**
  * Filter methods for working with {@link Element} collections.
@@ -20,66 +32,88 @@ import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
  */
 public class Filters {
 
-    private Filters() {
+    private final AccessorNamingUtils accessorNaming;
+    private final Types typeUtils;
+    private final TypeMirror typeMirror;
+
+    public Filters(AccessorNamingUtils accessorNaming, Types typeUtils, TypeMirror typeMirror) {
+        this.accessorNaming = accessorNaming;
+        this.typeUtils = typeUtils;
+        this.typeMirror = typeMirror;
     }
 
-    public static List<Accessor> getterMethodsIn(AccessorNamingUtils accessorNaming, List<Accessor> elements) {
+    public  List<Accessor> getterMethodsIn(List<ExecutableElement> elements) {
         List<Accessor> getterMethods = new LinkedList<>();
 
-        for ( Accessor method : elements ) {
+        for ( ExecutableElement method : elements ) {
             if ( accessorNaming.isGetterMethod( method ) ) {
-                getterMethods.add( method );
+                getterMethods.add( new ExecutableElementAccessor( method, getReturnType( method ), GETTER ) );
             }
         }
 
         return getterMethods;
     }
 
-    public static List<Accessor> fieldsIn(List<Accessor> accessors) {
+    public  List<Accessor> fieldsIn(List<VariableElement> accessors) {
         List<Accessor> fieldAccessors = new LinkedList<>();
 
-        for ( Accessor accessor : accessors ) {
-            if ( Executables.isFieldAccessor( accessor ) ) {
-                fieldAccessors.add( accessor );
+        for ( VariableElement accessor : accessors ) {
+            if ( Fields.isFieldAccessor( accessor ) ) {
+                fieldAccessors.add( new VariableElementAccessor( accessor ) );
             }
         }
 
         return fieldAccessors;
     }
 
-    public static List<ExecutableElementAccessor> presenceCheckMethodsIn(AccessorNamingUtils accessorNaming,
-                                                                         List<Accessor> elements) {
-        List<ExecutableElementAccessor> presenceCheckMethods = new LinkedList<>();
+    public List<Accessor> presenceCheckMethodsIn(List<ExecutableElement> elements) {
+        List<Accessor> presenceCheckMethods = new LinkedList<>();
 
-        for ( Accessor method : elements ) {
+        for ( ExecutableElement method : elements ) {
             if ( accessorNaming.isPresenceCheckMethod( method ) ) {
-                presenceCheckMethods.add( (ExecutableElementAccessor) method );
+                presenceCheckMethods.add( new ExecutableElementAccessor(
+                                method,
+                                getReturnType( method ),
+                                PRESENCE_CHECKER
+                ) );
             }
         }
 
         return presenceCheckMethods;
     }
 
-    public static List<Accessor> setterMethodsIn(AccessorNamingUtils accessorNaming, List<Accessor> elements) {
+    public  List<Accessor> setterMethodsIn(List<ExecutableElement> elements) {
         List<Accessor> setterMethods = new LinkedList<>();
 
-        for ( Accessor method : elements ) {
+        for ( ExecutableElement method : elements ) {
             if ( accessorNaming.isSetterMethod( method ) ) {
-                setterMethods.add( method );
+                setterMethods.add( new ExecutableElementAccessor( method, getFirstParameter( method ), SETTER ) );
             }
         }
         return setterMethods;
     }
 
-    public static List<Accessor> adderMethodsIn(AccessorNamingUtils accessorNaming, List<Accessor> elements) {
+    public  List<Accessor> adderMethodsIn( List<ExecutableElement> elements) {
         List<Accessor> adderMethods = new LinkedList<>();
 
-        for ( Accessor method : elements ) {
+        for ( ExecutableElement method : elements ) {
             if ( accessorNaming.isAdderMethod( method ) ) {
-                adderMethods.add( method );
+                adderMethods.add( new ExecutableElementAccessor( method, getFirstParameter( method ), ADDER ) );
             }
         }
 
         return adderMethods;
+    }
+
+    private TypeMirror getReturnType(ExecutableElement executableElement) {
+        return getWithinContext( executableElement ).getReturnType();
+    }
+
+    private TypeMirror getFirstParameter(ExecutableElement executableElement) {
+        return first( getWithinContext( executableElement ).getParameterTypes() );
+    }
+
+    private ExecutableType getWithinContext( ExecutableElement executableElement ) {
+        return (ExecutableType) typeUtils.asMemberOf( (DeclaredType) typeMirror, executableElement );
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Types.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Types.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.util;
+
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+import org.mapstruct.ap.spi.TypeHierarchyErroneousException;
+
+/**
+ * Provides functionality around {@link VariableElement}s.
+ *
+ * @author Sjaak Derksen
+ */
+public class Types {
+
+    private Types() {
+    }
+
+    /**
+     * @param element the type element
+     * @return returns true if the element has a superclass not equal to {@link java.lang.Object}
+     */
+    public static boolean hasNonObjectSuperclass(TypeElement element) {
+        if ( element.getSuperclass().getKind() == TypeKind.ERROR ) {
+            throw new TypeHierarchyErroneousException( element );
+        }
+
+        return element.getSuperclass().getKind() == TypeKind.DECLARED
+                && !asTypeElement( element.getSuperclass() ).getQualifiedName().toString().equals( "java.lang.Object" );
+    }
+
+    /**
+     *
+     * @param mirror the mirror
+     * @return the {@link TypeElement} for the provided mirror.
+     */
+    public static TypeElement asTypeElement(TypeMirror mirror) {
+        return (TypeElement) ( (DeclaredType) mirror ).asElement();
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/ValueProvider.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/ValueProvider.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.internal.util;
 
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 
 /**
  * This a wrapper class which provides the value that needs to be used in the models.
@@ -45,7 +46,7 @@ public class ValueProvider {
             return null;
         }
         String value = accessor.getSimpleName().toString();
-        if ( accessor.getExecutable() != null ) {
+        if ( accessor.getAccessorType() != AccessorType.FIELD ) {
             value += "()";
         }
         return new ValueProvider( value );

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/AbstractAccessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/AbstractAccessor.java
@@ -38,4 +38,5 @@ abstract class AbstractAccessor<T extends Element> implements Accessor {
     public T getElement() {
         return element;
     }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/Accessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/Accessor.java
@@ -8,6 +8,7 @@ package org.mapstruct.ap.internal.util.accessor;
 import java.util.Set;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 import javax.lang.model.type.TypeMirror;
@@ -23,7 +24,7 @@ public interface Accessor {
      * This returns the type that this accessor gives as a return.
      *
      * e.g. The {@link ExecutableElement#getReturnType()} if this is a method accessor,
-     * or {@link javax.lang.model.element.VariableElement#asType()} for field accessors.
+     * or {@link VariableElement#asType()} for field accessors.
      *
      * @return the type that the accessor gives as a return
      */
@@ -40,12 +41,14 @@ public interface Accessor {
     Set<Modifier> getModifiers();
 
     /**
-     * @return the {@link ExecutableElement}, or {@code null} if the accessor does not have one
-     */
-    ExecutableElement getExecutable();
-
-    /**
-     * @return the underlying {@link Element}
+     * @return the underlying {@link Element}, {@link VariableElement} or {@link ExecutableElement}
      */
     Element getElement();
+
+    /**
+     * The accessor type
+     *
+     * @return
+     */
+    AccessorType getAccessorType();
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/AccessorType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/AccessorType.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.util.accessor;
+
+public enum AccessorType {
+
+    FIELD,
+    GETTER,
+    SETTER,
+    ADDER,
+    PRESENCE_CHECKER;
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/ExecutableElementAccessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/ExecutableElementAccessor.java
@@ -15,22 +15,27 @@ import javax.lang.model.type.TypeMirror;
  */
 public class ExecutableElementAccessor extends AbstractAccessor<ExecutableElement> {
 
-    public ExecutableElementAccessor(ExecutableElement element) {
+    private final TypeMirror accessedType;
+    private final AccessorType accessorType;
+
+    public ExecutableElementAccessor(ExecutableElement element, TypeMirror accessedType, AccessorType accessorType) {
         super( element );
+        this.accessedType = accessedType;
+        this.accessorType = accessorType;
     }
 
     @Override
     public TypeMirror getAccessedType() {
-        return element.getReturnType();
-    }
-
-    @Override
-    public ExecutableElement getExecutable() {
-        return element;
+        return accessedType;
     }
 
     @Override
     public String toString() {
         return element.toString();
+    }
+
+    @Override
+    public AccessorType getAccessorType() {
+        return accessorType;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/VariableElementAccessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/VariableElementAccessor.java
@@ -5,7 +5,6 @@
  */
 package org.mapstruct.ap.internal.util.accessor;
 
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
@@ -26,12 +25,13 @@ public class VariableElementAccessor extends AbstractAccessor<VariableElement> {
     }
 
     @Override
-    public ExecutableElement getExecutable() {
-        return null;
-    }
-
-    @Override
     public String toString() {
         return element.toString();
     }
+
+    @Override
+    public AccessorType getAccessorType() {
+        return AccessorType.FIELD;
+    }
+
 }


### PR DESCRIPTION
…ys available

Currently the accessor type is defined in `PropertyMapper` while it should be an intrinsic property of `Accessor`.  Types are fetched and derived in context (again) all-over-the-place.. Sometimes that requires the parent type again and even the mapping method (to derive in context and resolve generics). 

This PR is the first in a number of refactoring with the goal to have a cleaner separation of concerns. 