### PR TITLE
Updated docs to add compilerArgs instead of replacing them.

### DIFF
--- a/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
@@ -210,7 +210,7 @@ When invoking javac directly, these options are passed to the compiler in the fo
 ----
 ...
 compileJava {
-    options.compilerArgs = [
+    options.compilerArgs += [
         '-Amapstruct.suppressGeneratorTimestamp=true',
         '-Amapstruct.suppressGeneratorVersionInfoComment=true',
         '-Amapstruct.verbose=true'


### PR DESCRIPTION
When configuring MapStruct compilerArgs *add* them, not *replace* them