### PR TITLE
#2150 Change the rules for how a constructor for mapping is picked

### DIFF
--- a/documentation/src/main/asciidoc/chapter-3-defining-a-mapper.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-3-defining-a-mapper.asciidoc
@@ -537,8 +537,10 @@ When doing a mapping MapStruct checks if there is a builder for the type being m
 If there is no builder, then MapStruct looks for a single accessible constructor.
 When there are multiple constructors then the following is done to pick the one which should be used:
 
-* If a parameterless constructor exists then it would be used to construct the object, and the other constructors will be ignored
-* If there are multiple constructors then the one annotated with annotation named `@Default` (from any package) will be used
+* If a constructor is annotated with an annotation named `@Default` (from any package) it will be used.
+* If a single public constructor exists then it will be used to construct the object, and the other non public constructors will be ignored.
+* If a parameterless constructor exists then it will be used to construct the object, and the other constructors will be ignored.
+* If there are multiple eligible constructors then there will be a compilation error due to ambigious constructors. In order to break the ambiquity an annotation named `@Default` (from any package) can used.
 
 When using a constructor then the names of the parameters of the constructor will be used and matched to the target properties.
 When the constructor has an annotation named `@ConstructorProperties` (from any package) then this annotation will be used to get the names of the parameters.

--- a/documentation/src/main/asciidoc/chapter-3-defining-a-mapper.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-3-defining-a-mapper.asciidoc
@@ -542,6 +542,48 @@ When there are multiple constructors then the following is done to pick the one 
 * If a parameterless constructor exists then it will be used to construct the object, and the other constructors will be ignored.
 * If there are multiple eligible constructors then there will be a compilation error due to ambigious constructors. In order to break the ambiquity an annotation named `@Default` (from any package) can used.
 
+.Deciding which constructor to use
+====
+[source, java, linenums]
+[subs="verbatim,attributes"]
+----
+public class Vehicle {
+
+    protected Vehicle() { }
+
+    // MapStruct will use this constructor, because it is a single public constructor
+    public Vehicle(String color) { }
+}
+
+public class Car {
+
+    // MapStruct will use this constructor, because it is a parameterless empty constructor
+    public Car() { }
+
+    public Car(String make, String color) { }
+}
+
+public class Truck {
+
+    public Truck() { }
+
+    // MapStruct will use this constructor, because it is annotated with @Default
+    @Default
+    public Truck(String make, String color) { }
+}
+
+public class Van {
+
+    // There will be a compilation error when using this class because MapStruct cannot pick a constructor
+
+    public Van(String make) { }
+
+    public Van(String make, String color) { }
+
+}
+----
+====
+
 When using a constructor then the names of the parameters of the constructor will be used and matched to the target properties.
 When the constructor has an annotation named `@ConstructorProperties` (from any package) then this annotation will be used to get the names of the parameters.
 

--- a/processor/src/test/java/org/mapstruct/ap/test/constructor/visibility/ConstructorVisibilityTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/constructor/visibility/ConstructorVisibilityTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.constructor.visibility;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.constructor.Default;
+import org.mapstruct.ap.test.constructor.PersonDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2150")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    PersonDto.class,
+    Default.class,
+})
+public class ConstructorVisibilityTest {
+
+    @Test
+    @WithClasses({
+        SimpleWithPublicConstructorMapper.class
+    })
+    public void shouldUseSinglePublicConstructorAlways() {
+        PersonDto source = new PersonDto();
+        source.setName( "Bob" );
+        source.setAge( 30 );
+
+        SimpleWithPublicConstructorMapper.Person target =
+            SimpleWithPublicConstructorMapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getName() ).isEqualTo( "Bob" );
+        assertThat( target.getAge() ).isEqualTo( 30 );
+    }
+
+    @Test
+    @WithClasses({
+        SimpleWithPublicParameterlessConstructorMapper.class
+    })
+    public void shouldUsePublicParameterConstructorIfPresent() {
+        PersonDto source = new PersonDto();
+        source.setName( "Bob" );
+        source.setAge( 30 );
+
+        SimpleWithPublicParameterlessConstructorMapper.Person target =
+            SimpleWithPublicParameterlessConstructorMapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getName() ).isEqualTo( "From Constructor" );
+        assertThat( target.getAge() ).isEqualTo( -1 );
+    }
+
+    @Test
+    @WithClasses({
+        SimpleWithPublicParameterlessConstructorAndDefaultAnnotatedMapper.class
+    })
+    public void shouldUseDefaultAnnotatedConstructorAlways() {
+        PersonDto source = new PersonDto();
+        source.setName( "Bob" );
+        source.setAge( 30 );
+
+        SimpleWithPublicParameterlessConstructorAndDefaultAnnotatedMapper.Person target =
+            SimpleWithPublicParameterlessConstructorAndDefaultAnnotatedMapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getName() ).isEqualTo( "Bob" );
+        assertThat( target.getAge() ).isEqualTo( 30 );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/constructor/visibility/SimpleWithPublicConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/constructor/visibility/SimpleWithPublicConstructorMapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.constructor.visibility;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.constructor.PersonDto;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface SimpleWithPublicConstructorMapper {
+
+    SimpleWithPublicConstructorMapper INSTANCE = Mappers.getMapper( SimpleWithPublicConstructorMapper.class );
+
+    Person map(PersonDto dto);
+
+    class Person {
+
+        private final String name;
+        private final int age;
+
+        protected Person() {
+            this( "From Constructor", -1 );
+        }
+
+        protected Person(String name) {
+            this( name, -1 );
+        }
+
+        public Person(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/constructor/visibility/SimpleWithPublicParameterlessConstructorAndDefaultAnnotatedMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/constructor/visibility/SimpleWithPublicParameterlessConstructorAndDefaultAnnotatedMapper.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.constructor.visibility;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.constructor.Default;
+import org.mapstruct.ap.test.constructor.PersonDto;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface SimpleWithPublicParameterlessConstructorAndDefaultAnnotatedMapper {
+
+    SimpleWithPublicParameterlessConstructorAndDefaultAnnotatedMapper INSTANCE = Mappers.getMapper(
+        SimpleWithPublicParameterlessConstructorAndDefaultAnnotatedMapper.class );
+
+    Person map(PersonDto dto);
+
+    class Person {
+
+        private final String name;
+        private final int age;
+
+        protected Person() {
+            this( "From Constructor", -1 );
+        }
+
+        protected Person(String name) {
+            this( name, -1 );
+        }
+
+        @Default
+        public Person(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/constructor/visibility/SimpleWithPublicParameterlessConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/constructor/visibility/SimpleWithPublicParameterlessConstructorMapper.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.constructor.visibility;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.constructor.PersonDto;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface SimpleWithPublicParameterlessConstructorMapper {
+
+    SimpleWithPublicParameterlessConstructorMapper INSTANCE = Mappers.getMapper(
+        SimpleWithPublicParameterlessConstructorMapper.class );
+
+    Person map(PersonDto dto);
+
+    class Person {
+
+        private final String name;
+        private final int age;
+
+        public Person() {
+            this( "From Constructor", -1 );
+        }
+
+        protected Person(String name) {
+            this( name, -1 );
+        }
+
+        public Person(String name, int age) {
+            this.name = name;
+            this.age = age;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public int getAge() {
+            return age;
+        }
+    }
+}


### PR DESCRIPTION
New rules:

1. Constructor annotated with @Default (from any package) has highest precedence
2. If there is a single public constructor then it would be used to construct the object
3. If a parameterless constructor exists then it would be used to construct the object, and the other constructors will be ignored

Fixes #2150