### PR TITLE
#1790 Use mapperPrism.values.nullValuePropertyMappingStrategy when retrieving NullValuePropertyMappingStrategy

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/MapperConfiguration.java
@@ -192,7 +192,7 @@ public class MapperConfiguration {
         else if ( beanPrism != null ) {
             return beanPrism;
         }
-        else if ( mapperConfigPrism != null && mapperPrism.values.nullValueCheckStrategy() == null ) {
+        else if ( mapperConfigPrism != null && mapperPrism.values.nullValuePropertyMappingStrategy() == null ) {
             return NullValuePropertyMappingStrategyPrism.valueOf(
                 mapperConfigPrism.nullValuePropertyMappingStrategy()
             );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Issue1790Config.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Issue1790Config.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1790;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.NullValueCheckStrategy;
+
+/**
+ * @author Filip Hrisafov
+ */
+@MapperConfig(nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
+public interface Issue1790Config {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Issue1790Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Issue1790Mapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1790;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(config = Issue1790Config.class, nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+public interface Issue1790Mapper {
+
+    Issue1790Mapper INSTANCE = Mappers.getMapper( Issue1790Mapper.class );
+
+    void toExistingCar(@MappingTarget Target target, Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Issue1790Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Issue1790Test.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1790;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("1790")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    Issue1790Config.class,
+    Issue1790Mapper.class,
+    Source.class,
+    Target.class,
+})
+public class Issue1790Test {
+
+    @Test
+    public void name() {
+        Target target = new Target();
+        target.setName( "My name is set" );
+
+        Source source = new Source();
+
+        Issue1790Mapper.INSTANCE.toExistingCar( target, source );
+
+        assertThat( target.getName() ).isEqualTo( "My name is set" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Issue1790Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Issue1790Test.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class Issue1790Test {
 
     @Test
-    public void name() {
+    public void shouldProperlyApplyNullValuePropertyMappingStrategyWhenInheriting() {
         Target target = new Target();
         target.setName( "My name is set" );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Source.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1790;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Source {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1790/Target.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1790;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Target {
+
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
Thanks to @saw303 for the good reproducal.

Fixes #1790