### PR TITLE
#695 Check for direct assignment for iterable, stream or map types

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/mappingcontrol/CloningListMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mappingcontrol/CloningListMapper.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.mappingcontrol;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.control.DeepClone;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(mappingControl = DeepClone.class)
+public interface CloningListMapper {
+
+    CloningListMapper INSTANCE = Mappers.getMapper( CloningListMapper.class );
+
+    CustomerDto clone(CustomerDto in);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/mappingcontrol/CustomerDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mappingcontrol/CustomerDto.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.mappingcontrol;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author Sjaak Derksen
+ */
+public class CustomerDto {
+
+    private Long id;
+    private String customerName;
+    private List<OrderItemDto> orders;
+    private Map<OrderItemKeyDto, OrderItemDto> stock;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getCustomerName() {
+        return customerName;
+    }
+
+    public void setCustomerName(String customerName) {
+        this.customerName = customerName;
+    }
+
+    public List<OrderItemDto> getOrders() {
+        return orders;
+    }
+
+    public void setOrders(List<OrderItemDto> orders) {
+        this.orders = orders;
+    }
+
+    public Map<OrderItemKeyDto, OrderItemDto> getStock() {
+        return stock;
+    }
+
+    public void setStock(Map<OrderItemKeyDto, OrderItemDto> stock) {
+        this.stock = stock;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/mappingcontrol/OrderItemDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mappingcontrol/OrderItemDto.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.mappingcontrol;
+
+/**
+ * @author Sjaak Derksen
+ */
+public class OrderItemDto {
+
+    private String name;
+    private Long quantity;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Long getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(Long quantity) {
+        this.quantity = quantity;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/mappingcontrol/OrderItemKeyDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mappingcontrol/OrderItemKeyDto.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.mappingcontrol;
+
+/**
+ * @author Sjaak Derksen
+ */
+public class OrderItemKeyDto {
+
+    private long stockNumber;
+
+    public long getStockNumber() {
+        return stockNumber;
+    }
+
+    public void setStockNumber(long stockNumber) {
+        this.stockNumber = stockNumber;
+    }
+}


### PR DESCRIPTION
Should be done on their type parameters instead of the types themselves.

I was updating our deep clone example to use the new functionality and realized that it is not working properly for collections.