### PR TITLE
#1645 Generate error when java 6 or java 7 is used

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
@@ -8,7 +8,6 @@ package org.mapstruct.ap;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -135,13 +134,13 @@ public class MappingProcessor extends AbstractProcessor {
         String unmappedTargetPolicy = processingEnv.getOptions().get( UNMAPPED_TARGET_POLICY );
 
         return new Options(
-            Boolean.valueOf( processingEnv.getOptions().get( SUPPRESS_GENERATOR_TIMESTAMP ) ),
-            Boolean.valueOf( processingEnv.getOptions().get( SUPPRESS_GENERATOR_VERSION_INFO_COMMENT ) ),
+            Boolean.parseBoolean( processingEnv.getOptions().get( SUPPRESS_GENERATOR_TIMESTAMP ) ),
+            Boolean.parseBoolean( processingEnv.getOptions().get( SUPPRESS_GENERATOR_VERSION_INFO_COMMENT ) ),
             unmappedTargetPolicy != null ? ReportingPolicyPrism.valueOf( unmappedTargetPolicy.toUpperCase() ) : null,
             processingEnv.getOptions().get( DEFAULT_COMPONENT_MODEL ),
             processingEnv.getOptions().get( DEFAULT_INJECTION_STRATEGY ),
-            Boolean.valueOf( processingEnv.getOptions().get( ALWAYS_GENERATE_SERVICE_FILE ) ),
-            Boolean.valueOf( processingEnv.getOptions().get( VERBOSE ) )
+            Boolean.parseBoolean( processingEnv.getOptions().get( ALWAYS_GENERATE_SERVICE_FILE ) ),
+            Boolean.parseBoolean( processingEnv.getOptions().get( VERBOSE ) )
         );
     }
 
@@ -357,7 +356,7 @@ public class MappingProcessor extends AbstractProcessor {
             processors.add( processorIterator.next() );
         }
 
-        Collections.sort( processors, new ProcessorComparator() );
+        processors.sort( new ProcessorComparator() );
 
         return processors;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/DefaultVersionInformation.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/DefaultVersionInformation.java
@@ -12,8 +12,11 @@ import java.util.jar.Manifest;
 
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.SourceVersion;
+import javax.tools.Diagnostic;
 
 import org.mapstruct.ap.internal.version.VersionInformation;
+
+import static org.mapstruct.ap.internal.util.Message.GENERAL_JAVA_VERSION_IS_NOT_SUPPORTED;
 
 /**
  * Provides information about the processor version and the processor context implementation version.
@@ -91,6 +94,14 @@ public class DefaultVersionInformation implements VersionInformation {
     static DefaultVersionInformation fromProcessingEnvironment(ProcessingEnvironment processingEnv) {
         String runtimeVersion = System.getProperty( "java.version" );
         String runtimeVendor = System.getProperty( "java.vendor" );
+
+        String javaSpecificationVersion = System.getProperty( "java.specification.version" );
+
+        if ( javaSpecificationVersion.equals( "1.6" ) || javaSpecificationVersion.equals( "1.7" ) ) {
+            String message = String.format( GENERAL_JAVA_VERSION_IS_NOT_SUPPORTED.getDescription(),
+                                                                        javaSpecificationVersion );
+            processingEnv.getMessager().printMessage( Diagnostic.Kind.ERROR, message );
+        }
 
         String compiler = getCompiler( processingEnv );
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -115,6 +115,7 @@ public enum Message {
     GENERAL_NOT_ALL_FORGED_CREATED( "Internal Error in creation of Forged Methods, it was expected all Forged Methods to finished with creation, but %s did not" ),
     GENERAL_NO_SUITABLE_CONSTRUCTOR( "%s does not have an accessible parameterless constructor." ),
     GENERAL_NO_QUALIFYING_METHOD( "No qualifying method found for qualifiers: %s and / or qualifying names: %s" ),
+    GENERAL_JAVA_VERSION_IS_NOT_SUPPORTED("Java %s are not supported by Mapstruct"),
 
     BUILDER_MORE_THAN_ONE_BUILDER_CREATION_METHOD( "More than one builder creation method for \"%s\". Found methods: \"%s\". Builder will not be used. Consider implementing a custom BuilderProvider SPI.", Diagnostic.Kind.WARNING ),
     BUILDER_NO_BUILD_METHOD_FOUND("No build method \"%s\" found in \"%s\" for \"%s\". Found methods: \"%s\".", Diagnostic.Kind.ERROR ),


### PR DESCRIPTION
I have tried to generate error when we use  java 6 or java 7, but I need some help. 
1. Should I write some tests for it and how can I do it?
2. I use java.specification.version . Is it right? I have tried SourceVersion.compare, but it doesn't work with Eclipse correctly (I have received RELEASE_8 on Oracle JDK and RELEASE_7 on Eclipse)
3. I saw two points with SpecificCompikerWorkarounds and rename folder, but workarounds it's too hard for me. About rename folder I didn't understand (honestly :))