### PR TITLE
Expand support for immutables

### DIFF
--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/TopLevelDto.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/TopLevelDto.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables;
+
+import java.util.Objects;
+
+public class TopLevelDto {
+
+    private ChildDto child;
+
+    public org.mapstruct.itest.immutables.TopLevelDto.ChildDto getChild() {
+        return child;
+    }
+
+    public TopLevelDto setChild(org.mapstruct.itest.immutables.TopLevelDto.ChildDto child) {
+        this.child = child;
+        return this;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TopLevelDto that = (TopLevelDto) o;
+        return Objects.equals(child, that.child);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(child);
+    }
+
+    public static class ChildDto {
+        private String string;
+
+        public String getString() {
+            return string;
+        }
+
+        public ChildDto setString(String string) {
+            this.string = string;
+            return this;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ChildDto childDto = (ChildDto) o;
+            return Objects.equals(string, childDto.string);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(string);
+        }
+    }
+}

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/inner/TopLevel.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/inner/TopLevel.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.inner;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface TopLevel {
+    Child getChild();
+
+    @Value.Immutable
+    interface Child {
+        String getString();
+    }
+}
+

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/inner/TopLevelMapper.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/inner/TopLevelMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.inner;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+import org.mapstruct.itest.immutables.*;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
+public interface TopLevelMapper {
+
+    TopLevelMapper INSTANCE = Mappers.getMapper( TopLevelMapper.class );
+
+    TopLevel toImmutable(TopLevelDto dto);
+    TopLevel.Child toImmutable(TopLevelDto.ChildDto dto);
+    TopLevelDto fromImmutable(TopLevel domain);
+    TopLevelDto.ChildDto fromImmutable(TopLevel.Child domain);
+}

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/style/AbstractTopLevelWithValueEnclosingStyle.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/style/AbstractTopLevelWithValueEnclosingStyle.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.style;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Enclosing
+@Value.Style(typeImmutableEnclosing = "*", typeImmutable = "*")
+public abstract class AbstractTopLevelWithValueEnclosingStyle {
+    public abstract Child getChild();
+
+    @Value.Immutable
+    interface Child {
+        String getString();
+    }
+}
+

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/style/BaseTopLevelWithStyle.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/style/BaseTopLevelWithStyle.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.style;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(typeImmutable = "Fixed*", typeAbstract = "Base*")
+public abstract class BaseTopLevelWithStyle {
+    public abstract Child getChild();
+
+    @Value.Immutable
+    interface Child {
+        String getString();
+    }
+}

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/style/FixedTopLevelMapper.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/style/FixedTopLevelMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.style;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+import org.mapstruct.itest.immutables.TopLevelDto;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
+public interface FixedTopLevelMapper {
+    FixedTopLevelMapper INSTANCE = Mappers.getMapper( FixedTopLevelMapper.class );
+
+    FixedTopLevelWithStyle toImmutable(TopLevelDto dto);
+    FixedTopLevelWithStyle.Child toImmutable(TopLevelDto.ChildDto dto);
+
+    TopLevelDto fromImmutable(FixedTopLevelWithStyle domain);
+}

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/style/TopLevelMapper.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/style/TopLevelMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.style;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+import org.mapstruct.itest.immutables.TopLevelDto;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
+public interface TopLevelMapper {
+
+    TopLevelMapper INSTANCE = Mappers.getMapper( TopLevelMapper.class );
+
+    TopLevelWithValueEnclosingStyle toImmutable(TopLevelDto dto);
+    TopLevelWithValueEnclosingStyle.Child toImmutable(TopLevelDto.ChildDto dto);
+
+    TopLevelDto fromImmutable(TopLevelWithValueEnclosingStyle domain);
+}

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/ve/TopLevelMapper.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/ve/TopLevelMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.ve;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+import org.mapstruct.itest.immutables.TopLevelDto;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
+public interface TopLevelMapper {
+
+    TopLevelMapper INSTANCE = Mappers.getMapper( TopLevelMapper.class );
+
+    TopLevelWithValueEnclosing toImmutable(TopLevelDto dto);
+    TopLevelWithValueEnclosing.Child toImmutable(TopLevelDto.ChildDto dto);
+    TopLevelDto fromImmutable(TopLevelWithValueEnclosing domain);
+    TopLevelDto.ChildDto fromImmutable(TopLevelWithValueEnclosing.Child domain);
+}

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/ve/TopLevelWithValueEnclosing.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/main/java/org/mapstruct/itest/immutables/ve/TopLevelWithValueEnclosing.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.ve;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Enclosing
+public interface TopLevelWithValueEnclosing {
+    Child getChild();
+
+    @Value.Immutable
+    interface Child {
+        String getString();
+    }
+}
+

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/ImmutablesMapperTest.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/ImmutablesMapperTest.java
@@ -10,14 +10,20 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Test for generation of Lombok Builder Mapper implementations
+ * Test for generation of org.immutables Mapper implementations
+ *
+ * Handles the Top Level and No Style case which is the out-of-the-box default
+ * most basic setup with org.immutables.
+ *
+ * The generated classes are named using the default style of Immutable*
+ * Coverage for other variants elsewhere
  *
  * @author Eric Martineau
  */
 public class ImmutablesMapperTest {
 
     @Test
-    public void testSimpleImmutableBuilderHappyPath() {
+    public void fromImmutableToPojo() {
         PersonDto personDto = PersonMapper.INSTANCE.toDto( ImmutablePerson.builder()
             .age( 33 )
             .name( "Bob" )
@@ -32,7 +38,7 @@ public class ImmutablesMapperTest {
     }
 
     @Test
-    public void testLombokToImmutable() {
+    public void fromPojoToImmutable() {
         Person person = PersonMapper.INSTANCE.fromDto( new PersonDto( "Bob", 33, new AddressDto( "Wild Drive" ) ) );
         assertThat( person.getAge() ).isEqualTo( 33 );
         assertThat( person.getName() ).isEqualTo( "Bob" );

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/TopLevelFixture.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/TopLevelFixture.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables;
+
+public class TopLevelFixture {
+
+    public static final String CHILD_VALUE = "simple";
+
+    public static TopLevelDto createDto() {
+        TopLevelDto.ChildDto child = new TopLevelDto.ChildDto().setString( CHILD_VALUE );
+        return new TopLevelDto().setChild( child );
+    }
+}

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/inner/InnerClassTest.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/inner/InnerClassTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.inner;
+
+import org.junit.Test;
+import org.mapstruct.itest.immutables.*;
+
+import static org.junit.Assert.*;
+import static org.mapstruct.itest.immutables.TopLevelFixture.CHILD_VALUE;
+
+// Shows support for inner classes using all defaults
+public class InnerClassTest {
+
+    private final TopLevelDto dto = TopLevelFixture.createDto();
+
+    private final TopLevel domain = ImmutableTopLevel.builder()
+            .child(ImmutableChild.builder().string(CHILD_VALUE).build())
+            .build();
+
+    @Test
+    public void toImmutable() {
+        assertEquals(domain, TopLevelMapper.INSTANCE.toImmutable(dto) );
+    }
+
+    @Test
+    public void fromImmutable() {
+        assertEquals(dto, TopLevelMapper.INSTANCE.fromImmutable(domain) );
+    }
+}

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/style/FixedStyledValueTest.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/style/FixedStyledValueTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.style;
+
+import org.junit.Test;
+import org.mapstruct.itest.immutables.TopLevelDto;
+import org.mapstruct.itest.immutables.TopLevelFixture;
+
+import static org.junit.Assert.*;
+import static org.mapstruct.itest.immutables.TopLevelFixture.CHILD_VALUE;
+
+// shows support for a @Value.Style example
+public class FixedStyledValueTest {
+    private final TopLevelDto dto = TopLevelFixture.createDto();
+
+    private final FixedTopLevelWithStyle domain = FixedTopLevelWithStyle.builder()
+        .child( FixedChild.builder()
+            .string(CHILD_VALUE)
+            .build())
+        .build();
+
+    @Test
+    public void toImmutable() {
+        assertEquals(domain, FixedTopLevelMapper.INSTANCE.toImmutable(dto) );
+    }
+
+    @Test
+    public void fromImmutable() {
+        assertEquals(dto, FixedTopLevelMapper.INSTANCE.fromImmutable(domain) );
+    }
+}

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/style/StyledValueEnclosingTest.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/style/StyledValueEnclosingTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.style;
+
+import org.junit.Test;
+import org.mapstruct.itest.immutables.TopLevelDto;
+import org.mapstruct.itest.immutables.TopLevelFixture;
+
+import static org.junit.Assert.*;
+import static org.mapstruct.itest.immutables.TopLevelFixture.CHILD_VALUE;
+
+// Shows support for @Value.Enclosing and @Value.Style
+public class StyledValueEnclosingTest {
+    private final TopLevelDto dto = TopLevelFixture.createDto();
+
+    private final TopLevelWithValueEnclosingStyle domain = TopLevelWithValueEnclosingStyle.builder()
+        .child( TopLevelWithValueEnclosingStyle.Child.builder()
+            .string(CHILD_VALUE)
+            .build())
+        .build();
+
+    @Test
+    public void toImmutable() {
+        assertEquals(domain, TopLevelMapper.INSTANCE.toImmutable(dto) );
+    }
+
+    @Test
+    public void fromImmutable() {
+        assertEquals(dto, TopLevelMapper.INSTANCE.fromImmutable(domain) );
+    }
+}

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/ve/ValueEnclosingTest.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/ve/ValueEnclosingTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.immutables.ve;
+
+import org.junit.Test;
+import org.mapstruct.itest.immutables.TopLevelDto;
+import org.mapstruct.itest.immutables.TopLevelFixture;
+
+import static org.junit.Assert.*;
+import static org.mapstruct.itest.immutables.TopLevelFixture.CHILD_VALUE;
+
+// shows support for @Value.Enclosing without any style
+public class ValueEnclosingTest {
+    private final TopLevelDto dto = TopLevelFixture.createDto();
+
+    private final TopLevelWithValueEnclosing domain = ImmutableTopLevelWithValueEnclosing.builder()
+            .child(ImmutableTopLevelWithValueEnclosing.Child.builder()
+                    .string(CHILD_VALUE)
+                    .build())
+            .build();
+
+    @Test
+    public void toImmutable() {
+        assertEquals(domain, TopLevelMapper.INSTANCE.toImmutable(dto) );
+    }
+
+    @Test
+    public void fromImmutable() {
+        assertEquals(dto, TopLevelMapper.INSTANCE.fromImmutable(domain) );
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/spi/ImmutablesBuilderProvider.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/ImmutablesBuilderProvider.java
@@ -5,13 +5,26 @@
  */
 package org.mapstruct.ap.spi;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.DeclaredType;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+import javax.lang.model.util.SimpleAnnotationValueVisitor8;
 
 import org.mapstruct.util.Experimental;
 
@@ -28,6 +41,8 @@ public class ImmutablesBuilderProvider extends DefaultBuilderProvider {
 
     private static final Pattern JAVA_JAVAX_PACKAGE = Pattern.compile( "^javax?\\..*" );
     private static final String IMMUTABLE_FQN = "org.immutables.value.Value.Immutable";
+    private static final String VALUE_ENCLOSING_FQN = "org.immutables.value.Value.Enclosing";
+    private static final String VALUE_STYLE_FQN = "org.immutables.value.Value.Style";
 
     @Override
     protected BuilderInfo findBuilderInfo(TypeElement typeElement) {
@@ -37,10 +52,7 @@ public class ImmutablesBuilderProvider extends DefaultBuilderProvider {
         }
         TypeElement immutableAnnotation = elementUtils.getTypeElement( IMMUTABLE_FQN );
         if ( immutableAnnotation != null ) {
-            BuilderInfo info = findBuilderInfoForImmutables(
-                typeElement,
-                immutableAnnotation
-            );
+            BuilderInfo info = findBuilderInfoForImmutables( typeElement, immutableAnnotation );
             if ( info != null ) {
                 return info;
             }
@@ -49,39 +61,266 @@ public class ImmutablesBuilderProvider extends DefaultBuilderProvider {
         return super.findBuilderInfo( typeElement );
     }
 
-    protected BuilderInfo findBuilderInfoForImmutables(TypeElement typeElement,
+    /**
+     * Finds the builder info for the given type or returns null if not found.
+     *
+     * @param targetTypeElement   a type which may require a builder
+     * @param immutableAnnotation type of the immutables annotation we're looking for
+     * @return BuilderInfo or null if none found
+     * @throws TypeHierarchyErroneousException if unable to process in this round
+     */
+    protected BuilderInfo findBuilderInfoForImmutables(TypeElement targetTypeElement,
                                                        TypeElement immutableAnnotation) {
-        for ( AnnotationMirror annotationMirror : elementUtils.getAllAnnotationMirrors( typeElement ) ) {
-            if ( typeUtils.isSameType( annotationMirror.getAnnotationType(), immutableAnnotation.asType() ) ) {
-                TypeElement immutableElement = asImmutableElement( typeElement );
-                if ( immutableElement != null ) {
-                    return super.findBuilderInfo( immutableElement );
-                }
-                else {
-                    // Immutables processor has not run yet. Trigger a postpone to the next round for MapStruct
-                    throw new TypeHierarchyErroneousException( typeElement );
-                }
-            }
-        }
-        return null;
+
+        TypeMirror immutableAnnotationType = immutableAnnotation.asType();
+        Optional<TypeElement> optionalTypeElement = findTypeWithImmutableAnnotation(
+            targetTypeElement,
+            immutableAnnotationType
+        );
+
+        return optionalTypeElement.flatMap( typeWithValueImmutableAnnotation ->
+            elementUtils.getAllAnnotationMirrors( typeWithValueImmutableAnnotation )
+                .stream()
+                .map( AnnotationMirror::getAnnotationType )
+                .filter( annotationMirror -> typeUtils.isSameType( annotationMirror, immutableAnnotationType ) )
+                .map( annotationMirror -> {
+                    TypeElement immutableElement = asImmutableElement( typeWithValueImmutableAnnotation );
+                    if ( immutableElement != null ) {
+                        return super.findBuilderInfo( immutableElement );
+                    }
+                    else {
+                        // Immutables processor has not run yet. Trigger a postpone to the next round for MapStruct
+                        throw new TypeHierarchyErroneousException( typeWithValueImmutableAnnotation );
+                    }
+                } )
+                .findFirst() )
+            .orElse( null );
     }
 
+    /**
+     * This method looks for the <code>Value.Immutable</code> on the targetTypeElement
+     * in the following order:
+     * <p>
+     * 1) directly on the element itself
+     * 2) on an interface in the same package that the element implements
+     * 3) on the superclass for the element
+     * <p>
+     *
+     * @param targetTypeElement             element to analyze for the immutables annotation
+     * @param immutableAnnotationTypeMirror type of the annotation we're looking for
+     * @return first found element with the type or empty
+     */
+    protected Optional<TypeElement> findTypeWithImmutableAnnotation(TypeElement targetTypeElement,
+                                                                    TypeMirror immutableAnnotationTypeMirror) {
+        Predicate<Element> hasImmutableAnnotation = element ->
+            elementUtils.getAllAnnotationMirrors( element )
+                .stream()
+                .anyMatch( am -> typeUtils.isSameType( am.getAnnotationType(), immutableAnnotationTypeMirror ) );
+
+
+        // 1. If the TypeElement has the immutable annotation
+        //   then use the targetTypeElement to find the builder
+        //
+        if ( hasImmutableAnnotation.test( targetTypeElement ) ) {
+            return Optional.of( targetTypeElement );
+        }
+
+        String targetPackage = findPackage( targetTypeElement );
+        return Stream.concat(
+            targetTypeElement.getInterfaces().stream(),
+            Stream.of( targetTypeElement.getSuperclass() )
+        )
+            .filter( intf -> intf.getKind() == TypeKind.DECLARED )
+            .map( DeclaredType.class::cast )
+            .map( DeclaredType::asElement )
+            .map( TypeElement.class::cast )
+            .filter( intf -> targetPackage.equals( findPackage( intf ) ) )
+            .filter( hasImmutableAnnotation )
+            .findFirst();
+    }
+
+    /**
+     * @param typeElement element that has the Value.Immutable annotation
+     * @return type that should have the builder or null if none found
+     */
     protected TypeElement asImmutableElement(TypeElement typeElement) {
+        // the java package that the generated builder is in
+        String packageQualifier;
+        // optional enclosing qualifier if the generated builder is an inner class
+        // the value.enclosing annotation customizes this qualifier
+        String enclosingQualifier = "";
+        // name of the builder, defaults to Immutable + non-abstract simple type name
+        // the style annotation customizes the builder
+        String builderName;
+
+        AnnotationMirror style = null;
+
         Element enclosingElement = typeElement.getEnclosingElement();
-        StringBuilder builderQualifiedName = new StringBuilder( typeElement.getQualifiedName().length() + 17 );
-        if ( enclosingElement.getKind() == ElementKind.PACKAGE ) {
-            builderQualifiedName.append( ( (PackageElement) enclosingElement ).getQualifiedName().toString() );
+        while ( enclosingElement.getKind() != ElementKind.PACKAGE ) {
+            // look for the first enclosing element with Value.Enclosing
+            if ( hasValueEnclosingAnnotation( enclosingElement ) && enclosingQualifier.isEmpty() ) {
+                style = findStyle( enclosingElement );
+                if ( style != null ) {
+                    enclosingQualifier = enclosingQualifierFromStyle( style, enclosingElement );
+                }
+                else {
+                    enclosingQualifier = "Immutable" + enclosingElement.getSimpleName().toString();
+                }
+            }
+            enclosingElement = enclosingElement.getEnclosingElement();
         }
-        else {
-            builderQualifiedName.append( ( (TypeElement) enclosingElement ).getQualifiedName().toString() );
+        packageQualifier = ( (PackageElement) enclosingElement ).getQualifiedName().toString();
+
+        builderName = builderFromStyle( style, typeElement, !enclosingQualifier.isEmpty() );
+
+        // check for @Value.Enclosing
+        // <builderQualifiedName> ::= <package> <opt_enclosingName> <builderName>
+        String bqn = Stream.of( packageQualifier, enclosingQualifier, builderName )
+            .filter( segment -> !segment.isEmpty() )
+            .collect( Collectors.joining( "." ) );
+
+        return elementUtils.getTypeElement( bqn );
+    }
+
+    protected String enclosingQualifierFromStyle(AnnotationMirror style, Element element) {
+        // Value.Style influences the qualifier name through the typeAbstract, typeImmutable, and typeImmutableEnclosing
+        return immutableNameFromStylePattern(
+            nameWithoutAbstractPrefix( style, element ),
+            getSingleAnnotationValue( "typeImmutable", style )
+                .orElse( getSingleAnnotationValue( "typeImmutableEnclosing", style )
+                    .orElse( "Immutable*" ) )
+        );
+    }
+
+    protected String builderFromStyle(AnnotationMirror style, TypeElement element, boolean valueEnclosingFound) {
+        assert element != null;
+
+        // if we're given a style, then use it. If not, then
+        // keep walking up until we find one or run out of enclosing elements
+        // If we don't find a style, then the naming behavior is driven
+        // by defaults as documented by the immutables annotations
+        AnnotationMirror resolvedStyle = Optional.ofNullable( style )
+            .orElseGet( () -> {
+                Element currentElement = element;
+                AnnotationMirror found = null;
+                while ( currentElement != null && found == null ) {
+                    found = findStyle( currentElement );
+                    currentElement = currentElement.getEnclosingElement();
+                }
+                return found;
+            } );
+
+        if ( resolvedStyle == null && !valueEnclosingFound ) {
+            // no @Value.Style found, use the default behavior from immutables
+            // no @Value.Enclosing
+            return "Immutable" + element.getSimpleName();
         }
 
-        if ( builderQualifiedName.length() > 0 ) {
-            builderQualifiedName.append( "." );
+        if ( resolvedStyle == null ) {
+            // no @Value.Style found, but there was a @Value.Enclosing, use the default behavior
+            return element.getSimpleName().toString();
         }
 
-        builderQualifiedName.append( "Immutable" ).append( typeElement.getSimpleName() );
-        return elementUtils.getTypeElement( builderQualifiedName );
+        // style is present, see what it has to say about the names
+        return immutableNameFromStylePattern(
+            // trim the abstract portion from the name (defaults to "Abstract*")
+            nameWithoutAbstractPrefix( resolvedStyle, element ),
+            // use the value from typeImmutable
+            getSingleAnnotationValue( "typeImmutable", resolvedStyle )
+                // Note: typeImmutable is defined as having a default value so we shouldn't
+                //       hit this orElse. Leaving this instead of throwing since
+                //       it's a reasonable default (and currently matches their docs)
+                .orElse( "Immutable*" )
+        );
+    }
+
+    protected String nameWithoutAbstractPrefix(AnnotationMirror style, Element element) {
+        final String simpleNameOfElement = element.getSimpleName().toString();
+        return getTypeAbstractValues( style )
+            .stream()
+            .filter( p -> simpleNameOfElement.startsWith( p.substring( 0, p.length() - 1 ) ) )
+            .map( p -> simpleNameOfElement.substring( p.length() - 1 ) )
+            .findFirst()
+            .orElse( element.getSimpleName().toString() );
+    }
+
+    protected Optional<String> getSingleAnnotationValue(String annotationKey, AnnotationMirror style) {
+        return elementUtils.getElementValuesWithDefaults( style )
+            .entrySet()
+            .stream()
+            .filter( entry -> annotationKey.equals( entry.getKey().getSimpleName().toString() ) )
+            .map( Map.Entry::getValue )
+            .map( value -> value.accept( new SimpleAnnotationValueVisitor8<String, Void>() {
+                @Override
+                public String visitString(String s, Void unused) {
+                    return s;
+                }
+            }, null ) )
+            .findFirst();
+    }
+
+    protected List<String> getTypeAbstractValues(AnnotationMirror styleOrNull) {
+
+        // this is the pattern if there is no style or if typeAbstract value not found
+        Supplier<List<String>> noStyleOrMissingDefault = () -> Collections.singletonList( "Abstract*" );
+
+        return Optional.ofNullable( styleOrNull )
+            .map( style -> elementUtils.getElementValuesWithDefaults( style )
+                .entrySet()
+                .stream()
+                .filter( entry -> "typeAbstract".equals( entry.getKey().getSimpleName().toString() ) )
+                .map( Map.Entry::getValue )
+                .map( value -> value.accept( new SimpleAnnotationValueVisitor8<List<String>, Void>() {
+                    @Override
+                    public List<String> visitArray(List<? extends AnnotationValue> values, Void unused) {
+                        return values.stream()
+                            .map( val -> val.accept( new SimpleAnnotationValueVisitor8<String, Void>() {
+                                public String visitString(String s, Void param) {
+                                    return s;
+                                }
+                            }, null ) )
+                            .collect( Collectors.toList() );
+                    }
+                }, null ) ).findFirst().orElseGet( noStyleOrMissingDefault ) )
+            .orElseGet( noStyleOrMissingDefault );
+    }
+
+    protected boolean hasValueEnclosingAnnotation(Element enclosingElement) {
+        TypeElement typeElement = elementUtils.getTypeElement( VALUE_ENCLOSING_FQN );
+
+        return Optional.ofNullable( typeElement )
+            .map( Element::asType )
+            .map( mirror ->
+                elementUtils.getAllAnnotationMirrors( enclosingElement )
+                    .stream()
+                    .anyMatch( am -> typeUtils.isSameType( am.getAnnotationType(), mirror ) ) )
+            .orElse( Boolean.FALSE );
+    }
+
+    protected AnnotationMirror findStyle(Element element) {
+        TypeElement styleTypeElement = elementUtils.getTypeElement( VALUE_STYLE_FQN );
+        if ( styleTypeElement == null ) {
+            return null;
+        }
+        TypeMirror styleAnnotation = styleTypeElement.asType();
+        return elementUtils.getAllAnnotationMirrors( element )
+            .stream()
+            .filter( am -> typeUtils.isSameType( am.getAnnotationType(), styleAnnotation ) )
+            .findFirst()
+            .orElse( null );
+    }
+
+    protected String immutableNameFromStylePattern(String simpleNameOfElement, String typeImmutablePattern) {
+        String fixedPattern = typeImmutablePattern.substring( 0, typeImmutablePattern.length() - 1 );
+        return fixedPattern + simpleNameOfElement;
+    }
+
+    protected String findPackage(Element element) {
+        Element current = element;
+        while ( current.getKind() != ElementKind.PACKAGE ) {
+            current = current.getEnclosingElement();
+        }
+        return current.getSimpleName().toString();
     }
 
 }


### PR DESCRIPTION
See #2198 for details

Added support for the following:
- inner classes
- `@Value.Enclosing`
- `@Value.Style`

The changes in src/main are limited to the `ImmutablesBuilderProvider` and aim to be backwards compatible by not breaking the contract on any of the `protected` methods. 

The existing immutables integration test project was expanded to include a few more examples with immutables that demonstrate the correct behavior with inner classes, `@Value.Enclosing` and `@Value.Style`
 
