### PR TITLE
Fix warning addAll in org.mapstruct.ap.internal.model.assignment

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -387,7 +387,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         private boolean canBeConstructed(Type typeToBeConstructed) {
             return !typeToBeConstructed.isAbstract()
                     && typeToBeConstructed.isAssignableTo( this.method.getResultType() )
-                    && typeToBeConstructed.hasEmptyAccessibleContructor();
+                    && typeToBeConstructed.hasEmptyAccessibleConstructor();
         }
 
         private void reportResultTypeFromBeanMappingNotConstructableError(Type resultType) {
@@ -410,7 +410,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                                 method.getResultType()
                 );
             }
-            else if ( !resultType.hasEmptyAccessibleContructor() ) {
+            else if ( !resultType.hasEmptyAccessibleConstructor() ) {
                 ctx.getMessager().printMessage(
                                 method.getExecutable(),
                                 BeanMappingPrism.getInstanceOn( method.getExecutable() ).mirror,
@@ -428,7 +428,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                                 returnType
                 );
             }
-            else if ( !returnType.hasEmptyAccessibleContructor() ) {
+            else if ( !returnType.hasEmptyAccessibleConstructor() ) {
                 ctx.getMessager().printMessage(
                                 method.getExecutable(),
                                 Message.GENERAL_NO_SUITABLE_CONSTRUCTOR,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AdderWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AdderWrapper.java
@@ -74,8 +74,7 @@ public class AdderWrapper extends AssignmentWrapper {
 
     @Override
     public Set<Type> getImportTypes() {
-        Set<Type> imported = new HashSet<>();
-        imported.addAll( super.getImportTypes() );
+        Set<Type> imported = new HashSet<>( super.getImportTypes() );
         imported.add( adderType.getTypeBound() );
         return imported;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ArrayCopyWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ArrayCopyWrapper.java
@@ -40,8 +40,7 @@ public class ArrayCopyWrapper extends AssignmentWrapper {
 
     @Override
     public Set<Type> getImportTypes() {
-        Set<Type> imported = new HashSet<>();
-        imported.addAll( getAssignment().getImportTypes() );
+        Set<Type> imported = new HashSet<>( getAssignment().getImportTypes() );
         imported.add( arraysType );
         imported.add( targetType );
         return imported;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.java
@@ -60,7 +60,7 @@ public class ExistingInstanceSetterWrapperForCollectionsAndMaps
 
     @Override
     public Set<Type> getImportTypes() {
-        Set<Type> imported = new HashSet<Type>( super.getImportTypes() );
+        Set<Type> imported = new HashSet<>( super.getImportTypes() );
         if ( isMapNullToDefault() && ( targetType.getImplementationType() != null ) ) {
             imported.add( targetType.getImplementationType() );
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/StreamAdderWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/StreamAdderWrapper.java
@@ -70,8 +70,7 @@ public class StreamAdderWrapper extends AssignmentWrapper {
 
     @Override
     public Set<Type> getImportTypes() {
-        Set<Type> imported = new HashSet<>();
-        imported.addAll( super.getImportTypes() );
+        Set<Type> imported = new HashSet<>( super.getImportTypes() );
         imported.add( adderType.getTypeBound() );
         return imported;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/UpdateWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/UpdateWrapper.java
@@ -74,8 +74,7 @@ public class UpdateWrapper extends AssignmentWrapper {
 
     @Override
     public Set<Type> getImportTypes() {
-        Set<Type> imported = new HashSet<>();
-        imported.addAll( super.getImportTypes() );
+        Set<Type> imported = new HashSet<>( super.getImportTypes() );
         if ( factoryMethod != null ) {
             imported.addAll( factoryMethod.getImportTypes() );
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -99,7 +99,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     private Type boundingBase = null;
 
-    private Boolean hasEmptyAccessibleContructor;
+    private Boolean hasEmptyAccessibleConstructor;
 
     private final Filters filters;
 
@@ -1018,20 +1018,20 @@ public class Type extends ModelElement implements Comparable<Type> {
         return boundingBase;
     }
 
-    public boolean hasEmptyAccessibleContructor() {
+    public boolean hasEmptyAccessibleConstructor() {
 
-        if ( this.hasEmptyAccessibleContructor == null ) {
-            hasEmptyAccessibleContructor = false;
+        if ( this.hasEmptyAccessibleConstructor == null ) {
+            hasEmptyAccessibleConstructor = false;
             List<ExecutableElement> constructors = ElementFilter.constructorsIn( typeElement.getEnclosedElements() );
             for ( ExecutableElement constructor : constructors ) {
                 if ( !constructor.getModifiers().contains( Modifier.PRIVATE )
                     && constructor.getParameters().isEmpty() ) {
-                    hasEmptyAccessibleContructor = true;
+                    hasEmptyAccessibleConstructor = true;
                     break;
                 }
             }
         }
-        return hasEmptyAccessibleContructor;
+        return hasEmptyAccessibleConstructor;
     }
 
     /**


### PR DESCRIPTION
Replace addAll in collections on constructor in org.mapstruct.ap.internal.model.assignment
Fix typo in org.mapstruct.ap.internal.model.common.Type

I'm sorry, but I have added "dist: trusty" in travis.yml . I can't pass checks without it. I'll remove it if you will help me to pass checks without it.