### PR TITLE
#1881 Use ReportingPolicy#IGNORE for unmappedSourcePolicy when mapping references are for forged methods

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -918,6 +918,9 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         }
 
         private ReportingPolicyPrism getUnmappedSourcePolicy() {
+            if ( mappingReferences.isForForgedMethods() ) {
+                return ReportingPolicyPrism.IGNORE;
+            }
             MapperConfiguration mapperSettings = MapperConfiguration.getInstanceOn( ctx.getMapperTypeElement() );
 
             return mapperSettings.unmappedSourcePolicy();

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1881/Issue1881Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1881/Issue1881Test.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1881;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("1881")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    VehicleDtoMapper.class,
+})
+public class Issue1881Test {
+
+    @Test
+    public void shouldCompileCorrectly() {
+        VehicleDtoMapper.VehicleDto vehicle = VehicleDtoMapper.INSTANCE.map( new VehicleDtoMapper.Vehicle(
+            "Test",
+            100,
+            "SUV"
+        ) );
+
+        assertThat( vehicle.getName() ).isEqualTo( "Test" );
+        assertThat( vehicle.getVehicleProperties() ).isNotNull();
+        assertThat( vehicle.getVehicleProperties().getSize() ).isEqualTo( 100 );
+        assertThat( vehicle.getVehicleProperties().getType() ).isEqualTo( "SUV" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1881/VehicleDtoMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1881/VehicleDtoMapper.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1881;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(unmappedSourcePolicy = ReportingPolicy.ERROR)
+public interface VehicleDtoMapper {
+
+  VehicleDtoMapper INSTANCE = Mappers.getMapper( VehicleDtoMapper.class );
+
+  @Mapping(source = "name", target = "name")
+  @Mapping(source = "size", target = "vehicleProperties.size")
+  @Mapping(source = "type", target = "vehicleProperties.type")
+  VehicleDto map(Vehicle vehicle);
+
+  class VehicleDto {
+    private String name;
+    private VehiclePropertiesDto vehicleProperties;
+
+    public String getName() {
+      return name;
+    }
+
+    public void setName(String name) {
+      this.name = name;
+    }
+
+    public VehiclePropertiesDto getVehicleProperties() {
+      return vehicleProperties;
+    }
+
+    public void setVehicleProperties(VehiclePropertiesDto vehicleProperties) {
+      this.vehicleProperties = vehicleProperties;
+    }
+  }
+
+  class Vehicle {
+    private final String name;
+    private final int size;
+    private final String type;
+
+    public Vehicle(String name, int size, String type) {
+      this.name = name;
+      this.size = size;
+      this.type = type;
+    }
+
+    public String getName() {
+      return name;
+    }
+
+    public int getSize() {
+      return size;
+    }
+
+    public String getType() {
+      return type;
+    }
+  }
+
+  class VehiclePropertiesDto {
+    private int size;
+    private String type;
+
+    public int getSize() {
+      return size;
+    }
+
+    public void setSize(int size) {
+      this.size = size;
+    }
+
+    public String getType() {
+      return type;
+    }
+
+    public void setType(String type) {
+      this.type = type;
+    }
+  }
+}


### PR DESCRIPTION
This aligns with the way the ReportingPolicy is handled for unmappedTargetPolicy when mapping references are for forged methods

Fixes #1881