### PR TITLE
1420 gradle incremental

### DIFF
--- a/copyright.txt
+++ b/copyright.txt
@@ -2,6 +2,7 @@
 ============
 
 Alexandr Shalugin - https://github.com/shalugin
+Amine Touzani - https://github.com/ttzn
 Andreas Gudian - https://github.com/agudian
 Andrei Arlou - https://github.com/Captain1653
 Andres Jose Sebastian Rincon Gonzalez - https://github.com/stianrincon

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -62,11 +62,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-		    <groupId>org.gradle</groupId>
-		    <artifactId>gradle-tooling-api</artifactId>
-		    <version>5.6.4</version>
-		    <scope>test</scope>
-		</dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-tooling-api</artifactId>
+            <version>5.6.4</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -24,6 +24,19 @@
         <mapstruct.version>${project.version}</mapstruct.version>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>
+    
+    <repositories>
+        <repository>
+            <id>gradle</id>
+            <url>https://repo.gradle.org/gradle/libs-releases</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
 
     <dependencies>
         <!-- Testing -->
@@ -40,6 +53,24 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-verifier</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.gradle</groupId>
+            <artifactId>gradle-test-kit</artifactId>
+            <version>5.6.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+		    <groupId>org.gradle</groupId>
+		    <artifactId>gradle-tooling-api</artifactId>
+		    <version>5.6.4</version>
+		    <scope>test</scope>
+		</dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/GradleIncrementalCompilationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/GradleIncrementalCompilationTest.java
@@ -1,0 +1,112 @@
+package org.mapstruct.itest.tests;
+
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class GradleIncrementalCompilationTest {
+    private static String PROJECT_DIR = "src/test/resources/gradleIncrementalCompilationTest";
+    private static String COMPILE_TASK_NAME = "compileJava";
+    private static String GRADLE_DISTRIBUTION_VERSION = "5.0";
+
+    @Rule
+    public final TemporaryFolder testBuildDir = new TemporaryFolder();
+    @Rule
+    public final TemporaryFolder testProjectDir = new TemporaryFolder();
+    private GradleRunner runner;
+    // The source file to change
+    private File targetFile; 
+    // Gradle compile task arguments
+    private List<String> compileArgs; 
+
+    @Before
+    public void setup() throws IOException {
+        // Copy test project files to the temp dir
+        FileUtils.copyDirectory( new File( PROJECT_DIR ), testProjectDir.getRoot() );
+        buildCompileArgs();
+        File sourceDirectory = new File( testProjectDir.getRoot(), "src/main/java" );
+        targetFile = new File( sourceDirectory, "org/mapstruct/itest/gradle/model/Target.java" );
+        runner = GradleRunner
+                             .create()
+                             .withGradleVersion( GRADLE_DISTRIBUTION_VERSION )
+                             .withProjectDir( testProjectDir.getRoot() );
+    }
+
+    private void buildCompileArgs() {
+        // Make Gradle use the temporary build folder by overriding the buildDir property
+        String buildDirPropertyArg = "-PbuildDir=" + testBuildDir.getRoot().getAbsolutePath();
+        File rootDirectory = new File("../");
+        
+        // Inject the path to the folder containing the mapstruct-processor JAR
+        String jarDirectoryArg = "-PmapstructRootPath=" + rootDirectory.getAbsolutePath();
+        compileArgs = Arrays.asList( COMPILE_TASK_NAME, buildDirPropertyArg, jarDirectoryArg);
+    }
+
+    private void replaceInFile(File file, CharSequence target, CharSequence replacement) throws IOException {
+        String content = FileUtils.readFileToString( file, Charset.defaultCharset() );
+        FileUtils.writeStringToFile( file, content.replace( target, replacement ), Charset.defaultCharset() );
+    }
+
+    private GradleRunner getRunner(String... additionalArguments) {
+        List<String> fullArguments = new ArrayList<String>( compileArgs );
+        fullArguments.addAll( Arrays.asList( additionalArguments ) );
+        return runner.withArguments( fullArguments );
+    }
+
+    private void assertCompileOutcome(BuildResult result, TaskOutcome outcome) {
+        assertEquals( outcome, result.task( ":" + COMPILE_TASK_NAME ).getOutcome() );
+    }
+
+    private void assertRecompiled(BuildResult result, int recompiledCount) {
+        assertCompileOutcome( result, recompiledCount > 0 ? SUCCESS : UP_TO_DATE );
+        assertThat(
+            result.getOutput(),
+            containsString( String.format( "Incremental compilation of %d classes completed", recompiledCount ) ) );
+    }
+
+    @Test
+    public void testUpToDate() throws IOException {
+        BuildResult result = getRunner().build();
+        System.out.println( result.getOutput() );
+        assertCompileOutcome( result, SUCCESS );
+
+        BuildResult secondBuildResult = getRunner().build();
+        assertCompileOutcome( secondBuildResult, UP_TO_DATE );
+    }
+
+    @Test
+    public void testChangedFile() throws IOException {
+        BuildResult result = getRunner( "--info" ).build();
+        System.out.println( result.getOutput() );
+        assertCompileOutcome( result, SUCCESS );
+
+        System.out.println( "### SECOND BUILD FOLLOWS\n" );
+
+        // Change return value in class Target
+        replaceInFile( targetFile, "original", "change" );
+
+        BuildResult secondBuildResult = getRunner( "--info" ).build();
+        System.out.println( secondBuildResult.getOutput() );
+
+        // 3 classes should be recompiled: Target -> TestMapper -> TestMapperImpl
+        assertRecompiled( secondBuildResult, 3 );
+    }
+}

