### PR TITLE
#2244 Mark mapstruct-processor jar as Spring-Boot-Jar-Type: annotation-processor

### DIFF
--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -123,6 +123,7 @@
                         </manifest>
                         <manifestEntries>
                             <Automatic-Module-Name>org.mapstruct.processor</Automatic-Module-Name>
+                            <Spring-Boot-Jar-Type>annotation-processor</Spring-Boot-Jar-Type>
                         </manifestEntries>
                     </archive>
                 </configuration>


### PR DESCRIPTION


Doing this would make sure that starting from Spring Boot 2.4 the mapstruct-processor will not be included in the fat jar produced by the Spring Boot maven plugin if people have it as a maven provided dependency.

This is an alternative if people are not using the maven-compiler-plugin annotationProcessorPaths

Fixes #2244