### PR TITLE
#1857 Use flatten-maven-plugin to remove test dependencies from released pom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ test-output
 # Misc.
 .DS_Store
 checkstyle.cache
+.flattened-pom.xml

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -578,6 +578,11 @@
                         </parameter>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>flatten-maven-plugin</artifactId>
+                    <version>1.2.2</version>
+                </plugin>
 
             </plugins>
         </pluginManagement>
@@ -614,6 +619,7 @@
                         <exclude>mvnw*</exclude>
                         <exclude>**/*.asciidoc</exclude>
                         <exclude>**/binding.xjb</exclude>
+                        <exclude>**/*.flattened-pom.xml</exclude>
                     </excludes>
                     <mapping>
                         <java>SLASHSTAR_STYLE</java>
@@ -699,6 +705,34 @@
                             <goal>javadoc-no-fork</goal>
                         </goals>
                         <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- Tidy up all POMs before they are published -->
+                        <id>flatten</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                        <configuration>
+                            <updatePomFile>true</updatePomFile>
+                            <flattenMode>ossrh</flattenMode>
+                            <pomElements>
+                                <parent>expand</parent>
+                            </pomElements>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>flatten-clean</id>
+                        <phase>clean</phase>
+                        <goals>
+                            <goal>clean</goal>
+                        </goals>
                     </execution>
                 </executions>
             </plugin>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -209,6 +209,21 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- The flatten plugin should run after the shading is done -->
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>flatten-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <!-- Tidy up all POMs before they are published -->
+                        <id>flatten</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>flatten</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
@@ -334,6 +349,7 @@
                     <artifactId>jaxb-api</artifactId>
                     <version>2.3.1</version>
                     <scope>provided</scope>
+                    <optional>true</optional>
                 </dependency>
             </dependencies>
         </profile>


### PR DESCRIPTION
For some reason when using annotationProcessorPaths IntelliJ includes the provided and test scoped dependencies on the annotation processor paths.
With this change there would be no test dependencies that IntelliJ can add.

Fixes #1857 