### PR TITLE
Add support for InjectionStrategy.CONSTRUCTOR

### DIFF
--- a/core/src/main/java/org/mapstruct/factory/Mappers.java
+++ b/core/src/main/java/org/mapstruct/factory/Mappers.java
@@ -82,20 +82,23 @@ public class Mappers {
             Class<T> implementation = (Class<T>) classLoader.loadClass( clazz.getName() + IMPLEMENTATION_SUFFIX );
             Constructor<?>[] constructors = implementation.getConstructors();
             Constructor<T> constructor;
-            if (constructors.length == 0) {
+            if ( constructors.length == 0 ) {
                 constructor = implementation.getDeclaredConstructor();
-                constructor.setAccessible(true);
-            } else {
+                constructor.setAccessible( true );
+            }
+            else {
                 constructor = (Constructor<T>) constructors[0];
             }
 
             Object[] params = Arrays.stream(constructor.getParameterTypes())
-                    .map(Mappers::getMapper)
-                    .toArray(Object[]::new);
-            return constructor.newInstance(params);
-        } catch (ClassNotFoundException e) {
+                    .map( Mappers::getMapper )
+                    .toArray( Object[]::new );
+            return constructor.newInstance( params );
+        }
+        catch ( ClassNotFoundException e ) {
             return getMapperFromServiceLoader( clazz, classLoader );
-        } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
+        }
+        catch ( InstantiationException | InvocationTargetException | IllegalAccessException e ) {
             throw new RuntimeException( e );
         }
     }

--- a/core/src/main/java/org/mapstruct/factory/Mappers.java
+++ b/core/src/main/java/org/mapstruct/factory/Mappers.java
@@ -90,7 +90,7 @@ public class Mappers {
                 constructor = (Constructor<T>) constructors[0];
             }
 
-            Object[] params = Arrays.stream(constructor.getParameterTypes())
+            Object[] params = Arrays.stream( constructor.getParameterTypes() )
                     .map( Mappers::getMapper )
                     .toArray( Object[]::new );
             return constructor.newInstance( params );


### PR DESCRIPTION
When generating mappers with the setting InjectionStrategy.CONSTRUCTOR the `Mappers.getMapper()` call can not instantiate the mapper because it has no default constructor.
This adds recursive instantiation of mappers and its dependent used mappers.
This allows to instantiate mappers without relying on any DI framework.
This is very important for unit tests.