### PR TITLE
Improve terms in qualifier docs

### DIFF
--- a/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
+++ b/documentation/src/main/asciidoc/mapstruct-reference-guide.asciidoc
@@ -1322,7 +1322,7 @@ public @interface GermanToEnglish {
 ----
 ====
 
-Please take note of the retention `TitleTranslator` on class level, `EnglishToGerman`, `GermanToEnglish` on method level!
+Please take note of the target `TitleTranslator` on type level, `EnglishToGerman`, `GermanToEnglish` on method level!
 
 Then, using the qualifiers, the mapping could look like this:
 


### PR DESCRIPTION
This sentence is talking about `@Target`, not `@Retention`.
Also, let's use 'type' instead of 'class' to line up with `ElementType.TYPE`.