### PR TITLE
#2021 Generate compilable code when Decorator is nested within the Mapper

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Decorator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Decorator.java
@@ -125,7 +125,22 @@ public class Decorator extends GeneratedType {
     @Override
     public SortedSet<Type> getImportTypes() {
         SortedSet<Type> importTypes = super.getImportTypes();
-        addIfImportRequired( importTypes, decoratorType );
+        // DecoratorType needs special handling in case it is nested
+        // calling addIfImportRequired is not the most correct approach since it would
+        // lead to checking if the type is to be imported and that would be false
+        // since the Decorator is a nested class within the Mapper.
+        // However, when generating the Decorator this is not needed,
+        // because the Decorator is a top level class itself
+        // In a nutshell creating the Decorator should have its own ProcessorContext, but it doesn't
+        if ( decoratorType.getPackageName().equalsIgnoreCase( getPackageName() ) ) {
+            if ( decoratorType.getTypeElement() != null &&
+                decoratorType.getTypeElement().getNestingKind().isNested() ) {
+                importTypes.add( decoratorType );
+            }
+        }
+        else {
+            importTypes.add( decoratorType );
+        }
         return importTypes;
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2021/Issue2021Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2021/Issue2021Mapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2021;
+
+import org.mapstruct.DecoratedWith;
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+@DecoratedWith(Issue2021Mapper.Decorator.class)
+public interface Issue2021Mapper {
+
+    abstract class Decorator implements Issue2021Mapper {
+
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2021/Issue2021Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2021/Issue2021Test.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2021;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2021")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    Issue2021Mapper.class
+})
+public class Issue2021Test {
+
+    @Test
+    public void shouldCompile() {
+
+    }
+}


### PR DESCRIPTION
We need to treat the import of the decoratorType specially when it is nested.
Calling addIfImportRequired is not the most correct approach since it would
lead to checking if the type is to be imported and that would be false
since the Decorator is a nested class within the Mapper.
However, when generating the Decorator this is not needed, because the Decorator is a top level class itself

In a nutshell creating the Decorator should have its own ProcessorContext, but it doesn't

Fixes #2021 

This was a tricky one. It was affected by the fix for #1460 and #1576