### PR TITLE
#1742 refactoring and making builder optional

### DIFF
--- a/core/src/main/java/org/mapstruct/Builder.java
+++ b/core/src/main/java/org/mapstruct/Builder.java
@@ -29,4 +29,12 @@ public @interface Builder {
      * @return the method that needs to tbe invoked on the builder
      */
     String buildMethod() default "build";
+
+    /**
+     * Toggling builders on / off. Builders are sometimes used solely for unit testing (fluent testdata)
+     * MapStruct will need to use the regular getters /setters in that case.
+     *
+     * @return when true, no builder patterns will be applied
+     */
+    boolean noBuilder() default false;
 }

--- a/core/src/main/java/org/mapstruct/Builder.java
+++ b/core/src/main/java/org/mapstruct/Builder.java
@@ -36,5 +36,5 @@ public @interface Builder {
      *
      * @return when true, no builder patterns will be applied
      */
-    boolean noBuilder() default false;
+    boolean disableBuilder() default false;
 }

--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -686,6 +686,11 @@ To finish the mapping MapStruct generates code that will invoke the build method
 
 [NOTE]
 ======
+Builder detection can be switched off by means of `@Builder#disableBuilder`. MapStruct will fall back on regular getters / setters in case builders are disabled.
+======
+
+[NOTE]
+======
 The <<object-factories>> are also considered for the builder type.
 E.g. If an object factory exists for our `PersonBuilder` then this factory would be used instead of the builder creation method.
 ======

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractBaseBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractBaseBuilder.java
@@ -7,6 +7,7 @@ package org.mapstruct.ap.internal.model;
 
 import javax.lang.model.element.AnnotationMirror;
 import org.mapstruct.ap.internal.model.common.Assignment;
+import org.mapstruct.ap.internal.model.common.BuilderType;
 import org.mapstruct.ap.internal.model.common.ParameterBinding;
 import org.mapstruct.ap.internal.model.common.SourceRHS;
 import org.mapstruct.ap.internal.model.common.Type;
