### PR TITLE
#2213: primitive arrays should be directly mapped

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -274,7 +274,9 @@ public class TypeFactory {
         else {
             isEnumType = false;
             isInterface = false;
-            name = mirror.toString();
+            // When the component type is primitive and is annotated with ElementType.TYPE_USE then
+            // the typeMirror#toString returns (@CustomAnnotation :: byte) for the javac compiler
+            name = mirror.getKind().isPrimitive() ? NativeTypes.getName( mirror.getKind() ) : mirror.toString();
             packageName = null;
             qualifiedName = name;
             typeElement = null;

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
@@ -367,7 +367,7 @@ public class MappingResolverImpl implements MappingResolver {
             }
 
             if ( type.isArrayType() ) {
-                return type.isJavaLangType();
+                return type.isJavaLangType() || type.getComponentType().isPrimitive();
             }
 
             if ( type.isIterableOrStreamType() ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2213/Car.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2213/Car.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2213;
+
+public class Car {
+    private int[] intData;
+    private Long[] longData;
+
+    public int[] getIntData() {
+        return intData;
+    }
+
+    public void setIntData(int[] intData) {
+        this.intData = intData;
+    }
+
+    public Long[] getLongData() {
+        return longData;
+    }
+
+    public void setLongData(Long[] longData) {
+        this.longData = longData;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2213/Car2.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2213/Car2.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2213;
+
+public class Car2 {
+    private int[] intData;
+    private Long[] longData;
+
+    public @NotNull int[] getIntData() {
+        return intData;
+    }
+
+    public void setIntData(int[] intData) {
+        this.intData = intData;
+    }
+
+    public @NotNull Long[] getLongData() {
+        return longData;
+    }
+
+    public void setLongData(Long[] longData) {
+        this.longData = longData;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2213/CarMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2213/CarMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2213;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.control.DeepClone;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(mappingControl = DeepClone.class)
+public interface CarMapper {
+
+    CarMapper INSTANCE = Mappers.getMapper( CarMapper.class );
+
+    Car toCar(Car2 car2);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2213/Issue2213Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2213/Issue2213Test.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2213;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses({
+    NotNull.class,
+    CarMapper.class,
+    Car.class,
+    Car2.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+@IssueKey("2213")
+public class Issue2213Test {
+
+    @Rule
+    public final GeneratedSource generatedSource = new GeneratedSource()
+        .addComparisonToFixtureFor( CarMapper.class );
+
+    @Test
+    public void testShouldNotGenerateIntermediatePrimitiveMappingMethod() {
+        Car2 car = new Car2();
+        int[] sourceInt = { 1, 2, 3 };
+        car.setIntData( sourceInt );
+        Long[] sourceLong = { 1L, 2L, 3L };
+        car.setLongData( sourceLong );
+        Car target = CarMapper.INSTANCE.toCar( car );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getIntData() )
+            .containsExactly( 1, 2, 3 )
+            .isNotSameAs( sourceInt );
+        assertThat( target.getLongData() )
+            .containsExactly( 1L, 2L, 3L )
+            .isNotSameAs( sourceLong );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2213/NotNull.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2213/NotNull.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2213;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({
+    ElementType.METHOD,
+    ElementType.TYPE_USE
+})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface NotNull {
+
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_2213/CarMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_2213/CarMapperImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2213;
+
+import java.util.Arrays;
+import javax.annotation.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2020-10-03T10:12:15+0200",
+    comments = "version: , compiler: javac, environment: Java 11.0.4 (AdoptOpenJDK)"
+)
+public class CarMapperImpl implements CarMapper {
+
+    @Override
+    public Car toCar(Car2 car2) {
+        if ( car2 == null ) {
+            return null;
+        }
+
+        Car car = new Car();
+
+        int[] intData = car2.getIntData();
+        if ( intData != null ) {
+            car.setIntData( Arrays.copyOf( intData, intData.length ) );
+        }
+        Long[] longData = car2.getLongData();
+        if ( longData != null ) {
+            car.setLongData( Arrays.copyOf( longData, longData.length ) );
+        }
+
+        return car;
+    }
+}


### PR DESCRIPTION

(we are cloning them anyways)

Additionally fix problem when annotations `ElementType.TYPE_USE` not handled correctly for javac

Fixes #2213 