### PR TITLE
#2001 Avoid NPE when checking whether import type element is nested

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -288,8 +288,15 @@ public abstract class GeneratedType extends ModelElement {
             }
 
             if ( typeToAdd.getPackageName().equals( packageName ) ) {
-                if ( !typeToAdd.getTypeElement().getNestingKind().isNested() ) {
-                    return false;
+                if ( typeToAdd.getTypeElement() != null ) {
+                    if ( !typeToAdd.getTypeElement().getNestingKind().isNested() ) {
+                        return false;
+                    }
+                }
+                else if ( typeToAdd.getComponentType() != null ) {
+                    if ( !typeToAdd.getComponentType().getTypeElement().getNestingKind().isNested() ) {
+                        return false;
+                    }
                 }
             }
         }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/Entity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/Entity.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2001;
+
+import java.util.Set;
+
+/**
+ * @author Filip Hrisafov
+ */
+public
+class Entity {
+
+    private Set<EntityExtra> extras;
+
+    public Set<EntityExtra> getExtras() {
+        return extras;
+    }
+
+    public void setExtras(Set<EntityExtra> extras) {
+        this.extras = extras;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/EntityExtra.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/EntityExtra.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2001;
+
+/**
+ * @author Filip Hrisafov
+ */
+public
+class EntityExtra {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/Form.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/Form.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2001;
+
+/**
+ * @author Filip Hrisafov
+ */
+public
+class Form {
+
+    private FormExtra[] extras;
+
+    public FormExtra[] getExtras() {
+        return extras;
+    }
+
+    public void setExtras(FormExtra[] extras) {
+        this.extras = extras;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/FormExtra.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/FormExtra.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2001;
+
+/**
+ * @author Filip Hrisafov
+ */
+public
+class FormExtra {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/Issue2001Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/Issue2001Mapper.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2001;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue2001Mapper {
+
+    Form map(Entity entity);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/Issue2001Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2001/Issue2001Test.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2001;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2001")
+@RunWith( AnnotationProcessorTestRunner.class )
+@WithClasses( {
+    Entity.class,
+    EntityExtra.class,
+    Form.class,
+    FormExtra.class,
+    Issue2001Mapper.class
+} )
+public class Issue2001Test {
+
+    @Test
+    public void shouldCompile() {
+
+    }
+}


### PR DESCRIPTION
When the typeToAdd is an array then TypeElement is null and ComponentType is the one that would be imported

Fixes #2001