### PR TITLE
#1788 allowing enum / not enum by removing checks

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -461,16 +461,6 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
             return false;
         }
 
-        if ( parameterType.isEnumType() && !( resultType.isEnumType() || resultType.isString() ) ) {
-            messager.printMessage( method, Message.RETRIEVAL_ENUM_TO_NON_ENUM );
-            return false;
-        }
-
-        if ( !( parameterType.isEnumType() || parameterType.isString() ) && resultType.isEnumType() ) {
-            messager.printMessage( method, Message.RETRIEVAL_NON_ENUM_TO_ENUM );
-            return false;
-        }
-
         for ( Type typeParameter : resultType.getTypeParameters() ) {
             if ( typeParameter.isTypeVar() ) {
                 messager.printMessage( method, Message.RETRIEVAL_TYPE_VAR_RESULT );

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -129,8 +129,6 @@ public enum Message {
     RETRIEVAL_NON_ITERABLE_TO_ITERABLE( "Can't generate mapping method from non-iterable type to iterable type." ),
     RETRIEVAL_PRIMITIVE_PARAMETER( "Can't generate mapping method with primitive parameter type." ),
     RETRIEVAL_PRIMITIVE_RETURN( "Can't generate mapping method with primitive return type." ),
-    RETRIEVAL_ENUM_TO_NON_ENUM( "Can't generate mapping method from enum type to non-enum type." ),
-    RETRIEVAL_NON_ENUM_TO_ENUM( "Can't generate mapping method from non-enum type to enum type." ),
     RETRIEVAL_TYPE_VAR_SOURCE( "Can't generate mapping method for a generic type variable source." ),
     RETRIEVAL_TYPE_VAR_RESULT( "Can't generate mapping method for a generic type variable target." ),
     RETRIEVAL_WILDCARD_SUPER_BOUND_SOURCE( "Can't generate mapping method for a wildcard super bound source." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1788/Issue1788Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1788/Issue1788Mapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1788;
+
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface Issue1788Mapper {
+
+    Container toContainer(Container.Type type);
+
+    class Container {
+        public enum Type {
+            ONE, TWO
+        }
+
+        //CHECKSTYLE:OFF
+        public Type type;
+        //CHECKSTYLE:ON
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1788/Issue1788Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1788/Issue1788Test.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._1788;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+@IssueKey( "1788" )
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses(
+    Issue1788Mapper.class
+)
+public class Issue1788Test {
+
+    @Test
+    public void shouldCompile() {
+    }
+}


### PR DESCRIPTION
We should try to reserve all enum-to-x mappings for the future. Perhaps have a `@NonValueMapping` annotation or something to allow to fallback on regular mapping always. 

Now I think of it.. Having some kind of marker is not a bad idea. We just introduced string-to-enum and enum-to-string which might break existing functionality.  Scanning for `@ValueMapping` only might not do the trick (not mandatory to have mappings)

Or we check if there's not an @BeanMapping before definitively establishing it's an enum mapping
