### PR TITLE
Fix minor warnings in test package bugs

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1005/Issue1005Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1005/Issue1005Test.java
@@ -37,7 +37,7 @@ public class Issue1005Test {
                 line = 17,
                 messageRegExp = "The result type .*\\.AbstractEntity may not be an abstract class nor interface.")
         })
-    public void shouldFailDueToAbstractResultType() throws Exception {
+    public void shouldFailDueToAbstractResultType() {
     }
 
     @WithClasses(Issue1005ErroneousAbstractReturnTypeMapper.class)
@@ -50,7 +50,7 @@ public class Issue1005Test {
                 messageRegExp = "The return type .*\\.AbstractEntity is an abstract class or interface. Provide a non" +
                     " abstract / non interface result type or a factory method.")
         })
-    public void shouldFailDueToAbstractReturnType() throws Exception {
+    public void shouldFailDueToAbstractReturnType() {
     }
 
     @WithClasses(Issue1005ErroneousInterfaceResultTypeMapper.class)
@@ -62,7 +62,7 @@ public class Issue1005Test {
                 line = 17,
                 messageRegExp = "The result type .*\\.HasPrimaryKey may not be an abstract class nor interface.")
         })
-    public void shouldFailDueToInterfaceResultType() throws Exception {
+    public void shouldFailDueToInterfaceResultType() {
     }
 
     @WithClasses(Issue1005ErroneousInterfaceReturnTypeMapper.class)
@@ -75,6 +75,6 @@ public class Issue1005Test {
                 messageRegExp = "The return type .*\\.HasKey is an abstract class or interface. Provide a non " +
                     "abstract / non interface result type or a factory method.")
         })