--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/GradleIncrementalCompilationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/GradleIncrementalCompilationTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.itest.tests;
 
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
@@ -29,14 +34,14 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * <p>This is supposed to be run from the mapstruct root project folder. 
+ * <p>This is supposed to be run from the mapstruct root project folder.
  * Otherwise, use <code>-Dmapstruct_root=path_to_project</code>.
  */
 @RunWith( Parameterized.class )
 public class GradleIncrementalCompilationTest {
-    private static Path ROOT_PATH;
-    private static String PROJECT_DIR = "integrationtest/src/test/resources/gradleIncrementalCompilationTest";
-    private static String COMPILE_TASK_NAME = "compileJava";
+    private static Path rootPath;
+    private static String projectDir = "integrationtest/src/test/resources/gradleIncrementalCompilationTest";
+    private static String compileTaskName = "compileJava";
 
     @Rule
     public final TemporaryFolder testBuildDir = new TemporaryFolder();
@@ -69,7 +74,7 @@ public class GradleIncrementalCompilationTest {
     }
 
     private void assertCompileOutcome(BuildResult result, TaskOutcome outcome) {
-        assertEquals( outcome, result.task( ":" + COMPILE_TASK_NAME ).getOutcome() );
+        assertEquals( outcome, result.task( ":" + compileTaskName ).getOutcome() );
     }
 
     private void assertRecompiled(BuildResult result, int recompiledCount) {
@@ -84,19 +89,19 @@ public class GradleIncrementalCompilationTest {
         String buildDirPropertyArg = "-PbuildDir=" + testBuildDir.getRoot().getAbsolutePath();
 
         // Inject the path to the folder containing the mapstruct-processor JAR
-        String jarDirectoryArg = "-PmapstructRootPath=" + ROOT_PATH.toString();
-        return Arrays.asList( COMPILE_TASK_NAME, buildDirPropertyArg, jarDirectoryArg );
+        String jarDirectoryArg = "-PmapstructRootPath=" + rootPath.toString();
+        return Arrays.asList( compileTaskName, buildDirPropertyArg, jarDirectoryArg );
     }
 
     @BeforeClass
     public static void setupClass() throws Exception {
-        ROOT_PATH = Paths.get( System.getProperty( "mapstruct_root", "." ) ).toAbsolutePath();
+        rootPath = Paths.get( System.getProperty( "mapstruct_root", "." ) ).toAbsolutePath();
     }
 
     @Before
     public void setup() throws IOException {
         // Copy test project files to the temp dir
-        Path gradleProjectPath = ROOT_PATH.resolve( PROJECT_DIR );
+        Path gradleProjectPath = rootPath.resolve( projectDir );
         FileUtils.copyDirectory( gradleProjectPath.toFile(), testProjectDir.getRoot() );
         compileArgs = buildCompileArgs();
         sourceDirectory = new File( testProjectDir.getRoot(), "src/main/java" );

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/build.gradle
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/build.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id 'java'
+}
+
+if (!project.hasProperty('mapstructRootPath'))
+    throw new IllegalArgumentException("Missing required property: mapstructRootPath")
+
+repositories {
+    jcenter()
+    mavenLocal()
+    flatDir {
+        dirs "${mapstructRootPath}/processor/target"
+        dirs "${mapstructRootPath}/core/target"
+    }    
+}
+
+// Extract version and artifactId values
+def apPom = new XmlParser().parse(file("${mapstructRootPath}/processor/pom.xml"))
+ext.apArtifactId = apPom.artifactId[0].text()
+ext.apVersion = apPom.parent[0].version[0].text()
+
+def libPom = new XmlParser().parse(file("${mapstructRootPath}/core/pom.xml"))
+ext.libArtifactId = libPom.artifactId[0].text()
+ext.libVersion = libPom.parent[0].version[0].text()
+
+dependencies {
+    annotationProcessor name: "${apArtifactId}-${apVersion}"
+    implementation name: "${libArtifactId}-${libVersion}"
+}

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/settings.gradle
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'gradle-incremental-compilation-test'

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/TestMapper.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/TestMapper.java
@@ -1,0 +1,11 @@
+package org.mapstruct.itest.gradle.lib;
+
+import org.mapstruct.Mapper;
+
+import org.mapstruct.itest.gradle.model.Target;
+import org.mapstruct.itest.gradle.model.Source;
+
+@Mapper
+public interface TestMapper {
+    public Target toTarget(Source source);
+}

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/TestMapper.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/TestMapper.java
@@ -1,11 +1,14 @@
 package org.mapstruct.itest.gradle.lib;
 
 import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 
 import org.mapstruct.itest.gradle.model.Target;
 import org.mapstruct.itest.gradle.model.Source;
 
-@Mapper
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface TestMapper {
+    @Mapping(source = "value", target = "field")
     public Target toTarget(Source source);
 }

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/TestMapper.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/TestMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.itest.gradle.lib;
 
 import org.mapstruct.Mapper;

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/UnrelatedComponent.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/UnrelatedComponent.java
@@ -1,7 +1,7 @@
 package org.mapstruct.itest.gradle.lib;
 
 public class UnrelatedComponent {
-    public boolean someLibraryMethod() {
+    public boolean unrelatedMethod() {
         return true;
     }
 }

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/UnrelatedComponent.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/UnrelatedComponent.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.itest.gradle.lib;
 
 public class UnrelatedComponent {

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/UnrelatedComponent.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/lib/UnrelatedComponent.java
@@ -1,0 +1,7 @@
+package org.mapstruct.itest.gradle.lib;
+
+public class UnrelatedComponent {
+    public boolean someLibraryMethod() {
+        return true;
+    }
+}

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Source.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Source.java
@@ -1,0 +1,7 @@
+package org.mapstruct.itest.gradle.model;
+
+public class Source {
+    public boolean someLibraryMethod() {
+        return true;
+    }
+}

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Source.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Source.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.itest.gradle.model;
 
 public class Source {

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Source.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Source.java
@@ -1,7 +1,13 @@
 package org.mapstruct.itest.gradle.model;
 
 public class Source {
-    public boolean someLibraryMethod() {
-        return true;
+    private int value;
+
+    public void setValue(int value) {
+        this.value = value;
+    }
+
+    public int getValue() {
+        return value;
     }
 }

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Target.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Target.java
@@ -1,0 +1,7 @@
+package org.mapstruct.itest.gradle.model;
+
+public class Target {
+    public String name() {
+        return "original";
+    }
+}

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Target.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Target.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.itest.gradle.model;
 
 public class Target {

--- a/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Target.java
+++ b/integrationtest/src/test/resources/gradleIncrementalCompilationTest/src/main/java/org/mapstruct/itest/gradle/model/Target.java
@@ -1,7 +1,26 @@
 package org.mapstruct.itest.gradle.model;
 
 public class Target {
-    public String name() {
+    private String field = getDefaultValue();
+    private String otherField;
+    
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    public String getField() {
+        return field;
+    }
+    
+    public void setOtherField(String otherField) {
+        this.otherField = otherField;
+    }
+    
+    public String getOtherField() {
+        return otherField;
+    }
+    
+    public String getDefaultValue() {
         return "original";
     }
 }

--- a/processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/processor/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+org.mapstruct.ap.MappingProcessor,isolating


### PR DESCRIPTION
As discussed in #1420, this PR makes Mapstruct compatible with Gradle's incremental annotation processing feature. The actual change is just one file with a single line of configuration; the bulk of this contribution is in the integration tests, written using the [Gradle TestKit](https://docs.gradle.org/current/userguide/test_kit.html).