### PR TITLE
Fix minor warnings in test packages java8stream and nestedbeans

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/StreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/StreamMappingTest.java
@@ -9,9 +9,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -55,7 +55,7 @@ public class StreamMappingTest {
     @Test
     public void shouldMapList() {
         Source source = new Source();
-        source.setStringStream( Arrays.asList( "Bob", "Alice" ).stream() );
+        source.setStringStream( Stream.of( "Bob", "Alice" ) );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -66,7 +66,7 @@ public class StreamMappingTest {
     @Test
     public void shouldMapListWithoutSetter() {
         Source source = new Source();
-        source.setStringStream2( Arrays.asList( "Bob", "Alice" ).stream() );
+        source.setStringStream2( Stream.of( "Bob", "Alice" ) );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -88,7 +88,7 @@ public class StreamMappingTest {
     @Test
     public void shouldMapArrayList() {
         Source source = new Source();
-        source.setStringArrayStream( new ArrayList<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
+        source.setStringArrayStream( new ArrayList<>( Arrays.asList( "Bob", "Alice" ) ).stream() );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -99,7 +99,7 @@ public class StreamMappingTest {
     @Test
     public void shouldReverseMapArrayList() {
         Target target = new Target();
-        target.setStringArrayList( new ArrayList<String>( Arrays.asList( "Bob", "Alice" ) ) );
+        target.setStringArrayList( new ArrayList<>( Arrays.asList( "Bob", "Alice" ) ) );
 
         Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
 
@@ -110,7 +110,7 @@ public class StreamMappingTest {
     @Test
     public void shouldMapSet() {
         Source source = new Source();
-        source.setStringStreamToSet( new HashSet<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
+        source.setStringStreamToSet( new HashSet<>( Arrays.asList( "Bob", "Alice" ) ).stream() );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -121,7 +121,7 @@ public class StreamMappingTest {
     @Test
     public void shouldReverseMapSet() {
         Target target = new Target();
-        target.setStringSet( new HashSet<String>( Arrays.asList( "Bob", "Alice" ) ) );
+        target.setStringSet( new HashSet<>( Arrays.asList( "Bob", "Alice" ) ) );
 
         Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
 
@@ -132,7 +132,7 @@ public class StreamMappingTest {
     @Test
     public void shouldMapListToCollection() {
         Source source = new Source();
-        source.setIntegerStream( Arrays.asList( 1, 2 ).stream() );
+        source.setIntegerStream( Stream.of( 1, 2 ) );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -154,7 +154,7 @@ public class StreamMappingTest {
     @Test
     public void shouldMapIntegerSetToStringSet() {
         Source source = new Source();
-        source.setAnotherIntegerStream( new HashSet<Integer>( Arrays.asList( 1, 2 ) ).stream() );
+        source.setAnotherIntegerStream( new HashSet<>( Arrays.asList( 1, 2 ) ).stream() );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -165,7 +165,7 @@ public class StreamMappingTest {
     @Test
     public void shouldReverseMapIntegerSetToStringSet() {
         Target target = new Target();
-        target.setAnotherStringSet( new HashSet<String>( Arrays.asList( "1", "2" ) ) );
+        target.setAnotherStringSet( new HashSet<>( Arrays.asList( "1", "2" ) ) );
 
         Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
 
@@ -176,7 +176,7 @@ public class StreamMappingTest {
     @Test
     public void shouldMapSetOfEnumToStringSet() {
         Source source = new Source();
-        source.setColours( EnumSet.of( Colour.BLUE, Colour.GREEN ).stream() );
+        source.setColours( Stream.of( Colour.BLUE, Colour.GREEN ) );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
@@ -187,7 +187,7 @@ public class StreamMappingTest {
     @Test
     public void shouldReverseMapSetOfEnumToStringSet() {
         Target target = new Target();
-        target.setColours( new HashSet<String>( Arrays.asList( "BLUE", "GREEN" ) ) );
+        target.setColours( new HashSet<>( Arrays.asList( "BLUE", "GREEN" ) ) );
 
         Source source = SourceTargetMapper.INSTANCE.targetToSource( target );
 
@@ -198,7 +198,7 @@ public class StreamMappingTest {
     @Test
     public void shouldMapIntegerStreamToNumberSet() {
         Set<Number> numbers = SourceTargetMapper.INSTANCE
-            .integerStreamToNumberSet( Arrays.asList( 123, 456 ).stream() );
+            .integerStreamToNumberSet( Stream.of( 123, 456 ) );
 
         assertThat( numbers ).isNotNull();
         assertThat( numbers ).containsOnly( 123, 456 );
@@ -207,7 +207,7 @@ public class StreamMappingTest {
     @Test
     public void shouldMapNonGenericList() {
         Source source = new Source();
-        source.setStringStream3( new ArrayList<String>( Arrays.asList( "Bob", "Alice" ) ).stream() );
+        source.setStringStream3( new ArrayList<>( Arrays.asList( "Bob", "Alice" ) ).stream() );
 
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/StringHolder.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/StringHolder.java
@@ -41,13 +41,10 @@ public class StringHolder {
         }
         StringHolder other = (StringHolder) obj;
         if ( string == null ) {
-            if ( other.string != null ) {
-                return false;
-            }
+            return other.string == null;
         }
-        else if ( !string.equals( other.string ) ) {
-            return false;
+        else {
+            return string.equals( other.string );
         }
-        return true;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/context/StreamWithContextTest.java
@@ -5,7 +5,6 @@
  */
 package org.mapstruct.ap.test.java8stream.context;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.stream.Stream;
 
@@ -26,15 +25,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class StreamWithContextTest {
 
     @Test
-    public void shouldApplyAfterMapping() throws Exception {
+    public void shouldApplyAfterMapping() {
         Stream<String> stringStream = StreamWithContextMapper.INSTANCE.intStreamToStringStream(
-            Arrays.asList( 1, 2, 3, 5 ).stream() );
+            Stream.of( 1, 2, 3, 5 ) );
 
         assertThat( stringStream ).containsOnly( "1", "2" );
     }
 
     @Test
-    public void shouldApplyBeforeMappingOnArray() throws Exception {
+    public void shouldApplyBeforeMappingOnArray() {
         Integer[] integers = new Integer[] { 1, 3 };
         Stream<Integer> stringStream = StreamWithContextMapper.INSTANCE.arrayToStream( integers );
 
@@ -42,9 +41,9 @@ public class StreamWithContextTest {
     }
 
     @Test
-    public void shouldApplyBeforeAndAfterMappingOnCollection() throws Exception {
+    public void shouldApplyBeforeAndAfterMappingOnCollection() {
         Collection<String> stringsStream = StreamWithContextMapper.INSTANCE.streamToCollection(
-            Arrays.asList( 10, 20, 40 ).stream() );
+            Stream.of( 10, 20, 40 ) );
 
         assertThat( stringsStream ).containsOnly( "23", "10", "20", "40", "230" );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/DefaultStreamImplementationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/DefaultStreamImplementationTest.java
@@ -8,7 +8,6 @@ package org.mapstruct.ap.test.java8stream.defaultimplementation;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -90,7 +89,7 @@ public class DefaultStreamImplementationTest {
 
     @Test
     public void shouldUseTargetParameterForMapping() {
-        List<TargetFoo> target = new ArrayList<TargetFoo>();
+        List<TargetFoo> target = new ArrayList<>();
         SourceTargetMapper.INSTANCE.sourceFoosToTargetFoosUsingTargetParameter(
             target,
             createSourceFooStream()
@@ -147,7 +146,7 @@ public class DefaultStreamImplementationTest {
 
     @Test
     public void shouldUseAndReturnTargetParameterForMapping() {
-        List<TargetFoo> target = new ArrayList<TargetFoo>();
+        List<TargetFoo> target = new ArrayList<>();
         Iterable<TargetFoo> result =
             SourceTargetMapper.INSTANCE
                 .sourceFoosToTargetFoosUsingTargetParameterAndReturn( createSourceFooStream(), target );
@@ -172,6 +171,6 @@ public class DefaultStreamImplementationTest {
     }
 
     private Stream<SourceFoo> createSourceFooStream() {
-        return Arrays.asList( new SourceFoo( "Bob" ), new SourceFoo( "Alice" ) ).stream();
+        return Stream.of( new SourceFoo( "Bob" ), new SourceFoo( "Alice" ) );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterStreamMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterStreamMappingTest.java
@@ -7,8 +7,8 @@ package org.mapstruct.ap.test.java8stream.defaultimplementation;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,7 +28,7 @@ public class NoSetterStreamMappingTest {
     @Test
     public void compilesAndMapsCorrectly() {
         NoSetterSource source = new NoSetterSource();
-        source.setListValues( Arrays.asList( "foo", "bar" ).stream() );
+        source.setListValues( Stream.of( "foo", "bar" ) );
 
         NoSetterTarget target = NoSetterMapper.INSTANCE.toTarget( source );
 
@@ -37,7 +37,7 @@ public class NoSetterStreamMappingTest {
         // now test existing instances
 
         NoSetterSource source2 = new NoSetterSource();
-        source2.setListValues( Arrays.asList( "baz" ).stream() );
+        source2.setListValues( Stream.of( "baz" ) );
         List<String> originalCollectionInstance = target.getListValues();
 
         NoSetterTarget target2 = NoSetterMapper.INSTANCE.toTargetWithExistingTarget( source2, target );

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/NoSetterTarget.java
@@ -13,7 +13,7 @@ import java.util.List;
  *
  */
 public class NoSetterTarget {
-    private List<String> listValues = new ArrayList<String>();
+    private List<String> listValues = new ArrayList<>();
 
     public List<String> getListValues() {
         return listValues;

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/Target.java
@@ -14,7 +14,7 @@ public class Target {
 
     public List<TargetFoo> getFooListNoSetter() {
         if ( fooListNoSetter == null ) {
-            fooListNoSetter = new ArrayList<TargetFoo>();
+            fooListNoSetter = new ArrayList<>();
         }
         return fooListNoSetter;
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/TargetFoo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/defaultimplementation/TargetFoo.java
@@ -45,14 +45,11 @@ public class TargetFoo implements Comparable<TargetFoo> {
         }
         TargetFoo other = (TargetFoo) obj;
         if ( name == null ) {
-            if ( other.name != null ) {
-                return false;
-            }
+            return other.name == null;
         }
-        else if ( !name.equals( other.name ) ) {
-            return false;
+        else {
+            return name.equals( other.name );
         }
-        return true;
     }
 
     @Override

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StreamToNonIterableMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StreamToNonIterableMappingTest.java
@@ -7,7 +7,7 @@ package org.mapstruct.ap.test.java8stream.streamtononiterable;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Arrays;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,7 +23,7 @@ public class StreamToNonIterableMappingTest {
     @Test
     public void shouldMapStringStreamToStringUsingCustomMapper() {
         Source source = new Source();
-        source.setNames( Arrays.asList( "Alice", "Bob", "Jim" ).stream() );
+        source.setNames( Stream.of( "Alice", "Bob", "Jim" ) );
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
         assertThat( target ).isNotNull();

--- a/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StringListMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/java8stream/streamtononiterable/StringListMapper.java
@@ -16,6 +16,6 @@ public class StringListMapper {
     }
 
     public Stream<String> stringToStringList(String string) {
-        return string == null ? null : Arrays.asList( string.split( "-" ) ).stream();
+        return string == null ? null : Arrays.stream( string.split( "-" ) );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/Car.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/Car.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.test.nestedbeans;
 
 import java.util.List;
+import java.util.Objects;
 
 public class Car {
 
@@ -60,10 +61,10 @@ public class Car {
         if ( year != car.year ) {
             return false;
         }
-        if ( name != null ? !name.equals( car.name ) : car.name != null ) {
+        if ( !Objects.equals( name, car.name ) ) {
             return false;
         }
-        return wheels != null ? wheels.equals( car.wheels ) : car.wheels == null;
+        return Objects.equals( wheels, car.wheels );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/CarDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/CarDto.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.test.nestedbeans;
 
 import java.util.List;
+import java.util.Objects;
 
 public class CarDto {
 
@@ -60,10 +61,10 @@ public class CarDto {
         if ( year != carDto.year ) {
             return false;
         }
-        if ( name != null ? !name.equals( carDto.name ) : carDto.name != null ) {
+        if ( !Objects.equals( name, carDto.name ) ) {
             return false;
         }
-        return wheels != null ? wheels.equals( carDto.wheels ) : carDto.wheels == null;
+        return Objects.equals( wheels, carDto.wheels );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/House.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/House.java
@@ -5,6 +5,8 @@
  */
 package org.mapstruct.ap.test.nestedbeans;
 
+import java.util.Objects;
+
 public class House {
 
     private String name;
@@ -60,10 +62,10 @@ public class House {
         if ( year != house.year ) {
             return false;
         }
-        if ( name != null ? !name.equals( house.name ) : house.name != null ) {
+        if ( !Objects.equals( name, house.name ) ) {
             return false;
         }
-        return roof != null ? roof.equals( house.roof ) : house.roof == null;
+        return Objects.equals( roof, house.roof );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/MultipleForgedMethodsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/MultipleForgedMethodsTest.java
@@ -34,8 +34,8 @@ public class MultipleForgedMethodsTest {
     @Test
     public void testNestedMapsAutoMap() {
 
-        HashMap<WordDto, WordDto> dtoAntonyms = new HashMap<WordDto, WordDto>();
-        HashMap<Word, Word> entityAntonyms = new HashMap<Word, Word>();
+        HashMap<WordDto, WordDto> dtoAntonyms = new HashMap<>();
+        HashMap<Word, Word> entityAntonyms = new HashMap<>();
 
         String[] words = { "black", "good", "up", "left", "fast" };
         String[] antonyms = { "white", "bad", "down", "right", "slow" };

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/NestedSimpleBeansMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/NestedSimpleBeansMappingTest.java
@@ -6,7 +6,6 @@
 package org.mapstruct.ap.test.nestedbeans;
 
 import java.util.List;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.assertj.core.groups.Tuple;
@@ -45,7 +44,7 @@ public class NestedSimpleBeansMappingTest {
     );
 
     @Test
-    public void shouldHaveAllFields() throws Exception {
+    public void shouldHaveAllFields() {
         // If this test fails that means something new was added to the structure of the User/UserDto.
         // Make sure that the other tests are also updated (the new field is asserted)
         String[] userFields = new String[] { "name", "car", "secondCar", "house" };
@@ -125,12 +124,9 @@ public class NestedSimpleBeansMappingTest {
     }
 
     private static void assertWheels(List<WheelDto> wheelDtos, List<Wheel> wheels) {
-        List<Tuple> wheelTuples = wheels.stream().map( new Function<Wheel, Tuple>() {
-            @Override
-            public Tuple apply(Wheel wheel) {
-                return tuple( wheel.isFront(), wheel.isRight() );
-            }
-        } ).collect( Collectors.<Tuple>toList() );
+        List<Tuple> wheelTuples = wheels.stream()
+            .map( wheel -> tuple( wheel.isFront(), wheel.isRight() ) )
+            .collect( Collectors.toList() );
         assertThat( wheelDtos )
             .extracting( "front", "right" )
             .containsExactlyElementsOf( wheelTuples );

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/RoofDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/RoofDto.java
@@ -5,6 +5,8 @@
  */
 package org.mapstruct.ap.test.nestedbeans;
 
+import java.util.Objects;
+
 public class RoofDto {
     private String color;
     private ExternalRoofType type;
@@ -48,7 +50,7 @@ public class RoofDto {
             return false;
         }
 
-        return color != null ? color.equals( roofDto.color ) : roofDto.color == null;
+        return Objects.equals( color, roofDto.color );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/User.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/User.java
@@ -5,6 +5,8 @@
  */
 package org.mapstruct.ap.test.nestedbeans;
 
+import java.util.Objects;
+
 public class User {
 
     private String name;
@@ -64,13 +66,13 @@ public class User {
 
         User user = (User) o;
 
-        if ( name != null ? !name.equals( user.name ) : user.name != null ) {
+        if ( !Objects.equals( name, user.name ) ) {
             return false;
         }
-        if ( car != null ? !car.equals( user.car ) : user.car != null ) {
+        if ( !Objects.equals( car, user.car ) ) {
             return false;
         }
-        return house != null ? house.equals( user.house ) : user.house == null;
+        return Objects.equals( house, user.house );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/UserDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/UserDto.java
@@ -5,6 +5,8 @@
  */
 package org.mapstruct.ap.test.nestedbeans;
 
+import java.util.Objects;
+
 public class UserDto {
 
     private String name;
@@ -64,13 +66,13 @@ public class UserDto {
 
         UserDto userDto = (UserDto) o;
 
-        if ( name != null ? !name.equals( userDto.name ) : userDto.name != null ) {
+        if ( !Objects.equals( name, userDto.name ) ) {
             return false;
         }
-        if ( car != null ? !car.equals( userDto.car ) : userDto.car != null ) {
+        if ( !Objects.equals( car, userDto.car ) ) {
             return false;
         }
-        return house != null ? house.equals( userDto.house ) : userDto.house == null;
+        return Objects.equals( house, userDto.house );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/EntityFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/exceptions/EntityFactory.java
@@ -21,10 +21,7 @@ public class EntityFactory {
         try {
             entity = entityClass.newInstance();
         }
-        catch ( IllegalAccessException exception ) {
-            throw new MappingException( "Rare exception thrown, refer to stack trace", exception );
-        }
-        catch ( InstantiationException exception ) {
+        catch ( IllegalAccessException | InstantiationException exception ) {
             throw new MappingException( "Rare exception thrown, refer to stack trace", exception );
         }
         catch ( Exception exception ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/AntonymsDictionary.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/AntonymsDictionary.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.test.nestedbeans.maps;
 
 import java.util.Map;
+import java.util.Objects;
 
 public class AntonymsDictionary {
     private Map<Word, Word> antonyms;
@@ -36,7 +37,7 @@ public class AntonymsDictionary {
 
         AntonymsDictionary antonymsDictionary = (AntonymsDictionary) o;
 
-        return antonyms != null ? antonyms.equals( antonymsDictionary.antonyms ) : antonymsDictionary.antonyms == null;
+        return Objects.equals( antonyms, antonymsDictionary.antonyms );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/Word.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/Word.java
@@ -5,6 +5,8 @@
  */
 package org.mapstruct.ap.test.nestedbeans.maps;
 
+import java.util.Objects;
+
 public class Word {
     private String textValue;
 
@@ -34,7 +36,7 @@ public class Word {
 
         Word word = (Word) o;
 
-        return textValue != null ? textValue.equals( word.textValue ) : word.textValue == null;
+        return Objects.equals( textValue, word.textValue );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/WordDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/maps/WordDto.java
@@ -5,6 +5,8 @@
  */
 package org.mapstruct.ap.test.nestedbeans.maps;
 
+import java.util.Objects;
+
 public class WordDto {
     private String textValue;
 
@@ -34,7 +36,7 @@ public class WordDto {
 
         WordDto wordDto = (WordDto) o;
 
-        return textValue != null ? textValue.equals( wordDto.textValue ) : wordDto.textValue == null;
+        return Objects.equals( textValue, wordDto.textValue );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/multiplecollections/Garage.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/multiplecollections/Garage.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.test.nestedbeans.multiplecollections;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.mapstruct.ap.test.nestedbeans.Car;
 
@@ -48,10 +49,10 @@ public class Garage {
 
         Garage garage = (Garage) o;
 
-        if ( cars != null ? !cars.equals( garage.cars ) : garage.cars != null ) {
+        if ( !Objects.equals( cars, garage.cars ) ) {
             return false;
         }
-        return usedCars != null ? usedCars.equals( garage.usedCars ) : garage.usedCars == null;
+        return Objects.equals( usedCars, garage.usedCars );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/multiplecollections/GarageDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/multiplecollections/GarageDto.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.test.nestedbeans.multiplecollections;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.mapstruct.ap.test.nestedbeans.CarDto;
 
@@ -49,10 +50,10 @@ public class GarageDto {
 
         GarageDto garageDto = (GarageDto) o;
 
-        if ( cars != null ? !cars.equals( garageDto.cars ) : garageDto.cars != null ) {
+        if ( !Objects.equals( cars, garageDto.cars ) ) {
             return false;
         }
-        return usedCars != null ? usedCars.equals( garageDto.usedCars ) : garageDto.usedCars == null;
+        return Objects.equals( usedCars, garageDto.usedCars );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/other/RoofDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/other/RoofDto.java
@@ -5,6 +5,8 @@
  */
 package org.mapstruct.ap.test.nestedbeans.other;
 
+import java.util.Objects;
+
 public class RoofDto {
     private String color;
 
@@ -34,7 +36,7 @@ public class RoofDto {
 
         RoofDto roofDto = (RoofDto) o;
 
-        return color != null ? color.equals( roofDto.color ) : roofDto.color == null;
+        return Objects.equals( color, roofDto.color );
 
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/other/UserDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedbeans/other/UserDto.java
@@ -5,6 +5,8 @@
  */
 package org.mapstruct.ap.test.nestedbeans.other;
 
+import java.util.Objects;
+
 public class UserDto {
 
     private String name;
@@ -55,13 +57,13 @@ public class UserDto {
 
         UserDto userDto = (UserDto) o;
 
-        if ( name != null ? !name.equals( userDto.name ) : userDto.name != null ) {
+        if ( !Objects.equals( name, userDto.name ) ) {
             return false;
         }
-        if ( car != null ? !car.equals( userDto.car ) : userDto.car != null ) {
+        if ( !Objects.equals( car, userDto.car ) ) {
             return false;
         }
-        return house != null ? house.equals( userDto.house ) : userDto.house == null;
+        return Objects.equals( house, userDto.house );
 
     }
 


### PR DESCRIPTION
Fix minor warnings in test packages java8stream and nestedbeans:

remove unnecessary generic types from collection,
remove unnecessary throws from test methods,
simplify equals in test dto