### PR TITLE
Fix minor warnings in packages test and testutil

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/dependency/GraphAnalyzerTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/dependency/GraphAnalyzerTest.java
@@ -165,7 +165,7 @@ public class GraphAnalyzerTest {
     }
 
     private Set<String> asStrings(Set<List<String>> cycles) {
-        Set<String> asStrings = new HashSet<String>();
+        Set<String> asStrings = new HashSet<>();
 
         for ( List<String> cycle : cycles ) {
             asStrings.add( asString( cycle ) );

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameTest.java
@@ -21,7 +21,7 @@ import org.mapstruct.factory.Mappers;
 public class DestinationClassNameTest {
     @Test
     @WithClasses({ DestinationClassNameMapper.class })
-    public void shouldGenerateRightName() throws Exception {
+    public void shouldGenerateRightName() {
         DestinationClassNameMapper instance = DestinationClassNameMapper.INSTANCE;
         assertThat( instance.getClass().getSimpleName() ).isEqualTo( "MyDestinationClassNameMapperCustomImpl" );
     }
@@ -48,7 +48,7 @@ public class DestinationClassNameTest {
 
     @Test
     @WithClasses({ DestinationClassNameMapperConfig.class, DestinationClassNameMapperWithConfig.class })
-    public void shouldGenerateRightNameWithConfig() throws Exception {
+    public void shouldGenerateRightNameWithConfig() {
         DestinationClassNameMapperWithConfig instance = DestinationClassNameMapperWithConfig.INSTANCE;
         assertThat( instance.getClass().getSimpleName() )
                 .isEqualTo( "MyDestinationClassNameMapperWithConfigConfigImpl" );
@@ -56,7 +56,7 @@ public class DestinationClassNameTest {
 
     @Test
     @WithClasses({ DestinationClassNameMapperConfig.class, DestinationClassNameMapperWithConfigOverride.class })
-    public void shouldGenerateRightNameWithConfigOverride() throws Exception {
+    public void shouldGenerateRightNameWithConfigOverride() {
         DestinationClassNameMapperWithConfigOverride instance = DestinationClassNameMapperWithConfigOverride.INSTANCE;
         assertThat( instance.getClass().getSimpleName() )
                 .isEqualTo( "CustomDestinationClassNameMapperWithConfigOverrideMyImpl" );
@@ -64,7 +64,7 @@ public class DestinationClassNameTest {
 
     @Test
     @WithClasses({ DestinationClassNameMapperDecorated.class, DestinationClassNameMapperDecorator.class })
-    public void shouldGenerateRightNameWithDecorator() throws Exception {
+    public void shouldGenerateRightNameWithDecorator() {
         DestinationClassNameMapperDecorated instance = DestinationClassNameMapperDecorated.INSTANCE;
         assertThat( instance.getClass().getSimpleName() )
                 .isEqualTo( "MyDestinationClassNameMapperDecoratedCustomImpl" );

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationPackageNameTest.java
@@ -21,7 +21,7 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 public class DestinationPackageNameTest {
     @Test
     @WithClasses({ DestinationPackageNameMapper.class })
-    public void shouldGenerateInRightPackage() throws Exception {
+    public void shouldGenerateInRightPackage() {
         DestinationPackageNameMapper instance = DestinationPackageNameMapper.INSTANCE;
         assertThat( instance.getClass().getName() )
                 .isEqualTo( "org.mapstruct.ap.test.destination.dest.DestinationPackageNameMapperImpl" );
@@ -29,7 +29,7 @@ public class DestinationPackageNameTest {
 
     @Test
     @WithClasses({ DestinationPackageNameMapperWithSuffix.class })
-    public void shouldGenerateInRightPackageWithSuffix() throws Exception {
+    public void shouldGenerateInRightPackageWithSuffix() {
         DestinationPackageNameMapperWithSuffix instance = DestinationPackageNameMapperWithSuffix.INSTANCE;
         assertThat( instance.getClass().getName() )
                 .isEqualTo( "org.mapstruct.ap.test.destination.dest.DestinationPackageNameMapperWithSuffixMyImpl" );
@@ -37,7 +37,7 @@ public class DestinationPackageNameTest {
 
     @Test
     @WithClasses({ DestinationPackageNameMapperConfig.class, DestinationPackageNameMapperWithConfig.class })
-    public void shouldGenerateRightSuffixWithConfig() throws Exception {
+    public void shouldGenerateRightSuffixWithConfig() {
         DestinationPackageNameMapperWithConfig instance = DestinationPackageNameMapperWithConfig.INSTANCE;
         assertThat( instance.getClass().getName() )
                 .isEqualTo( "org.mapstruct.ap.test.destination.dest.DestinationPackageNameMapperWithConfigImpl" );
@@ -45,7 +45,7 @@ public class DestinationPackageNameTest {
 
     @Test
     @WithClasses({ DestinationPackageNameMapperConfig.class, DestinationPackageNameMapperWithConfigOverride.class })
-    public void shouldGenerateRightSuffixWithConfigOverride() throws Exception {
+    public void shouldGenerateRightSuffixWithConfigOverride() {
         DestinationPackageNameMapperWithConfigOverride instance =
                 DestinationPackageNameMapperWithConfigOverride.INSTANCE;
         assertThat( instance.getClass().getName() )
@@ -56,7 +56,7 @@ public class DestinationPackageNameTest {
 
     @Test
     @WithClasses({ DestinationPackageNameMapperDecorated.class, DestinationPackageNameMapperDecorator.class })
-    public void shouldGenerateRightSuffixWithDecorator() throws Exception {
+    public void shouldGenerateRightSuffixWithDecorator() {
         DestinationPackageNameMapperDecorated instance = DestinationPackageNameMapperDecorated.INSTANCE;
         assertThat( instance.getClass().getName() )
                 .isEqualTo( "org.mapstruct.ap.test.destination.dest.DestinationPackageNameMapperDecoratedImpl" );

--- a/processor/src/test/java/org/mapstruct/ap/test/exceptions/ExceptionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/exceptions/ExceptionTest.java
@@ -65,7 +65,7 @@ public class ExceptionTest {
     @Test( expected = RuntimeException.class )
     @IssueKey( "198" )
     public void shouldThrowRuntimeInIterableMapping() throws TestException2 {
-        List<Integer> source = new ArrayList<Integer>();
+        List<Integer> source = new ArrayList<>();
         source.add( 1 );
         SourceTargetMapper sourceTargetMapper = SourceTargetMapper.INSTANCE;
         sourceTargetMapper.integerListToLongList( source );
@@ -74,7 +74,7 @@ public class ExceptionTest {
     @Test( expected = TestException2.class )
     @IssueKey( "198" )
     public void shouldThrowTestException2InIterableMapping() throws TestException2 {
-        List<Integer> source = new ArrayList<Integer>();
+        List<Integer> source = new ArrayList<>();
         source.add( 2 );
         SourceTargetMapper sourceTargetMapper = SourceTargetMapper.INSTANCE;
         sourceTargetMapper.integerListToLongList( source );
@@ -83,7 +83,7 @@ public class ExceptionTest {
     @Test( expected = RuntimeException.class )
     @IssueKey( "198" )
     public void shouldThrowRuntimeInMapKeyMapping() throws TestException2 {
-        Map<Integer, String> source = new HashMap<Integer, String>();
+        Map<Integer, String> source = new HashMap<>();
         source.put( 1, "test" );
         SourceTargetMapper sourceTargetMapper = SourceTargetMapper.INSTANCE;
         sourceTargetMapper.integerKeyMapToLongKeyMap( source );
@@ -92,7 +92,7 @@ public class ExceptionTest {
     @Test( expected = TestException2.class )
     @IssueKey( "198" )
     public void shouldThrowTestException2InMapKeyMapping() throws TestException2 {
-        Map<Integer, String> source = new HashMap<Integer, String>();
+        Map<Integer, String> source = new HashMap<>();
         source.put( 2, "test" );
         SourceTargetMapper sourceTargetMapper = SourceTargetMapper.INSTANCE;
         sourceTargetMapper.integerKeyMapToLongKeyMap( source );
@@ -101,7 +101,7 @@ public class ExceptionTest {
     @Test( expected = RuntimeException.class )
     @IssueKey( "198" )
     public void shouldThrowRuntimeInMapValueMapping() throws TestException2 {
-        Map<String, Integer> source = new HashMap<String, Integer>();
+        Map<String, Integer> source = new HashMap<>();
         source.put( "test", 1 );
         SourceTargetMapper sourceTargetMapper = SourceTargetMapper.INSTANCE;
         sourceTargetMapper.integerValueMapToLongValueMap( source );
@@ -110,7 +110,7 @@ public class ExceptionTest {
     @Test( expected = TestException2.class )
     @IssueKey( "198" )
     public void shouldThrowTestException2InMapValueMapping() throws TestException2 {
-        Map<String, Integer> source = new HashMap<String, Integer>();
+        Map<String, Integer> source = new HashMap<>();
         source.put( "test", 2 );
         SourceTargetMapper sourceTargetMapper = SourceTargetMapper.INSTANCE;
         sourceTargetMapper.integerValueMapToLongValueMap( source );

--- a/processor/src/test/java/org/mapstruct/ap/test/factories/FactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/factories/FactoryTest.java
@@ -84,11 +84,11 @@ public class FactoryTest {
         foo4.setProp( "foo4" );
         source.setProp4( foo4 );
 
-        List<String> fooList = new ArrayList<String>();
+        List<String> fooList = new ArrayList<>();
         fooList.add( "fooListEntry" );
         source.setPropList( fooList );
 
-        Map<String, String> fooMap = new HashMap<String, String>();
+        Map<String, String> fooMap = new HashMap<>();
         fooMap.put( "key", "fooValue" );
         source.setPropMap( fooMap );
         return source;

--- a/processor/src/test/java/org/mapstruct/ap/test/fields/FieldsMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/fields/FieldsMappingTest.java
@@ -23,7 +23,7 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 public class FieldsMappingTest {
 
     @Test
-    public void shouldMapSourceToTarget() throws Exception {
+    public void shouldMapSourceToTarget() {
         Source source = new Source();
         source.normalInt = 4;
         source.normalList = Lists.newArrayList( 10, 11, 12 );
@@ -42,7 +42,7 @@ public class FieldsMappingTest {
     }
 
     @Test
-    public void shouldMapTargetToSource() throws Exception {
+    public void shouldMapTargetToSource() {
         Target target = new Target();
         target.finalInt = "40";
         target.normalInt = "4";

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/genericsupertype/MapperWithGenericSuperClassTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/genericsupertype/MapperWithGenericSuperClassTest.java
@@ -32,7 +32,7 @@ public class MapperWithGenericSuperClassTest {
         Vessel vessel = new Vessel();
         vessel.setName( "Pacific Queen" );
 
-        SearchResult<Vessel> vessels = new SearchResult<Vessel>();
+        SearchResult<Vessel> vessels = new SearchResult<>();
         vessels.setValues( Arrays.asList( vessel ) );
         vessels.setSize( 1L );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritance/complex/ComplexInheritanceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritance/complex/ComplexInheritanceTest.java
@@ -108,14 +108,14 @@ public class ComplexInheritanceTest {
     private SourceExt createSourceExt(int foo) {
         SourceExt s = new SourceExt();
         s.setFoo( foo );
-        s.setBar( Long.valueOf( 47 ) );
+        s.setBar( 47L );
         return s;
     }
 
     private SourceExt2 createSourceExt2(int foo) {
         SourceExt2 s = new SourceExt2();
         s.setFoo( foo );
-        s.setBaz( Long.valueOf( 47 ) );
+        s.setBaz( 47L );
         return s;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/inheritance/complex/SourceBaseMappingHelper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/inheritance/complex/SourceBaseMappingHelper.java
@@ -5,9 +5,9 @@
  */
 package org.mapstruct.ap.test.inheritance.complex;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class SourceBaseMappingHelper {
     public Reference asReference(SourceBase source) {
@@ -33,13 +33,8 @@ public class SourceBaseMappingHelper {
         if ( collection == null ) {
             return null;
         }
-
-        List<Number> list = new ArrayList<Number>( collection.size() );
-
-        for ( Integer original : collection ) {
-            list.add( Integer.valueOf( original + 1 ) );
-        }
-
-        return list;
+        return collection.stream()
+            .map( original -> original + 1 )
+            .collect( Collectors.toList() );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/naming/VariableNamingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/naming/VariableNamingTest.java
@@ -9,6 +9,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
@@ -35,11 +36,11 @@ public class VariableNamingTest {
         Source source = new Source();
 
         source.setSomeNumber( 42 );
-        source.setValues( Arrays.<Long>asList( 42L, 121L ) );
+        source.setValues( Arrays.asList( 42L, 121L ) );
 
-        Map<Long, Date> map = new HashMap<Long, Date>();
-        map.put( 42L, new GregorianCalendar( 1980, 0, 1 ).getTime() );
-        map.put( 121L, new GregorianCalendar( 2013, 6, 20 ).getTime() );
+        Map<Long, Date> map = new HashMap<>();
+        map.put( 42L, new GregorianCalendar( 1980, Calendar.JANUARY, 1 ).getTime() );
+        map.put( 121L, new GregorianCalendar( 2013, Calendar.JULY, 20 ).getTime() );
         source.setMap( map );
 
         Break target = SourceTargetMapper.INSTANCE.sourceToBreak( source );

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/NestedMappingMethodInvocationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/NestedMappingMethodInvocationTest.java
@@ -8,6 +8,7 @@ package org.mapstruct.ap.test.nestedmethodcall;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Locale;
@@ -70,13 +71,13 @@ public class NestedMappingMethodInvocationTest {
         ObjectFactory.class,
         TargetDto.class
     } )
-    public void shouldMapViaMethodAndConversion() throws DatatypeConfigurationException {
+    public void shouldMapViaMethodAndConversion() {
         SourceTypeTargetDtoMapper instance = SourceTypeTargetDtoMapper.INSTANCE;
 
         TargetDto target = instance.sourceToTarget( createSource() );
 
         assertThat( target ).isNotNull();
-        assertThat( target.getDate() ).isEqualTo( new GregorianCalendar( 2013, 6, 6 ).getTime() );
+        assertThat( target.getDate() ).isEqualTo( new GregorianCalendar( 2013, Calendar.JULY, 6 ).getTime() );
     }
 
     @Test
@@ -86,7 +87,7 @@ public class NestedMappingMethodInvocationTest {
         ObjectFactory.class,
         TargetDto.class
     } )
-    public void shouldMapViaConversionAndMethod() throws DatatypeConfigurationException {
+    public void shouldMapViaConversionAndMethod() {
         SourceTypeTargetDtoMapper instance = SourceTypeTargetDtoMapper.INSTANCE;
 
         SourceType source = instance.targetToSource( createTarget() );
@@ -97,36 +98,36 @@ public class NestedMappingMethodInvocationTest {
     }
 
     private OrderType createOrderType() throws DatatypeConfigurationException {
-        List<JAXBElement<XMLGregorianCalendar>> dates = new ArrayList<JAXBElement<XMLGregorianCalendar>>();
+        List<JAXBElement<XMLGregorianCalendar>> dates = new ArrayList<>();
         dates.add(
-                new JAXBElement<XMLGregorianCalendar>(
-                        QNAME,
-                        XMLGregorianCalendar.class,
-                        createXmlCal( 1999, 3, 2 )
-                )
+            new JAXBElement<>(
+                QNAME,
+                XMLGregorianCalendar.class,
+                createXmlCal( 1999, 3, 2 )
+            )
         );
         dates.add(
-                new JAXBElement<XMLGregorianCalendar>(
-                        QNAME,
-                        XMLGregorianCalendar.class,
-                        createXmlCal( 2004, 7, 28 )
-                )
+            new JAXBElement<>(
+                QNAME,
+                XMLGregorianCalendar.class,
+                createXmlCal( 2004, 7, 28 )
+            )
         );
 
-        List<JAXBElement<String>> description = new ArrayList<JAXBElement<String>>();
-        description.add( new JAXBElement<String>( QNAME, String.class, "elem1" ) );
-        description.add( new JAXBElement<String>( QNAME, String.class, "elem2" ) );
+        List<JAXBElement<String>> description = new ArrayList<>();
+        description.add( new JAXBElement<>( QNAME, String.class, "elem1" ) );
+        description.add( new JAXBElement<>( QNAME, String.class, "elem2" ) );
 
         OrderType orderType = new OrderType();
-        orderType.setOrderNumber( new JAXBElement<Long>( QNAME, Long.class, 5L ) );
+        orderType.setOrderNumber( new JAXBElement<>( QNAME, Long.class, 5L ) );
         orderType.setOrderDetails(
-                new JAXBElement<OrderDetailsType>(
-                        QNAME,
-                        OrderDetailsType.class,
-                        new OrderDetailsType()
-                )
+            new JAXBElement<>(
+                QNAME,
+                OrderDetailsType.class,
+                new OrderDetailsType()
+            )
         );
-        orderType.getOrderDetails().getValue().setName( new JAXBElement<String>( QNAME, String.class, "test" ) );
+        orderType.getOrderDetails().getValue().setName( new JAXBElement<>( QNAME, String.class, "test" ) );
         orderType.getOrderDetails().getValue().setDescription( description );
         orderType.setDates( dates );
 
@@ -141,13 +142,13 @@ public class NestedMappingMethodInvocationTest {
 
     private SourceType createSource() {
          SourceType source = new SourceType();
-         source.setDate( new JAXBElement<String>( QNAME, String.class, "06.07.2013" ) );
+         source.setDate( new JAXBElement<>( QNAME, String.class, "06.07.2013" ) );
          return source;
     }
 
     private TargetDto createTarget() {
          TargetDto target = new TargetDto();
-         target.setDate( new GregorianCalendar( 2013, 6, 6 ).getTime() );
+         target.setDate( new GregorianCalendar( 2013, Calendar.JULY, 6 ).getTime() );
          return target;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/ObjectFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/ObjectFactory.java
@@ -15,6 +15,6 @@ import javax.xml.namespace.QName;
 public class ObjectFactory {
 
     public JAXBElement<String> createDate(String date) {
-        return new JAXBElement<String>(  new QName( "dont-care" ), String.class, "06.07.2013" );
+        return new JAXBElement<>( new QName( "dont-care" ), String.class, "06.07.2013" );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/_target/ChartPositions.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedsourceproperties/_target/ChartPositions.java
@@ -13,7 +13,7 @@ import java.util.List;
  */
 public class ChartPositions {
 
-    private final List<Long> positions = new ArrayList<Long>();
+    private final List<Long> positions = new ArrayList<>();
 
     public List<Long> getPositions() {
         return positions;

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedtargetproperties/ChartEntryToArtist.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedtargetproperties/ChartEntryToArtist.java
@@ -52,10 +52,10 @@ public abstract class ChartEntryToArtist {
 
     protected List<Integer> mapPosition(Integer in) {
         if ( in != null ) {
-            return new ArrayList<Integer>( Arrays.asList( in ) );
+            return new ArrayList<>( Arrays.asList( in ) );
         }
         else {
-            return new ArrayList<Integer>();
+            return new ArrayList<>();
         }
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedtargetproperties/ChartEntryToArtistUpdate.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedtargetproperties/ChartEntryToArtistUpdate.java
@@ -46,7 +46,7 @@ public abstract class ChartEntryToArtistUpdate {
             return Arrays.asList( in );
         }
         else {
-            return Collections.<Integer>emptyList();
+            return Collections.emptyList();
         }
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluepropertymapping/NullValuePropertyMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluepropertymapping/NullValuePropertyMappingTest.java
@@ -59,25 +59,25 @@ public class NullValuePropertyMappingTest {
     @Test
     @WithClasses({ NvpmsConfig.class, CustomerNvpmsOnConfigMapper.class })
     public void testHierarchyIgnoreOnConfig() {
-        testConfig( ( Customer s, CustomerDTO t ) -> CustomerNvpmsOnConfigMapper.INSTANCE.map( s, t ) );
+        testConfig( CustomerNvpmsOnConfigMapper.INSTANCE::map );
     }
 
     @Test
     @WithClasses(CustomerNvpmsOnMapperMapper.class)
     public void testHierarchyIgnoreOnMapping() {
-        testConfig( ( Customer s, CustomerDTO t ) -> CustomerNvpmsOnMapperMapper.INSTANCE.map( s, t ) );
+        testConfig( CustomerNvpmsOnMapperMapper.INSTANCE::map );
     }
 
     @Test
     @WithClasses(CustomerNvpmsOnBeanMappingMethodMapper.class)
     public void testHierarchyIgnoreOnBeanMappingMethod() {
-        testConfig( ( Customer s, CustomerDTO t ) -> CustomerNvpmsOnBeanMappingMethodMapper.INSTANCE.map( s, t ) );
+        testConfig( CustomerNvpmsOnBeanMappingMethodMapper.INSTANCE::map );
     }
 
     @Test
     @WithClasses(CustomerNvpmsPropertyMappingMapper.class)
     public void testHierarchyIgnoreOnPropertyMappingMehtod() {
-        testConfig( ( Customer s, CustomerDTO t ) -> CustomerNvpmsPropertyMappingMapper.INSTANCE.map( s, t ) );
+        testConfig( CustomerNvpmsPropertyMappingMapper.INSTANCE::map );
     }
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/prism/EnumPrismsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/prism/EnumPrismsTest.java
@@ -7,8 +7,9 @@ package org.mapstruct.ap.test.prism;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.mapstruct.CollectionMappingStrategy;
@@ -67,12 +68,8 @@ public class EnumPrismsTest {
     }
 
     private static List<String> namesOf(Enum<?>[] values) {
-        List<String> names = new ArrayList<String>( values.length );
-
-        for ( Enum<?> e : values ) {
-            names.add( e.name() );
-        }
-
-        return names;
+        return Stream.of( values )
+            .map( Enum::name )
+            .collect( Collectors.toList() );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/references/ReferencedCustomMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/references/ReferencedCustomMapper.java
@@ -27,7 +27,7 @@ public class ReferencedCustomMapper {
             return (T) new SomeOtherType( string );
         }
         else if ( clazz == GenericWrapper.class ) {
-            return (T) new GenericWrapper<String>( string );
+            return (T) new GenericWrapper<>( string );
         }
 
         return null;

--- a/processor/src/test/java/org/mapstruct/ap/test/references/ReferencedMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/references/ReferencedMapperTest.java
@@ -66,7 +66,7 @@ public class ReferencedMapperTest {
     @Test
     @IssueKey( "136" )
     public void shouldUseGenericFactoryForMap() {
-        Map<String, String> source = new HashMap<String, String>();
+        Map<String, String> source = new HashMap<>();
         source.put( "foo1", "bar1" );
         source.put( "foo2", "bar2" );
         Map<SomeType, SomeOtherType> result = SourceTargetMapper.INSTANCE.fromStringMap( source );
@@ -85,7 +85,7 @@ public class ReferencedMapperTest {
         source.setProp1( new SomeType( "42" ) );
         source.setProp2( new SomeType( "1701" ) );
         source.setProp3( new SomeType( "true" ) );
-        source.setProp4( new GenericWrapper<SomeType>( new SomeType( "x" ) ) );
+        source.setProp4( new GenericWrapper<>( new SomeType( "x" ) ) );
 
         TargetWithPrimitives result = SourceTargetMapperWithPrimitives.INSTANCE.sourceToTarget( source );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/references/SomeOtherType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/references/SomeOtherType.java
@@ -45,13 +45,10 @@ public class SomeOtherType extends BaseType {
         }
         SomeOtherType other = (SomeOtherType) obj;
         if ( value == null ) {
-            if ( other.value != null ) {
-                return false;
-            }
+            return other.value == null;
         }
-        else if ( !value.equals( other.value ) ) {
-            return false;
+        else {
+            return value.equals( other.value );
         }
-        return true;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/references/SomeType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/references/SomeType.java
@@ -45,13 +45,10 @@ public class SomeType extends BaseType {
         }
         SomeType other = (SomeType) obj;
         if ( value == null ) {
-            if ( other.value != null ) {
-                return false;
-            }
+            return other.value == null;
         }
-        else if ( !value.equals( other.value ) ) {
-            return false;
+        else {
+            return value.equals( other.value );
         }
-        return true;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/generics/ConversionTest.java
@@ -43,19 +43,19 @@ public class ConversionTest {
 
         // setup source
         Source source = new Source();
-        source.setFooInteger( new Wrapper<Integer>( 5 ) );
-        source.setFooString( new Wrapper<String>( "test" ) );
-        source.setFooStringArray( new Wrapper<String[]>( new String[] { "test1", "test2" } ) );
-        source.setFooLongArray( new ArrayWrapper<Long>( new Long[] { 5L, 3L } ) );
-        source.setFooTwoArgs( new TwoArgWrapper<Integer, Boolean>( new TwoArgHolder<Integer, Boolean>( 3, true ) ) );
-        source.setFooNested( new Wrapper<Wrapper<BigDecimal>>( new Wrapper<BigDecimal>( new BigDecimal( 5 ) ) ) );
-        source.setFooUpperBoundCorrect( new UpperBoundWrapper<TypeB>( typeB ) );
-        source.setFooWildCardExtendsString( new WildCardExtendsWrapper<String>( "test3" ) );
-        source.setFooWildCardExtendsTypeCCorrect( new WildCardExtendsWrapper<TypeC>( typeC ) );
-        source.setFooWildCardExtendsTypeBCorrect( new WildCardExtendsWrapper<TypeB>( typeB ) );
-        source.setFooWildCardSuperString( new WildCardSuperWrapper<String>( "test4" ) );
-        source.setFooWildCardExtendsMBTypeCCorrect( new WildCardExtendsMBWrapper<TypeC>( typeC ) );
-        source.setFooWildCardSuperTypeBCorrect( new WildCardSuperWrapper<TypeB>( typeB ) );
+        source.setFooInteger( new Wrapper<>( 5 ) );
+        source.setFooString( new Wrapper<>( "test" ) );
+        source.setFooStringArray( new Wrapper<>( new String[] { "test1", "test2" } ) );
+        source.setFooLongArray( new ArrayWrapper<>( new Long[] { 5L, 3L } ) );
+        source.setFooTwoArgs( new TwoArgWrapper<>( new TwoArgHolder<>( 3, true ) ) );
+        source.setFooNested( new Wrapper<>( new Wrapper<>( new BigDecimal( 5 ) ) ) );
+        source.setFooUpperBoundCorrect( new UpperBoundWrapper<>( typeB ) );
+        source.setFooWildCardExtendsString( new WildCardExtendsWrapper<>( "test3" ) );
+        source.setFooWildCardExtendsTypeCCorrect( new WildCardExtendsWrapper<>( typeC ) );
+        source.setFooWildCardExtendsTypeBCorrect( new WildCardExtendsWrapper<>( typeB ) );
+        source.setFooWildCardSuperString( new WildCardSuperWrapper<>( "test4" ) );
+        source.setFooWildCardExtendsMBTypeCCorrect( new WildCardExtendsMBWrapper<>( typeC ) );
+        source.setFooWildCardSuperTypeBCorrect( new WildCardSuperWrapper<>( typeB ) );
 
         // define wrapper
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/test1/ObjectFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/test1/ObjectFactory.java
@@ -35,25 +35,25 @@ public class ObjectFactory {
 
     @XmlElementDecl(namespace = "http://www.mapstruct.org/ap/test/jaxb/selection/test1", name = "Order")
     public JAXBElement<OrderType> createOrder(OrderType value) {
-        return new JAXBElement<OrderType>( ORDER_QNAME, OrderType.class, null, value );
+        return new JAXBElement<>( ORDER_QNAME, OrderType.class, null, value );
     }
 
     @XmlElementDecl(namespace = "http://www.mapstruct.org/ap/test/jaxb/selection/test1",
         name = "orderNumber1", scope = OrderType.class)
     public JAXBElement<Long> createOrderTypeOrderNumber1(Long value) {
-        return new JAXBElement<Long>( ORDER_TYPE_ORDER_NUMBER1_QNAME, Long.class, OrderType.class, value );
+        return new JAXBElement<>( ORDER_TYPE_ORDER_NUMBER1_QNAME, Long.class, OrderType.class, value );
     }
 
     @XmlElementDecl(namespace = "http://www.mapstruct.org/ap/test/jaxb/selection/test1",
         name = "orderNumber2", scope = OrderType.class)
     public JAXBElement<Long> createOrderTypeOrderNumber2(Long value) {
-        return new JAXBElement<Long>( ORDER_TYPE_ORDER_NUMBER2_QNAME, Long.class, OrderType.class, value );
+        return new JAXBElement<>( ORDER_TYPE_ORDER_NUMBER2_QNAME, Long.class, OrderType.class, value );
     }
 
     @XmlElementDecl(namespace = "http://www.mapstruct.org/ap/test/jaxb/selection/test1",
         name = "shippingDetails", scope = OrderType.class)
     public JAXBElement<OrderShippingDetailsType> createOrderTypeShippingDetails(OrderShippingDetailsType value) {
-        return new JAXBElement<OrderShippingDetailsType>(
+        return new JAXBElement<>(
             ORDER_TYPE_SHIPPING_DETAILS_QNAME,
             OrderShippingDetailsType.class, OrderType.class, value
         );
@@ -62,7 +62,7 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "http://www.mapstruct.org/itest/jaxb/xsd/test1",
         name = "description", scope = OrderType.class)
     public JAXBElement<String> createOrderTypeDescription(String value) {
-        return new JAXBElement<String>(ORDER_TYPE_DESCRIPTION_QNAME, String.class, OrderType.class, value);
+        return new JAXBElement<>( ORDER_TYPE_DESCRIPTION_QNAME, String.class, OrderType.class, value );
     }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/test2/ObjectFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/test2/ObjectFactory.java
@@ -29,7 +29,7 @@ public class ObjectFactory {
 
     @XmlElementDecl(namespace = "http://www.mapstruct.org/ap/test/jaxb/selection/test2", name = "OrderShippingDetails")
     public JAXBElement<OrderShippingDetailsType> createOrderShippingDetails(OrderShippingDetailsType value) {
-        return new JAXBElement<OrderShippingDetailsType>(
+        return new JAXBElement<>(
             ORDER_SHIPPING_DETAILS_QNAME,
             OrderShippingDetailsType.class, null, value
         );
@@ -38,7 +38,7 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "http://www.mapstruct.org/ap/test/jaxb/selection/test2", name = "orderShippedFrom",
         scope = OrderShippingDetailsType.class)
     public JAXBElement<String> createOrderShippingDetailsTypeOrderShippedFrom(String value) {
-        return new JAXBElement<String>(
+        return new JAXBElement<>(
             ORDER_SHIPPING_DETAILS_TYPE_ORDER_SHIPPED_FROM_QNAME, String.class,
             OrderShippingDetailsType.class, value
         );
@@ -47,7 +47,7 @@ public class ObjectFactory {
     @XmlElementDecl(namespace = "http://www.mapstruct.org/ap/test/jaxb/selection/test2", name = "orderShippedTo",
         scope = OrderShippingDetailsType.class)
     public JAXBElement<String> createOrderShippingDetailsTypeOrderShippedTo(String value) {
-        return new JAXBElement<String>(
+        return new JAXBElement<>(
             ORDER_SHIPPING_DETAILS_TYPE_ORDER_SHIPPED_TO_QNAME, String.class,
             OrderShippingDetailsType.class, value
         );

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/ObjectFactory.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/underscores/ObjectFactory.java
@@ -34,23 +34,23 @@ public class ObjectFactory {
 
     @XmlElementDecl( namespace = "http://www.mapstruct.org/itest/jaxb/xsd/underscores", name = "Super" )
     public JAXBElement<SuperType> createSuper(SuperType value) {
-        return new JAXBElement<SuperType>(SUPER_QNAME, SuperType.class, null, value );
+        return new JAXBElement<>( SUPER_QNAME, SuperType.class, null, value );
     }
 
     @XmlElementDecl( namespace = "http://www.mapstruct.org/itest/jaxb/xsd/underscores", name = "Sub" )
     public JAXBElement<SubType> createSub(SubType value) {
-        return new JAXBElement<SubType>(SUB_QNAME, SubType.class, null, value );
+        return new JAXBElement<>( SUB_QNAME, SubType.class, null, value );
     }
 
     @XmlElementDecl( namespace = "http://www.mapstruct.org/itest/jaxb/xsd/underscores",
             name = "inherited_underscore", scope = SuperType.class )
     public JAXBElement<String> createSuperTypeInheritedUnderscore(String value) {
-        return new JAXBElement<String>(SUPER_TYPE_INHERITED_UNDERSCORE_QNAME, String.class, SuperType.class, value );
+        return new JAXBElement<>( SUPER_TYPE_INHERITED_UNDERSCORE_QNAME, String.class, SuperType.class, value );
     }
 
     @XmlElementDecl( namespace = "http://www.mapstruct.org/itest/jaxb/xsd/underscores",
             name = "declared_underscore", scope = SubType.class )
     public JAXBElement<String> createSubTypeDeclaredUnderscore(String value) {
-        return new JAXBElement<String>(SUB_TYPE_DECLARED_UNDERSCORE_QNAME, String.class, SubType.class, value );
+        return new JAXBElement<>( SUB_TYPE_DECLARED_UNDERSCORE_QNAME, String.class, SubType.class, value );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/QualifierTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/QualifierTest.java
@@ -68,7 +68,7 @@ public class QualifierTest {
         OriginalRelease foreignMovies = new OriginalRelease();
         foreignMovies.setTitle( "Sixth Sense, The" );
         foreignMovies.setKeyWords( Arrays.asList( "evergreen", "magnificent" ) );
-        Map<String, List<String>> facts = new HashMap<String, List<String>>();
+        Map<String, List<String>> facts = new HashMap<>();
         facts.put( "director", Arrays.asList( "M. Night Shyamalan" ) );
         facts.put( "cast", Arrays.asList( "Bruce Willis", "Haley Joel Osment", "Toni Collette" ) );
         facts.put( "plot keywords", Arrays.asList( "boy", "child psychologist", "I see dead people" ) );
@@ -150,7 +150,7 @@ public class QualifierTest {
         OriginalRelease foreignMovies = new OriginalRelease();
         foreignMovies.setTitle( "Sixth Sense, The" );
         foreignMovies.setKeyWords( Arrays.asList( "evergreen", "magnificent" ) );
-        Map<String, List<String>> facts = new HashMap<String, List<String>>();
+        Map<String, List<String>> facts = new HashMap<>();
         facts.put( "director", Arrays.asList( "M. Night Shyamalan" ) );
         facts.put( "cast", Arrays.asList( "Bruce Willis", "Haley Joel Osment", "Toni Collette" ) );
         facts.put( "plot keywords", Arrays.asList( "boy", "child psychologist", "I see dead people" ) );

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/handwritten/PlotWords.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/handwritten/PlotWords.java
@@ -29,14 +29,9 @@ public class PlotWords {
     @EnglishToGerman
     @Named( "EnglishToGerman"  )
     public List<String> translate( List<String> keywords ) {
-        List<String> result = new ArrayList<String>();
+        List<String> result = new ArrayList<>();
         for ( String keyword : keywords ) {
-            if ( EN_GER.containsKey( keyword ) ) {
-                result.add( EN_GER.get( keyword ) );
-            }
-            else {
-                result.add( keyword );
-            }
+            result.add( EN_GER.getOrDefault( keyword, keyword ) );
         }
         return result;
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/iterable/IterableAndQualifiersTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/iterable/IterableAndQualifiersTest.java
@@ -39,7 +39,7 @@ public class IterableAndQualifiersTest {
     public void testGenerationBasedOnQualifier() {
 
         TopologyDto topologyDto1 = new TopologyDto();
-        List<TopologyFeatureDto> topologyFeatures1 = new ArrayList<TopologyFeatureDto>();
+        List<TopologyFeatureDto> topologyFeatures1 = new ArrayList<>();
         RiverDto riverDto = new RiverDto();
         riverDto.setName( "Rhine" );
         riverDto.setLength( 5 );
@@ -53,7 +53,7 @@ public class IterableAndQualifiersTest {
         assertThat( ( (RiverEntity) result1.getTopologyFeatures().get( 0 ) ).getLength() ).isEqualTo( 5 );
 
         TopologyDto topologyDto2 = new TopologyDto();
-        List<TopologyFeatureDto> topologyFeatures2 = new ArrayList<TopologyFeatureDto>();
+        List<TopologyFeatureDto> topologyFeatures2 = new ArrayList<>();
         CityDto cityDto = new CityDto();
         cityDto.setName( "Amsterdam" );
         cityDto.setPopulation( 800000 );

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/named/NamedTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/named/NamedTest.java
@@ -62,7 +62,7 @@ public class NamedTest {
         OriginalRelease foreignMovies = new OriginalRelease();
         foreignMovies.setTitle( "Sixth Sense, The" );
         foreignMovies.setKeyWords( Arrays.asList( "evergreen", "magnificent" ) );
-        Map<String, List<String>> facts = new HashMap<String, List<String>>();
+        Map<String, List<String>> facts = new HashMap<>();
         facts.put( "director", Arrays.asList( "M. Night Shyamalan" ) );
         facts.put( "cast", Arrays.asList( "Bruce Willis", "Haley Joel Osment", "Toni Collette" ) );
         facts.put( "plot keywords", Arrays.asList( "boy", "child psychologist", "I see dead people" ) );
@@ -96,7 +96,7 @@ public class NamedTest {
         OriginalRelease foreignMovies = new OriginalRelease();
         foreignMovies.setTitle( "Sixth Sense, The" );
         foreignMovies.setKeyWords( Arrays.asList( "evergreen", "magnificent" ) );
-        Map<String, List<String>> facts = new HashMap<String, List<String>>();
+        Map<String, List<String>> facts = new HashMap<>();
         facts.put( "director", Arrays.asList( "M. Night Shyamalan" ) );
         facts.put( "cast", Arrays.asList( "Bruce Willis", "Haley Joel Osment", "Toni Collette" ) );
         facts.put( "plot keywords", Arrays.asList( "boy", "child psychologist", "I see dead people" ) );

--- a/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceConstantsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceConstantsTest.java
@@ -228,8 +228,7 @@ public class SourceConstantsTest {
 
     private Date getDate(String format, String date) throws ParseException {
         SimpleDateFormat dateFormat = new SimpleDateFormat( format );
-        Date result = dateFormat.parse( date );
-        return result;
+        return dateFormat.parse( date );
     }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/JavaExpressionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/JavaExpressionTest.java
@@ -73,8 +73,7 @@ public class JavaExpressionTest {
 
     private Date getTime(String format, String date) throws ParseException {
         SimpleDateFormat dateFormat = new SimpleDateFormat( format );
-        Date result = dateFormat.parse( date );
-        return result;
+        return dateFormat.parse( date );
     }
 
    @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/TargetList.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/expressions/java/TargetList.java
@@ -14,7 +14,7 @@ import java.util.List;
  */
 public class TargetList {
 
-    private List<String> list = new ArrayList<String>();
+    private List<String> list = new ArrayList<>();
 
     public List<String> getList() {
         return list;

--- a/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/SoccerTeamTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/presencecheck/spi/SoccerTeamTarget.java
@@ -22,7 +22,7 @@ public class SoccerTeamTarget {
 
     public void addPlayer(String player) {
         if ( this.players == null ) {
-            this.players = new ArrayList<String>();
+            this.players = new ArrayList<>();
         }
         this.players.add( player );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/updatemethods/selection/ExternalSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/updatemethods/selection/ExternalSelectionTest.java
@@ -111,7 +111,7 @@ public class ExternalSelectionTest {
         SecretaryDto secretaryDto = new SecretaryDto();
         secretaryDto.setName( "Jim" );
         departmentDto.setEmployees( Arrays.asList( employeeDto ) );
-        Map<SecretaryDto, EmployeeDto> secretaryToEmployee = new HashMap<SecretaryDto, EmployeeDto>();
+        Map<SecretaryDto, EmployeeDto> secretaryToEmployee = new HashMap<>();
         secretaryToEmployee.put( secretaryDto, employeeDto );
         departmentDto.setSecretaryToEmployee( secretaryToEmployee );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/value/EnumToEnumMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/EnumToEnumMappingTest.java
@@ -186,7 +186,7 @@ public class EnumToEnumMappingTest {
 
     @IssueKey( "1091" )
     @Test
-    public void shouldMapAnyRemainingToNullCorrectly() throws Exception {
+    public void shouldMapAnyRemainingToNullCorrectly() {
         ExternalOrderType externalOrderType = SpecialOrderMapper.INSTANCE.anyRemainingToNull( OrderType.RETAIL );
         assertThat( externalOrderType )
             .isNotNull()

--- a/processor/src/test/java/org/mapstruct/ap/testutil/assertions/JavaFileAssert.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/assertions/JavaFileAssert.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
@@ -92,9 +93,9 @@ public class JavaFileAssert extends FileAssert {
      * @param expected the file that should be matched
      */
     public void hasSameMapperContent(File expected) {
-        Charset charset = Charset.forName( "UTF-8" );
+        Charset charset = StandardCharsets.UTF_8;
         try {
-            List<Delta<String>> diffs = new ArrayList<Delta<String>>( this.diff.diff(
+            List<Delta<String>> diffs = new ArrayList<>( this.diff.diff(
                 actual,
                 charset,
                 expected,

--- a/processor/src/test/java/org/mapstruct/ap/testutil/compilation/model/CompilationOutcomeDescriptor.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/compilation/model/CompilationOutcomeDescriptor.java
@@ -28,8 +28,6 @@ import org.mapstruct.ap.testutil.compilation.annotation.ExpectedNote;
  */
 public class CompilationOutcomeDescriptor {
 
-    private static final String LINE_SEPARATOR = System.lineSeparator( );
-
     private CompilationResult compilationResult;
     private List<DiagnosticDescriptor> diagnostics;
     private List<String> notes;
@@ -57,12 +55,12 @@ public class CompilationOutcomeDescriptor {
         if ( expectedCompilationResult == null ) {
             return new CompilationOutcomeDescriptor(
                 CompilationResult.SUCCEEDED,
-                Collections.<DiagnosticDescriptor>emptyList(),
+                Collections.emptyList(),
                 notes
             );
         }
         else {
-            List<DiagnosticDescriptor> diagnosticDescriptors = new ArrayList<DiagnosticDescriptor>();
+            List<DiagnosticDescriptor> diagnosticDescriptors = new ArrayList<>();
             for ( org.mapstruct.ap.testutil.compilation.annotation.Diagnostic diagnostic :
                 expectedCompilationResult.diagnostics() ) {
                 diagnosticDescriptors.add( DiagnosticDescriptor.forDiagnostic( diagnostic ) );
@@ -76,7 +74,7 @@ public class CompilationOutcomeDescriptor {
         CompilationResult compilationResult =
             compilationSuccessful ? CompilationResult.SUCCEEDED : CompilationResult.FAILED;
         List<String> notes = new ArrayList<>();
-        List<DiagnosticDescriptor> diagnosticDescriptors = new ArrayList<DiagnosticDescriptor>();
+        List<DiagnosticDescriptor> diagnosticDescriptors = new ArrayList<>();
         for ( Diagnostic<? extends JavaFileObject> diagnostic : diagnostics ) {
             //ignore notes created by the compiler
             if ( diagnostic.getKind() != Kind.NOTE ) {
@@ -93,7 +91,7 @@ public class CompilationOutcomeDescriptor {
     public static CompilationOutcomeDescriptor forResult(String sourceDir, CompilerResult compilerResult) {
         CompilationResult compilationResult =
             compilerResult.isSuccess() ? CompilationResult.SUCCEEDED : CompilationResult.FAILED;
-        List<DiagnosticDescriptor> diagnosticDescriptors = new ArrayList<DiagnosticDescriptor>();
+        List<DiagnosticDescriptor> diagnosticDescriptors = new ArrayList<>();
 
         for ( CompilerMessage message : compilerResult.getCompilerMessages() ) {
             if ( message.getKind() != CompilerMessage.Kind.NOTE ) {

--- a/processor/src/test/java/org/mapstruct/ap/testutil/compilation/model/DiagnosticDescriptor.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/compilation/model/DiagnosticDescriptor.java
@@ -42,11 +42,11 @@ public class DiagnosticDescriptor {
     }
 
     public static DiagnosticDescriptor forDiagnostic(Diagnostic diagnostic) {
-        String soureFileName = diagnostic.type() != void.class
+        String sourceFileName = diagnostic.type() != void.class
             ? diagnostic.type().getName().replace( ".", File.separator ) + ".java"
             : null;
         return new DiagnosticDescriptor(
-            soureFileName,
+            sourceFileName,
             diagnostic.kind(),
             diagnostic.line() != -1 ? diagnostic.line() : null,
             diagnostic.alternativeLine() != -1 ? diagnostic.alternativeLine() : null,

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/AnnotationProcessorTestRunner.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/AnnotationProcessorTestRunner.java
@@ -68,7 +68,7 @@ public class AnnotationProcessorTestRunner extends ParentRunner<Runner> {
         WithSingleCompiler singleCompiler = klass.getAnnotation( WithSingleCompiler.class );
 
         if (singleCompiler != null) {
-            return Arrays.<Runner> asList( new InnerAnnotationProcessorRunner( klass, singleCompiler.value() ) );
+            return Arrays.asList( new InnerAnnotationProcessorRunner( klass, singleCompiler.value() ) );
         }
         else if ( IS_AT_LEAST_JAVA_9 ) {
             // Current tycho-compiler-jdt (0.26.0) is not compatible with Java 11
@@ -77,7 +77,7 @@ public class AnnotationProcessorTestRunner extends ParentRunner<Runner> {
             return Arrays.asList( new InnerAnnotationProcessorRunner( klass, Compiler.JDK11 ) );
         }
 
-        return Arrays.<Runner> asList(
+        return Arrays.asList(
             new InnerAnnotationProcessorRunner( klass, Compiler.JDK ),
             new InnerAnnotationProcessorRunner( klass, Compiler.ECLIPSE )
             );

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingStatement.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingStatement.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import com.puppycrawl.tools.checkstyle.api.AutomaticBean;
 import org.junit.runners.model.FrameworkMethod;
@@ -102,7 +101,7 @@ abstract class CompilingStatement extends Statement {
         return compilationCache.getLastSourceOutputDir();
     }
 
-    protected void setupDirectories() throws Exception {
+    protected void setupDirectories() {
         String compilationRoot = getBasePath()
             + TARGET_COMPILATION_TESTS
             + method.getDeclaringClass().getName()
@@ -154,7 +153,7 @@ abstract class CompilingStatement extends Statement {
             System.getProperty( "java.class.path" ).split( File.pathSeparator );
         String testClasses = "target" + File.separator + "test-classes";
 
-        List<String> classpath = new ArrayList<String>();
+        List<String> classpath = new ArrayList<>();
         for ( String path : bootClasspath ) {
             if ( !path.contains( testClasses ) && isWhitelisted( path, whitelist ) ) {
                 classpath.add( path );
@@ -273,7 +272,7 @@ abstract class CompilingStatement extends Statement {
 
         assertThat( expectedNotesRemaining )
             .describedAs( "There are unmatched notes: " +
-                expectedNotesRemaining.stream().collect( Collectors.joining( LINE_SEPARATOR ) ).toString() )
+                String.join( LINE_SEPARATOR, expectedNotesRemaining ) )
             .isEmpty();
     }
 
@@ -340,7 +339,7 @@ abstract class CompilingStatement extends Statement {
      * @return A set containing the classes to be compiled for this test
      */
     private Set<Class<?>> getTestClasses() {
-        Set<Class<?>> testClasses = new HashSet<Class<?>>();
+        Set<Class<?>> testClasses = new HashSet<>();
 
         WithClasses withClasses = method.getAnnotation( WithClasses.class );
         if ( withClasses != null ) {
@@ -368,7 +367,7 @@ abstract class CompilingStatement extends Statement {
      * for this test
      */
     private Map<Class<?>, Class<?>> getServices() {
-        Map<Class<?>, Class<?>> services = new HashMap<Class<?>, Class<?>>();
+        Map<Class<?>, Class<?>> services = new HashMap<>();
 
         addServices( services, method.getAnnotation( WithServiceImplementations.class ) );
         addService( services, method.getAnnotation( WithServiceImplementation.class ) );
@@ -428,7 +427,7 @@ abstract class CompilingStatement extends Statement {
                     method.getMethod().getDeclaringClass().getAnnotation( ProcessorOption.class ) );
         }
 
-        List<String> result = new ArrayList<String>( processorOptions.size() );
+        List<String> result = new ArrayList<>( processorOptions.size() );
         for ( ProcessorOption option : processorOptions ) {
             result.add( asOptionString( option ) );
         }
@@ -455,7 +454,7 @@ abstract class CompilingStatement extends Statement {
     }
 
     protected static Set<File> getSourceFiles(Collection<Class<?>> classes) {
-        Set<File> sourceFiles = new HashSet<File>( classes.size() );
+        Set<File> sourceFiles = new HashSet<>( classes.size() );
 
         for ( Class<?> clazz : classes ) {
             sourceFiles.add(
@@ -537,12 +536,12 @@ abstract class CompilingStatement extends Statement {
     private void deleteDirectory(File path) {
         if ( path.exists() ) {
             File[] files = path.listFiles();
-            for ( int i = 0; i < files.length; i++ ) {
-                if ( files[i].isDirectory() ) {
-                    deleteDirectory( files[i] );
+            for ( File file : files ) {
+                if ( file.isDirectory() ) {
+                    deleteDirectory( file );
                 }
                 else {
-                    files[i].delete();
+                    file.delete();
                 }
             }
         }
@@ -587,7 +586,7 @@ abstract class CompilingStatement extends Statement {
             if ( result != 0 ) {
                 return result;
             }
-            result = Long.valueOf( o1.getLine() ).compareTo( o2.getLine() );
+            result = o1.getLine().compareTo( o2.getLine() );
             if ( result != 0 ) {
                 return result;
             }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/GeneratedSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/GeneratedSource.java
@@ -10,6 +10,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.rules.TestRule;
@@ -39,9 +40,9 @@ public class GeneratedSource implements TestRule {
      * static ThreadLocal, as the {@link CompilingStatement} must inject itself statically for this rule to gain access
      * to the statement's information. As test execution of different classes in parallel is supported.
      */
-    private static ThreadLocal<CompilingStatement> compilingStatement = new ThreadLocal<CompilingStatement>();
+    private static ThreadLocal<CompilingStatement> compilingStatement = new ThreadLocal<>();
 
-    private List<Class<?>> fixturesFor = new ArrayList<Class<?>>();
+    private List<Class<?>> fixturesFor = new ArrayList<>();
 
     @Override
     public Statement apply(Statement base, Description description) {
@@ -67,9 +68,7 @@ public class GeneratedSource implements TestRule {
      * @return the same rule for chaining
      */
     public GeneratedSource addComparisonToFixtureFor(Class<?>... fixturesFor) {
-        for ( Class<?> fixture : fixturesFor ) {
-            this.fixturesFor.add( fixture );
-        }
+        this.fixturesFor.addAll( Arrays.asList( fixturesFor ) );
         return this;
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/JdkCompilingStatement.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/JdkCompilingStatement.java
@@ -49,7 +49,7 @@ class JdkCompilingStatement extends CompilingStatement {
                                                                        String classOutputDir,
                                                                        String additionalCompilerClasspath) {
         JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
-        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<JavaFileObject>();
+        DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
         StandardJavaFileManager fileManager = compiler.getStandardFileManager( null, null, null );
 
         Iterable<? extends JavaFileObject> compilationUnits =
@@ -97,7 +97,7 @@ class JdkCompilingStatement extends CompilingStatement {
     }
 
     private static List<File> asFiles(List<String> paths) {
-        List<File> classpath = new ArrayList<File>();
+        List<File> classpath = new ArrayList<>();
         for ( String path : paths ) {
             classpath.add( new File( path ) );
         }
@@ -112,7 +112,7 @@ class JdkCompilingStatement extends CompilingStatement {
      */
     @Override
     protected List<DiagnosticDescriptor> filterExpectedDiagnostics(List<DiagnosticDescriptor> expectedDiagnostics) {
-        List<DiagnosticDescriptor> filtered = new ArrayList<DiagnosticDescriptor>( expectedDiagnostics.size() );
+        List<DiagnosticDescriptor> filtered = new ArrayList<>( expectedDiagnostics.size() );
 
         DiagnosticDescriptor previous = null;
         for ( DiagnosticDescriptor diag : expectedDiagnostics ) {

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/ModifiableURLClassLoader.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/ModifiableURLClassLoader.java
@@ -99,19 +99,8 @@ final class ModifiableURLClassLoader extends URLClassLoader {
         try {
             ClassLoader.class.getMethod( "registerAsParallelCapable" ).invoke( null );
         }
-        catch ( NoSuchMethodException e ) {
-            return; // ignore
-        }
-        catch ( SecurityException e ) {
-            return; // ignore
-        }
-        catch ( IllegalAccessException e ) {
-            return; // ignore
-        }
-        catch ( IllegalArgumentException e ) {
-            return; // ignore
-        }
-        catch ( InvocationTargetException e ) {
+        catch ( NoSuchMethodException | SecurityException | IllegalAccessException
+            | IllegalArgumentException | InvocationTargetException e ) {
             return; // ignore
         }
     }


### PR DESCRIPTION
Fix minor warnings in packages test and testutil:

remove unnecessary generic types for collection,
replace numbers months on Calendar constants,
simplify conditions in test dto