### PR TITLE
#1608 Oracle's JavaBean getter/setter support

### DIFF
--- a/integrationtest/src/test/resources/namingStrategyTest/strategy/src/main/java/org/mapstruct/itest/naming/CustomAccessorNamingStrategy.java
+++ b/integrationtest/src/test/resources/namingStrategyTest/strategy/src/main/java/org/mapstruct/itest/naming/CustomAccessorNamingStrategy.java
@@ -29,20 +29,20 @@ public class CustomAccessorNamingStrategy  extends DefaultAccessorNamingStrategy
     public boolean isSetterMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
-        return methodName.matches( "^with[A-Z].*" );
+        return IntrospectorUtils.isWither( methodName );
     }
 
     @Override
     public boolean isAdderMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
-        return methodName.matches( "^add[A-Z].*" );
+        return IntrospectorUtils.isAdder( methodName );
     }
 
     @Override
     public String getPropertyName(ExecutableElement getterOrSetterMethod) {
         String methodName = getterOrSetterMethod.getSimpleName().toString();
         return IntrospectorUtils.decapitalize(
-            methodName.matches( "^with[A-Z].*" ) ? methodName.substring( 4 ) : methodName );
+            IntrospectorUtils.isWither( methodName ) ? methodName.substring( 4 ) : methodName );
     }
 
     @Override

--- a/integrationtest/src/test/resources/namingStrategyTest/strategy/src/main/java/org/mapstruct/itest/naming/CustomAccessorNamingStrategy.java
+++ b/integrationtest/src/test/resources/namingStrategyTest/strategy/src/main/java/org/mapstruct/itest/naming/CustomAccessorNamingStrategy.java
@@ -29,20 +29,20 @@ public class CustomAccessorNamingStrategy  extends DefaultAccessorNamingStrategy
     public boolean isSetterMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
-        return methodName.startsWith( "with" ) && methodName.length() > 4;
+        return methodName.matches( "^with[A-Z].*" );
     }
 
     @Override
     public boolean isAdderMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
