### PR TITLE
#2125 Parameter matching should be done based on name of all source parameters properties when source name is absent

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -1068,8 +1068,31 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
 
                 SourceReference sourceRef = mappingRef.getSourceReference();
                 // sourceRef is not defined, check if a source property has the same name
-                if ( sourceRef == null && method.getSourceParameters().size() == 1 ) {
-                    sourceRef = getSourceRefByTargetName( method.getSourceParameters().get( 0 ), targetPropertyName );
+                if ( sourceRef == null ) {
+                    for ( Parameter sourceParameter : method.getSourceParameters() ) {
+                        SourceReference matchingSourceRef = getSourceRefByTargetName(
+                            sourceParameter,
+                            targetPropertyName
+                        );
+                        if ( matchingSourceRef != null ) {
+                            if ( sourceRef != null ) {
+                                errorOccured = true;
+                                // This can only happen when the target property matches multiple properties
+                                // within the different source parameters
+                                ctx.getMessager()
+                                    .printMessage(
+                                        method.getExecutable(),
+                                        mappingRef.getMapping().getMirror(),
+                                        Message.BEANMAPPING_SEVERAL_POSSIBLE_SOURCES,
+                                        targetPropertyName
+                                    );
+                                break;
+                            }
+                            // We can't break here since it is possible that the same property exists in multiple
+                            // source parameters
+                            sourceRef = matchingSourceRef;
+                        }
+                    }
                 }
 
                 if ( sourceRef == null ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Comment.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Comment.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2125;
+
+/**
+ * @author Filip Hrisafov
+ */
+public
+class Comment {
+    private final Integer issueId;
+    private final String comment;
+
+    public Comment(Integer issueId, String comment) {
+        this.issueId = issueId;
+        this.comment = comment;
+    }
+
+    public Integer getIssueId() {
+        return issueId;
+    }
+
+    public String getComment() {
+        return comment;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Issue.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Issue.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2125;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Issue {
+    private final Integer issueId;
+
+    public Issue(Integer issueId) {
+        this.issueId = issueId;
+    }
+
+    public Integer getIssueId() {
+        return issueId;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Issue2125ErroneousMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Issue2125ErroneousMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2125;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+@Mapper
+public interface Issue2125ErroneousMapper {
+
+    @Mapping(target = "issueId", qualifiedByName = "mapIssueNumber")
+    Comment cloneWithQualifier(Comment comment, Issue issue);
+
+    @Named("mapIssueNumber")
+    default Integer mapIssueNumber(Integer issueNumber) {
+        return issueNumber != null ? issueNumber + 1 : null;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Issue2125Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Issue2125Mapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2125;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue2125Mapper {
+
+    Issue2125Mapper INSTANCE = Mappers.getMapper( Issue2125Mapper.class );
+
+    Comment clone(Comment comment, Repository repository);
+
+    @Mapping(target = "issueId", qualifiedByName = "mapIssueNumber")
+    Comment cloneWithQualifier(Comment comment, Repository repository);
+
+    @Named("mapIssueNumber")
+    default Integer mapIssueNumber(Integer issueNumber) {
+        return issueNumber != null ? issueNumber + 1 : null;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Issue2125Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Issue2125Test.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2125;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("2125")
+@WithClasses({
+    Comment.class,
+    Issue.class,
+    Repository.class,
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class Issue2125Test {
+
+    @Test
+    @WithClasses({
+        Issue2125Mapper.class
+    })
+    public void shouldSelectProperMethod() {
+
+        Comment comment = Issue2125Mapper.INSTANCE.clone(
+            new Comment( 2125, "Fix issue" ),
+            new Repository( "mapstruct", "mapstruct" )
+        );
+
+        assertThat( comment ).isNotNull();
+        assertThat( comment.getIssueId() ).isEqualTo( 2125 );
+
+        comment = Issue2125Mapper.INSTANCE.cloneWithQualifier(
+            new Comment( 2125, "Fix issue" ),
+            new Repository( "mapstruct", "mapstruct" )
+        );
+
+        assertThat( comment ).isNotNull();
+        assertThat( comment.getIssueId() ).isEqualTo( 2126 );
+    }
+
+    @Test
+    @WithClasses({
+        Issue2125ErroneousMapper.class
+    })
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = Issue2125ErroneousMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 15,
+                message = "Several possible source properties for target property \"issueId\".")
+        })
+    public void shouldReportErrorWhenMultipleSourcesMatch() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Repository.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2125/Repository.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2125;
+
+/**
+ * @author Filip Hrisafov
+ */
+public
+class Repository {
+
+    private final String owner;
+    private final String name;
+
+    public Repository(String owner, String name) {
+        this.owner = owner;
+        this.name = name;
+    }
+
+    public String getOwner() {
+        return owner;
+    }
+
+    public String getName() {
+        return name;
+    }
+}


### PR DESCRIPTION
Fixes #2125