### PR TITLE
#1797 Use EnumSet.noneOf when creating a new instance of EnumSet

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableCreation.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableCreation.java
@@ -12,6 +12,8 @@ import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 
+import static org.mapstruct.ap.internal.util.Collections.first;
+
 /**
  * Model element that can be used to create a type of {@link Iterable} or {@link java.util.Map}. If an implementation
  * type is used and the target type has a constructor with {@code int} as parameter and the source parameter is of
@@ -69,6 +71,20 @@ public class IterableCreation extends ModelElement {
         if ( factoryMethod == null && resultType.getImplementationType() != null ) {
             types.addAll( resultType.getImplementationType().getImportTypes() );
         }
+
+        if ( isEnumSet() ) {
+            types.add( getEnumSetElementType() );
+            // The result type itself is an EnumSet
+            types.add( resultType );
+        }
         return types;
+    }
+
+    public Type getEnumSetElementType() {
+        return first( getResultType().determineTypeArguments( Iterable.class ) );
+    }
+
+    public boolean isEnumSet() {
+        return "java.util.EnumSet".equals( resultType.getFullyQualifiedName() );
     }
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableCreation.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableCreation.ftl
@@ -9,6 +9,8 @@
 <@compress single_line=true>
     <#if factoryMethod??>
         <@includeModel object=factoryMethod targetType=resultType/>
+    <#elseif enumSet>
+        EnumSet.noneOf( <@includeModel object=enumSetElementType raw=true/>.class )
     <#else>
     new
         <#if resultType.implementationType??>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1797/Customer.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1797/Customer.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1797;
+
+import java.util.EnumSet;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Customer {
+
+    public enum Type {
+        ONE, TWO
+    }
+
+    private final EnumSet<Type> types;
+
+    public Customer(EnumSet<Type> types) {
+        this.types = types;
+    }
+
+    public EnumSet<Type> getTypes() {
+        return types;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1797/CustomerDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1797/CustomerDto.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1797;
+
+import java.util.EnumSet;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class CustomerDto {
+
+    public enum Type {
+        ONE, TWO
+    }
+
+    private EnumSet<Type> types;
+
+    public EnumSet<Type> getTypes() {
+        return types;
+    }
+
+    public void setTypes(EnumSet<Type> types) {
+        this.types = types;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1797/Issue1797Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1797/Issue1797Mapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1797;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue1797Mapper {
+
+    Issue1797Mapper INSTANCE = Mappers.getMapper( Issue1797Mapper.class );
+
+    CustomerDto map(Customer customer);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1797/Issue1797Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1797/Issue1797Test.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1797;
+
+import java.util.EnumSet;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("1797")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    Customer.class,
+    CustomerDto.class,
+    Issue1797Mapper.class
+})
+public class Issue1797Test {
+
+    @Test
+    public void shouldCorrectlyMapEnumSetToEnumSet() {
+
+        Customer customer = new Customer( EnumSet.of( Customer.Type.ONE ) );
+
+        CustomerDto customerDto = Issue1797Mapper.INSTANCE.map( customer );
+
+        assertThat( customerDto.getTypes() ).containsExactly( CustomerDto.Type.ONE );
+    }
+}


### PR DESCRIPTION
Fixes #1797 