### PR TITLE
#2221: Fix configuration inheritance when there are multiple matching source parameters of the same type

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2221/Issue2221Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2221/Issue2221Test.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2221;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2221")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    RestConfig.class,
+    RestSiteDto.class,
+    RestSiteMapper.class,
+    SiteDto.class,
+})
+public class Issue2221Test {
+
+    @Test
+    public void multiSourceInheritConfigurationShouldWork() {
+        SiteDto site = RestSiteMapper.INSTANCE.convert(
+            new RestSiteDto( "restTenant", "restSite", "restCti" ),
+            "parameterTenant",
+            "parameterSite"
+        );
+
+        assertThat( site ).isNotNull();
+        assertThat( site.getTenantId() ).isEqualTo( "parameterTenant" );
+        assertThat( site.getSiteId() ).isEqualTo( "parameterSite" );
+        assertThat( site.getCtiId() ).isEqualTo( "restCti" );
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2221/RestConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2221/RestConfig.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2221;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.Mapping;
+
+/**
+ * @author Filip Hrisafov
+ */
+@MapperConfig
+public interface RestConfig {
+
+    @Mapping(target = "tenantId", source = "tenantId")
+    @Mapping(target = "siteId", source = "siteId")
+    @Mapping(target = "ctiId", source = "source.cti", defaultValue = "unknown")
+    SiteDto convert(RestSiteDto source, String tenantId, String siteId);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2221/RestSiteDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2221/RestSiteDto.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2221;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class RestSiteDto {
+
+    private final String tenantId;
+    private final String siteId;
+    private final String cti;
+
+    public RestSiteDto(String tenantId, String siteId, String cti) {
+        this.tenantId = tenantId;
+        this.siteId = siteId;
+        this.cti = cti;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public String getSiteId() {
+        return siteId;
+    }
+
+    public String getCti() {
+        return cti;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2221/RestSiteMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2221/RestSiteMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2221;
+
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(config = RestConfig.class)
+public interface RestSiteMapper {
+
+    RestSiteMapper INSTANCE = Mappers.getMapper( RestSiteMapper.class );
+
+    @InheritConfiguration
+    SiteDto convert(RestSiteDto source, String tenantId, String siteId);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2221/SiteDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2221/SiteDto.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2221;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class SiteDto {
+
+    private final String tenantId;
+    private final String siteId;
+    private final String ctiId;
+
+    public SiteDto(String tenantId, String siteId, String ctiId) {
+        this.tenantId = tenantId;
+        this.siteId = siteId;
+        this.ctiId = ctiId;
+    }
+
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    public String getSiteId() {
+        return siteId;
+    }
+
+    public String getCtiId() {
+        return ctiId;
+    }
+}


### PR DESCRIPTION
Fixes #2221

I also did some small refactoring as the `Collectors.reducing( (a, b) -> null )` was really confusing to me.