@@ -73,7 +74,7 @@ class AbstractBaseBuilder<B extends AbstractBaseBuilder<B>> {
      *
      * @return See above
      */
-    Assignment createForgedAssignment(SourceRHS sourceRHS, ForgedMethod forgedMethod) {
+    Assignment createForgedAssignment(SourceRHS sourceRHS, BuilderType builderType, ForgedMethod forgedMethod) {
 
         if ( ctx.getForgedMethodsUnderCreation().containsKey( forgedMethod ) ) {
             return createAssignment( sourceRHS, ctx.getForgedMethodsUnderCreation().get( forgedMethod ) );
@@ -93,6 +94,7 @@ class AbstractBaseBuilder<B extends AbstractBaseBuilder<B>> {
         else {
             forgedMappingMethod = new BeanMappingMethod.Builder()
                 .forgedMethod( forgedMethod )
+                .returnTypeBuilder( builderType )
                 .mappingContext( ctx )
                 .build();
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
@@ -63,7 +63,7 @@ public abstract class AbstractMappingMethodBuilder<B extends AbstractMappingMeth
             true
         );
 
-        return createForgedAssignment( sourceRHS, forgedMethod );
+        return createForgedAssignment( sourceRHS, ctx.getTypeFactory().builderTypeFor( targetType ), forgedMethod );
     }
 
     private String getName(Type sourceType, Type targetType) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
@@ -8,6 +8,7 @@ package org.mapstruct.ap.internal.model;
 import org.mapstruct.ap.internal.model.common.Assignment;
 import org.mapstruct.ap.internal.model.common.SourceRHS;
 import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.source.BeanMapping;
 import org.mapstruct.ap.internal.model.source.ForgedMethod;
 import org.mapstruct.ap.internal.model.source.ForgedMethodHistory;
 import org.mapstruct.ap.internal.util.Strings;
@@ -63,7 +64,12 @@ public abstract class AbstractMappingMethodBuilder<B extends AbstractMappingMeth
             true
         );
 
-        return createForgedAssignment( sourceRHS, ctx.getTypeFactory().builderTypeFor( targetType ), forgedMethod );
+        return createForgedAssignment(
+                        sourceRHS,
+                        ctx.getTypeFactory()
+                           .builderTypeFor( targetType, BeanMapping.builderPrismFor( method ).orElse( null ) ),
+                        forgedMethod
+        );
     }
 
     private String getName(Type sourceType, Type targetType) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -590,7 +590,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                         Accessor sourceReadAccessor =
                             sourceParameter.getType().getPropertyReadAccessors().get( targetPropertyName );
 
-                        ExecutableElementAccessor sourcePresenceChecker =
+                        Accessor sourcePresenceChecker =
                             sourceParameter.getType().getPropertyPresenceCheckers().get( targetPropertyName );
 
                         if ( sourceReadAccessor != null ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -6,6 +6,9 @@
 package org.mapstruct.ap.internal.model;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
+import static org.mapstruct.ap.internal.util.Message.BEANMAPPING_ABSTRACT;
+import static org.mapstruct.ap.internal.util.Message.BEANMAPPING_NOT_ASSIGNABLE;
+import static org.mapstruct.ap.internal.util.Message.GENERAL_ABSTRACT_RETURN_TYPE;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
@@ -27,6 +30,7 @@ import javax.tools.Diagnostic;
 import org.mapstruct.ap.internal.model.PropertyMapping.ConstantMappingBuilder;
 import org.mapstruct.ap.internal.model.PropertyMapping.JavaExpressionMappingBuilder;
 import org.mapstruct.ap.internal.model.PropertyMapping.PropertyMappingBuilder;
+import org.mapstruct.ap.internal.model.common.BuilderType;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.dependency.GraphAnalyzer;
@@ -50,7 +54,6 @@ import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
-import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
 
 /**
  * A {@link MappingMethod} implemented by a {@link Mapper} class which maps one bean type to another, optionally
@@ -63,20 +66,23 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
     private final List<PropertyMapping> propertyMappings;
     private final Map<String, List<PropertyMapping>> mappingsByParameter;
     private final List<PropertyMapping> constantMappings;
-    private final Type resultType;
+    private final Type returnTypeToConstruct;
+    private final BuilderType returnTypeBuilder;
     private final MethodReference finalizerMethod;
 
     public static class Builder {
 
         private MappingBuilderContext ctx;
         private Method method;
+
+        /* returnType to construct can have a builder */
+        private BuilderType returnTypeBuilder;
+
         private Map<String, Accessor> unprocessedTargetProperties;
         private Map<String, Accessor> unprocessedSourceProperties;
         private Set<String> targetProperties;
         private final List<PropertyMapping> propertyMappings = new ArrayList<>();
         private final Set<Parameter> unprocessedSourceParameters = new HashSet<>();
-        private NullValueMappingStrategyPrism nullValueMappingStrategy;
-        private SelectionParameters selectionParameters;
         private final Set<String> existingVariableNames = new HashSet<>();
         private Map<String, List<Mapping>> methodMappings;
         private SingleMappingByTargetPropertyNameFunction singleMapping;
@@ -87,27 +93,69 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             return this;
         }
 
+        public Builder returnTypeBuilder( BuilderType returnTypeBuilder ) {
+            this.returnTypeBuilder = returnTypeBuilder;
+            return this;
+        }
+
         public Builder sourceMethod(SourceMethod sourceMethod) {
             singleMapping = new SourceMethodSingleMapping( sourceMethod );
-            return setupMethodWithMapping( sourceMethod );
+            this.method = sourceMethod;
+            return this;
         }
 
         public Builder forgedMethod(Method method) {
             singleMapping = new EmptySingleMapping();
-            return setupMethodWithMapping( method );
+            this.method = method;
+            return this;
         }
 
-        private Builder setupMethodWithMapping(Method sourceMethod) {
-            this.method = sourceMethod;
-            this.methodMappings = sourceMethod.getMappingOptions().getMappings();
-            CollectionMappingStrategyPrism cms = sourceMethod.getMapperConfiguration().getCollectionMappingStrategy();
-            Type mappingType = method.getResultType();
-            if ( !method.isUpdateMethod() ) {
-                mappingType = mappingType.getEffectiveType();
+        public BeanMappingMethod build() {
+
+            BeanMapping beanMapping = method.getMappingOptions().getBeanMapping();
+            SelectionParameters selectionParameters = beanMapping != null ? beanMapping.getSelectionParameters() : null;
+
+            /* the return type that needs to be constructed (new or factorized), so for instance: */
+            /*  1) the return type of a non-update method */
+            /*  2) or the implementation type that needs to be used when the return type is abstract */
+            /*  3) or the builder whenever the return type is immutable */
+            Type returnTypeToConstruct = null;
+
+            /* factory or builder method to construct the returnTypeToConstruct */
+            MethodReference factoryMethod = null;
+
+            // determine which return type to construct
+            if ( !method.getReturnType().isVoid() ) {
+                Type returnTypeImpl = getReturnTypeToConstructFromSelectionParameters( selectionParameters );
+                if ( returnTypeImpl != null ) {
+                    factoryMethod = getFactoryMethod( returnTypeImpl, selectionParameters );
+                    if ( factoryMethod != null || canBeConstructed( returnTypeImpl ) ) {
+                        returnTypeToConstruct = returnTypeImpl;
+                    }
+                    else {
+                        reportResultTypeFromBeanMappingNotConstructableError( returnTypeImpl );
+                    }
+                }
+                else {
+                    returnTypeImpl = isBuilderRequired() ? returnTypeBuilder.getBuilder() : method.getReturnType();
+                    factoryMethod = getFactoryMethod( returnTypeImpl, selectionParameters );
+                    if ( factoryMethod != null || canBeConstructed( returnTypeImpl ) ) {
+                        returnTypeToConstruct = returnTypeImpl;
+                    }
+                    else {
+                        reportReturnTypeNotConstructableError( returnTypeImpl );
+                    }
+                }
             }
 
-            Map<String, Accessor> accessors = mappingType
-                .getPropertyWriteAccessors( cms );
+            /* the type that needs to be used in the mapping process as target */
+            Type resultTypeToMap = returnTypeToConstruct == null ? method.getResultType() : returnTypeToConstruct;
+
+            this.methodMappings = this.method.getMappingOptions().getMappings();
+            CollectionMappingStrategyPrism cms = this.method.getMapperConfiguration().getCollectionMappingStrategy();
+
+            // determine accessors
+            Map<String, Accessor> accessors = resultTypeToMap.getPropertyWriteAccessors( cms );
             this.targetProperties = accessors.keySet();
 
             this.unprocessedTargetProperties = new LinkedHashMap<>( accessors );
@@ -125,17 +173,13 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             }
             existingVariableNames.addAll( method.getParameterNames() );
 
-            BeanMapping beanMapping = method.getMappingOptions().getBeanMapping();
+            // get bean mapping (when specified as annotation )
             if ( beanMapping != null ) {
                 for ( String ignoreUnmapped : beanMapping.getIgnoreUnmappedSourceProperties() ) {
                     unprocessedSourceProperties.remove( ignoreUnmapped );
                 }
             }
 
-            return this;
-        }
-
-        public BeanMappingMethod build() {
             // map properties with mapping
             boolean mappingErrorOccured = handleDefinedMappings();
             if ( mappingErrorOccured ) {
@@ -158,87 +202,29 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             reportErrorForUnmappedTargetPropertiesIfRequired();
             reportErrorForUnmappedSourcePropertiesIfRequired();
 
-            // get bean mapping (when specified as annotation )
-            BeanMapping beanMapping = method.getMappingOptions().getBeanMapping();
-            BeanMappingPrism beanMappingPrism = BeanMappingPrism.getInstanceOn( method.getExecutable() );
-
             // mapNullToDefault
             NullValueMappingStrategyPrism nullValueMappingStrategy =
                 beanMapping != null ? beanMapping.getNullValueMappingStrategy() : null;
             boolean mapNullToDefault = method.getMapperConfiguration().isMapToDefault( nullValueMappingStrategy );
 
-
-            // selectionParameters
-            SelectionParameters selectionParameters = beanMapping != null ? beanMapping.getSelectionParameters() : null;
-
-            // check if there's a factory method for the result type
-            MethodReference factoryMethod = null;
-            if ( !method.isUpdateMethod() ) {
-                factoryMethod = ObjectFactoryMethodResolver.getFactoryMethod(
-                    method,
-                    method.getResultType(),
-                    selectionParameters,
-                    ctx
-                );
-            }
-
-            // if there's no factory method, try the resultType in the @BeanMapping
-            Type resultType = null;
-            if ( factoryMethod == null ) {
-                if ( selectionParameters != null && selectionParameters.getResultType() != null ) {
-                    resultType = ctx.getTypeFactory().getType( selectionParameters.getResultType() ).getEffectiveType();
-                    if ( resultType.isAbstract() ) {
-                        ctx.getMessager().printMessage(
-                            method.getExecutable(),
-                            beanMappingPrism.mirror,
-                            Message.BEANMAPPING_ABSTRACT,
-                            resultType,
-                            method.getResultType()
-                        );
-                    }
-                    else if ( !resultType.isAssignableTo( method.getResultType() ) ) {
-                        ctx.getMessager().printMessage(
-                            method.getExecutable(),
-                            beanMappingPrism.mirror,
-                            Message.BEANMAPPING_NOT_ASSIGNABLE, resultType, method.getResultType()
-                        );
-                    }
-                    else if ( !resultType.hasEmptyAccessibleContructor() ) {
-                        ctx.getMessager().printMessage(
-                            method.getExecutable(),
-                            beanMappingPrism.mirror,
-                            Message.GENERAL_NO_SUITABLE_CONSTRUCTOR,
-                            resultType
-                        );
-                    }
-                }
-                else if ( !method.isUpdateMethod() && method.getReturnType().getEffectiveType().isAbstract() ) {
-                    ctx.getMessager().printMessage(
-                        method.getExecutable(),
-                        Message.GENERAL_ABSTRACT_RETURN_TYPE,
-                        method.getReturnType().getEffectiveType()
-                    );
-                }
-                else if ( !method.isUpdateMethod() &&
-                    !method.getReturnType().getEffectiveType().hasEmptyAccessibleContructor() ) {
-                    ctx.getMessager().printMessage(
-                        method.getExecutable(),
-                        Message.GENERAL_NO_SUITABLE_CONSTRUCTOR,
-                        method.getReturnType().getEffectiveType()
-                    );
-                }
-            }
-
+            // sort
             sortPropertyMappingsByDependencies();
 
+            // before / after mappings
             List<LifecycleCallbackMethodReference> beforeMappingMethods = LifecycleMethodResolver.beforeMappingMethods(
-                method,
-                selectionParameters,
-                ctx,
-                existingVariableNames
+                            method,
+                            resultTypeToMap,
+                            selectionParameters,
+                            ctx,
+                            existingVariableNames
             );
-            List<LifecycleCallbackMethodReference> afterMappingMethods =
-                LifecycleMethodResolver.afterMappingMethods( method, selectionParameters, ctx, existingVariableNames );
+            List<LifecycleCallbackMethodReference> afterMappingMethods = LifecycleMethodResolver.afterMappingMethods(
+                            method,
+                            resultTypeToMap,
+                            selectionParameters,
+                            ctx,
+                            existingVariableNames
+            );
 
             if (factoryMethod != null && method instanceof ForgedMethod ) {
                 ( (ForgedMethod) method ).addThrownTypes( factoryMethod.getThrownTypes() );
@@ -246,7 +232,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
 
             MethodReference finalizeMethod = null;
 
-            if ( shouldCallFinalizerMethod( resultType == null ? method.getResultType() : resultType ) ) {
+            if ( shouldCallFinalizerMethod( returnTypeToConstruct ) ) {
                 finalizeMethod = getFinalizerMethod();
             }
 
@@ -256,32 +242,41 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 propertyMappings,
                 factoryMethod,
                 mapNullToDefault,
-                resultType,
+                returnTypeToConstruct,
+                returnTypeBuilder,
                 beforeMappingMethods,
                 afterMappingMethods,
                 finalizeMethod
             );
         }
 
-        private boolean shouldCallFinalizerMethod(Type resultType) {
-            Type returnType = method.getReturnType();
-            if ( returnType.isVoid() ) {
+        /**
+         * @return builder is required when there is a returnTypeBuilder and the mapping method is not update method.
+         * However, builder is also required when there is a returnTypeBuilder, the mapping target is the builder and
+         * builder is not assignable to the return type (so without building).
+         */
+        private boolean isBuilderRequired() {
+            return returnTypeBuilder != null
+                    && ( !method.isUpdateMethod() || !method.isMappingTargetAssignableToReturnType() );
+        }
+
+        private boolean shouldCallFinalizerMethod(Type returnTypeToConstruct ) {
+            if ( returnTypeToConstruct == null ) {
                 return false;
             }
-            Type mappingType = method.isUpdateMethod() ? resultType : resultType.getEffectiveType();
-            if ( mappingType.isAssignableTo( returnType ) ) {
+            else if ( returnTypeToConstruct.isAssignableTo( method.getReturnType() ) ) {
                 // If the mapping type can be assigned to the return type then we
                 // don't need a finalizer method
                 return false;
             }
 
-            return returnType.getBuilderType() != null;
+            return returnTypeBuilder != null;
         }
 
         private MethodReference getFinalizerMethod() {
             return BuilderFinisherMethodResolver.getBuilderFinisherMethod(
                 method,
-                method.getReturnType().getBuilderType(),
+                returnTypeBuilder,
                 ctx
             );
         }
@@ -371,6 +366,87 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 );
             }
         }
+
+        private Type getReturnTypeToConstructFromSelectionParameters(SelectionParameters selectionParams) {
+            if ( selectionParams != null && selectionParams.getResultType() != null ) {
+                return ctx.getTypeFactory().getType( selectionParams.getResultType() );
+            }
+            return null;
+        }
+
+        private boolean canBeConstructed(Type typeToBeConstructed) {
+            return !typeToBeConstructed.isAbstract()
+                    && typeToBeConstructed.isAssignableTo( this.method.getResultType() )
+                    && typeToBeConstructed.hasEmptyAccessibleContructor();
+        }
+
+        private void reportResultTypeFromBeanMappingNotConstructableError(Type resultType) {
+
+            if ( resultType.isAbstract() ) {
+                ctx.getMessager().printMessage(
+                                method.getExecutable(),
+                                BeanMappingPrism.getInstanceOn( method.getExecutable() ).mirror,
+                                BEANMAPPING_ABSTRACT,
+                                resultType,
+                                method.getResultType()
+                );
+            }
+            else if ( !resultType.isAssignableTo( method.getResultType() ) ) {
+                ctx.getMessager().printMessage(
+                                method.getExecutable(),
+                                BeanMappingPrism.getInstanceOn( method.getExecutable() ).mirror,
+                                BEANMAPPING_NOT_ASSIGNABLE,
+                                resultType,
+                                method.getResultType()
+                );
+            }
+            else if ( !resultType.hasEmptyAccessibleContructor() ) {
+                ctx.getMessager().printMessage(
+                                method.getExecutable(),
+                                BeanMappingPrism.getInstanceOn( method.getExecutable() ).mirror,
+                                Message.GENERAL_NO_SUITABLE_CONSTRUCTOR,
+                                resultType
+                );
+            }
+        }
+
+        private void reportReturnTypeNotConstructableError(Type returnType) {
+            if ( returnType.isAbstract() ) {
+                ctx.getMessager().printMessage(
+                                method.getExecutable(),
+                                GENERAL_ABSTRACT_RETURN_TYPE,
+                                returnType
+                );
+            }
+            else if ( !returnType.hasEmptyAccessibleContructor() ) {
+                ctx.getMessager().printMessage(
+                                method.getExecutable(),
+                                Message.GENERAL_NO_SUITABLE_CONSTRUCTOR,
+                                returnType
+                );
+            }
+        }
+
+        /**
+         * Find a factory method for a return type or for a builder.
+         * @param returnTypeImpl the return type implementation to construct
+         * @param selectionParameters
+         * @return
+         */
+        private MethodReference getFactoryMethod(Type returnTypeImpl, SelectionParameters selectionParameters) {
+            MethodReference factoryMethod = ObjectFactoryMethodResolver.getFactoryMethod( method,
+                            returnTypeImpl,
+                            selectionParameters,
+                            ctx
+            );
+            if ( factoryMethod == null && returnTypeBuilder != null ) {
+                factoryMethod = ObjectFactoryMethodResolver.getBuilderFactoryMethod( method, returnTypeBuilder );
+            }
+
+            return factoryMethod;
+        }
+
+
 
         /**
          * Iterates over all defined mapping methods ({@code @Mapping(s)}), either directly given or inherited from the
@@ -840,7 +916,8 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                               List<PropertyMapping> propertyMappings,
                               MethodReference factoryMethod,
                               boolean mapNullToDefault,
-                              Type resultType,
+                              Type returnTypeToConstruct,
+                              BuilderType returnTypeBuilder,
                               List<LifecycleCallbackMethodReference> beforeMappingReferences,
                               List<LifecycleCallbackMethodReference> afterMappingReferences,
                               MethodReference finalizerMethod) {
@@ -854,6 +931,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         );
 
         this.propertyMappings = propertyMappings;
+        this.returnTypeBuilder = returnTypeBuilder;
         this.finalizerMethod = finalizerMethod;
 
         // intialize constant mappings as all mappings, but take out the ones that can be contributed to a
@@ -870,11 +948,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 }
             }
         }
-        this.resultType = resultType;
-    }
-
-    public List<PropertyMapping> getPropertyMappings() {
-        return propertyMappings;
+        this.returnTypeToConstruct = returnTypeToConstruct;
     }
 
     public List<PropertyMapping> getConstantMappings() {
@@ -886,14 +960,8 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         return mappingsByParameter.get( parameter.getName() );
     }
 
-    @Override
-    public Type getResultType() {
-        if ( resultType == null ) {
-            return super.getResultType();
-        }
-        else {
-            return resultType;
-        }
+    public Type getReturnTypeToConstruct() {
+        return returnTypeToConstruct;
     }
 
     public MethodReference getFinalizerMethod() {
@@ -908,12 +976,11 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             types.addAll( propertyMapping.getImportTypes() );
         }
 
-        if ( !isExistingInstanceMapping() ) {
-            types.addAll( getResultType().getEffectiveType().getImportTypes() );
+        if ( returnTypeToConstruct != null  ) {
+            types.addAll( returnTypeToConstruct.getImportTypes() );
         }
-
-        if ( getResultType().getBuilderType() != null ) {
-            types.add( getResultType().getBuilderType().getOwningType() );
+        if ( returnTypeBuilder != null ) {
+            types.add( returnTypeBuilder.getOwningType() );
         }
 
         return types;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BuilderFinisherMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BuilderFinisherMethodResolver.java
@@ -11,10 +11,8 @@ import javax.lang.model.element.ExecutableElement;
 
 import org.mapstruct.ap.internal.model.common.BuilderType;
 import org.mapstruct.ap.internal.model.source.BeanMapping;
-import org.mapstruct.ap.internal.model.source.MappingOptions;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.prism.BuilderPrism;
-import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 
@@ -38,11 +36,7 @@ public class BuilderFinisherMethodResolver {
             return null;
         }
 
-        Optional<BuilderPrism> beanMethodBuilder = Optional.ofNullable( method.getMappingOptions() )
-                                                           .map( MappingOptions::getBeanMapping )
-                                                           .flatMap( BeanMapping::getBuilder );
-        Optional<BuilderPrism> builderMapping = method.getMapperConfiguration().getBuilderPrism( beanMethodBuilder );
-
+        Optional<BuilderPrism> builderMapping = BeanMapping.builderPrismFor( method );
         if ( !builderMapping.isPresent() && buildMethods.size() == 1 ) {
             return MethodReference.forMethodCall( first( buildMethods ).getSimpleName().toString() );
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
@@ -20,6 +20,7 @@ import org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism;
 import org.mapstruct.ap.internal.prism.NullValuePropertyMappingStrategyPrism;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 
 import static org.mapstruct.ap.internal.prism.NullValuePropertyMappingStrategyPrism.SET_TO_DEFAULT;
 import static org.mapstruct.ap.internal.prism.NullValuePropertyMappingStrategyPrism.SET_TO_NULL;
@@ -57,7 +58,7 @@ public class CollectionAssignmentBuilder {
     private Accessor targetReadAccessor;
     private Type targetType;
     private String targetPropertyName;
-    private PropertyMapping.TargetWriteAccessorType targetAccessorType;
+    private AccessorType targetAccessorType;
     private Assignment assignment;
     private SourceRHS sourceRHS;
     private NullValueCheckStrategyPrism nvcs;
@@ -88,7 +89,7 @@ public class CollectionAssignmentBuilder {
         return this;
     }
 
-    public CollectionAssignmentBuilder targetAccessorType(PropertyMapping.TargetWriteAccessorType targetAccessorType) {
+    public CollectionAssignmentBuilder targetAccessorType(AccessorType targetAccessorType) {
         this.targetAccessorType = targetAccessorType;
         return this;
     }
@@ -129,8 +130,7 @@ public class CollectionAssignmentBuilder {
         CollectionMappingStrategyPrism cms = method.getMapperConfiguration().getCollectionMappingStrategy();
         boolean targetImmutable = cms == CollectionMappingStrategyPrism.TARGET_IMMUTABLE || targetReadAccessor == null;
 
-        if ( targetAccessorType == PropertyMapping.TargetWriteAccessorType.SETTER ||
-            targetAccessorType == PropertyMapping.TargetWriteAccessorType.FIELD ) {
+        if ( targetAccessorType == AccessorType.SETTER || targetAccessorType == AccessorType.FIELD ) {
 
             if ( result.isCallingUpdateMethod() && !targetImmutable ) {
 
@@ -149,7 +149,7 @@ public class CollectionAssignmentBuilder {
                     result,
                     method.getThrownTypes(),
                     factoryMethod,
-                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType ),
+                    targetAccessorType == AccessorType.FIELD,
                     targetType,
                     true,
                     nvpms == SET_TO_NULL && !targetType.isPrimitive(),
@@ -165,7 +165,7 @@ public class CollectionAssignmentBuilder {
                     nvcs,
                     nvpms,
                     ctx.getTypeFactory(),
-                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+      targetAccessorType == AccessorType.FIELD
                 );
             }
             else if ( result.getType() == Assignment.AssignmentType.DIRECT ||
@@ -176,7 +176,7 @@ public class CollectionAssignmentBuilder {
                     method.getThrownTypes(),
                     targetType,
                     ctx.getTypeFactory(),
-                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+      targetAccessorType == AccessorType.FIELD
                 );
             }
             else {
@@ -185,7 +185,7 @@ public class CollectionAssignmentBuilder {
                     result,
                     method.getThrownTypes(),
                     targetType,
-                    PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+      targetAccessorType == AccessorType.FIELD
                 );
             }
         }
@@ -203,7 +203,7 @@ public class CollectionAssignmentBuilder {
                 result,
                 method.getThrownTypes(),
                 targetType,
-                PropertyMapping.TargetWriteAccessorType.isFieldAssignment( targetAccessorType )
+  targetAccessorType == AccessorType.FIELD
             );
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
@@ -139,7 +139,7 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
 
         MethodReference factoryMethod = null;
         if ( !method.isUpdateMethod() ) {
-            factoryMethod = ObjectFactoryMethodResolver.getFactoryMethod( method, method.getResultType(), null, ctx );
+            factoryMethod = ObjectFactoryMethodResolver.getFactoryMethod( method, null, ctx );
         }
 
         Set<String> existingVariables = new HashSet<>( method.getParameterNames() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/HelperMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/HelperMethod.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-
 import javax.lang.model.element.ExecutableElement;
 
 import org.mapstruct.ap.internal.model.common.Accessibility;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleMethodResolver.java
@@ -32,6 +32,49 @@ public final class LifecycleMethodResolver {
 
     /**
      * @param method the method to obtain the beforeMapping methods for
+     * @param alternativeTarget alternative to {@link Method#getResultType()} e.g. when target is abstract
+     * @param selectionParameters method selectionParameters
+     * @param ctx the builder context
+     * @param existingVariableNames the existing variable names in the mapping method
+     * @return all applicable {@code @BeforeMapping} methods for the given method
+     */
+    public static List<LifecycleCallbackMethodReference> beforeMappingMethods(Method method,
+                                                                              Type alternativeTarget,
+                                                                              SelectionParameters selectionParameters,
+                                                                              MappingBuilderContext ctx,
+                                                                              Set<String> existingVariableNames) {
+        return collectLifecycleCallbackMethods( method,
+                        alternativeTarget,
+                        selectionParameters,
+                        filterBeforeMappingMethods( getAllAvailableMethods( method, ctx.getSourceModel() ) ),
+                        ctx,
+                        existingVariableNames );
+    }
+
+    /**
+     * @param method the method to obtain the afterMapping methods for
+     * @param alternativeTarget alternative to {@link Method#getResultType()} e.g. when target is abstract
+     * @param selectionParameters method selectionParameters
+     * @param ctx the builder context
+     * @param existingVariableNames list of already used variable names
+     * @return all applicable {@code @AfterMapping} methods for the given method
+     */
+    public static List<LifecycleCallbackMethodReference> afterMappingMethods(Method method,
+                                                                             Type alternativeTarget,
+                                                                             SelectionParameters selectionParameters,
+                                                                             MappingBuilderContext ctx,
+                                                                             Set<String> existingVariableNames) {
+        return collectLifecycleCallbackMethods( method,
+                        alternativeTarget,
+                        selectionParameters,
+                        filterAfterMappingMethods( getAllAvailableMethods( method, ctx.getSourceModel() ) ),
+                        ctx,
+                        existingVariableNames );
+    }
+
+
+    /**
+     * @param method the method to obtain the beforeMapping methods for
      * @param selectionParameters method selectionParameters
      * @param ctx the builder context
      * @param existingVariableNames the existing variable names in the mapping method
@@ -42,6 +85,7 @@ public final class LifecycleMethodResolver {
                                                                               MappingBuilderContext ctx,
                                                                               Set<String> existingVariableNames) {
         return collectLifecycleCallbackMethods( method,
+            method.getResultType(),
             selectionParameters,
             filterBeforeMappingMethods( getAllAvailableMethods( method, ctx.getSourceModel() ) ),
             ctx,
@@ -60,6 +104,7 @@ public final class LifecycleMethodResolver {
                                                                              MappingBuilderContext ctx,
                                                                              Set<String> existingVariableNames) {
         return collectLifecycleCallbackMethods( method,
+            method.getResultType(),
             selectionParameters,
             filterAfterMappingMethods( getAllAvailableMethods( method, ctx.getSourceModel() ) ),
             ctx,
@@ -87,17 +132,11 @@ public final class LifecycleMethodResolver {
     }
 
     private static List<LifecycleCallbackMethodReference> collectLifecycleCallbackMethods(
-            Method method, SelectionParameters selectionParameters, List<SourceMethod> callbackMethods,
+            Method method, Type targetType, SelectionParameters selectionParameters, List<SourceMethod> callbackMethods,
             MappingBuilderContext ctx, Set<String> existingVariableNames) {
 
         MethodSelectors selectors =
             new MethodSelectors( ctx.getTypeUtils(), ctx.getElementUtils(), ctx.getTypeFactory(), ctx.getMessager() );
-
-        Type targetType = method.getResultType();
-
-        if ( !method.isUpdateMethod() ) {
-            targetType = targetType.getEffectiveType();
-        }
 
         List<SelectedMethod<SourceMethod>> matchingMethods = selectors.getMatchingMethods(
             method,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -198,7 +198,7 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
             MethodReference factoryMethod = null;
             if ( !method.isUpdateMethod() ) {
                 factoryMethod = ObjectFactoryMethodResolver
-                    .getFactoryMethod( method, method.getResultType(), null, ctx );
+                    .getFactoryMethod( method, null, ctx );
             }
 
             keyAssignment = new LocalVarWrapper( keyAssignment, method.getThrownTypes(), keyTargetType, false );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MethodReference.java
@@ -157,7 +157,7 @@ public class MethodReference extends ModelElement implements Assignment {
 
     @Override
     public String getSourceReference() {
-        return assignment.getSourceReference();
+        return assignment != null ? assignment.getSourceReference() : null;
     }
 
     @Override
@@ -353,7 +353,8 @@ public class MethodReference extends ModelElement implements Assignment {
     @Override
     public String toString() {
         String mapper = declaringMapper != null ? declaringMapper.getType().getName().toString() : "";
-        String argument = getAssignment() != null ? getAssignment().toString() : getSourceReference();
+        String argument = getAssignment() != null ? getAssignment().toString() :
+                        ( getSourceReference() != null ? getSourceReference() : "" );
         String returnTypeAsString = returnType != null ? returnType.toString() : "";
         List<String> arguments = sourceParameters.stream()
             .map( p -> p.isMappingContext() || p.isMappingTarget() || p.isTargetType() ? p.getName() : argument )

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -12,7 +12,6 @@ import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.type.DeclaredType;
 
 import org.mapstruct.ap.internal.model.assignment.AdderWrapper;
 import org.mapstruct.ap.internal.model.assignment.ArrayCopyWrapper;
@@ -41,8 +40,6 @@ import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
 import org.mapstruct.ap.internal.prism.NullValuePropertyMappingStrategyPrism;
-import org.mapstruct.ap.internal.util.AccessorNamingUtils;
-import org.mapstruct.ap.internal.util.Executables;
 import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.NativeTypes;
@@ -74,7 +71,6 @@ public class PropertyMapping extends ModelElement {
     private final Assignment assignment;
     private final List<String> dependsOn;
     private final Assignment defaultValueAssignment;
-
 
     @SuppressWarnings("unchecked")
     private static class MappingBuilderBase<T extends MappingBuilderBase<T>> extends AbstractBaseBuilder<T> {
@@ -115,19 +111,15 @@ public class PropertyMapping extends ModelElement {
 
         public T targetWriteAccessor(Accessor targetWriteAccessor) {
             this.targetWriteAccessor = targetWriteAccessor;
+            this.targetType = ctx.getTypeFactory().getType( targetWriteAccessor.getAccessedType() );
+            this.targetBuilderType = ctx.getTypeFactory().builderTypeFor( this.targetType );
             this.targetWriteAccessorType = targetWriteAccessor.getAccessorType();
-            this.targetType = determineTargetType();
-
             return (T) this;
         }
 
         T mirror(AnnotationMirror mirror) {
             this.positionHint = mirror;
             return (T) this;
-        }
-
-        private Type determineTargetType() {
-            return ctx.getTypeFactory().getType(  targetWriteAccessor.getAccessedType()  );
         }
 
         public T targetPropertyName(String targetPropertyName) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -37,6 +37,7 @@ import org.mapstruct.ap.internal.model.source.PropertyEntry;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.SourceReference;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
+import org.mapstruct.ap.internal.prism.BuilderPrism;
 import org.mapstruct.ap.internal.prism.NullValueCheckStrategyPrism;
 import org.mapstruct.ap.internal.prism.NullValueMappingStrategyPrism;
 import org.mapstruct.ap.internal.prism.NullValuePropertyMappingStrategyPrism;
@@ -112,7 +113,8 @@ public class PropertyMapping extends ModelElement {
         public T targetWriteAccessor(Accessor targetWriteAccessor) {
             this.targetWriteAccessor = targetWriteAccessor;
             this.targetType = ctx.getTypeFactory().getType( targetWriteAccessor.getAccessedType() );
-            this.targetBuilderType = ctx.getTypeFactory().builderTypeFor( this.targetType );
+            BuilderPrism builderPrism = BeanMapping.builderPrismFor( method ).orElse( null );
+            this.targetBuilderType = ctx.getTypeFactory().builderTypeFor( this.targetType, builderPrism );
             this.targetWriteAccessorType = targetWriteAccessor.getAccessorType();
             return (T) this;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/BuilderType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/BuilderType.java
@@ -82,13 +82,6 @@ public class BuilderType {
         return buildMethods;
     }
 
-    public BuilderInfo asBuilderInfo() {
-        return new BuilderInfo.Builder()
-            .builderCreationMethod( this.builderCreationMethod )
-            .buildMethod( this.buildMethods )
-            .build();
-    }
-
     public static BuilderType create(BuilderInfo builderInfo, Type typeToBuild, TypeFactory typeFactory,
         Types typeUtils) {
         if ( builderInfo == null ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -13,6 +13,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -34,12 +35,12 @@ import javax.lang.model.util.Types;
 import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
 import org.mapstruct.ap.internal.util.Executables;
+import org.mapstruct.ap.internal.util.Fields;
 import org.mapstruct.ap.internal.util.Filters;
 import org.mapstruct.ap.internal.util.JavaStreamConstants;
 import org.mapstruct.ap.internal.util.Nouns;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
-import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
-import org.mapstruct.ap.spi.BuilderInfo;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
 import org.mapstruct.ap.internal.util.NativeTypes;
@@ -67,7 +68,6 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     private final ImplementationType implementationType;
     private final Type componentType;
-    private final BuilderType builderType;
 
     private final String packageName;
     private final String name;
@@ -89,9 +89,10 @@ public class Type extends ModelElement implements Comparable<Type> {
     private Boolean isToBeImported;
 
     private Map<String, Accessor> readAccessors = null;
-    private Map<String, ExecutableElementAccessor> presenceCheckers = null;
+    private Map<String, Accessor> presenceCheckers = null;
 
-    private List<Accessor> allAccessors = null;
+    private List<ExecutableElement> allMethods = null;
+    private List<VariableElement> allFields = null;
     private List<Accessor> setters = null;
     private List<Accessor> adders = null;
     private List<Accessor> alternativeTargetAccessors = null;
@@ -100,12 +101,13 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     private Boolean hasEmptyAccessibleContructor;
 
+    private final Filters filters;
+
     //CHECKSTYLE:OFF
     public Type(Types typeUtils, Elements elementUtils, TypeFactory typeFactory,
                 AccessorNamingUtils accessorNaming,
                 TypeMirror typeMirror, TypeElement typeElement,
                 List<Type> typeParameters, ImplementationType implementationType, Type componentType,
-                BuilderInfo builderInfo,
                 String packageName, String name, String qualifiedName,
                 boolean isInterface, boolean isEnumType, boolean isIterableType,
                 boolean isCollectionType, boolean isMapType, boolean isStreamType,
@@ -157,7 +159,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         this.isToBeImported = isToBeImported;
         this.toBeImportedTypes = toBeImportedTypes;
         this.notToBeImportedTypes = notToBeImportedTypes;
-        this.builderType = BuilderType.create( builderInfo, this, this.typeFactory, this.typeUtils );
+        this.filters = new Filters( accessorNaming, typeUtils, typeMirror );
     }
     //CHECKSTYLE:ON
 
@@ -198,18 +200,6 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     public Type getComponentType() {
         return componentType;
-    }
-
-    public BuilderType getBuilderType() {
-        return builderType;
-    }
-
-    /**
-     * The effective type that should be used when searching for getters / setters, creating new types etc
-     * @return the effective type for mappings
-     */
-    public Type getEffectiveType() {
-        return builderType != null ? builderType.getBuilder() : this;
     }
 
     public boolean isPrimitive() {
@@ -419,7 +409,6 @@ public class Type extends ModelElement implements Comparable<Type> {
             typeParameters,
             implementationType,
             componentType,
-            builderType == null ? null : builderType.asBuilderInfo(),
             packageName,
             name,
             qualifiedName,
@@ -462,7 +451,6 @@ public class Type extends ModelElement implements Comparable<Type> {
             bounds,
             implementationType,
             componentType,
-            builderType == null ? null : builderType.asBuilderInfo(),
             packageName,
             name,
             qualifiedName,
@@ -505,30 +493,30 @@ public class Type extends ModelElement implements Comparable<Type> {
      */
     public Map<String, Accessor> getPropertyReadAccessors() {
         if ( readAccessors == null ) {
-            List<Accessor> getterList = Filters.getterMethodsIn( accessorNaming, getAllAccessors() );
+            List<Accessor> getterList = filters.getterMethodsIn( getAllMethods() );
             Map<String, Accessor> modifiableGetters = new LinkedHashMap<>();
             for ( Accessor getter : getterList ) {
-                String propertyName = accessorNaming.getPropertyName( getter );
+                String propertyName = getPropertyName( getter );
                 if ( modifiableGetters.containsKey( propertyName ) ) {
                     // In the DefaultAccessorNamingStrategy, this can only be the case for Booleans: isFoo() and
                     // getFoo(); The latter is preferred.
                     if ( !getter.getSimpleName().toString().startsWith( "is" ) ) {
-                        modifiableGetters.put( accessorNaming.getPropertyName( getter ), getter );
+                        modifiableGetters.put( getPropertyName( getter ),getter );
                     }
 
                 }
                 else {
-                    modifiableGetters.put( accessorNaming.getPropertyName( getter ), getter );
+                    modifiableGetters.put( getPropertyName( getter ), getter );
                 }
             }
 
-            List<Accessor> fieldsList = Filters.fieldsIn( getAllAccessors() );
+            List<Accessor> fieldsList = filters.fieldsIn( getAllFields() );
             for ( Accessor field : fieldsList ) {
-                String propertyName = accessorNaming.getPropertyName( field );
+                String propertyName = getPropertyName( field );
                 if ( !modifiableGetters.containsKey( propertyName ) ) {
                     // If there was no getter or is method for booleans, then resort to the field.
                     // If a field was already added do not add it again.
-                    modifiableGetters.put( propertyName, field );
+                    modifiableGetters.put( propertyName,  field );
                 }
             }
             readAccessors = Collections.unmodifiableMap( modifiableGetters );
@@ -541,15 +529,12 @@ public class Type extends ModelElement implements Comparable<Type> {
      *
      * @return an unmodifiable map of all presence checkers, indexed by property name
      */
-    public Map<String, ExecutableElementAccessor> getPropertyPresenceCheckers() {
+    public Map<String, Accessor> getPropertyPresenceCheckers() {
         if ( presenceCheckers == null ) {
-            List<ExecutableElementAccessor> checkerList = Filters.presenceCheckMethodsIn(
-                accessorNaming,
-                getAllAccessors()
-            );
-            Map<String, ExecutableElementAccessor> modifiableCheckers = new LinkedHashMap<>();
-            for ( ExecutableElementAccessor checker : checkerList ) {
-                modifiableCheckers.put( accessorNaming.getPropertyName( checker ), checker );
+            List<Accessor> checkerList = filters.presenceCheckMethodsIn( getAllMethods() );
+            Map<String, Accessor> modifiableCheckers = new LinkedHashMap<>();
+            for ( Accessor checker : checkerList ) {
+                modifiableCheckers.put( getPropertyName( checker ), checker );
             }
             presenceCheckers = Collections.unmodifiableMap( modifiableCheckers );
         }
@@ -577,7 +562,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         Map<String, Accessor> result = new LinkedHashMap<>();
 
         for ( Accessor candidate : candidates ) {
-            String targetPropertyName = accessorNaming.getPropertyName( candidate );
+            String targetPropertyName = getPropertyName( candidate );
 
             Accessor readAccessor = getPropertyReadAccessors().get( targetPropertyName );
 
@@ -593,12 +578,12 @@ public class Type extends ModelElement implements Comparable<Type> {
 
                 // first check if there's a setter method.
                 Accessor adderMethod = null;
-                if ( accessorNaming.isSetterMethod( candidate )
+                if ( candidate.getAccessorType() == AccessorType.SETTER
                     // ok, the current accessor is a setter. So now the strategy determines what to use
                     && cmStrategy == CollectionMappingStrategyPrism.ADDER_PREFERRED ) {
                     adderMethod = getAdderForType( targetType, targetPropertyName );
                 }
-                else if ( accessorNaming.isGetterMethod( candidate ) ) {
+                else if ( candidate.getAccessorType() == AccessorType.GETTER ) {
                     // the current accessor is a getter (no setter available). But still, an add method is according
                     // to the above strategy (SETTER_PREFERRED || ADDER_PREFERRED) preferred over the getter.
                     adderMethod = getAdderForType( targetType, targetPropertyName );
@@ -608,7 +593,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                     candidate = adderMethod;
                 }
             }
-            else if ( Executables.isFieldAccessor( candidate ) && ( Executables.isFinal( candidate ) ||
+            else if ( candidate.getAccessorType() == AccessorType.FIELD  && ( Executables.isFinal( candidate ) ||
                 result.containsKey( targetPropertyName ) ) ) {
                 // if the candidate is a field and a mapping already exists, then use that one, skip it.
                 continue;
@@ -636,18 +621,36 @@ public class Type extends ModelElement implements Comparable<Type> {
         if ( parameter != null ) {
             return parameter.getType();
         }
-        else if ( accessorNaming.isGetterMethod( candidate ) || Executables.isFieldAccessor( candidate ) ) {
+        else if ( candidate.getAccessorType() == AccessorType.GETTER
+                        || candidate.getAccessorType() == AccessorType.FIELD ) {
             return typeFactory.getReturnType( (DeclaredType) typeMirror, candidate );
         }
         return null;
     }
 
-    private List<Accessor> getAllAccessors() {
-        if ( allAccessors == null ) {
-            allAccessors = Executables.getAllEnclosedAccessors( elementUtils, typeElement );
+    private List<ExecutableElement> getAllMethods() {
+        if ( allMethods == null ) {
+            allMethods = Executables.getAllEnclosedExecutableElements( elementUtils, typeElement );
         }
 
-        return allAccessors;
+        return allMethods;
+    }
+
+    private List<VariableElement> getAllFields() {
+        if ( allFields == null ) {
+            allFields = Fields.getAllEnclosedFields( elementUtils, typeElement );
+        }
+
+        return allFields;
+    }
+
+    private String getPropertyName(Accessor accessor ) {
+        if ( accessor.getAccessorType() == AccessorType.FIELD ) {
+            return accessorNaming.getPropertyName( (VariableElement) accessor.getElement() );
+        }
+        else {
+            return accessorNaming.getPropertyName( (ExecutableElement) accessor.getElement() );
+        }
     }
 
     /**
@@ -709,19 +712,14 @@ public class Type extends ModelElement implements Comparable<Type> {
      * @return accessor candidates
      */
     private List<Accessor> getAccessorCandidates(Type property, Class<?> superclass) {
-        TypeMirror typeArg = first( property.determineTypeArguments( superclass ) ).getTypeBound()
-            .getTypeMirror();
+        TypeMirror typeArg = first( property.determineTypeArguments( superclass ) ).getTypeBound().getTypeMirror();
         // now, look for a method that
         // 1) starts with add,
         // 2) and has typeArg as one and only arg
         List<Accessor> adderList = getAdders();
         List<Accessor> candidateList = new ArrayList<>();
         for ( Accessor adder : adderList ) {
-            ExecutableElement executable = adder.getExecutable();
-            if ( executable == null ) {
-                // it should not be null, but to be safe
-                continue;
-            }
+            ExecutableElement executable = (ExecutableElement) adder.getElement();
             VariableElement arg = executable.getParameters().get( 0 );
             if ( typeUtils.isSameType( boxed( arg.asType() ), boxed( typeArg ) ) ) {
                 candidateList.add( adder );
@@ -746,7 +744,7 @@ public class Type extends ModelElement implements Comparable<Type> {
      */
     private List<Accessor> getSetters() {
         if ( setters == null ) {
-            setters = Collections.unmodifiableList( Filters.setterMethodsIn( accessorNaming, getAllAccessors() ) );
+            setters = Collections.unmodifiableList( filters.setterMethodsIn( getAllMethods() ) );
         }
         return setters;
     }
@@ -761,7 +759,7 @@ public class Type extends ModelElement implements Comparable<Type> {
      */
     private List<Accessor> getAdders() {
         if ( adders == null ) {
-            adders = Collections.unmodifiableList( Filters.adderMethodsIn( accessorNaming, getAllAccessors() ) );
+            adders = Collections.unmodifiableList( filters.adderMethodsIn( getAllMethods() ) );
         }
         return adders;
     }
@@ -781,10 +779,9 @@ public class Type extends ModelElement implements Comparable<Type> {
 
             List<Accessor> result = new ArrayList<>();
             List<Accessor> setterMethods = getSetters();
-            List<Accessor> readAccessors =
-                new ArrayList<>( getPropertyReadAccessors().values() );
+            List<Accessor> readAccessors = new ArrayList<>( getPropertyReadAccessors().values() );
             // All the fields are also alternative accessors
-            readAccessors.addAll( Filters.fieldsIn( getAllAccessors() ) );
+            readAccessors.addAll( filters.fieldsIn( getAllFields() ) );
 
             // there could be a read accessor (field or  method) for a list/map that is not present as setter.
             // an accessor could substitute the setter in that case and act as setter.
@@ -794,7 +791,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                     !correspondingSetterMethodExists( readAccessor, setterMethods ) ) {
                     result.add( readAccessor );
                 }
-                else if ( Executables.isFieldAccessor( readAccessor ) &&
+                else if ( readAccessor.getAccessorType() == AccessorType.FIELD &&
                     !correspondingSetterMethodExists( readAccessor, setterMethods ) ) {
                     result.add( readAccessor );
                 }
@@ -807,10 +804,10 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     private boolean correspondingSetterMethodExists(Accessor getterMethod,
                                                     List<Accessor> setterMethods) {
-        String getterPropertyName = accessorNaming.getPropertyName( getterMethod );
+        String getterPropertyName = getPropertyName( getterMethod );
 
         for ( Accessor setterMethod : setterMethods ) {
-            String setterPropertyName = accessorNaming.getPropertyName( setterMethod );
+            String setterPropertyName = getPropertyName( setterMethod );
             if ( getterPropertyName.equals( setterPropertyName ) ) {
                 return true;
             }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -13,7 +13,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -93,6 +92,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     private List<ExecutableElement> allMethods = null;
     private List<VariableElement> allFields = null;
+
     private List<Accessor> setters = null;
     private List<Accessor> adders = null;
     private List<Accessor> alternativeTargetAccessors = null;
@@ -501,7 +501,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                     // In the DefaultAccessorNamingStrategy, this can only be the case for Booleans: isFoo() and
                     // getFoo(); The latter is preferred.
                     if ( !getter.getSimpleName().toString().startsWith( "is" ) ) {
-                        modifiableGetters.put( getPropertyName( getter ),getter );
+                        modifiableGetters.put( getPropertyName( getter ), getter );
                     }
 
                 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -523,7 +523,7 @@ public class TypeFactory {
     }
 
     private BuilderInfo findBuilder(TypeMirror type, BuilderPrism builderPrism, boolean report) {
-        if ( builderPrism != null && builderPrism.noBuilder() ) {
+        if ( builderPrism != null && builderPrism.disableBuilder() ) {
             return null;
         }
         try {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -49,6 +49,7 @@ import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.RoundContext;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 import org.mapstruct.ap.spi.AstModifyingAnnotationProcessor;
 import org.mapstruct.ap.spi.BuilderInfo;
 import org.mapstruct.ap.spi.MoreThanOneBuilderCreationMethodException;
@@ -354,10 +355,10 @@ public class TypeFactory {
     }
 
     public Parameter getSingleParameter(DeclaredType includingType, Accessor method) {
-        ExecutableElement executable = method.getExecutable();
-        if ( executable == null ) {
+        if ( method.getAccessorType() == AccessorType.FIELD ) {
             return null;
         }
+        ExecutableElement executable = (ExecutableElement) method.getElement();
         List<? extends VariableElement> parameters = executable.getParameters();
 
         if ( parameters.size() != 1 ) {
@@ -369,7 +370,7 @@ public class TypeFactory {
     }
 
     public List<Parameter> getParameters(DeclaredType includingType, Accessor accessor) {
-        ExecutableElement method = accessor.getExecutable();
+        ExecutableElement method = (ExecutableElement) accessor.getElement();
         TypeMirror methodType = getMethodType( includingType, accessor.getElement() );
         if ( method == null || methodType.getKind() != TypeKind.EXECUTABLE ) {
             return new ArrayList<>();
@@ -427,10 +428,10 @@ public class TypeFactory {
     }
 
     public List<Type> getThrownTypes(Accessor accessor) {
-        if (accessor.getExecutable() == null) {
+        if (accessor.getAccessorType() == AccessorType.FIELD) {
             return new ArrayList<>();
         }
-        return extractTypes( accessor.getExecutable().getThrownTypes() );
+        return extractTypes( ( (ExecutableElement) accessor.getElement() ).getThrownTypes() );
     }
 
     private List<Type> extractTypes(List<? extends TypeMirror> typeMirrors) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -39,6 +39,7 @@ import javax.lang.model.type.WildcardType;
 import javax.lang.model.util.Elements;
 import javax.lang.model.util.Types;
 
+import org.mapstruct.ap.internal.prism.BuilderPrism;
 import org.mapstruct.ap.internal.util.AnnotationProcessingException;
 import org.mapstruct.ap.internal.util.Collections;
 import org.mapstruct.ap.internal.util.Extractor;
@@ -521,7 +522,10 @@ public class TypeFactory {
         return null;
     }
 
-    private BuilderInfo findBuilder(TypeMirror type, boolean report) {
+    private BuilderInfo findBuilder(TypeMirror type, BuilderPrism builderPrism, boolean report) {
+        if ( builderPrism != null && builderPrism.noBuilder() ) {
+            return null;
+        }
         try {
             return roundContext.getAnnotationProcessorContext()
                 .getBuilderProvider()
@@ -664,17 +668,17 @@ public class TypeFactory {
         return true;
     }
 
-    public BuilderType builderTypeFor( Type type ) {
+    public BuilderType builderTypeFor( Type type, BuilderPrism builderPrism ) {
         if ( type != null ) {
-            BuilderInfo builderInfo = findBuilder( type.getTypeMirror(), true );
+            BuilderInfo builderInfo = findBuilder( type.getTypeMirror(), builderPrism, true );
             return BuilderType.create( builderInfo, type, this, this.typeUtils );
         }
         return null;
     }
 
-    public Type effectiveResultTypeFor( Type type ) {
+    public Type effectiveResultTypeFor( Type type, BuilderPrism builderPrism ) {
         if ( type != null ) {
-            BuilderInfo builderInfo = findBuilder( type.getTypeMirror(), false );
+            BuilderInfo builderInfo = findBuilder( type.getTypeMirror(), builderPrism, false );
             BuilderType builderType = BuilderType.create( builderInfo, type, this, this.typeUtils );
             return builderType != null ? builderType.getBuilder() : type;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
@@ -183,6 +183,7 @@ public class BeanMapping {
     public static Optional<BuilderPrism> builderPrismFor(Method method) {
         return method.getMapperConfiguration()
                      .getBuilderPrism( Optional.ofNullable( method.getMappingOptions().getBeanMapping() )
-                                               .map( b -> b.builder ) );
+                                               .map( b -> b.builder )
+                                               .orElse( null ) );
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
@@ -175,7 +175,14 @@ public class BeanMapping {
         return ignoreUnmappedSourceProperties;
     }
 
-    public Optional<BuilderPrism> getBuilder() {
-        return Optional.ofNullable( builder );
+    /**
+     * derives the builder prism given the options and configuration
+     * @param method containing mandatory configuration and the mapping options (optionally containing a beanmapping)
+     * @return a BuilderPrism as optional
+     */
+    public static Optional<BuilderPrism> builderPrismFor(Method method) {
+        return method.getMapperConfiguration()
+                     .getBuilderPrism( Optional.ofNullable( method.getMappingOptions().getBeanMapping() )
+                                               .map( b -> b.builder ) );
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMapping.java
@@ -7,6 +7,7 @@ package org.mapstruct.ap.internal.model.source;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.util.Types;
@@ -174,7 +175,7 @@ public class BeanMapping {
         return ignoreUnmappedSourceProperties;
     }
 
-    public BuilderPrism getBuilder() {
-        return builder;
+    public Optional<BuilderPrism> getBuilder() {
+        return Optional.ofNullable( builder );
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
@@ -8,7 +8,6 @@ package org.mapstruct.ap.internal.model.source;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-
 import javax.lang.model.element.ExecutableElement;
 
 import org.mapstruct.ap.internal.model.common.Accessibility;
@@ -51,9 +50,9 @@ public class ForgedMethod implements Method {
      * @param parameterProvidedMethods additional factory/lifecycle methods to consider that are provided by context
      *            parameters
      */
-    public ForgedMethod(String name, Type sourceType, Type returnType, MapperConfiguration mapperConfiguration,
-                        ExecutableElement positionHintElement, List<Parameter> additionalParameters,
-                        ParameterProvidedMethods parameterProvidedMethods) {
+    public ForgedMethod(String name, Type sourceType, Type returnType,
+                        MapperConfiguration mapperConfiguration, ExecutableElement positionHintElement,
+                        List<Parameter> additionalParameters, ParameterProvidedMethods parameterProvidedMethods) {
         this(
             name,
             sourceType,
@@ -82,11 +81,11 @@ public class ForgedMethod implements Method {
      * @param mappingOptions the mapping options for this method
      * @param forgedNameBased forges a name based (matched) mapping method
      */
-    public ForgedMethod(String name, Type sourceType, Type returnType, MapperConfiguration mapperConfiguration,
-                        ExecutableElement positionHintElement, List<Parameter> additionalParameters,
-                        ParameterProvidedMethods parameterProvidedMethods, ForgedMethodHistory history,
-                        MappingOptions mappingOptions, boolean forgedNameBased) {
-        String sourceParamName = Strings.decapitalize( sourceType.getName() );
+     public ForgedMethod(String name, Type sourceType, Type returnType, MapperConfiguration mapperConfiguration,
+                         ExecutableElement positionHintElement, List<Parameter> additionalParameters,
+                         ParameterProvidedMethods parameterProvidedMethods, ForgedMethodHistory history,
+                         MappingOptions mappingOptions, boolean forgedNameBased) {
+         String sourceParamName = Strings.decapitalize( sourceType.getName() );
         String sourceParamSafeName = Strings.getSafeVariableName( sourceParamName );
 
         this.parameters = new ArrayList<>( 1 + additionalParameters.size() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ForgedMethod.java
@@ -50,9 +50,9 @@ public class ForgedMethod implements Method {
      * @param parameterProvidedMethods additional factory/lifecycle methods to consider that are provided by context
      *            parameters
      */
-    public ForgedMethod(String name, Type sourceType, Type returnType,
-                        MapperConfiguration mapperConfiguration, ExecutableElement positionHintElement,
-                        List<Parameter> additionalParameters, ParameterProvidedMethods parameterProvidedMethods) {
+    public ForgedMethod(String name, Type sourceType, Type returnType, MapperConfiguration mapperConfiguration,
+                        ExecutableElement positionHintElement, List<Parameter> additionalParameters,
+                        ParameterProvidedMethods parameterProvidedMethods) {
         this(
             name,
             sourceType,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
@@ -291,7 +291,10 @@ public class MappingOptions {
         CollectionMappingStrategyPrism cms = method.getMapperConfiguration().getCollectionMappingStrategy();
         Type writeType = method.getResultType();
         if ( !method.isUpdateMethod() ) {
-            writeType = typeFactory.effectiveResultTypeFor( writeType );
+            writeType = typeFactory.effectiveResultTypeFor(
+                            writeType,
+                            BeanMapping.builderPrismFor( method ).orElse( null )
+            );
         }
         Map<String, Accessor> writeAccessors = writeType.getPropertyWriteAccessors( cms );
         List<String> mappedPropertyNames = new ArrayList<>();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
@@ -291,7 +291,7 @@ public class MappingOptions {
         CollectionMappingStrategyPrism cms = method.getMapperConfiguration().getCollectionMappingStrategy();
         Type writeType = method.getResultType();
         if ( !method.isUpdateMethod() ) {
-            writeType = writeType.getEffectiveType();
+            writeType = typeFactory.effectiveResultTypeFor( writeType );
         }
         Map<String, Accessor> writeAccessors = writeType.getPropertyWriteAccessors( cms );
         List<String> mappedPropertyNames = new ArrayList<>();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/Method.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/Method.java
@@ -129,7 +129,6 @@ public interface Method {
      */
     Type getResultType();
 
-
     /**
      *
      * @return the names of the parameters of this mapping method
@@ -187,4 +186,13 @@ public interface Method {
      * @return the mapping options for this method
      */
     MappingOptions getMappingOptions();
+
+    /**
+     *
+     * @return true when @MappingTarget annotated parameter is the same type as the return type. The method has
+     * to be an update method in order for this to be true.
+     */
+    default boolean isMappingTargetAssignableToReturnType() {
+        return isUpdateMethod() ? getResultType().isAssignableTo( getReturnType() ) : false;
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/PropertyEntry.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/PropertyEntry.java
@@ -7,6 +7,7 @@ package org.mapstruct.ap.internal.model.source;
 
 import java.util.Arrays;
 
+import org.mapstruct.ap.internal.model.common.BuilderType;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
@@ -22,8 +23,9 @@ public class PropertyEntry {
     private final String[] fullName;
     private final Accessor readAccessor;
     private final Accessor writeAccessor;
-    private final ExecutableElementAccessor presenceChecker;
+    private final Accessor presenceChecker;
     private final Type type;
+    private final BuilderType builderType;
 
     /**
      * Constructor used to create {@link TargetReference} property entries from a mapping
@@ -34,12 +36,13 @@ public class PropertyEntry {
      * @param type
      */
     private PropertyEntry(String[] fullName, Accessor readAccessor, Accessor writeAccessor,
-                          ExecutableElementAccessor presenceChecker, Type type) {
+                          Accessor presenceChecker, Type type, BuilderType builderType) {
         this.fullName = fullName;
         this.readAccessor = readAccessor;
         this.writeAccessor = writeAccessor;
         this.presenceChecker = presenceChecker;
         this.type = type;
+        this.builderType = builderType;
     }
 
     /**
@@ -49,11 +52,12 @@ public class PropertyEntry {
      * @param readAccessor its read accessor
      * @param writeAccessor its write accessor
      * @param type type of the property
+     * @param builderType the builder for the type
      * @return the property entry for given parameters.
      */
     public static PropertyEntry forTargetReference(String[] fullName, Accessor readAccessor,
-                                                   Accessor writeAccessor, Type type) {
-        return new PropertyEntry( fullName, readAccessor, writeAccessor, null, type );
+                                                   Accessor writeAccessor, Type type, BuilderType builderType ) {
+        return new PropertyEntry( fullName, readAccessor, writeAccessor, null, type, null );
     }
 
     /**
@@ -66,8 +70,8 @@ public class PropertyEntry {
      * @return the property entry for given parameters.
      */
     public static PropertyEntry forSourceReference(String name, Accessor readAccessor,
-                                                   ExecutableElementAccessor presenceChecker, Type type) {
-        return new PropertyEntry( new String[]{name}, readAccessor, null, presenceChecker, type );
+                                                   Accessor presenceChecker, Type type) {
+        return new PropertyEntry( new String[]{name}, readAccessor, null, presenceChecker, type, null );
     }
 
     public String getName() {
@@ -82,12 +86,16 @@ public class PropertyEntry {
         return writeAccessor;
     }
 
-    public ExecutableElementAccessor getPresenceChecker() {
+    public Accessor getPresenceChecker() {
         return presenceChecker;
     }
 
     public Type getType() {
         return type;
+    }
+
+    public BuilderType getBuilderType() {
+        return builderType;
     }
 
     public String getFullName() {
@@ -97,7 +105,7 @@ public class PropertyEntry {
     public PropertyEntry pop() {
         if ( fullName.length > 1 ) {
             String[] newFullName = Arrays.copyOfRange( fullName, 1, fullName.length );
-            return new PropertyEntry(newFullName, readAccessor, writeAccessor, presenceChecker, type );
+            return new PropertyEntry(newFullName, readAccessor, writeAccessor, presenceChecker, type, builderType );
         }
         else {
             return null;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/PropertyEntry.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/PropertyEntry.java
@@ -11,8 +11,6 @@ import org.mapstruct.ap.internal.model.common.BuilderType;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
-import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
-
 
 /**
  * A PropertyEntry contains information on the name, readAccessor (for source), readAccessor and writeAccessor
@@ -57,7 +55,7 @@ public class PropertyEntry {
      */
     public static PropertyEntry forTargetReference(String[] fullName, Accessor readAccessor,
                                                    Accessor writeAccessor, Type type, BuilderType builderType ) {
-        return new PropertyEntry( fullName, readAccessor, writeAccessor, null, type, null );
+        return new PropertyEntry( fullName, readAccessor, writeAccessor, null, type, builderType );
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -5,20 +5,18 @@
  */
 package org.mapstruct.ap.internal.model.source;
 
-import static org.mapstruct.ap.internal.util.Collections.first;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.util.Types;
 
 import org.mapstruct.ap.internal.model.common.Accessibility;
+import org.mapstruct.ap.internal.model.common.BuilderType;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
@@ -28,6 +26,8 @@ import org.mapstruct.ap.internal.util.Executables;
 import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.MapperConfiguration;
 import org.mapstruct.ap.internal.util.Strings;
+
+import static org.mapstruct.ap.internal.util.Collections.first;
 
 /**
  * Represents a mapping method with source and target type and the mappings between the properties of source and target
@@ -50,6 +50,7 @@ public class SourceMethod implements Method {
     private final Parameter targetTypeParameter;
     private final boolean isObjectFactory;
     private final Type returnType;
+    private final BuilderType builderType;
     private final Accessibility accessibility;
     private final List<Type> exceptionTypes;
     private final MapperConfiguration config;
@@ -80,6 +81,7 @@ public class SourceMethod implements Method {
         private ExecutableElement executable;
         private List<Parameter> parameters;
         private Type returnType = null;
+        private BuilderType builderType = null;
         private List<Type> exceptionTypes;
         private Map<String, List<Mapping>> mappings;
         private IterableMapping iterableMapping = null;
@@ -207,6 +209,7 @@ public class SourceMethod implements Method {
         this.executable = builder.executable;
         this.parameters = builder.parameters;
         this.returnType = builder.returnType;
+        this.builderType = builder.builderType;
         this.exceptionTypes = builder.exceptionTypes;
         this.accessibility = Accessibility.fromModifiers( builder.executable.getModifiers() );
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
@@ -261,7 +261,7 @@ public class SourceReference {
             for ( String entryName : entryNames ) {
                 boolean matchFound = false;
                 Map<String, Accessor> sourceReadAccessors = newType.getPropertyReadAccessors();
-                Map<String, ExecutableElementAccessor> sourcePresenceCheckers = newType.getPropertyPresenceCheckers();
+                Map<String, Accessor> sourcePresenceCheckers = newType.getPropertyPresenceCheckers();
 
                 for ( Map.Entry<String, Accessor> getter : sourceReadAccessors.entrySet() ) {
                     if ( getter.getKey().equals( entryName ) ) {
@@ -297,7 +297,7 @@ public class SourceReference {
 
         private String name;
         private Accessor readAccessor;
-        private ExecutableElementAccessor presenceChecker;
+        private Accessor presenceChecker;
         private Type type;
         private Parameter sourceParameter;
 
@@ -311,7 +311,7 @@ public class SourceReference {
             return this;
         }
 
-        public BuilderFromProperty presenceChecker(ExecutableElementAccessor presenceChecker) {
+        public BuilderFromProperty presenceChecker(Accessor presenceChecker) {
             this.presenceChecker = presenceChecker;
             return this;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceReference.java
@@ -24,7 +24,6 @@ import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
-import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
 
 /**
  * This class describes the source side of a property mapping.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
@@ -13,12 +13,12 @@ import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.DeclaredType;
 
+import org.mapstruct.ap.internal.model.common.BuilderType;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.prism.CollectionMappingStrategyPrism;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
-import org.mapstruct.ap.internal.util.Executables;
 import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
@@ -147,8 +147,7 @@ public class TargetReference {
             Parameter parameter = method.getMappingTargetParameter();
 
             boolean foundEntryMatch;
-            Type resultType = method.getResultType();
-            resultType = typeBasedOnMethod( resultType );
+            Type resultType = typeBasedOnMethod( method.getResultType() );
 
             // there can be 4 situations
             // 1. Return type
@@ -208,8 +207,9 @@ public class TargetReference {
 
                     // check if an entry alread exists, otherwise create
                     String[] fullName = Arrays.copyOfRange( entryNames, 0, i + 1 );
+                    BuilderType builderType = method.isUpdateMethod() ? null : typeFactory.builderTypeFor( nextType );
                     PropertyEntry propertyEntry = PropertyEntry.forTargetReference( fullName, targetReadAccessor,
-                        targetWriteAccessor, nextType );
+                        targetWriteAccessor, nextType, builderType );
                     targetEntries.add( propertyEntry );
                 }
 
@@ -264,11 +264,11 @@ public class TargetReference {
          * search for setters and getters within the updating type.
          */
         private Type typeBasedOnMethod(Type type) {
-            if ( method.isUpdateMethod() ) {
+            if ( method.isUpdateMethod()   ) {
                 return type;
             }
             else {
-                return type.getEffectiveType();
+                return typeFactory.effectiveResultTypeFor( type );
             }
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/TargetReference.java
@@ -23,6 +23,7 @@ import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 
 /**
  * This class describes the target side of a property mapping.
@@ -198,8 +199,8 @@ public class TargetReference {
                     break;
                 }
 
-                if ( isLast || ( accessorNaming.isSetterMethod( targetWriteAccessor )
-                    || Executables.isFieldAccessor( targetWriteAccessor ) ) ) {
+                if ( isLast || ( targetWriteAccessor.getAccessorType() == AccessorType.SETTER  ||
+                                targetWriteAccessor.getAccessorType() == AccessorType.FIELD ) ) {
                     // only intermediate nested properties when they are a true setter or field accessor
                     // the last may be other readAccessor (setter / getter / adder).
 
@@ -228,8 +229,7 @@ public class TargetReference {
         private Type findNextType(Type initial, Accessor targetWriteAccessor, Accessor targetReadAccessor) {
             Type nextType;
             Accessor toUse = targetWriteAccessor != null ? targetWriteAccessor : targetReadAccessor;
-            if ( accessorNaming.isGetterMethod( toUse ) ||
-                Executables.isFieldAccessor( toUse ) ) {
+            if ( toUse.getAccessorType() == AccessorType.GETTER  || toUse.getAccessorType() == AccessorType.FIELD ) {
                 nextType = typeFactory.getReturnType(
                     (DeclaredType) typeBasedOnMethod( initial ).getTypeMirror(),
                     toUse

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -41,11 +41,13 @@ import org.mapstruct.ap.internal.model.ValueMappingMethod;
 import org.mapstruct.ap.internal.model.common.FormattingParameters;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
+import org.mapstruct.ap.internal.model.source.BeanMapping;
 import org.mapstruct.ap.internal.model.source.MappingOptions;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.SourceMethod;
 import org.mapstruct.ap.internal.option.Options;
+import org.mapstruct.ap.internal.prism.BuilderPrism;
 import org.mapstruct.ap.internal.prism.DecoratedWithPrism;
 import org.mapstruct.ap.internal.prism.InheritConfigurationPrism;
 import org.mapstruct.ap.internal.prism.InheritInverseConfigurationPrism;
@@ -369,11 +371,12 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
             }
             else {
                 this.messager.note( 1, Message.BEANMAPPING_CREATE_NOTE, method );
+                BuilderPrism builderPrism = BeanMapping.builderPrismFor( method ).orElse( null );
                 BeanMappingMethod.Builder builder = new BeanMappingMethod.Builder();
                 BeanMappingMethod beanMappingMethod = builder
                     .mappingContext( mappingContext )
                     .sourceMethod( method )
-                    .returnTypeBuilder( typeFactory.builderTypeFor( method.getReturnType() ) )
+                    .returnTypeBuilder( typeFactory.builderTypeFor( method.getReturnType(), builderPrism ) )
                     .build();
 
                 if ( beanMappingMethod != null ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -373,6 +373,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
                 BeanMappingMethod beanMappingMethod = builder
                     .mappingContext( mappingContext )
                     .sourceMethod( method )
+                    .returnTypeBuilder( typeFactory.builderTypeFor( method.getReturnType() ) )
                     .build();
 
                 if ( beanMappingMethod != null ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -406,7 +406,7 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
 
         if ( returnType.getTypeMirror().getKind() != TypeKind.VOID &&
                         !resultType.isAssignableTo( returnType ) &&
-                        !resultType.isAssignableTo( typeFactory.effectiveResultTypeFor( returnType ) ) ) {
+                        !resultType.isAssignableTo( typeFactory.effectiveResultTypeFor( returnType, null ) ) ) {
             messager.printMessage( method, Message.RETRIEVAL_NON_ASSIGNABLE_RESULTTYPE );
             return false;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -387,8 +387,7 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
 
     private boolean checkParameterAndReturnType(ExecutableElement method, List<Parameter> sourceParameters,
                                                 Parameter targetParameter, List<Parameter> contextParameters,
-                                                Type resultType, Type returnType,
-                                                boolean containsTargetTypeParameter) {
+                                                Type resultType, Type returnType, boolean containsTargetTypeParameter) {
         if ( sourceParameters.isEmpty() ) {
             messager.printMessage( method, Message.RETRIEVAL_NO_INPUT_ARGS );
             return false;
@@ -406,8 +405,8 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
         }
 
         if ( returnType.getTypeMirror().getKind() != TypeKind.VOID &&
-            !resultType.isAssignableTo( returnType ) &&
-            !resultType.isAssignableTo( returnType.getEffectiveType() )) {
+                        !resultType.isAssignableTo( returnType ) &&
+                        !resultType.isAssignableTo( typeFactory.effectiveResultTypeFor( returnType ) ) ) {
             messager.printMessage( method, Message.RETRIEVAL_NON_ASSIGNABLE_RESULTTYPE );
             return false;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/AccessorNamingUtils.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/AccessorNamingUtils.java
@@ -16,7 +16,6 @@ import javax.lang.model.util.SimpleTypeVisitor6;
 
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.AccessorType;
-import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
 import org.mapstruct.ap.spi.AccessorNamingStrategy;
 import org.mapstruct.ap.spi.MethodType;
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/AccessorNamingUtils.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/AccessorNamingUtils.java
@@ -7,6 +7,7 @@ package org.mapstruct.ap.internal.util;
 
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -14,6 +15,7 @@ import javax.lang.model.util.SimpleElementVisitor6;
 import javax.lang.model.util.SimpleTypeVisitor6;
 
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
 import org.mapstruct.ap.spi.AccessorNamingStrategy;
 import org.mapstruct.ap.spi.MethodType;
@@ -33,46 +35,42 @@ public final class AccessorNamingUtils {
         this.accessorNamingStrategy = accessorNamingStrategy;
     }
 
-    public boolean isGetterMethod(Accessor method) {
-        ExecutableElement executable = method.getExecutable();
-        return executable != null && isPublicNotStatic( method ) &&
+    public boolean isGetterMethod(ExecutableElement executable) {
+        return executable != null && isPublicNotStatic( executable ) &&
             executable.getParameters().isEmpty() &&
             accessorNamingStrategy.getMethodType( executable ) == MethodType.GETTER;
     }
 
-    public boolean isPresenceCheckMethod(Accessor method) {
-        if ( !( method instanceof ExecutableElementAccessor ) ) {
-            return false;
-        }
-        ExecutableElement executable = method.getExecutable();
+    public boolean isPresenceCheckMethod(ExecutableElement executable) {
+
         return executable != null
-            && isPublicNotStatic( method )
+            && isPublicNotStatic( executable )
             && executable.getParameters().isEmpty()
             && ( executable.getReturnType().getKind() == TypeKind.BOOLEAN ||
             "java.lang.Boolean".equals( getQualifiedName( executable.getReturnType() ) ) )
             && accessorNamingStrategy.getMethodType( executable ) == MethodType.PRESENCE_CHECKER;
     }
 
-    public boolean isSetterMethod(Accessor method) {
-        ExecutableElement executable = method.getExecutable();
+    public boolean isSetterMethod(ExecutableElement executable) {
         return executable != null
-            && isPublicNotStatic( method )
+            && isPublicNotStatic( executable )
             && executable.getParameters().size() == 1
             && accessorNamingStrategy.getMethodType( executable ) == MethodType.SETTER;
     }
 
-    public boolean isAdderMethod(Accessor method) {
-        ExecutableElement executable = method.getExecutable();
+    public boolean isAdderMethod(ExecutableElement executable) {
         return executable != null
-            && isPublicNotStatic( method )
+            && isPublicNotStatic( executable )
             && executable.getParameters().size() == 1
             && accessorNamingStrategy.getMethodType( executable ) == MethodType.ADDER;
     }
 
-    public String getPropertyName(Accessor accessor) {
-        ExecutableElement executable = accessor.getExecutable();
-        return executable != null ? accessorNamingStrategy.getPropertyName( executable ) :
-            accessor.getSimpleName().toString();
+    public String getPropertyName(ExecutableElement executable) {
+        return accessorNamingStrategy.getPropertyName( executable );
+    }
+
+    public String getPropertyName(VariableElement variable) {
+        return variable.getSimpleName().toString();
     }
 
     /**
@@ -82,8 +80,12 @@ public final class AccessorNamingUtils {
      * {@code addChild(Child v)}, the element name would be 'Child'.
      */
     public String getElementNameForAdder(Accessor adderMethod) {
-        ExecutableElement executable = adderMethod.getExecutable();
-        return executable != null ? accessorNamingStrategy.getElementName( executable ) : null;
+        if ( adderMethod.getAccessorType() == AccessorType.ADDER ) {
+            return accessorNamingStrategy.getElementName( (ExecutableElement) adderMethod.getElement() );
+        }
+        else {
+            return null;
+        }
     }
 
     private static String getQualifiedName(TypeMirror type) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
@@ -5,20 +5,14 @@
  */
 package org.mapstruct.ap.internal.util;
 
-import static javax.lang.model.util.ElementFilter.fieldsIn;
-import static javax.lang.model.util.ElementFilter.methodsIn;
-import static org.mapstruct.ap.internal.util.workarounds.SpecificCompilerWorkarounds.replaceTypeElementIfNecessary;
-
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
-
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -27,9 +21,10 @@ import javax.lang.model.util.Elements;
 import org.mapstruct.ap.internal.prism.AfterMappingPrism;
 import org.mapstruct.ap.internal.prism.BeforeMappingPrism;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
-import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
-import org.mapstruct.ap.internal.util.accessor.VariableElementAccessor;
 import org.mapstruct.ap.spi.TypeHierarchyErroneousException;
+
+import static javax.lang.model.util.ElementFilter.methodsIn;
+import static org.mapstruct.ap.internal.util.workarounds.SpecificCompilerWorkarounds.replaceTypeElementIfNecessary;
 
 /**
  * Provides functionality around {@link ExecutableElement}s.
@@ -54,29 +49,16 @@ public class Executables {
     private Executables() {
     }
 
-    /**
-     * An {@link Accessor} is a field accessor, if it doesn't have an executable element, is public and it is not
-     * static.
-     *
-     * @param accessor the accessor to ber checked
-     *
-     * @return {@code true} if the {@code accessor} is for a {@code public} non {@code static} field.
-     */
-    public static boolean isFieldAccessor(Accessor accessor) {
-        ExecutableElement executable = accessor.getExecutable();
-        return executable == null && isPublic( accessor ) && isNotStatic( accessor );
+    static boolean isPublicNotStatic(ExecutableElement method) {
+        return isPublic( method ) && isNotStatic( method );
     }
 
-    static boolean isPublicNotStatic(Accessor accessor) {
-        return isPublic( accessor ) && isNotStatic( accessor );
-    }
-
-    static boolean isPublic(Accessor method) {
+    static boolean isPublic(ExecutableElement method) {
         return method.getModifiers().contains( Modifier.PUBLIC );
     }
 
-    private static boolean isNotStatic(Accessor accessor) {
-        return !accessor.getModifiers().contains( Modifier.STATIC );
+    private static boolean isNotStatic(ExecutableElement method) {
+        return !method.getModifiers().contains( Modifier.STATIC );
     }
 
     public static boolean isFinal(Accessor accessor) {
@@ -112,34 +94,14 @@ public class Executables {
      * @return the executable elements usable in the type
      */
     public static List<ExecutableElement> getAllEnclosedExecutableElements(Elements elementUtils, TypeElement element) {
-        List<ExecutableElement> executables = new ArrayList<>();
-        for ( Accessor accessor : getAllEnclosedAccessors( elementUtils, element ) ) {
-            if ( accessor.getExecutable() != null ) {
-                executables.add( accessor.getExecutable() );
-            }
-        }
-        return executables;
-    }
-
-    /**
-     * Finds all executable elements/variable elements within the given type element, including executable/variable
-     * elements defined in super classes and implemented interfaces and including the fields in the . Methods defined
-     * in {@link java.lang.Object} are ignored, as well as implementations of {@link java.lang.Object#equals(Object)}.
-     *
-     * @param elementUtils element helper
-     * @param element the element to inspect
-     *
-     * @return the executable elements usable in the type
-     */
-    public static List<Accessor> getAllEnclosedAccessors(Elements elementUtils, TypeElement element) {
-        List<Accessor> enclosedElements = new ArrayList<>();
+        List<ExecutableElement> enclosedElements = new ArrayList<>();
         element = replaceTypeElementIfNecessary( elementUtils, element );
         addEnclosedElementsInHierarchy( elementUtils, enclosedElements, element, element );
 
         return enclosedElements;
     }
 
-    private static void addEnclosedElementsInHierarchy(Elements elementUtils, List<Accessor> alreadyAdded,
+    private static void addEnclosedElementsInHierarchy(Elements elementUtils, List<ExecutableElement> alreadyAdded,
                                                        TypeElement element, TypeElement parentType) {
         if ( element != parentType ) { // otherwise the element was already checked for replacement
             element = replaceTypeElementIfNecessary( elementUtils, element );
@@ -150,23 +112,22 @@ public class Executables {
         }
 
         addNotYetOverridden( elementUtils, alreadyAdded, methodsIn( element.getEnclosedElements() ), parentType );
-        addFields( alreadyAdded, fieldsIn( element.getEnclosedElements() ) );
 
         if ( hasNonObjectSuperclass( element ) ) {
             addEnclosedElementsInHierarchy(
-                elementUtils,
-                alreadyAdded,
-                asTypeElement( element.getSuperclass() ),
-                parentType
+                            elementUtils,
+                            alreadyAdded,
+                            asTypeElement( element.getSuperclass() ),
+                            parentType
             );
         }
 
         for ( TypeMirror interfaceType : element.getInterfaces() ) {
             addEnclosedElementsInHierarchy(
-                elementUtils,
-                alreadyAdded,
-                asTypeElement( interfaceType ),
-                parentType
+                            elementUtils,
+                            alreadyAdded,
+                            asTypeElement( interfaceType ),
+                            parentType
             );
         }
 
@@ -178,28 +139,18 @@ public class Executables {
      * @param methodsToAdd methods to add to alreadyAdded, if they are not yet overridden by an element in the list
      * @param parentType the type for with elements are collected
      */
-    private static void addNotYetOverridden(Elements elementUtils, List<Accessor> alreadyCollected,
+    private static void addNotYetOverridden(Elements elementUtils, List<ExecutableElement> alreadyCollected,
                                             List<ExecutableElement> methodsToAdd, TypeElement parentType) {
-        List<Accessor> safeToAdd = new ArrayList<>( methodsToAdd.size() );
+        List<ExecutableElement> safeToAdd = new ArrayList<>( methodsToAdd.size() );
         for ( ExecutableElement toAdd : methodsToAdd ) {
             if ( isNotObjectEquals( toAdd )
-                && wasNotYetOverridden( elementUtils, alreadyCollected, toAdd, parentType ) ) {
-                safeToAdd.add( new ExecutableElementAccessor( toAdd ) );
+                            && wasNotYetOverridden( elementUtils, alreadyCollected, toAdd, parentType ) ) {
+                safeToAdd.add( toAdd );
             }
         }
 
         alreadyCollected.addAll( 0, safeToAdd );
     }
-
-    private static void addFields(List<Accessor> alreadyCollected, List<VariableElement> variablesToAdd) {
-        List<Accessor> safeToAdd = new ArrayList<>( variablesToAdd.size() );
-        for ( VariableElement toAdd : variablesToAdd ) {
-            safeToAdd.add( new VariableElementAccessor( toAdd ) );
-        }
-
-        alreadyCollected.addAll( 0, safeToAdd );
-    }
-
 
     /**
      * @param executable the executable to check
@@ -209,8 +160,8 @@ public class Executables {
      */
     private static boolean isNotObjectEquals(ExecutableElement executable) {
         if ( executable.getSimpleName().contentEquals( "equals" ) && executable.getParameters().size() == 1
-            && asTypeElement( executable.getParameters().get( 0 ).asType() ).getQualifiedName().contentEquals(
-            "java.lang.Object"
+                        && asTypeElement( executable.getParameters().get( 0 ).asType() ).getQualifiedName().contentEquals(
+                        "java.lang.Object"
         ) ) {
             return false;
         }
@@ -225,10 +176,10 @@ public class Executables {
      * @param parentType the type for which elements are collected
      * @return {@code true}, iff the given executable was not yet overridden by a method in the given list.
      */
-    private static boolean wasNotYetOverridden(Elements elementUtils, List<Accessor> alreadyCollected,
+    private static boolean wasNotYetOverridden(Elements elementUtils, List<ExecutableElement> alreadyCollected,
                                                ExecutableElement executable, TypeElement parentType) {
-        for ( ListIterator<Accessor> it = alreadyCollected.listIterator(); it.hasNext(); ) {
-            ExecutableElement executableInSubtype = it.next().getExecutable();
+        for ( ListIterator<ExecutableElement> it = alreadyCollected.listIterator(); it.hasNext(); ) {
+            ExecutableElement executableInSubtype = it.next();
             if ( executableInSubtype == null ) {
                 continue;
             }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
@@ -160,8 +160,8 @@ public class Executables {
      */
     private static boolean isNotObjectEquals(ExecutableElement executable) {
         if ( executable.getSimpleName().contentEquals( "equals" ) && executable.getParameters().size() == 1
-                        && asTypeElement( executable.getParameters().get( 0 ).asType() ).getQualifiedName().contentEquals(
-                        "java.lang.Object"
+                && asTypeElement( executable.getParameters().get( 0 ).asType() ).getQualifiedName().contentEquals(
+                "java.lang.Object"
         ) ) {
             return false;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Fields.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Fields.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.util;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Elements;
+
+import org.mapstruct.ap.spi.TypeHierarchyErroneousException;
+
+import static javax.lang.model.util.ElementFilter.fieldsIn;
+import static org.mapstruct.ap.internal.util.workarounds.SpecificCompilerWorkarounds.replaceTypeElementIfNecessary;
+
+/**
+ * Provides functionality around {@link VariableElement}s.
+ *
+ * @author Sjaak Derksen
+ */
+public class Fields {
+
+    private Fields() {
+    }
+
+    public static boolean isFieldAccessor(VariableElement method) {
+        return isPublic( method ) && isNotStatic( method );
+    }
+
+    static boolean isPublic(VariableElement method) {
+        return method.getModifiers().contains( Modifier.PUBLIC );
+    }
+
+    private static boolean isNotStatic(VariableElement method) {
+        return !method.getModifiers().contains( Modifier.STATIC );
+    }
+
+    /**
+     * Finds all variable elements within the given type element, including variable
+     * elements defined in super classes and implemented interfaces and including the fields in the .
+     *
+     * @param elementUtils element helper
+     * @param element the element to inspect
+     *
+     * @return the executable elements usable in the type
+     */
+    public static List<VariableElement> getAllEnclosedFields(Elements elementUtils, TypeElement element) {
+        List<VariableElement> enclosedElements = new ArrayList<>();
+        element = replaceTypeElementIfNecessary( elementUtils, element );
+        addEnclosedElementsInHierarchy( elementUtils, enclosedElements, element, element );
+
+        return enclosedElements;
+    }
+
+    private static void addEnclosedElementsInHierarchy(Elements elementUtils, List<VariableElement> alreadyAdded,
+                                                       TypeElement element, TypeElement parentType) {
+        if ( element != parentType ) { // otherwise the element was already checked for replacement
+            element = replaceTypeElementIfNecessary( elementUtils, element );
+        }
+
+        if ( element.asType().getKind() == TypeKind.ERROR ) {
+            throw new TypeHierarchyErroneousException( element );
+        }
+
+        addFields( alreadyAdded, fieldsIn( element.getEnclosedElements() ) );
+
+
+        if ( hasNonObjectSuperclass( element ) ) {
+            addEnclosedElementsInHierarchy(
+                            elementUtils,
+                            alreadyAdded,
+                            asTypeElement( element.getSuperclass() ),
+                            parentType
+            );
+        }
+    }
+
+    private static void addFields(List<VariableElement> alreadyCollected, List<VariableElement> variablesToAdd) {
+        List<VariableElement> safeToAdd = new ArrayList<>( variablesToAdd.size() );
+        for ( VariableElement toAdd : variablesToAdd ) {
+            safeToAdd.add( toAdd );
+        }
+
+        alreadyCollected.addAll( 0, safeToAdd );
+    }
+
+    private static TypeElement asTypeElement(TypeMirror mirror) {
+        return (TypeElement) ( (DeclaredType) mirror ).asElement();
+    }
+
+    private static boolean hasNonObjectSuperclass(TypeElement element) {
+        if ( element.getSuperclass().getKind() == TypeKind.ERROR ) {
+            throw new TypeHierarchyErroneousException( element );
+        }
+
+        return element.getSuperclass().getKind() == TypeKind.DECLARED
+                        && !asTypeElement( element.getSuperclass() ).getQualifiedName().toString().equals( "java.lang.Object" );
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Fields.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Fields.java
@@ -7,7 +7,6 @@ package org.mapstruct.ap.internal.util;
 
 import java.util.ArrayList;
 import java.util.List;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -102,6 +101,6 @@ public class Fields {
         }
 
         return element.getSuperclass().getKind() == TypeKind.DECLARED
-                        && !asTypeElement( element.getSuperclass() ).getQualifiedName().toString().equals( "java.lang.Object" );
+            && !asTypeElement( element.getSuperclass() ).getQualifiedName().toString().equals( "java.lang.Object" );
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Filters.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Filters.java
@@ -7,11 +7,23 @@ package org.mapstruct.ap.internal.util;
 
 import java.util.LinkedList;
 import java.util.List;
-
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.ExecutableType;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.Types;
 
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
+import org.mapstruct.ap.internal.util.accessor.VariableElementAccessor;
+
+import static org.mapstruct.ap.internal.util.Collections.first;
+import static org.mapstruct.ap.internal.util.accessor.AccessorType.ADDER;
+import static org.mapstruct.ap.internal.util.accessor.AccessorType.GETTER;
+import static org.mapstruct.ap.internal.util.accessor.AccessorType.PRESENCE_CHECKER;
+import static org.mapstruct.ap.internal.util.accessor.AccessorType.SETTER;
 
 /**
  * Filter methods for working with {@link Element} collections.
@@ -20,66 +32,88 @@ import org.mapstruct.ap.internal.util.accessor.ExecutableElementAccessor;
  */
 public class Filters {
 
-    private Filters() {
+    private final AccessorNamingUtils accessorNaming;
+    private final Types typeUtils;
+    private final TypeMirror typeMirror;
+
+    public Filters(AccessorNamingUtils accessorNaming, Types typeUtils, TypeMirror typeMirror) {
+        this.accessorNaming = accessorNaming;
+        this.typeUtils = typeUtils;
+        this.typeMirror = typeMirror;
     }
 
-    public static List<Accessor> getterMethodsIn(AccessorNamingUtils accessorNaming, List<Accessor> elements) {
+    public  List<Accessor> getterMethodsIn(List<ExecutableElement> elements) {
         List<Accessor> getterMethods = new LinkedList<>();
 
-        for ( Accessor method : elements ) {
+        for ( ExecutableElement method : elements ) {
             if ( accessorNaming.isGetterMethod( method ) ) {
-                getterMethods.add( method );
+                getterMethods.add( new ExecutableElementAccessor( method, getReturnType( method ), GETTER ) );
             }
         }
 
         return getterMethods;
     }
 
-    public static List<Accessor> fieldsIn(List<Accessor> accessors) {
+    public  List<Accessor> fieldsIn(List<VariableElement> accessors) {
         List<Accessor> fieldAccessors = new LinkedList<>();
 
-        for ( Accessor accessor : accessors ) {
-            if ( Executables.isFieldAccessor( accessor ) ) {
-                fieldAccessors.add( accessor );
+        for ( VariableElement accessor : accessors ) {
+            if ( Fields.isFieldAccessor( accessor ) ) {
+                fieldAccessors.add( new VariableElementAccessor( accessor ) );
             }
         }
 
         return fieldAccessors;
     }
 
-    public static List<ExecutableElementAccessor> presenceCheckMethodsIn(AccessorNamingUtils accessorNaming,
-                                                                         List<Accessor> elements) {
-        List<ExecutableElementAccessor> presenceCheckMethods = new LinkedList<>();
+    public List<Accessor> presenceCheckMethodsIn(List<ExecutableElement> elements) {
+        List<Accessor> presenceCheckMethods = new LinkedList<>();
 
-        for ( Accessor method : elements ) {
+        for ( ExecutableElement method : elements ) {
             if ( accessorNaming.isPresenceCheckMethod( method ) ) {
-                presenceCheckMethods.add( (ExecutableElementAccessor) method );
+                presenceCheckMethods.add( new ExecutableElementAccessor(
+                                method,
+                                getReturnType( method ),
+                                PRESENCE_CHECKER
+                ) );
             }
         }
 
         return presenceCheckMethods;
     }
 
-    public static List<Accessor> setterMethodsIn(AccessorNamingUtils accessorNaming, List<Accessor> elements) {
+    public  List<Accessor> setterMethodsIn(List<ExecutableElement> elements) {
         List<Accessor> setterMethods = new LinkedList<>();
 
-        for ( Accessor method : elements ) {
+        for ( ExecutableElement method : elements ) {
             if ( accessorNaming.isSetterMethod( method ) ) {
-                setterMethods.add( method );
+                setterMethods.add( new ExecutableElementAccessor( method, getFirstParameter( method ), SETTER ) );
             }
         }
         return setterMethods;
     }
 
-    public static List<Accessor> adderMethodsIn(AccessorNamingUtils accessorNaming, List<Accessor> elements) {
+    public  List<Accessor> adderMethodsIn( List<ExecutableElement> elements) {
         List<Accessor> adderMethods = new LinkedList<>();
 
-        for ( Accessor method : elements ) {
+        for ( ExecutableElement method : elements ) {
             if ( accessorNaming.isAdderMethod( method ) ) {
-                adderMethods.add( method );
+                adderMethods.add( new ExecutableElementAccessor( method, getFirstParameter( method ), ADDER ) );
             }
         }
 
         return adderMethods;
+    }
+
+    private TypeMirror getReturnType(ExecutableElement executableElement) {
+        return getWithinContext( executableElement ).getReturnType();
+    }
+
+    private TypeMirror getFirstParameter(ExecutableElement executableElement) {
+        return first( getWithinContext( executableElement ).getParameterTypes() );
+    }
+
+    private ExecutableType getWithinContext( ExecutableElement executableElement ) {
+        return (ExecutableType) typeUtils.asMemberOf( (DeclaredType) typeMirror, executableElement );
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
@@ -272,9 +272,9 @@ public class MapperConfiguration {
         return mapperPrism.disableSubMappingMethodsGeneration(); // fall back to default defined in the annotation
     }
 
-    public Optional<BuilderPrism> getBuilderPrism(Optional<BuilderPrism> beanMappingBuilderPrism) {
-        if ( beanMappingBuilderPrism != null && beanMappingBuilderPrism.isPresent()  ) {
-            return beanMappingBuilderPrism;
+    public Optional<BuilderPrism> getBuilderPrism(BuilderPrism beanMappingBuilderPrism) {
+        if ( beanMappingBuilderPrism != null  ) {
+            return Optional.ofNullable( beanMappingBuilderPrism );
         }
         else if ( mapperPrism.values.builder() != null ) {
             return Optional.ofNullable( mapperPrism.builder() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
@@ -8,6 +8,7 @@ package org.mapstruct.ap.internal.util;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
@@ -271,15 +272,18 @@ public class MapperConfiguration {
         return mapperPrism.disableSubMappingMethodsGeneration(); // fall back to default defined in the annotation
     }
 
-    public BuilderPrism getBuilderPrism() {
-        if ( mapperPrism.values.builder() != null ) {
-            return mapperPrism.builder();
+    public Optional<BuilderPrism> getBuilderPrism(Optional<BuilderPrism> beanMappingBuilderPrism) {
+        if ( beanMappingBuilderPrism != null && beanMappingBuilderPrism.isPresent()  ) {
+            return beanMappingBuilderPrism;
+        }
+        else if ( mapperPrism.values.builder() != null ) {
+            return Optional.ofNullable( mapperPrism.builder() );
         }
         else if ( mapperConfigPrism != null && mapperConfigPrism.values.builder() != null ) {
-            return mapperConfigPrism.builder();
+            return Optional.ofNullable( mapperConfigPrism.builder() );
         }
         else {
-            return null;
+            return Optional.empty();
         }
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/ValueProvider.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/ValueProvider.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.internal.util;
 
 import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 
 /**
  * This a wrapper class which provides the value that needs to be used in the models.
@@ -45,7 +46,7 @@ public class ValueProvider {
             return null;
         }
         String value = accessor.getSimpleName().toString();
-        if ( accessor.getExecutable() != null ) {
+        if ( accessor.getAccessorType() != AccessorType.FIELD ) {
             value += "()";
         }
         return new ValueProvider( value );

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/AbstractAccessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/AbstractAccessor.java
@@ -38,4 +38,5 @@ abstract class AbstractAccessor<T extends Element> implements Accessor {
     public T getElement() {
         return element;
     }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/Accessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/Accessor.java
@@ -8,6 +8,7 @@ package org.mapstruct.ap.internal.util.accessor;
 import java.util.Set;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.VariableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.Name;
 import javax.lang.model.type.TypeMirror;
@@ -23,7 +24,7 @@ public interface Accessor {
      * This returns the type that this accessor gives as a return.
      *
      * e.g. The {@link ExecutableElement#getReturnType()} if this is a method accessor,
-     * or {@link javax.lang.model.element.VariableElement#asType()} for field accessors.
+     * or {@link VariableElement#asType()} for field accessors.
      *
      * @return the type that the accessor gives as a return
      */
@@ -40,12 +41,14 @@ public interface Accessor {
     Set<Modifier> getModifiers();
 
     /**
-     * @return the {@link ExecutableElement}, or {@code null} if the accessor does not have one
-     */
-    ExecutableElement getExecutable();
-
-    /**
-     * @return the underlying {@link Element}
+     * @return the underlying {@link Element}, {@link VariableElement} or {@link ExecutableElement}
      */
     Element getElement();
+
+    /**
+     * The accessor type
+     *
+     * @return
+     */
+    AccessorType getAccessorType();
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/AccessorType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/AccessorType.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.util.accessor;
+
+public enum AccessorType {
+
+    FIELD,
+    GETTER,
+    SETTER,
+    ADDER,
+    PRESENCE_CHECKER;
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/ExecutableElementAccessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/ExecutableElementAccessor.java
@@ -15,22 +15,27 @@ import javax.lang.model.type.TypeMirror;
  */
 public class ExecutableElementAccessor extends AbstractAccessor<ExecutableElement> {
 
-    public ExecutableElementAccessor(ExecutableElement element) {
+    private final TypeMirror accessedType;
+    private final AccessorType accessorType;
+
+    public ExecutableElementAccessor(ExecutableElement element, TypeMirror accessedType, AccessorType accessorType) {
         super( element );
+        this.accessedType = accessedType;
+        this.accessorType = accessorType;
     }
 
     @Override
     public TypeMirror getAccessedType() {
-        return element.getReturnType();
-    }
-
-    @Override
-    public ExecutableElement getExecutable() {
-        return element;
+        return accessedType;
     }
 
     @Override
     public String toString() {
         return element.toString();
+    }
+
+    @Override
+    public AccessorType getAccessorType() {
+        return accessorType;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/VariableElementAccessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/VariableElementAccessor.java
@@ -5,7 +5,6 @@
  */
 package org.mapstruct.ap.internal.util.accessor;
 
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/VariableElementAccessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/accessor/VariableElementAccessor.java
@@ -26,12 +26,13 @@ public class VariableElementAccessor extends AbstractAccessor<VariableElement> {
     }
 
     @Override
-    public ExecutableElement getExecutable() {
-        return null;
-    }
-
-    @Override
     public String toString() {
         return element.toString();
     }
+
+    @Override
+    public AccessorType getAccessorType() {
+        return AccessorType.FIELD;
+    }
+
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -10,7 +10,7 @@
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     <#assign targetType = resultType />
     <#if !existingInstanceMapping>
-        <#assign targetType = resultType.effectiveType />
+        <#assign targetType = returnTypeToConstruct />
     </#if>
     <#list beforeMappingReferencesWithoutMappingTarget as callback>
     	<@includeModel object=callback targetBeanName=resultName targetType=targetType/>
@@ -25,7 +25,7 @@
     </#if>
 
     <#if !existingInstanceMapping>
-        <@includeModel object=resultType.effectiveType/> ${resultName} = <#if factoryMethod??><@includeModel object=factoryMethod targetType=resultType.effectiveType/><#else>new <@includeModel object=resultType.effectiveType/>()</#if>;
+        <@includeModel object=returnTypeToConstruct/> ${resultName} = <#if factoryMethod??><@includeModel object=factoryMethod targetType=returnTypeToConstruct/><#else>new <@includeModel object=returnTypeToConstruct/>()</#if>;
 
     </#if>
     <#list beforeMappingReferencesWithMappingTarget as callback>

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/DateFormatValidatorFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/DateFormatValidatorFactoryTest.java
@@ -167,7 +167,6 @@ public class DateFormatValidatorFactoryTest {
                         null,
                         null,
                         null,
-                        null,
                         fullQualifiedName,
                         false,
                         false,

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
@@ -115,7 +115,6 @@ public class DefaultConversionContextTest {
                         null,
                         null,
                         null,
-                        null,
                         fullQualifiedName,
                         false,
                         false,

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/multiple/MultipleBuilderMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/multiple/MultipleBuilderMapperTest.java
@@ -113,18 +113,7 @@ public class MultipleBuilderMapperTest {
         TooManyBuilderCreationMethodsMapper.class
     })
     @ExpectedCompilationOutcome(value = CompilationResult.SUCCEEDED,
-        // We have 2 diagnostics, as we don't do caching of the types, so a type is processed multiple types
         diagnostics = {
-            @Diagnostic(
-                type = Case.class,
-                kind = javax.tools.Diagnostic.Kind.WARNING,
-                line = 11,
-                messageRegExp = "More than one builder creation method for \".*\\.multiple\\.builder.Case\"\\. " +
-                    "Found methods: " +
-                    "\".*wrongBuilder\\(\\) ?, " +
-                    ".*builder\\(\\) ?\"\\. " +
-                    "Builder will not be used\\. Consider implementing a custom BuilderProvider SPI\\."
-            ),
             @Diagnostic(
                 type = Case.class,
                 kind = javax.tools.Diagnostic.Kind.WARNING,

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleMapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builder.off;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Builder;
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED)
+public interface SimpleMapper {
+
+    @BeanMapping( builder = @Builder( noBuilder = true ) )
+    @Mapping(target = "name", source = "fullName")
+    SimpleNotRealyImmutablePerson toNotRealyImmutable(SimpleMutablePerson source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleMapper.java
@@ -14,7 +14,7 @@ import org.mapstruct.Mapping;
 @Mapper(collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED)
 public interface SimpleMapper {
 
-    @BeanMapping( builder = @Builder( noBuilder = true ) )
+    @BeanMapping( builder = @Builder( disableBuilder = true ) )
     @Mapping(target = "name", source = "fullName")
     SimpleNotRealyImmutablePerson toNotRealyImmutable(SimpleMutablePerson source);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleMutablePerson.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleMutablePerson.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builder.off;
+
+import java.util.List;
+
+public class SimpleMutablePerson {
+    private String fullName;
+
+    public String getFullName() {
+        return fullName;
+    }
+
+    public void setFullName(String fullName) {
+        this.fullName = fullName;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleMutablePerson.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleMutablePerson.java
@@ -5,8 +5,6 @@
  */
 package org.mapstruct.ap.test.builder.off;
 
-import java.util.List;
-
 public class SimpleMutablePerson {
     private String fullName;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleNotRealyImmutableBuilderTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleNotRealyImmutableBuilderTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builder.off;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+import org.mapstruct.factory.Mappers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("1743")
+@WithClasses({
+    SimpleMutablePerson.class,
+    SimpleNotRealyImmutablePerson.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class SimpleNotRealyImmutableBuilderTest {
+
+    @Rule
+    public final GeneratedSource generatedSource = new GeneratedSource();
+
+    @Test
+    @WithClasses({ SimpleMapper.class })
+    public void testSimpleImmutableBuilderHappyPath() {
+        SimpleMapper mapper = Mappers.getMapper( SimpleMapper.class );
+        SimpleMutablePerson source = new SimpleMutablePerson();
+        source.setFullName( "Bob" );
+
+        SimpleNotRealyImmutablePerson targetObject = mapper.toNotRealyImmutable( source );
+
+        assertThat( targetObject.getName() ).isEqualTo( "Bob" );
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleNotRealyImmutablePerson.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/off/SimpleNotRealyImmutablePerson.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builder.off;
+
+public class SimpleNotRealyImmutablePerson {
+
+    private String name;
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public SimpleNotRealyImmutablePerson() {
+    }
+
+    SimpleNotRealyImmutablePerson(Builder builder) {
+        this.name = builder.name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public static class Builder {
+
+        private String name;
+
+        public Builder name(String name) {
+            throw new IllegalStateException( "name should not be called on builder" );
+        }
+
+        public SimpleNotRealyImmutablePerson build() {
+            return new SimpleNotRealyImmutablePerson( this );
+        }
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
@@ -160,22 +160,18 @@ public class ConversionTest {
         ErroneousSourceTargetMapper6.class,
         NoProperties.class
     })
-    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
-        diagnostics = {
-            @Diagnostic(type = ErroneousSourceTargetMapper6.class,
-                kind = javax.tools.Diagnostic.Kind.ERROR,
-                line = 16,
-                messageRegExp = "No target bean properties found: can't map property \".*NoProperties "
-                    + "foo\\.wrapped\" to"
-                    + " \"org.mapstruct.ap.test.selection.generics.TypeA " +
-                    "foo\\.wrapped\""),
-            @Diagnostic(type = ErroneousSourceTargetMapper6.class,
-                kind = javax.tools.Diagnostic.Kind.ERROR,
-                line = 16,
-                messageRegExp = ".*\\.generics\\.WildCardSuperWrapper<.*\\.generics\\.TypeA> does not have an " +
-                    "accessible parameterless constructor\\.")
-
-        })
+    @ExpectedCompilationOutcome( value = CompilationResult.FAILED, diagnostics = {
+        @Diagnostic( type = ErroneousSourceTargetMapper6.class, kind = javax.tools.Diagnostic.Kind.ERROR,
+                        line = 16, messageRegExp =
+                        ".*\\.generics\\.WildCardSuperWrapper<.*\\.generics\\.TypeA> does not have an "
+                                        + "accessible parameterless constructor\\." ),
+        @Diagnostic( type = ErroneousSourceTargetMapper6.class, kind = javax.tools.Diagnostic.Kind.ERROR,
+                        line = 16, messageRegExp =
+                        "No target bean properties found: can't map property \".*NoProperties "
+                                        + "foo\\.wrapped\" to"
+                                        + " \"org.mapstruct.ap.test.selection.generics.TypeA "
+                                        + "foo\\.wrapped\"" )
+    } )
     public void shouldFailOnNonMatchingWildCards() {
     }
 }


### PR DESCRIPTION
Currently the accessor type is defined in PropertyMapper while it should be an intrinsic property of Accessor. Types are fetched and derived in context (again) all-over-the-place.. Sometimes that requires the parent type again and even the mapping method (to derive in context and resolve generics).

Next, builderType is part of type. One could say there is a relation from builderType to Type but not the other way around. A builderType could be in a completely different package. It's still not as I want.. But I managed to move the builderType (mostly) to the place were its relevant: the `BeanMappingMethod`. 

Done!

I'm still not completely happy with the number of places were I do need to consult the typeFactory for the `effectiveType` or the `builderType`. This indicates a bad separation of concerns. Probably stemming from the fact that we do analyse a nested target and try to find the associated types in `TargetReference`. I think that in the end `TargetReference` and `SourceReference` should be handled in the `BeanMappingMethod` and not in `Mapping` upfront but in the context of the `BeanMappingMethod`.

I experimented with making annotations and annotation fields `Optional`. I think we should apply this pattern, because we keep on doing null checks all over the place.

Fixes #1742 