### PR TITLE
#2197 Strip leading underscores and digits when sanitizing identifier name

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Strings.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Strings.java
@@ -174,15 +174,16 @@ public class Strings {
     public static String sanitizeIdentifierName(String identifier) {
         if ( identifier != null && identifier.length() > 0 ) {
 
-            int firstNonUnderScoreIndex = 0;
-            while ( firstNonUnderScoreIndex < identifier.length() &&
-                identifier.charAt( firstNonUnderScoreIndex ) == UNDERSCORE ) {
-                firstNonUnderScoreIndex++;
+            int firstAlphabeticIndex = 0;
+            while ( firstAlphabeticIndex < identifier.length() &&
+                ( identifier.charAt( firstAlphabeticIndex ) == UNDERSCORE ||
+                    Character.isDigit( identifier.charAt( firstAlphabeticIndex ) ) ) ) {
+                firstAlphabeticIndex++;
             }
 
-            if ( firstNonUnderScoreIndex < identifier.length()) {
+            if ( firstAlphabeticIndex < identifier.length()) {
                 // If it is not consisted of only underscores
-                return identifier.substring( firstNonUnderScoreIndex ).replace( "[]", "Array" );
+                return identifier.substring( firstAlphabeticIndex ).replace( "[]", "Array" );
             }
 
             return identifier.replace( "[]", "Array" );

--- a/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
@@ -85,6 +85,8 @@ public class StringsTest {
         assertThat( Strings.getSafeVariableName( "prop", "prop", "prop_" ) ).isEqualTo( "prop1" );
         assertThat( Strings.getSafeVariableName( "_Test" ) ).isEqualTo( "test" );
         assertThat( Strings.getSafeVariableName( "__Test" ) ).isEqualTo( "test" );
+        assertThat( Strings.getSafeVariableName( "_0Test" ) ).isEqualTo( "test" );
+        assertThat( Strings.getSafeVariableName( "_0123Test" ) ).isEqualTo( "test" );
     }
 
     @Test
@@ -103,6 +105,10 @@ public class StringsTest {
         assertThat( Strings.getSafeVariableName( "_Test", new ArrayList<>() ) ).isEqualTo( "test" );
         assertThat( Strings.getSafeVariableName( "__Test", Arrays.asList( "test" ) ) ).isEqualTo( "test1" );
         assertThat( Strings.getSafeVariableName( "___", new ArrayList<>() ) ).isEqualTo( "___" );
+        assertThat( Strings.getSafeVariableName( "_0Test", new ArrayList<>() ) ).isEqualTo( "test" );
+        assertThat( Strings.getSafeVariableName( "__0Test", Arrays.asList( "test" ) ) ).isEqualTo( "test1" );
+        assertThat( Strings.getSafeVariableName( "___0", new ArrayList<>() ) ).isEqualTo( "___0" );
+        assertThat( Strings.getSafeVariableName( "__0123456789Test", Arrays.asList( "test" ) ) ).isEqualTo( "test1" );
     }
 
     @Test
@@ -114,6 +120,11 @@ public class StringsTest {
         assertThat( Strings.sanitizeIdentifierName( "__int[]" ) ).isEqualTo( "intArray" );
         assertThat( Strings.sanitizeIdentifierName( "test_" ) ).isEqualTo( "test_" );
         assertThat( Strings.sanitizeIdentifierName( "___" ) ).isEqualTo( "___" );
+        assertThat( Strings.sanitizeIdentifierName( "_0Test" ) ).isEqualTo( "Test" );
+        assertThat( Strings.sanitizeIdentifierName( "_0123456789Test" ) ).isEqualTo( "Test" );
+        assertThat( Strings.sanitizeIdentifierName( "_0int[]" ) ).isEqualTo( "intArray" );
+        assertThat( Strings.sanitizeIdentifierName( "__0int[]" ) ).isEqualTo( "intArray" );
+        assertThat( Strings.sanitizeIdentifierName( "___0" ) ).isEqualTo( "___0" );
     }
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2197/Issue2197Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2197/Issue2197Mapper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2197;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue2197Mapper {
+
+    Issue2197Mapper INSTANCE = Mappers.getMapper( Issue2197Mapper.class );
+
+    _0Target map(Source source);
+
+    // CHECKSTYLE:OFF
+    class _0Target {
+    // CHECKSTYLE:ON
+        private final String value;
+
+        public _0Target(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    class Source {
+        private final String value;
+
+        public Source(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2197/Issue2197Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2197/Issue2197Test.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2197;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("2197")
+@WithClasses(Issue2197Mapper.class)
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue2197Test {
+
+    @Rule
+    public final GeneratedSource generatedSource = new GeneratedSource()
+        .addComparisonToFixtureFor( Issue2197Mapper.class );
+
+    @Test
+    public void underscoreAndDigitPrefixShouldBeStrippedFromGeneratedLocalVariables() {
+        Issue2197Mapper._0Target target = Issue2197Mapper.INSTANCE.map( new Issue2197Mapper.Source( "value1" ) );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getValue() ).isEqualTo( "value1" );
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_2197/Issue2197MapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_2197/Issue2197MapperImpl.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2197;
+
+import javax.annotation.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2019-02-10T09:58:11+0100",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_181 (Oracle Corporation)"
+)
+public class Issue2197MapperImpl implements Issue2197Mapper {
+
+    @Override
+    public _0Target map(Source source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        String value = null;
+
+        value = source.getValue();
+
+        _0Target target = new _0Target( value );
+
+        return target;
+    }
+}


### PR DESCRIPTION
Fixes #2197 