-        return methodName.startsWith( "add" ) && methodName.length() > 3;
+        return methodName.matches( "^add[A-Z].*" );
     }
 
     @Override
     public String getPropertyName(ExecutableElement getterOrSetterMethod) {
         String methodName = getterOrSetterMethod.getSimpleName().toString();
         return IntrospectorUtils.decapitalize(
-            methodName.startsWith( "with" ) ? methodName.substring( 4 ) : methodName );
+            methodName.matches( "^with[A-Z].*" ) ? methodName.substring( 4 ) : methodName );
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -500,7 +500,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                 if ( modifiableGetters.containsKey( propertyName ) ) {
                     // In the DefaultAccessorNamingStrategy, this can only be the case for Booleans: isFoo() and
                     // getFoo(); The latter is preferred.
-                    if ( !getter.getSimpleName().toString().startsWith( "is" ) ) {
+                    if ( !getter.getSimpleName().toString().matches( "^is[A-Z].*" ) ) {
                         modifiableGetters.put( getPropertyName( getter ), getter );
                     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -43,6 +43,7 @@ import org.mapstruct.ap.internal.util.accessor.AccessorType;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
 import org.mapstruct.ap.internal.util.NativeTypes;
+import org.mapstruct.ap.spi.util.IntrospectorUtils;
 
 /**
  * Represents (a reference to) the type of a bean property, parameter etc. Types are managed per generated source file.
@@ -500,7 +501,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                 if ( modifiableGetters.containsKey( propertyName ) ) {
                     // In the DefaultAccessorNamingStrategy, this can only be the case for Booleans: isFoo() and
                     // getFoo(); The latter is preferred.
-                    if ( !getter.getSimpleName().toString().matches( "^is[A-Z].*" ) ) {
+                    if ( !IntrospectorUtils.isBooleanGetter( getter.getSimpleName().toString() ) ) {
                         modifiableGetters.put( getPropertyName( getter ), getter );
                     }
 

--- a/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
@@ -71,10 +71,10 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
     public boolean isGetterMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
-        boolean isNonBooleanGetterName = methodName.matches( "^get[A-Z].*" ) &&
+        boolean isNonBooleanGetterName = IntrospectorUtils.isGetter( methodName ) &&
             method.getReturnType().getKind() != TypeKind.VOID;
 
-        boolean isBooleanGetterName = methodName.matches( "^is[A-Z].*" );
+        boolean isBooleanGetterName = IntrospectorUtils.isBooleanGetter( methodName );
         boolean returnTypeIsBoolean = method.getReturnType().getKind() == TypeKind.BOOLEAN ||
             Boolean.class.getName().equals( getQualifiedName( method.getReturnType() ) );
 
@@ -94,7 +94,7 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
     public boolean isSetterMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
-        return methodName.matches( "^set[A-Z].*" ) || isFluentSetter( method );
+        return IntrospectorUtils.isSetter( methodName ) || isFluentSetter( method );
     }
 
     protected boolean isFluentSetter(ExecutableElement method) {
@@ -133,7 +133,7 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
     public boolean isAdderMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
-        return methodName.matches( "^add[A-Z].*" );
+        return IntrospectorUtils.isAdder( methodName );
     }
 
     /**
@@ -149,7 +149,7 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
      */
     public boolean isPresenceCheckMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
-        return methodName.matches( "^has[A-Z].*" );
+        return IntrospectorUtils.isPresenceChecker( methodName );
     }
 
     /**
@@ -166,13 +166,15 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
     @Override
     public String getPropertyName(ExecutableElement getterOrSetterMethod) {
         String methodName = getterOrSetterMethod.getSimpleName().toString();
-        if ( methodName.matches( "^get[A-Z].*" ) || methodName.matches( "^set[A-Z].*" ) ) {
+        if ( IntrospectorUtils.isGetter( methodName ) || IntrospectorUtils.isSetter( methodName ) ) {
             return IntrospectorUtils.decapitalize( methodName.substring( 3 ) );
         }
         else if ( isFluentSetter( getterOrSetterMethod ) ) {
             return methodName;
         }
-        return IntrospectorUtils.decapitalize( methodName.substring( methodName.matches( "^is[A-Z].*" ) ? 2 : 3 ) );
+        return IntrospectorUtils.decapitalize(
+            methodName.substring( IntrospectorUtils.isBooleanGetter( methodName ) ? 2 : 3 )
+        );
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
@@ -71,12 +71,12 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
     public boolean isGetterMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
-        boolean isNonBooleanGetterName = methodName.startsWith( "get" ) && methodName.length() > 3 &&
+        boolean isNonBooleanGetterName = methodName.matches( "^get[A-Z].*" ) &&
             method.getReturnType().getKind() != TypeKind.VOID;
 
-        boolean isBooleanGetterName = methodName.startsWith( "is" ) && methodName.length() > 2;
+        boolean isBooleanGetterName = methodName.matches( "^is[A-Z].*" );
         boolean returnTypeIsBoolean = method.getReturnType().getKind() == TypeKind.BOOLEAN ||
-            "java.lang.Boolean".equals( getQualifiedName( method.getReturnType() ) );
+            Boolean.class.getName().equals( getQualifiedName( method.getReturnType() ) );
 
         return isNonBooleanGetterName || ( isBooleanGetterName && returnTypeIsBoolean );
     }
@@ -94,7 +94,7 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
     public boolean isSetterMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
-        return methodName.startsWith( "set" ) && methodName.length() > 3 || isFluentSetter( method );
+        return methodName.matches( "^set[A-Z].*" ) || isFluentSetter( method );
     }
 
     protected boolean isFluentSetter(ExecutableElement method) {
@@ -133,7 +133,7 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
     public boolean isAdderMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
-        return methodName.startsWith( "add" ) && methodName.length() > 3;
+        return methodName.matches( "^add[A-Z].*" );
     }
 
     /**
@@ -149,7 +149,7 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
      */
     public boolean isPresenceCheckMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
-        return methodName.startsWith( "has" ) && methodName.length() > 3;
+        return methodName.matches( "^has[A-Z].*" );
     }
 
     /**
@@ -166,13 +166,13 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
     @Override
     public String getPropertyName(ExecutableElement getterOrSetterMethod) {
         String methodName = getterOrSetterMethod.getSimpleName().toString();
-        if ( methodName.startsWith( "get" ) || methodName.startsWith( "set" ) ) {
+        if ( methodName.matches( "^get[A-Z].*" ) || methodName.matches( "^set[A-Z].*" ) ) {
             return IntrospectorUtils.decapitalize( methodName.substring( 3 ) );
         }
         else if ( isFluentSetter( getterOrSetterMethod ) ) {
             return methodName;
         }
-        return IntrospectorUtils.decapitalize( methodName.substring( methodName.startsWith( "is" ) ? 2 : 3 ) );
+        return IntrospectorUtils.decapitalize( methodName.substring( methodName.matches( "^is[A-Z].*" ) ? 2 : 3 ) );
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/spi/util/IntrospectorUtils.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/util/IntrospectorUtils.java
@@ -14,7 +14,7 @@ package org.mapstruct.ap.spi.util;
  */
 public class IntrospectorUtils {
 
-    private static final String METHOD_NAME_PATTERN = "^%s[A-Z].*";
+    private static final String METHOD_NAME_PATTERN = "^%s\\p{javaUpperCase}.*";
     private static final String GETTER_METHOD_NAME_PATTERN = String.format( METHOD_NAME_PATTERN, "get" );
     private static final String BOOLEAN_GETTER_METHOD_NAME_PATTERN = String.format( METHOD_NAME_PATTERN, "is" );
     private static final String SETTER_METHOD_NAME_PATTERN = String.format( METHOD_NAME_PATTERN, "set" );

--- a/processor/src/main/java/org/mapstruct/ap/spi/util/IntrospectorUtils.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/util/IntrospectorUtils.java
@@ -14,6 +14,14 @@ package org.mapstruct.ap.spi.util;
  */
 public class IntrospectorUtils {
 
+    private static final String METHOD_NAME_PATTERN = "^%s[A-Z].*";
+    private static final String GETTER_METHOD_NAME_PATTERN = String.format( METHOD_NAME_PATTERN, "get" );
+    private static final String BOOLEAN_GETTER_METHOD_NAME_PATTERN = String.format( METHOD_NAME_PATTERN, "is" );
+    private static final String SETTER_METHOD_NAME_PATTERN = String.format( METHOD_NAME_PATTERN, "set" );
+    private static final String WITHER_METHOD_NAME_PATTERN = String.format( METHOD_NAME_PATTERN, "with" );
+    private static final String ADDER_METHOD_NAME_PATTERN = String.format( METHOD_NAME_PATTERN, "add" );
+    private static final String PRESENCE_CHECKER_METHOD_NAME_PATTERN = String.format( METHOD_NAME_PATTERN, "has" );
+
     private IntrospectorUtils() {
     }
 
@@ -44,4 +52,27 @@ public class IntrospectorUtils {
         return new String( chars );
     }
 
+    public static boolean isGetter(final String methodName) {
+        return methodName.matches( GETTER_METHOD_NAME_PATTERN );
+    }
+
+    public static boolean isBooleanGetter(final String methodName) {
+        return methodName.matches( BOOLEAN_GETTER_METHOD_NAME_PATTERN );
+    }
+
+    public static boolean isSetter(final String methodName) {
+        return methodName.matches( SETTER_METHOD_NAME_PATTERN );
+    }
+
+    public static boolean isWither(final String methodName) {
+        return methodName.matches( WITHER_METHOD_NAME_PATTERN );
+    }
+
+    public static boolean isAdder(final String methodName) {
+        return methodName.matches( ADDER_METHOD_NAME_PATTERN );
+    }
+
+    public static boolean isPresenceChecker(final String methodName) {
+        return methodName.matches( PRESENCE_CHECKER_METHOD_NAME_PATTERN );
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/spi/util/IntrospectorUtilsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/spi/util/IntrospectorUtilsTest.java
@@ -28,6 +28,7 @@ public class IntrospectorUtilsTest {
     @Test
     public void testIsGetter() {
         assertThat( IntrospectorUtils.isGetter( "getA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isGetter( "getÜ" ) ).isTrue();
         assertThat( IntrospectorUtils.isGetter( "geta" ) ).isFalse();
         assertThat( IntrospectorUtils.isGetter( "invalidName" ) ).isFalse();
     }
@@ -35,6 +36,7 @@ public class IntrospectorUtilsTest {
     @Test
     public void testIsBooleanGetter() {
         assertThat( IntrospectorUtils.isBooleanGetter( "isA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isBooleanGetter( "isÄ" ) ).isTrue();
         assertThat( IntrospectorUtils.isBooleanGetter( "isa" ) ).isFalse();
         assertThat( IntrospectorUtils.isBooleanGetter( "invalidName" ) ).isFalse();
     }
@@ -42,6 +44,7 @@ public class IntrospectorUtilsTest {
     @Test
     public void testIsSetter() {
         assertThat( IntrospectorUtils.isSetter( "setA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isSetter( "setÖ" ) ).isTrue();
         assertThat( IntrospectorUtils.isSetter( "seta" ) ).isFalse();
         assertThat( IntrospectorUtils.isSetter( "invalidName" ) ).isFalse();
     }
@@ -49,6 +52,7 @@ public class IntrospectorUtilsTest {
     @Test
     public void testIsWither() {
         assertThat( IntrospectorUtils.isWither( "withA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isWither( "withÜ" ) ).isTrue();
         assertThat( IntrospectorUtils.isWither( "witha" ) ).isFalse();
         assertThat( IntrospectorUtils.isWither( "invalidName" ) ).isFalse();
     }
@@ -56,6 +60,7 @@ public class IntrospectorUtilsTest {
     @Test
     public void testIsAdder() {
         assertThat( IntrospectorUtils.isAdder( "addA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isAdder( "addÄ" ) ).isTrue();
         assertThat( IntrospectorUtils.isAdder( "adda" ) ).isFalse();
         assertThat( IntrospectorUtils.isAdder( "invalidName" ) ).isFalse();
     }
@@ -63,6 +68,7 @@ public class IntrospectorUtilsTest {
     @Test
     public void testIsPresenceChecker() {
         assertThat( IntrospectorUtils.isPresenceChecker( "hasA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isPresenceChecker( "hasÖ" ) ).isTrue();
         assertThat( IntrospectorUtils.isPresenceChecker( "hasa" ) ).isFalse();
         assertThat( IntrospectorUtils.isPresenceChecker( "invalidName" ) ).isFalse();
     }

--- a/processor/src/test/java/org/mapstruct/ap/spi/util/IntrospectorUtilsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/spi/util/IntrospectorUtilsTest.java
@@ -25,4 +25,45 @@ public class IntrospectorUtilsTest {
         assertThat( IntrospectorUtils.decapitalize( "a" ) ).isEqualTo( "a" );
     }
 
+    @Test
+    public void testIsGetter() {
+        assertThat( IntrospectorUtils.isGetter( "getA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isGetter( "geta" ) ).isFalse();
+        assertThat( IntrospectorUtils.isGetter( "invalidName" ) ).isFalse();
+    }
+
+    @Test
+    public void testIsBooleanGetter() {
+        assertThat( IntrospectorUtils.isBooleanGetter( "isA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isBooleanGetter( "isa" ) ).isFalse();
+        assertThat( IntrospectorUtils.isBooleanGetter( "invalidName" ) ).isFalse();
+    }
+
+    @Test
+    public void testIsSetter() {
+        assertThat( IntrospectorUtils.isSetter( "setA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isSetter( "seta" ) ).isFalse();
+        assertThat( IntrospectorUtils.isSetter( "invalidName" ) ).isFalse();
+    }
+
+    @Test
+    public void testIsWither() {
+        assertThat( IntrospectorUtils.isWither( "withA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isWither( "witha" ) ).isFalse();
+        assertThat( IntrospectorUtils.isWither( "invalidName" ) ).isFalse();
+    }
+
+    @Test
+    public void testIsAdder() {
+        assertThat( IntrospectorUtils.isAdder( "addA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isAdder( "adda" ) ).isFalse();
+        assertThat( IntrospectorUtils.isAdder( "invalidName" ) ).isFalse();
+    }
+
+    @Test
+    public void testIsPresenceChecker() {
+        assertThat( IntrospectorUtils.isPresenceChecker( "hasA" ) ).isTrue();
+        assertThat( IntrospectorUtils.isPresenceChecker( "hasa" ) ).isFalse();
+        assertThat( IntrospectorUtils.isPresenceChecker( "invalidName" ) ).isFalse();
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1650/AMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1650/AMapper.java
@@ -15,12 +15,12 @@ public interface AMapper {
 
     AMapper INSTANCE = Mappers.getMapper( AMapper.class );
 
-    @Mapping(source = "b.c", target = "cPrime")
+    @Mapping(source = "b.c", target = "CPrime")
     APrime toAPrime(A a, @MappingTarget APrime mappingTarget);
 
     CPrime toCPrime(C c, @MappingTarget CPrime mappingTarget);
 
-    @Mapping(source = "b.c", target = "cPrime")
+    @Mapping(source = "b.c", target = "CPrime")
     APrime toAPrime(A a);
 
     CPrime toCPrime(C c);

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1650/APrime.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1650/APrime.java
@@ -9,11 +9,11 @@ public class APrime {
 
     private CPrime cPrime;
 
-    public CPrime getcPrime() {
+    public CPrime getCPrime() {
         return cPrime;
     }
 
-    public void setcPrime(CPrime cPrime) {
+    public void setCPrime(CPrime cPrime) {
         this.cPrime = cPrime;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1650/Issue1650Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1650/Issue1650Test.java
@@ -36,10 +36,10 @@ public class Issue1650Test {
 
        // update mapping
        AMapper.INSTANCE.toAPrime( a, aPrime );
-       assertThat( aPrime.getcPrime() ).isNotNull();
+       assertThat( aPrime.getCPrime() ).isNotNull();
 
        // create mapping
         APrime aPrime1 = AMapper.INSTANCE.toAPrime( a );
-        assertThat( aPrime1.getcPrime() ).isNotNull();
+        assertThat( aPrime1.getCPrime() ).isNotNull();
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_846/Mapper846.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_846/Mapper846.java
@@ -44,11 +44,11 @@ public class Mapper846 {
         A() {
         }
 
-        public String getaName() {
+        public String getAName() {
             return aName;
         }
 
-        public void setaName(String name) {
+        public void setAName(String name) {
             this.aName = name;
         }
     }
@@ -56,7 +56,7 @@ public class Mapper846 {
     @Mapper
     interface MyMapper {
 
-        @Mapping(source = "name", target = "aName")
+        @Mapping(source = "name", target = "AName")
         A convert(BInterface b);
 
         @InheritInverseConfiguration

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/abstractBuilder/AbstractBuilderTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/abstractBuilder/AbstractBuilderTest.java
@@ -41,6 +41,8 @@ public class AbstractBuilderTest {
 
         assertThat( product.getPrice() ).isEqualTo( 31 );
         assertThat( product.getName() ).isEqualTo( "router" );
+        assertThat( product.getSettlementPrice() ).isEqualTo( 31 );
+        assertThat( product.getIssuer() ).isTrue();
     }
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/abstractBuilder/ImmutableProduct.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/abstractBuilder/ImmutableProduct.java
@@ -8,10 +8,14 @@ package org.mapstruct.ap.test.builder.abstractBuilder;
 public class ImmutableProduct extends AbstractImmutableProduct {
 
     private final Integer price;
+    private final Integer settlementPrice;
+    private final boolean issuer;
 
     public ImmutableProduct(ImmutableProductBuilder builder) {
         super( builder );
         this.price = builder.price;
+        this.settlementPrice = builder.settlementPrice;
+        this.issuer = builder.issuer;
     }
 
     public static ImmutableProductBuilder builder() {
@@ -22,11 +26,33 @@ public class ImmutableProduct extends AbstractImmutableProduct {
         return price;
     }
 
+    public Integer getSettlementPrice() {
+        return settlementPrice;
+    }
+
+    public boolean getIssuer() {
+        return issuer;
+    }
+
     public static class ImmutableProductBuilder extends AbstractProductBuilder<ImmutableProduct> {
         private Integer price;
+        private Integer settlementPrice;
+        private boolean issuer;
 
         public ImmutableProductBuilder price(Integer price) {
             this.price = price;
+            return this;
+        }
+
+        // Builder setter method is 'similar' to JavaBean setter starting with 'set'
+        public ImmutableProductBuilder settlementPrice(Integer settlementPrice) {
+            this.settlementPrice = settlementPrice;
+            return this;
+        }
+
+        // Builder setter method is 'similar' to JavaBean setter starting with 'is'
+        public ImmutableProductBuilder issuer(boolean issuer) {
+            this.issuer = issuer;
             return this;
         }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/abstractBuilder/ProductMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/abstractBuilder/ProductMapper.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.test.builder.abstractBuilder;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
@@ -13,6 +14,8 @@ public interface ProductMapper {
 
     ProductMapper INSTANCE = Mappers.getMapper( ProductMapper.class );
 
+    @Mapping(target = "settlementPrice", source = "price")
+    @Mapping(target = "issuer", constant = "true")
     ImmutableProduct fromMutable(ProductDto source);
 
     ProductDto fromImmutable(ImmutableProduct source);

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/JodaTimeTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/JodaTimeTest.java
@@ -59,14 +59,14 @@ public class JodaTimeTest {
         in.setDateTime( dt );
         XmlGregorianCalendarBean res = DateTimeToXmlGregorianCalendar.INSTANCE.toXmlGregorianCalendarBean( in );
 
-        assertThat( res.getxMLGregorianCalendar().getYear() ).isEqualTo( 2010 );
-        assertThat( res.getxMLGregorianCalendar().getMonth() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getDay() ).isEqualTo( 15 );
-        assertThat( res.getxMLGregorianCalendar().getHour() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getMinute() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getSecond() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getMillisecond() ).isEqualTo( 100 );
-        assertThat( res.getxMLGregorianCalendar().getTimezone() ).isEqualTo( -60 );
+        assertThat( res.getXMLGregorianCalendar().getYear() ).isEqualTo( 2010 );
+        assertThat( res.getXMLGregorianCalendar().getMonth() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getDay() ).isEqualTo( 15 );
+        assertThat( res.getXMLGregorianCalendar().getHour() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getMinute() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getSecond() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getMillisecond() ).isEqualTo( 100 );
+        assertThat( res.getXMLGregorianCalendar().getTimezone() ).isEqualTo( -60 );
     }
 
     @Test
@@ -78,11 +78,11 @@ public class JodaTimeTest {
         in.setDateTime( dt );
         XmlGregorianCalendarBean res = DateTimeToXmlGregorianCalendar.INSTANCE.toXmlGregorianCalendarBean( in );
 
-        assertThat( res.getxMLGregorianCalendar().getYear() ).isEqualTo( 2010 );
-        assertThat( res.getxMLGregorianCalendar().getMonth() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getDay() ).isEqualTo( 15 );
-        assertThat( res.getxMLGregorianCalendar().getHour() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getMinute() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getYear() ).isEqualTo( 2010 );
+        assertThat( res.getXMLGregorianCalendar().getMonth() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getDay() ).isEqualTo( 15 );
+        assertThat( res.getXMLGregorianCalendar().getHour() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getMinute() ).isEqualTo( 1 );
     }
 
     @Test
@@ -92,7 +92,7 @@ public class JodaTimeTest {
         XmlGregorianCalendarBean in = new XmlGregorianCalendarBean();
         XMLGregorianCalendar xcal =
             DatatypeFactory.newInstance().newXMLGregorianCalendar( 2010, 1, 15, 1, 1, 1, 100, 60 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         DateTimeBean res = XmlGregorianCalendarToDateTime.INSTANCE.toDateTimeBean( in );
         assertThat( res.getDateTime().getYear() ).isEqualTo( 2010 );
@@ -118,7 +118,7 @@ public class JodaTimeTest {
         xcal.setMinute( 34 );
         xcal.setSecond( 45 );
         xcal.setMillisecond( 500 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         DateTimeBean res = XmlGregorianCalendarToDateTime.INSTANCE.toDateTimeBean( in );
         assertThat( res.getDateTime().getYear() ).isEqualTo( 1999 );
@@ -144,7 +144,7 @@ public class JodaTimeTest {
         xcal.setMinute( 34 );
         xcal.setSecond( 45 );
         xcal.setTimezone( 60 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         DateTimeBean res = XmlGregorianCalendarToDateTime.INSTANCE.toDateTimeBean( in );
         assertThat( res.getDateTime().getYear() ).isEqualTo( 1999 );
@@ -169,7 +169,7 @@ public class JodaTimeTest {
         xcal.setHour( 23 );
         xcal.setMinute( 34 );
         xcal.setSecond( 45 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         DateTimeBean res = XmlGregorianCalendarToDateTime.INSTANCE.toDateTimeBean( in );
         assertThat( res.getDateTime().getYear() ).isEqualTo( 1999 );
@@ -194,7 +194,7 @@ public class JodaTimeTest {
         xcal.setHour( 23 );
         xcal.setMinute( 34 );
         xcal.setTimezone( 60 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         DateTimeBean res = XmlGregorianCalendarToDateTime.INSTANCE.toDateTimeBean( in );
         assertThat( res.getDateTime().getYear() ).isEqualTo( 1999 );
@@ -218,7 +218,7 @@ public class JodaTimeTest {
         xcal.setDay( 25 );
         xcal.setHour( 23 );
         xcal.setMinute( 34 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         DateTimeBean res = XmlGregorianCalendarToDateTime.INSTANCE.toDateTimeBean( in );
         assertThat( res.getDateTime().getYear() ).isEqualTo( 1999 );
@@ -241,7 +241,7 @@ public class JodaTimeTest {
         xcal.setMonth( 5 );
         xcal.setDay( 25 );
         xcal.setHour( 23 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         DateTimeBean res = XmlGregorianCalendarToDateTime.INSTANCE.toDateTimeBean( in );
         assertThat( res.getDateTime() ).isNull();
@@ -259,7 +259,7 @@ public class JodaTimeTest {
         XmlGregorianCalendarBean xcb2 = DateTimeToXmlGregorianCalendar.INSTANCE.toXmlGregorianCalendarBean( dtb2 );
 
         assertThat( dtb1.getDateTime() ).isEqualTo( dtb2.getDateTime() );
-        assertThat( xcb1.getxMLGregorianCalendar() ).isEqualTo( xcb2.getxMLGregorianCalendar() );
+        assertThat( xcb1.getXMLGregorianCalendar() ).isEqualTo( xcb2.getXMLGregorianCalendar() );
 
     }
 
@@ -272,14 +272,14 @@ public class JodaTimeTest {
         in.setLocalDateTime( dt );
         XmlGregorianCalendarBean res = LocalDateTimeToXmlGregorianCalendar.INSTANCE.toXmlGregorianCalendarBean( in );
 
-        assertThat( res.getxMLGregorianCalendar().getYear() ).isEqualTo( 2010 );
-        assertThat( res.getxMLGregorianCalendar().getMonth() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getDay() ).isEqualTo( 15 );
-        assertThat( res.getxMLGregorianCalendar().getHour() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getMinute() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getSecond() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getMillisecond() ).isEqualTo( 100 );
-        assertThat( res.getxMLGregorianCalendar().getTimezone() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
+        assertThat( res.getXMLGregorianCalendar().getYear() ).isEqualTo( 2010 );
+        assertThat( res.getXMLGregorianCalendar().getMonth() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getDay() ).isEqualTo( 15 );
+        assertThat( res.getXMLGregorianCalendar().getHour() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getMinute() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getSecond() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getMillisecond() ).isEqualTo( 100 );
+        assertThat( res.getXMLGregorianCalendar().getTimezone() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
     }
 
     @Test
@@ -291,14 +291,14 @@ public class JodaTimeTest {
         in.setLocalDateTime( dt );
         XmlGregorianCalendarBean res = LocalDateTimeToXmlGregorianCalendar.INSTANCE.toXmlGregorianCalendarBean( in );
 
-        assertThat( res.getxMLGregorianCalendar().getYear() ).isEqualTo( 2010 );
-        assertThat( res.getxMLGregorianCalendar().getMonth() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getDay() ).isEqualTo( 15 );
-        assertThat( res.getxMLGregorianCalendar().getHour() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getMinute() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getSecond() ).isEqualTo( 0 );
-        assertThat( res.getxMLGregorianCalendar().getMillisecond() ).isEqualTo( 0 );
-        assertThat( res.getxMLGregorianCalendar().getTimezone() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
+        assertThat( res.getXMLGregorianCalendar().getYear() ).isEqualTo( 2010 );
+        assertThat( res.getXMLGregorianCalendar().getMonth() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getDay() ).isEqualTo( 15 );
+        assertThat( res.getXMLGregorianCalendar().getHour() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getMinute() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getSecond() ).isEqualTo( 0 );
+        assertThat( res.getXMLGregorianCalendar().getMillisecond() ).isEqualTo( 0 );
+        assertThat( res.getXMLGregorianCalendar().getTimezone() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
     }
 
     @Test
@@ -308,7 +308,7 @@ public class JodaTimeTest {
         XmlGregorianCalendarBean in = new XmlGregorianCalendarBean();
         XMLGregorianCalendar xcal =
             DatatypeFactory.newInstance().newXMLGregorianCalendar( 2010, 1, 15, 1, 1, 1, 100, 60 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         LocalDateTimeBean res = XmlGregorianCalendarToLocalDateTime.INSTANCE.toDateTimeBean( in );
         assertThat( res.getLocalDateTime().getYear() ).isEqualTo( 2010 );
@@ -332,7 +332,7 @@ public class JodaTimeTest {
         xcal.setHour( 23 );
         xcal.setMinute( 34 );
         xcal.setSecond( 45 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         LocalDateTimeBean res = XmlGregorianCalendarToLocalDateTime.INSTANCE.toDateTimeBean( in );
         assertThat( res.getLocalDateTime().getYear() ).isEqualTo( 1999 );
@@ -356,7 +356,7 @@ public class JodaTimeTest {
         xcal.setHour( 23 );
         xcal.setMinute( 34 );
         xcal.setTimezone( 60 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         LocalDateTimeBean res = XmlGregorianCalendarToLocalDateTime.INSTANCE.toDateTimeBean( in );
         assertThat( res.getLocalDateTime().getYear() ).isEqualTo( 1999 );
@@ -378,7 +378,7 @@ public class JodaTimeTest {
         xcal.setMonth( 5 );
         xcal.setDay( 25 );
         xcal.setHour( 23 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         LocalDateTimeBean res = XmlGregorianCalendarToLocalDateTime.INSTANCE.toDateTimeBean( in );
         assertThat( res.getLocalDateTime() ).isNull();
@@ -394,14 +394,14 @@ public class JodaTimeTest {
         in.setLocalDate( dt );
         XmlGregorianCalendarBean res = LocalDateToXmlGregorianCalendar.INSTANCE.toXmlGregorianCalendarBean( in );
 
-        assertThat( res.getxMLGregorianCalendar().getYear() ).isEqualTo( 2010 );
-        assertThat( res.getxMLGregorianCalendar().getMonth() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getDay() ).isEqualTo( 15 );
-        assertThat( res.getxMLGregorianCalendar().getHour() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
-        assertThat( res.getxMLGregorianCalendar().getMinute() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
-        assertThat( res.getxMLGregorianCalendar().getSecond() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
-        assertThat( res.getxMLGregorianCalendar().getMillisecond() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
-        assertThat( res.getxMLGregorianCalendar().getTimezone() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
+        assertThat( res.getXMLGregorianCalendar().getYear() ).isEqualTo( 2010 );
+        assertThat( res.getXMLGregorianCalendar().getMonth() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getDay() ).isEqualTo( 15 );
+        assertThat( res.getXMLGregorianCalendar().getHour() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
+        assertThat( res.getXMLGregorianCalendar().getMinute() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
+        assertThat( res.getXMLGregorianCalendar().getSecond() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
+        assertThat( res.getXMLGregorianCalendar().getMillisecond() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
+        assertThat( res.getXMLGregorianCalendar().getTimezone() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
     }
 
     @Test
@@ -414,7 +414,7 @@ public class JodaTimeTest {
             5,
             25,
             DatatypeConstants.FIELD_UNDEFINED );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         LocalDateBean res = XmlGregorianCalendarToLocalDate.INSTANCE.toLocalDateBean( in );
         assertThat( res.getLocalDate().getYear() ).isEqualTo( 1999 );
@@ -432,7 +432,7 @@ public class JodaTimeTest {
             5,
             DatatypeConstants.FIELD_UNDEFINED,
             DatatypeConstants.FIELD_UNDEFINED );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         LocalDateBean res = XmlGregorianCalendarToLocalDate.INSTANCE.toLocalDateBean( in );
         assertThat( res.getLocalDate() ).isNull();
@@ -448,14 +448,14 @@ public class JodaTimeTest {
         in.setLocalTime( dt );
         XmlGregorianCalendarBean res = LocalTimeToXmlGregorianCalendar.INSTANCE.toXmlGregorianCalendarBean( in );
 
-        assertThat( res.getxMLGregorianCalendar().getYear() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
-        assertThat( res.getxMLGregorianCalendar().getMonth() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
-        assertThat( res.getxMLGregorianCalendar().getDay() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
-        assertThat( res.getxMLGregorianCalendar().getHour() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getMinute() ).isEqualTo( 1 );
-        assertThat( res.getxMLGregorianCalendar().getSecond() ).isEqualTo( 0 );
-        assertThat( res.getxMLGregorianCalendar().getMillisecond() ).isEqualTo( 100 );
-        assertThat( res.getxMLGregorianCalendar().getTimezone() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
+        assertThat( res.getXMLGregorianCalendar().getYear() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
+        assertThat( res.getXMLGregorianCalendar().getMonth() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
+        assertThat( res.getXMLGregorianCalendar().getDay() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
+        assertThat( res.getXMLGregorianCalendar().getHour() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getMinute() ).isEqualTo( 1 );
+        assertThat( res.getXMLGregorianCalendar().getSecond() ).isEqualTo( 0 );
+        assertThat( res.getXMLGregorianCalendar().getMillisecond() ).isEqualTo( 100 );
+        assertThat( res.getXMLGregorianCalendar().getTimezone() ).isEqualTo( DatatypeConstants.FIELD_UNDEFINED );
     }
 
     @Test
@@ -465,7 +465,7 @@ public class JodaTimeTest {
         XmlGregorianCalendarBean in = new XmlGregorianCalendarBean();
         XMLGregorianCalendar xcal =
             DatatypeFactory.newInstance().newXMLGregorianCalendarTime( 1, 1, 1, 100, 60 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         LocalTimeBean res = XmlGregorianCalendarToLocalTime.INSTANCE.toLocalTimeBean( in );
         assertThat( res.getLocalTime().getHourOfDay() ).isEqualTo( 1 );
@@ -483,7 +483,7 @@ public class JodaTimeTest {
         xcal.setHour( 23 );
         xcal.setMinute( 34 );
         xcal.setSecond( 45 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         LocalTimeBean res = XmlGregorianCalendarToLocalTime.INSTANCE.toLocalTimeBean( in );
         assertThat( res.getLocalTime().getHourOfDay() ).isEqualTo( 23 );
@@ -501,7 +501,7 @@ public class JodaTimeTest {
         xcal.setHour( 23 );
         xcal.setMinute( 34 );
         xcal.setTimezone( 60 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         LocalTimeBean res = XmlGregorianCalendarToLocalTime.INSTANCE.toLocalTimeBean( in );
         assertThat( res.getLocalTime().getHourOfDay() ).isEqualTo( 23 );
@@ -520,7 +520,7 @@ public class JodaTimeTest {
         xcal.setMonth( 5 );
         xcal.setDay( 25 );
         xcal.setHour( 23 );
-        in.setxMLGregorianCalendar( xcal );
+        in.setXMLGregorianCalendar( xcal );
 
         LocalTimeBean res = XmlGregorianCalendarToLocalTime.INSTANCE.toLocalTimeBean( in );
         assertThat( res.getLocalTime() ).isNull();

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/bean/XmlGregorianCalendarBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/bean/XmlGregorianCalendarBean.java
@@ -15,11 +15,11 @@ public class XmlGregorianCalendarBean {
 
     XMLGregorianCalendar xMLGregorianCalendar;
 
-    public XMLGregorianCalendar getxMLGregorianCalendar() {
+    public XMLGregorianCalendar getXMLGregorianCalendar() {
         return xMLGregorianCalendar;
     }
 
-    public void setxMLGregorianCalendar(XMLGregorianCalendar xMLGregorianCalendar) {
+    public void setXMLGregorianCalendar(XMLGregorianCalendar xMLGregorianCalendar) {
         this.xMLGregorianCalendar = xMLGregorianCalendar;
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/DateTimeToXmlGregorianCalendar.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/DateTimeToXmlGregorianCalendar.java
@@ -20,6 +20,6 @@ public interface DateTimeToXmlGregorianCalendar {
 
     DateTimeToXmlGregorianCalendar INSTANCE = Mappers.getMapper( DateTimeToXmlGregorianCalendar.class );
 
-    @Mapping( target = "xMLGregorianCalendar", source = "dateTime")
+    @Mapping( target = "XMLGregorianCalendar", source = "dateTime")
     XmlGregorianCalendarBean toXmlGregorianCalendarBean( DateTimeBean in );
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/LocalDateTimeToXmlGregorianCalendar.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/LocalDateTimeToXmlGregorianCalendar.java
@@ -20,7 +20,7 @@ public interface LocalDateTimeToXmlGregorianCalendar {
 
     LocalDateTimeToXmlGregorianCalendar INSTANCE = Mappers.getMapper( LocalDateTimeToXmlGregorianCalendar.class );
 
-    @Mapping( target = "xMLGregorianCalendar", source = "localDateTime")
+    @Mapping( target = "XMLGregorianCalendar", source = "localDateTime")
     XmlGregorianCalendarBean toXmlGregorianCalendarBean( LocalDateTimeBean in );
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/LocalDateToXmlGregorianCalendar.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/LocalDateToXmlGregorianCalendar.java
@@ -20,7 +20,7 @@ public interface LocalDateToXmlGregorianCalendar {
 
     LocalDateToXmlGregorianCalendar INSTANCE = Mappers.getMapper( LocalDateToXmlGregorianCalendar.class );
 
-    @Mapping( target = "xMLGregorianCalendar", source = "localDate")
+    @Mapping( target = "XMLGregorianCalendar", source = "localDate")
     XmlGregorianCalendarBean toXmlGregorianCalendarBean( LocalDateBean in );
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/LocalTimeToXmlGregorianCalendar.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/LocalTimeToXmlGregorianCalendar.java
@@ -20,7 +20,7 @@ public interface LocalTimeToXmlGregorianCalendar {
 
     LocalTimeToXmlGregorianCalendar INSTANCE = Mappers.getMapper( LocalTimeToXmlGregorianCalendar.class );
 
-    @Mapping( target = "xMLGregorianCalendar", source = "localTime")
+    @Mapping( target = "XMLGregorianCalendar", source = "localTime")
     XmlGregorianCalendarBean toXmlGregorianCalendarBean( LocalTimeBean in );
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/XmlGregorianCalendarToDateTime.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/XmlGregorianCalendarToDateTime.java
@@ -20,6 +20,6 @@ public interface XmlGregorianCalendarToDateTime {
 
     XmlGregorianCalendarToDateTime INSTANCE = Mappers.getMapper( XmlGregorianCalendarToDateTime.class );
 
-    @Mapping( target = "dateTime", source = "xMLGregorianCalendar" )
+    @Mapping( target = "dateTime", source = "XMLGregorianCalendar" )
     DateTimeBean toDateTimeBean( XmlGregorianCalendarBean in );
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/XmlGregorianCalendarToLocalDate.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/XmlGregorianCalendarToLocalDate.java
@@ -20,6 +20,6 @@ public interface XmlGregorianCalendarToLocalDate {
 
     XmlGregorianCalendarToLocalDate INSTANCE = Mappers.getMapper( XmlGregorianCalendarToLocalDate.class );
 
-    @Mapping( target = "localDate", source = "xMLGregorianCalendar" )
+    @Mapping( target = "localDate", source = "XMLGregorianCalendar" )
     LocalDateBean toLocalDateBean( XmlGregorianCalendarBean in );
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/XmlGregorianCalendarToLocalDateTime.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/XmlGregorianCalendarToLocalDateTime.java
@@ -20,6 +20,6 @@ public interface XmlGregorianCalendarToLocalDateTime {
 
     XmlGregorianCalendarToLocalDateTime INSTANCE = Mappers.getMapper( XmlGregorianCalendarToLocalDateTime.class );
 
-    @Mapping( target = "localDateTime", source = "xMLGregorianCalendar" )
+    @Mapping( target = "localDateTime", source = "XMLGregorianCalendar" )
     LocalDateTimeBean toDateTimeBean( XmlGregorianCalendarBean in );
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/XmlGregorianCalendarToLocalTime.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/mapper/XmlGregorianCalendarToLocalTime.java
@@ -20,6 +20,6 @@ public interface XmlGregorianCalendarToLocalTime {
 
     XmlGregorianCalendarToLocalTime INSTANCE = Mappers.getMapper( XmlGregorianCalendarToLocalTime.class );
 
-    @Mapping( target = "localTime", source = "xMLGregorianCalendar" )
+    @Mapping( target = "localTime", source = "XMLGregorianCalendar" )
     LocalTimeBean toLocalTimeBean( XmlGregorianCalendarBean in );
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomAccessorNamingStrategy.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomAccessorNamingStrategy.java
@@ -29,20 +29,20 @@ public class CustomAccessorNamingStrategy extends DefaultAccessorNamingStrategy 
     public boolean isSetterMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
-        return methodName.matches( "^with[A-Z].*" );
+        return IntrospectorUtils.isWither( methodName );
     }
 
     @Override
     public boolean isAdderMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
-        return methodName.matches( "^add[A-Z].*" );
+        return IntrospectorUtils.isAdder( methodName );
     }
 
     @Override
     public String getPropertyName(ExecutableElement getterOrSetterMethod) {
         String methodName = getterOrSetterMethod.getSimpleName().toString();
         return IntrospectorUtils.decapitalize(
-            methodName.matches( "^with[A-Z].*" ) ? methodName.substring( 4 ) : methodName );
+            IntrospectorUtils.isWither( methodName ) ? methodName.substring( 4 ) : methodName );
     }
 
     @Override

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomAccessorNamingStrategy.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/spi/CustomAccessorNamingStrategy.java
@@ -29,20 +29,20 @@ public class CustomAccessorNamingStrategy extends DefaultAccessorNamingStrategy 
     public boolean isSetterMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
 
-        return methodName.startsWith( "with" ) && methodName.length() > 4;
+        return methodName.matches( "^with[A-Z].*" );
     }
 
     @Override
     public boolean isAdderMethod(ExecutableElement method) {
         String methodName = method.getSimpleName().toString();
-        return methodName.startsWith( "add" ) && methodName.length() > 3;
+        return methodName.matches( "^add[A-Z].*" );
     }
 
     @Override
     public String getPropertyName(ExecutableElement getterOrSetterMethod) {
         String methodName = getterOrSetterMethod.getSimpleName().toString();
         return IntrospectorUtils.decapitalize(
-            methodName.startsWith( "with" ) ? methodName.substring( 4 ) : methodName );
+            methodName.matches( "^with[A-Z].*" ) ? methodName.substring( 4 ) : methodName );
     }
 
     @Override


### PR DESCRIPTION
Originally Oracle declares what can be named getter/setter. And it's not only about using proper prefix "get", "set", "is", but also the character following the prefix has to be uppercase. This pull request fixes the naming pattern for bean properties. All existing tests and their test data are updated accordingly.