-    public void shouldFailDueToInterfaceReturnType() throws Exception {
+    public void shouldFailDueToInterfaceReturnType() {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1061/Issue1061Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1061/Issue1061Test.java
@@ -20,7 +20,7 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 public class Issue1061Test {
 
     @Test
-    public void shouldCompile() throws Exception {
+    public void shouldCompile() {
 
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1131/Issue1131Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1131/Issue1131Mapper.java
@@ -20,7 +20,7 @@ import org.mapstruct.factory.Mappers;
 public abstract class Issue1131Mapper {
     public static final Issue1131Mapper INSTANCE = Mappers.getMapper( Issue1131Mapper.class );
 
-    public static final List<String> CALLED_METHODS = new ArrayList<String>();
+    public static final List<String> CALLED_METHODS = new ArrayList<>();
 
     public abstract void merge(Source source, @MappingTarget Target target);
 
@@ -40,7 +40,7 @@ public abstract class Issue1131Mapper {
     @ObjectFactory
     protected List<Target.Nested> createWithSourceList(List<Source.Nested> source) {
         CALLED_METHODS.add( "create(List<Source.Nested>)" );
-        List<Target.Nested> result = new ArrayList<Target.Nested>();
+        List<Target.Nested> result = new ArrayList<>();
         result.add( new Target.Nested( "from createWithSourceList" ) );
         return result;
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1131/Issue1131MapperWithContext.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1131/Issue1131MapperWithContext.java
@@ -22,7 +22,7 @@ public abstract class Issue1131MapperWithContext {
     public static final Issue1131MapperWithContext INSTANCE = Mappers.getMapper( Issue1131MapperWithContext.class );
 
     public static class MappingContext {
-        private final List<String> calledMethods = new ArrayList<String>();
+        private final List<String> calledMethods = new ArrayList<>();
 
         public Target.Nested create(Source.Nested source) {
             calledMethods.add( "create(Source.Nested)" );
@@ -32,10 +32,10 @@ public abstract class Issue1131MapperWithContext {
         public List<Target.Nested> create(List<Source.Nested> source) {
             calledMethods.add( "create(List<Source.Nested>)" );
             if ( source == null ) {
-                return new ArrayList<Target.Nested>();
+                return new ArrayList<>();
             }
             else {
-                return new ArrayList<Target.Nested>( source.size() );
+                return new ArrayList<>( source.size() );
             }
         }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1131/Issue1131Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1131/Issue1131Test.java
@@ -34,7 +34,7 @@ public class Issue1131Test {
         Source source = new Source();
         source.setNested( new Source.Nested() );
         source.getNested().setProperty( "something" );
-        source.setMoreNested( new ArrayList<Source.Nested>() );
+        source.setMoreNested( new ArrayList<>() );
 
         Target target = new Target();
 
@@ -55,7 +55,7 @@ public class Issue1131Test {
         Source source = new Source();
         source.setNested( new Source.Nested() );
         source.getNested().setProperty( "something" );
-        source.setMoreNested( new ArrayList<Source.Nested>() );
+        source.setMoreNested( new ArrayList<>() );
 
         Target target = new Target();
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1148/Issue1148Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1148/Issue1148Test.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class Issue1148Test {
 
     @Test
-    public void shouldNotUseSameMethodForDifferentMappingsNestedSource() throws Exception {
+    public void shouldNotUseSameMethodForDifferentMappingsNestedSource() {
         Entity.Dto dto = new Entity.Dto();
         dto.nestedDto = new Entity.NestedDto( 30 );
         dto.nestedDto2 = new Entity.NestedDto( 40 );
@@ -36,7 +36,7 @@ public class Issue1148Test {
     }
 
     @Test
-    public void shouldNotUseSameMethodForDifferentMappingsNestedTarget() throws Exception {
+    public void shouldNotUseSameMethodForDifferentMappingsNestedTarget() {
         Entity.Dto dto = new Entity.Dto();
         dto.recipientId = 10;
         dto.senderId = 20;
@@ -52,7 +52,7 @@ public class Issue1148Test {
     }
 
     @Test
-    public void shouldNotUseSameMethodForDifferentMappingsSymmetric() throws Exception {
+    public void shouldNotUseSameMethodForDifferentMappingsSymmetric() {
         Entity.Dto dto = new Entity.Dto();
         dto.sameLevel = new Entity.ClientDto(new Entity.NestedDto( 30 ));
         dto.sameLevel2 = new Entity.ClientDto(new Entity.NestedDto( 40 ));
@@ -68,7 +68,7 @@ public class Issue1148Test {
     }
 
     @Test
-    public void shouldNotUseSameMethodForDifferentMappingsHalfSymmetric() throws Exception {
+    public void shouldNotUseSameMethodForDifferentMappingsHalfSymmetric() {
         Entity.Dto dto = new Entity.Dto();
         dto.level = new Entity.ClientDto(new Entity.NestedDto( 80 ));
         dto.level2 = new Entity.ClientDto(new Entity.NestedDto( 90 ));
@@ -82,7 +82,7 @@ public class Issue1148Test {
     }
 
     @Test
-    public void shouldNotUseSameMethodForDifferentMappingsNestedSourceMultiple() throws Exception {
+    public void shouldNotUseSameMethodForDifferentMappingsNestedSourceMultiple() {
         Entity.Dto dto1 = new Entity.Dto();
         dto1.nestedDto = new Entity.NestedDto( 30 );
         Entity.Dto dto2 = new Entity.Dto();
@@ -94,7 +94,7 @@ public class Issue1148Test {
     }
 
     @Test
-    public void shouldNotUseSameMethodForDifferentMappingsNestedTargetMultiple() throws Exception {
+    public void shouldNotUseSameMethodForDifferentMappingsNestedTargetMultiple() {
         Entity.Dto dto1 = new Entity.Dto();
         dto1.recipientId = 10;
         Entity.Dto dto2 = new Entity.Dto();
@@ -111,7 +111,7 @@ public class Issue1148Test {
     }
 
     @Test
-    public void shouldNotUseSameMethodForDifferentMappingsSymmetricMultiple() throws Exception {
+    public void shouldNotUseSameMethodForDifferentMappingsSymmetricMultiple() {
         Entity.Dto dto1 = new Entity.Dto();
         dto1.sameLevel = new Entity.ClientDto(new Entity.NestedDto( 30 ));
         Entity.Dto dto2 = new Entity.Dto();

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1155/Issue1155Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1155/Issue1155Test.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class Issue1155Test {
 
     @Test
-    public void shouldCompile() throws Exception {
+    public void shouldCompile() {
 
         Entity.Dto dto = new Entity.Dto();
         dto.clientId = 10;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1164/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1164/SourceTargetMapper.java
@@ -21,14 +21,14 @@ public abstract class SourceTargetMapper {
     public abstract Target map(Source source);
 
     protected List<List<Target.TargetNested>> mapLists(List<List<Source.SourceNested>> lists) {
-        return new ArrayList<List<Target.TargetNested>>();
+        return new ArrayList<>();
     }
 
     protected Map<String, List<Target.MapNested>> map(Map<Integer, List<Source.SourceNested>> map) {
-        return new HashMap<String, List<Target.MapNested>>();
+        return new HashMap<>();
     }
 
     protected GenericHolder<List<Target.GenericNested>> map(GenericHolder<List<Source.SourceNested>> genericHolder) {
-        return new GenericHolder<List<Target.GenericNested>>();
+        return new GenericHolder<>();
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1170/PetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1170/PetMapper.java
@@ -5,9 +5,9 @@
  */
 package org.mapstruct.ap.test.bugs._1170;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.mapstruct.Mapper;
 
@@ -36,8 +36,6 @@ public class PetMapper {
      * @param pet
      *
      * @return
-     *
-     * @throws DogException
      */
     public Long toPet(String pet)  {
         return PETS_TO_TARGET.get( pet );
@@ -53,24 +51,17 @@ public class PetMapper {
      * @param pets
      *
      * @return
-     *
-     * @throws CatException
-     * @throws DogException
      */
     public List<Long> toPets(List<? extends String> pets)  {
-        List<Long> result = new ArrayList<Long>();
-        for ( String pet : pets ) {
-            result.add( toPet( pet ) );
-        }
-        return result;
+        return pets.stream()
+            .map( this::toPet )
+            .collect( Collectors.toList() );
     }
 
     public List<String> toSourcePets(List<Long> pets)  {
-        List<String> result = new ArrayList<String>();
-        for ( Long pet : pets ) {
-            result.add( PETS_TO_SOURCE.get( pet ) );
-        }
-        return result;
+        return pets.stream()
+            .map( PETS_TO_SOURCE::get )
+            .collect( Collectors.toList() );
     }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1170/_target/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1170/_target/Target.java
@@ -14,23 +14,23 @@ import java.util.List;
  */
 public class Target {
 
-    private List<Long> withoutWildcards = new ArrayList<Long>();
+    private List<Long> withoutWildcards = new ArrayList<>();
 
-    private List<Long> wildcardInSources = new ArrayList<Long>();
+    private List<Long> wildcardInSources = new ArrayList<>();
 
-    private List<Long> wildcardInTargets = new ArrayList<Long>();
+    private List<Long> wildcardInTargets = new ArrayList<>();
 
-    private List<Long> wildcardInBoths = new ArrayList<Long>();
+    private List<Long> wildcardInBoths = new ArrayList<>();
 
-    private List<Long> wildcardAdderToSetters = new ArrayList<Long>();
+    private List<Long> wildcardAdderToSetters = new ArrayList<>();
 
-    private List<Long> wildcardInSourcesAddAll = new ArrayList<Long>();
+    private List<Long> wildcardInSourcesAddAll = new ArrayList<>();
 
-    private List<BigDecimal> sameTypeWildcardInSources = new ArrayList<BigDecimal>();
+    private List<BigDecimal> sameTypeWildcardInSources = new ArrayList<>();
 
-    private List<BigDecimal> sameTypeWildcardInTargets = new ArrayList<BigDecimal>();
+    private List<BigDecimal> sameTypeWildcardInTargets = new ArrayList<>();
 
-    private List<BigDecimal> sameTypeWildcardInBoths = new ArrayList<BigDecimal>();
+    private List<BigDecimal> sameTypeWildcardInBoths = new ArrayList<>();
 
     public List<Long> getWithoutWildcards() {
         return withoutWildcards;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1170/source/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1170/source/Source.java
@@ -14,23 +14,23 @@ import java.util.List;
  */
 public class Source {
 
-    private List<String> withoutWildcards = new ArrayList<String>();
+    private List<String> withoutWildcards = new ArrayList<>();
 
-    private List<String> wildcardInSources = new ArrayList<String>();
+    private List<String> wildcardInSources = new ArrayList<>();
 
-    private List<String> wildcardInTargets = new ArrayList<String>();
+    private List<String> wildcardInTargets = new ArrayList<>();
 
-    private List<String> wildcardInBoths = new ArrayList<String>();
+    private List<String> wildcardInBoths = new ArrayList<>();
 
-    private List<String> wildcardInSourcesAddAll = new ArrayList<String>();
+    private List<String> wildcardInSourcesAddAll = new ArrayList<>();
 
-    private List<String>  wildcardAdderToSetters = new ArrayList<String>();
+    private List<String>  wildcardAdderToSetters = new ArrayList<>();
 
-    private List<BigDecimal> sameTypeWildcardInSources = new ArrayList<BigDecimal>();
+    private List<BigDecimal> sameTypeWildcardInSources = new ArrayList<>();
 
-    private List<BigDecimal> sameTypeWildcardInTargets = new ArrayList<BigDecimal>();
+    private List<BigDecimal> sameTypeWildcardInTargets = new ArrayList<>();
 
-    private List<BigDecimal> sameTypeWildcardInBoths = new ArrayList<BigDecimal>();
+    private List<BigDecimal> sameTypeWildcardInBoths = new ArrayList<>();
 
     public List<String> getWithoutWildcards() {
         return withoutWildcards;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/Issue1255Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1255/Issue1255Test.java
@@ -27,7 +27,7 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 public class Issue1255Test {
 
     @Test
-    public void shouldMapSomeBToSomeAWithoutField1() throws Exception {
+    public void shouldMapSomeBToSomeAWithoutField1() {
         SomeB someB = new SomeB();
         someB.setField1( "value1" );
         someB.setField2( "value2" );
@@ -41,7 +41,7 @@ public class Issue1255Test {
     }
 
     @Test
-    public void shouldMapSomeAToSomeB() throws Exception {
+    public void shouldMapSomeAToSomeB() {
         SomeA someA = new SomeA();
         someA.setField1( "value1" );
         someA.setField2( "value2" );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1273/Entity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1273/Entity.java
@@ -10,7 +10,7 @@ import java.util.List;
 
 public class Entity {
 
-    List<Long> longs = new ArrayList<Long>();
+    List<Long> longs = new ArrayList<>();
 
     public List<Long> getLongs() {
         return longs;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1338/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1338/Source.java
@@ -17,7 +17,7 @@ public class Source {
 
     public void addProperty(String property) {
         if ( properties == null ) {
-            properties = new ArrayList<String>();
+            properties = new ArrayList<>();
         }
         properties.add( property );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1359/Issue1359Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1359/Issue1359Test.java
@@ -35,7 +35,7 @@ public class Issue1359Test {
         Target target = new Target();
         assertThat( target ).extracting( "properties" ).contains( null, atIndex( 0 ) );
 
-        Set<String> properties = new HashSet<String>();
+        Set<String> properties = new HashSet<>();
         properties.add( "first" );
         Source source = new Source( properties );
         Issue1359Mapper.INSTANCE.map( target, source );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1453/AuctionDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1453/AuctionDto.java
@@ -24,7 +24,7 @@ public class AuctionDto {
     }
 
     public void setPayments(List<? extends PaymentDto> payments) {
-        this.payments = payments == null ? null : new ArrayList<PaymentDto>( payments );
+        this.payments = payments == null ? null : new ArrayList<>( payments );
     }
 
     List<? super PaymentDto> takeOtherPayments() {
@@ -40,7 +40,7 @@ public class AuctionDto {
     }
 
     public void setMapPayments(Map<? extends PaymentDto, ? extends PaymentDto> mapPayments) {
-        this.mapPayments = mapPayments == null ? null : new HashMap<PaymentDto, PaymentDto>( mapPayments );
+        this.mapPayments = mapPayments == null ? null : new HashMap<>( mapPayments );
     }
 
     public Map<? super PaymentDto, ? super PaymentDto> getMapSuperPayments() {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1523/java8/Issue1523Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1523/java8/Issue1523Test.java
@@ -58,7 +58,7 @@ public class Issue1523Test {
         // default one was explicitly set to UTC, thus +01:00 is a different one
         source.setValue( ZonedDateTime.parse( "2018-06-15T00:00:00+01:00" ) );
         Calendar cal = Calendar.getInstance( TimeZone.getTimeZone( "GMT+01:00" ) );
-        cal.set( 2018, 02, 15, 00, 00, 00 );
+        cal.set( 2018, Calendar.MARCH, 15, 00, 00, 00 );
         source.setValue2( cal );
 
         Target target = Issue1523Mapper.INSTANCE.map( source );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1561/NestedTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1561/NestedTarget.java
@@ -14,7 +14,7 @@ import java.util.stream.Stream;
  */
 public class NestedTarget {
 
-    private List<String> properties = new ArrayList<String>();
+    private List<String> properties = new ArrayList<>();
 
     public Stream<String> getProperties() {
         return properties.stream();

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1596/Issue1596Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1596/Issue1596Test.java
@@ -41,7 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class Issue1596Test {
 
     @Test
-    public void shouldIncludeBuildeType() {
+    public void shouldIncludeBuildType() {
 
         ItemDTO item = ImmutableItemDTO.builder().id( "test" ).build();
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_374/Issue374Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_374/Issue374Test.java
@@ -53,7 +53,7 @@ public class Issue374Test {
     @WithClasses( { Issue374Mapper.class, Source.class, Target.class } )
     public void shouldMapExistingIterableTargetToDefault() {
 
-        List<String> targetList = new ArrayList<String>();
+        List<String> targetList = new ArrayList<>();
         targetList.add( "test" );
         List<String> resultList = Issue374Mapper.INSTANCE.mapIterable( null, targetList );
         assertThat( resultList ).isEqualTo( targetList );
@@ -64,7 +64,7 @@ public class Issue374Test {
     @WithClasses( { Issue374Mapper.class, Source.class, Target.class } )
     public void shouldMapExistingMapTargetToDefault() {
 
-        Map<Integer, String> targetMap = new HashMap<Integer, String>();
+        Map<Integer, String> targetMap = new HashMap<>();
         targetMap.put( 5, "test" );
         Map<Integer, String> resultMap  = Issue374Mapper.INSTANCE.mapMap( null, targetMap );
         assertThat( resultMap ).isEmpty();
@@ -85,7 +85,7 @@ public class Issue374Test {
     @WithClasses( { Issue374VoidMapper.class, Source.class, Target.class } )
     public void shouldMapExistingIterableTargetVoidReturnToDefault() {
 
-        List<String> targetList = new ArrayList<String>();
+        List<String> targetList = new ArrayList<>();
         targetList.add( "test" );
         Issue374VoidMapper.INSTANCE.mapIterable( null, targetList );
         assertThat( targetList ).isEmpty();
@@ -95,7 +95,7 @@ public class Issue374Test {
     @WithClasses( { Issue374VoidMapper.class, Source.class, Target.class } )
     public void shouldMapExistingMapTargetVoidReturnToDefault() {
 
-        Map<Integer, String> targetMap = new HashMap<Integer, String>();
+        Map<Integer, String> targetMap = new HashMap<>();
         targetMap.put( 5, "test" );
         Issue374VoidMapper.INSTANCE.mapMap( null, targetMap );
         assertThat( targetMap ).isEmpty();

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/Issue513Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_513/Issue513Test.java
@@ -43,7 +43,7 @@ public class Issue513Test {
         Source source = new Source();
         SourceElement sourceElement = new SourceElement();
         sourceElement.setValue( "test" );
-        source.setCollection( Arrays.asList( new SourceElement[]{ sourceElement } ) );
+        source.setCollection( Arrays.asList( sourceElement ) );
 
         Issue513Mapper.INSTANCE.map( source );
 
@@ -56,7 +56,7 @@ public class Issue513Test {
         SourceKey sourceKey = new SourceKey();
         sourceKey.setValue( MappingKeyException.class.getSimpleName() );
         SourceValue sourceValue = new SourceValue();
-        HashMap<SourceKey, SourceValue> map = new HashMap<SourceKey, SourceValue>();
+        HashMap<SourceKey, SourceValue> map = new HashMap<>();
         map.put( sourceKey, sourceValue );
         source.setMap( map );
 
@@ -71,7 +71,7 @@ public class Issue513Test {
         SourceKey sourceKey = new SourceKey();
         SourceValue sourceValue = new SourceValue();
         sourceValue.setValue( MappingValueException.class.getSimpleName() );
-        HashMap<SourceKey, SourceValue> map = new HashMap<SourceKey, SourceValue>();
+        HashMap<SourceKey, SourceValue> map = new HashMap<>();
         map.put( sourceKey, sourceValue );
         source.setMap( map );
 
@@ -86,7 +86,7 @@ public class Issue513Test {
         SourceKey sourceKey = new SourceKey();
         SourceValue sourceValue = new SourceValue();
         sourceValue.setValue( MappingException.class.getSimpleName() );
-        HashMap<SourceKey, SourceValue> map = new HashMap<SourceKey, SourceValue>();
+        HashMap<SourceKey, SourceValue> map = new HashMap<>();
         map.put( sourceKey, sourceValue );
         source.setMap( map );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_516/Target.java
@@ -26,7 +26,7 @@ public class Target {
 
     public void addElement(String element) {
         if ( elements == null ) {
-            elements = new ArrayList<String>();
+            elements = new ArrayList<>();
         }
         elements.add( element );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_634/GenericContainerTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_634/GenericContainerTest.java
@@ -33,7 +33,7 @@ public class GenericContainerTest {
     @IssueKey("634")
     public void canMapGenericSourceTypeToGenericTargetType() {
         List<Foo> items = Arrays.asList( new Foo( "42" ), new Foo( "84" ) );
-        Source<Foo> source = new Source<Foo>( items );
+        Source<Foo> source = new Source<>( items );
 
         Target<Bar> target = SourceTargetMapper.INSTANCE.mapSourceToTarget( source );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableWithBoundedElementTypeTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/IterableWithBoundedElementTypeTest.java
@@ -44,7 +44,7 @@ public class IterableWithBoundedElementTypeTest {
         IterableContainer result = MapperWithForgedIterableMapping.INSTANCE.toContainerWithIterable( source );
 
         ( (IterableAssert<Integer>) assertThat( result.getValues() ) )
-                .contains( Integer.valueOf( 42 ), Integer.valueOf( 47 ) );
+                .contains( 42, 47 );
     }
 
     @Test
@@ -55,6 +55,6 @@ public class IterableWithBoundedElementTypeTest {
         IterableContainer result = MapperWithCustomListMapping.INSTANCE.toContainerWithIterable( source );
 
         ( (IterableAssert<Integer>) assertThat( result.getValues() ) )
-                .contains( Integer.valueOf( 66 ), Integer.valueOf( 71 ) );
+                .contains( 66, 71 );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/MapperWithCustomListMapping.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_775/MapperWithCustomListMapping.java
@@ -5,9 +5,9 @@
  */
 package org.mapstruct.ap.test.bugs._775;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
@@ -23,11 +23,8 @@ public abstract class MapperWithCustomListMapping {
     public abstract IterableContainer toContainerWithIterable(ListContainer source);
 
     protected List<Integer> hexListToIntList(Collection<String> source) {
-        List<Integer> iterable = new ArrayList<Integer>( source.size() );
-        for ( String string : source ) {
-            iterable.add( Integer.parseInt( string, 16 ) );
-        }
-
-        return iterable;
+        return source.stream()
+            .map( string -> Integer.parseInt( string, 16 ) )
+            .collect( Collectors.toList() );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_849/Issue849Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_849/Issue849Test.java
@@ -7,7 +7,6 @@ package org.mapstruct.ap.test.bugs._849;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.Serializable;
 import java.util.Arrays;
 
 import org.junit.Test;
@@ -29,7 +28,7 @@ public class Issue849Test {
     public void shouldCompileWithAllImportsDeclared() {
 
         Source source = new Source();
-        source.setSourceList( Arrays.asList( (Serializable) "test" ) );
+        source.setSourceList( Arrays.asList( "test" ) );
 
         Target target = Issue849Mapper.INSTANCE.mapSourceToTarget( source );
         assertThat( target.getTargetList() ).containsExactly( "test" );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_849/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_849/Target.java
@@ -19,7 +19,7 @@ public class Target {
 
     public List<Serializable> getTargetList() {
         if ( targetList == null ) {
-            targetList = new ArrayList<Serializable>();
+            targetList = new ArrayList<>();
         }
         return targetList;
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_865/Issue865Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_865/Issue865Test.java
@@ -27,7 +27,7 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 public class Issue865Test {
 
     @Test
-    public void shouldGenerateNpeCheckBeforCallingAddAllWhenInUpdateMethods() {
+    public void shouldGenerateNpeCheckBeforeCallingAddAllWhenInUpdateMethods() {
 
         ProjectDto dto = new ProjectDto();
         dto.setName( "myProject" );
@@ -41,7 +41,8 @@ public class Issue865Test {
         assertThat( entity.getCoreUsers() ).isNull();
     }
 
-    public void shouldGenerateNpeCheckBeforCallingAddAllWhenInUpdateMethodsAndTargetWithoutSetter() {
+    @Test
+    public void shouldGenerateNpeCheckBeforeCallingAddAllWhenInUpdateMethodsAndTargetWithoutSetter() {
 
         ProjectDto dto = new ProjectDto();
         dto.setName( "myProject" );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Domain.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Domain.java
@@ -14,8 +14,8 @@ import java.util.Set;
  * @author Sjaak Derksen
  */
 public class Domain {
-    static final Set<String> DEFAULT_STRINGS = new HashSet<String>();
-    static final Set<Long> DEFAULT_LONGS = new HashSet<Long>();
+    static final Set<String> DEFAULT_STRINGS = new HashSet<>();
+    static final Set<Long> DEFAULT_LONGS = new HashSet<>();
 
     private Set<String> strings = DEFAULT_STRINGS;
     private Set<Long> longs = DEFAULT_LONGS;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/DomainWithoutSetter.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/DomainWithoutSetter.java
@@ -16,11 +16,11 @@ import java.util.Set;
  */
 public class DomainWithoutSetter {
 
-    private final Set<String> strings = new HashSet<String>();
-    private final Set<Long> longs = new HashSet<Long>();
-    private final Set<String> stringsInitialized = new HashSet<String>();
-    private final Set<Long> longsInitialized = new HashSet<Long>();
-    private final List<String> stringsWithDefault = new ArrayList<String>();
+    private final Set<String> strings = new HashSet<>();
+    private final Set<Long> longs = new HashSet<>();
+    private final Set<String> stringsInitialized = new HashSet<>();
+    private final Set<Long> longsInitialized = new HashSet<>();
+    private final List<String> stringsWithDefault = new ArrayList<>();
 
     public Set<String> getStrings() {
         return strings;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Dto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Dto.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class Dto {
 
     private List<String> strings;
-    private List<String> stringsInitialized = new ArrayList<String>( Arrays.asList( "5" ) );
+    private List<String> stringsInitialized = new ArrayList<>( Arrays.asList( "5" ) );
     private List<String> stringsWithDefault;
 
     public List<String> getStrings() {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/DtoWithPresenceCheck.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/DtoWithPresenceCheck.java
@@ -16,7 +16,7 @@ import java.util.List;
 public class DtoWithPresenceCheck {
 
     private List<String> strings;
-    private List<String> stringsInitialized = new ArrayList<String>( Arrays.asList( "5" ) );
+    private List<String> stringsInitialized = new ArrayList<>( Arrays.asList( "5" ) );
     private List<String> stringsWithDefault;
 
     public boolean hasStrings() {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Issue913SetterMapperForCollectionsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_913/Issue913SetterMapperForCollectionsTest.java
@@ -76,8 +76,8 @@ public class Issue913SetterMapperForCollectionsTest {
 
         Dto dto = new Dto();
         Domain domain = new Domain();
-        domain.setLongs( new HashSet<Long>() );
-        domain.setStrings( new HashSet<String>() );
+        domain.setLongs( new HashSet<>() );
+        domain.setStrings( new HashSet<>() );
         DomainDtoWithNvmsNullMapper.INSTANCE.update( dto, domain );
 
         doControlAsserts( domain );
@@ -100,8 +100,8 @@ public class Issue913SetterMapperForCollectionsTest {
         Dto dto = new Dto();
         dto.setStringsInitialized( null );
         Domain domain = new Domain();
-        domain.setLongs( new HashSet<Long>() );
-        domain.setStrings( new HashSet<String>() );
+        domain.setLongs( new HashSet<>() );
+        domain.setStrings( new HashSet<>() );
         DomainDtoWithNvmsNullMapper.INSTANCE.update( dto, domain );
 
         assertThat( domain.getStringsInitialized() ).isNull();
@@ -122,8 +122,8 @@ public class Issue913SetterMapperForCollectionsTest {
 
         Dto dto = new Dto();
         Domain domain1 = new Domain();
-        domain1.setLongs( new HashSet<Long>() );
-        domain1.setStrings( new HashSet<String>() );
+        domain1.setLongs( new HashSet<>() );
+        domain1.setStrings( new HashSet<>() );
         Domain domain2 = DomainDtoWithNvmsNullMapper.INSTANCE.updateWithReturn( dto, domain1 );
 
         doControlAsserts( domain1, domain2 );
@@ -163,10 +163,10 @@ public class Issue913SetterMapperForCollectionsTest {
 
         Dto dto = new Dto();
         Domain domain = new Domain();
-        Set<Long> longIn = new HashSet<Long>();
+        Set<Long> longIn = new HashSet<>();
         longIn.add( 10L );
         domain.setLongs( longIn );
-        domain.setStrings( new HashSet<String>() );
+        domain.setStrings( new HashSet<>() );
         DomainDtoWithNvmsDefaultMapper.INSTANCE.update( dto, domain );
 
         doControlAsserts( domain );
@@ -189,10 +189,10 @@ public class Issue913SetterMapperForCollectionsTest {
 
         Dto dto = new Dto();
         Domain domain1 = new Domain();
-        Set<Long> longIn = new HashSet<Long>();
+        Set<Long> longIn = new HashSet<>();
         longIn.add( 10L );
         domain1.setLongs( longIn );
-        domain1.setStrings( new HashSet<String>() );
+        domain1.setStrings( new HashSet<>() );
         domain1.getStrings().add( "30" );
         Domain domain2 = DomainDtoWithNvmsDefaultMapper.INSTANCE.updateWithReturn( dto, domain1 );
 
@@ -234,9 +234,9 @@ public class Issue913SetterMapperForCollectionsTest {
 
         DtoWithPresenceCheck dto = new DtoWithPresenceCheck();
         Domain domain = new Domain();
-        domain.setLongs( new HashSet<Long>() );
+        domain.setLongs( new HashSet<>() );
         domain.getLongs().add( 10L );
-        domain.setStrings( new HashSet<String>() );
+        domain.setStrings( new HashSet<>() );
         domain.getStrings().add( "30" );
         DomainDtoWithPresenceCheckMapper.INSTANCE.update( dto, domain );
 
@@ -257,9 +257,9 @@ public class Issue913SetterMapperForCollectionsTest {
 
         DtoWithPresenceCheck dto = new DtoWithPresenceCheck();
         Domain domain1 = new Domain();
-        domain1.setLongs( new HashSet<Long>() );
+        domain1.setLongs( new HashSet<>() );
         domain1.getLongs().add( 10L );
-        domain1.setStrings( new HashSet<String>() );
+        domain1.setStrings( new HashSet<>() );
         domain1.getStrings().add( "30" );
         Domain domain2 = DomainDtoWithPresenceCheckMapper.INSTANCE.updateWithReturn( dto, domain1 );
 
@@ -300,9 +300,9 @@ public class Issue913SetterMapperForCollectionsTest {
 
         DtoWithPresenceCheck dto = new DtoWithPresenceCheck();
         Domain domain = new Domain();
-        domain.setLongs( new HashSet<Long>() );
+        domain.setLongs( new HashSet<>() );
         domain.getLongs().add( 10L );
-        domain.setStrings( new HashSet<String>() );
+        domain.setStrings( new HashSet<>() );
         domain.getStrings().add( "30" );
         DomainDtoWithNcvsAlwaysMapper.INSTANCE.update( dto, domain );
 
@@ -323,9 +323,9 @@ public class Issue913SetterMapperForCollectionsTest {
 
         DtoWithPresenceCheck dto = new DtoWithPresenceCheck();
         Domain domain1 = new Domain();
-        domain1.setLongs( new HashSet<Long>() );
+        domain1.setLongs( new HashSet<>() );
         domain1.getLongs().add( 10L );
-        domain1.setStrings( new HashSet<String>() );
+        domain1.setStrings( new HashSet<>() );
         domain1.getStrings().add( "30" );
         Domain domain2 = DomainDtoWithNcvsAlwaysMapper.INSTANCE.updateWithReturn( dto, domain1 );
 


### PR DESCRIPTION
Fix minor warnings in test package bugs:

remove unnecessary generic type for collections,
remove unnecessary exceptions from signature test methods