### PR TITLE
#1689 1.2.0 - Map accessors with default (package private) visibility

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Executables.java
@@ -77,7 +77,7 @@ public class Executables {
 
     public static boolean isGetterMethod(Accessor method) {
         ExecutableElement executable = method.getExecutable();
-        return executable != null && isPublic( method ) &&
+        return executable != null && isMappableAccessor( method ) &&
             executable.getParameters().isEmpty() &&
             ACCESSOR_NAMING_STRATEGY.getMethodType( executable ) == MethodType.GETTER;
     }
@@ -92,7 +92,7 @@ public class Executables {
      */
     public static boolean isFieldAccessor(Accessor accessor) {
         ExecutableElement executable = accessor.getExecutable();
-        return executable == null && isPublic( accessor ) && isNotStatic( accessor );
+        return executable == null && isMappableAccessor( accessor ) && isNotStatic( accessor );
     }
 
     public static boolean isPresenceCheckMethod(Accessor method) {
@@ -101,7 +101,7 @@ public class Executables {
         }
         ExecutableElement executable = method.getExecutable();
         return executable != null
-            && isPublic( method )
+            && isMappableAccessor( method )
             && executable.getParameters().isEmpty()
             && ( executable.getReturnType().getKind() == TypeKind.BOOLEAN ||
             "java.lang.Boolean".equals( getQualifiedName( executable.getReturnType() ) ) )
@@ -111,7 +111,7 @@ public class Executables {
     public static boolean isSetterMethod(Accessor method) {
         ExecutableElement executable = method.getExecutable();
         return executable != null
-            && isPublic( method )
+            && isMappableAccessor( method )
             && executable.getParameters().size() == 1
             && ACCESSOR_NAMING_STRATEGY.getMethodType( executable ) == MethodType.SETTER;
     }
@@ -119,13 +119,29 @@ public class Executables {
     public static boolean isAdderMethod(Accessor method) {
         ExecutableElement executable = method.getExecutable();
         return executable != null
-            && isPublic( method )
+            && isMappableAccessor( method )
             && executable.getParameters().size() == 1
             && ACCESSOR_NAMING_STRATEGY.getMethodType( executable ) == MethodType.ADDER;
     }
 
     private static boolean isPublic(Accessor method) {
         return method.getModifiers().contains( Modifier.PUBLIC );
+    }
+
+    private static boolean isPackagePrivate(Accessor method) {
+        return !isPublic( method ) && !isProtected( method ) && !isPrivate( method );
+    }
+
+    private static boolean isMappableAccessor(Accessor method) {
+        return isPublic( method ) || isPackagePrivate( method );
+    }
+
+    private static boolean isPrivate(Accessor method) {
+        return method.getModifiers().contains( Modifier.PRIVATE );
+    }
+
+    private static boolean isProtected(Accessor method) {
+        return method.getModifiers().contains( Modifier.PROTECTED );
     }
 
     private static boolean isNotStatic(Accessor accessor) {

--- a/processor/src/test/java/org/mapstruct/ap/test/fields/FieldsMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/fields/FieldsMappingTest.java
@@ -41,6 +41,7 @@ public class FieldsMappingTest {
         source.normalInt = 4;
         source.normalList = Lists.newArrayList( 10, 11, 12 );
         source.fieldOnlyWithGetter = 20;
+        source.packagePrivatefield = "cool";
 
         Target target = SourceTargetMapper.INSTANCE.toSource( source );
 
@@ -52,6 +53,7 @@ public class FieldsMappingTest {
         assertThat( target.privateFinalList ).containsOnly( 3, 4, 5 );
         // +21 from the source getter and append 11 on the setter from the target
         assertThat( target.fieldWithMethods ).isEqualTo( "4111" );
+        assertThat( target.packagePrivatefield ).isEqualTo( "cool" );
     }
 
     @Test
@@ -63,6 +65,7 @@ public class FieldsMappingTest {
         target.normalList = Lists.newArrayList( "10", "11", "12" );
         target.privateFinalList = Lists.newArrayList( 10, 11, 12 );
         target.fieldWithMethods = "20";
+        target.packagePrivatefield = "cool";
 
         Source source = SourceTargetMapper.INSTANCE.toSource( target );
 
@@ -74,5 +77,6 @@ public class FieldsMappingTest {
         assertThat( source.getPrivateFinalList() ).containsOnly( 3, 4, 5, 10, 11, 12 );
         // 23 is appended on the target getter
         assertThat( source.fieldOnlyWithGetter ).isEqualTo( 2023 );
+        assertThat( source.packagePrivatefield ).isEqualTo( "cool" );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/fields/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/fields/Source.java
@@ -33,6 +33,7 @@ public class Source {
     public final List<Integer> finalList = Arrays.asList( 1, 2, 3 );
     public List<Integer> normalList;
     public Integer fieldOnlyWithGetter;
+    String packagePrivatefield;
     // CHECKSTYLE:ON
 
     private final List<Integer> privateFinalList = new ArrayList<Integer>( Arrays.asList( 3, 4, 5 ) );

--- a/processor/src/test/java/org/mapstruct/ap/test/fields/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/fields/Target.java
@@ -32,6 +32,7 @@ public class Target {
     public List<String> normalList;
     public List<Integer> privateFinalList;
     public String fieldWithMethods;
+    String packagePrivatefield;
     // CHECKSTYLE:ON
 
     public String getFieldWithMethods() {


### PR DESCRIPTION
Map accessors with default (package private) visibility with MapStruct 1.2.0

I need this 1.2.0 version because i'm working on a legacy java7 project.

How to change the version to a 1.2.1 please ?