### PR TITLE
default component model: mapper reference use singleton INSTANCE if i…

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/DefaultMapperReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/DefaultMapperReference.java
@@ -21,19 +21,22 @@ import org.mapstruct.ap.internal.util.Strings;
  */
 public class DefaultMapperReference extends MapperReference {
 
+    private final boolean isSingleton;
     private final boolean isAnnotatedMapper;
     private final Set<Type> importTypes;
 
-    private DefaultMapperReference(Type type, boolean isAnnotatedMapper, Set<Type> importTypes, String variableName) {
+    private DefaultMapperReference(Type type, boolean isAnnotatedMapper, boolean isSingleton,
+                                   Set<Type> importTypes, String variableName) {
         super( type, variableName );
         this.isAnnotatedMapper = isAnnotatedMapper;
         this.importTypes = importTypes;
+        this.isSingleton = isSingleton;
     }
 
-    public static DefaultMapperReference getInstance(Type type, boolean isAnnotatedMapper, TypeFactory typeFactory,
-                                                     List<String> otherMapperReferences) {
+    public static DefaultMapperReference getInstance(Type type, boolean isAnnotatedMapper, boolean isSingleton,
+                                                     TypeFactory typeFactory, List<String> otherMapperReferences) {
         Set<Type> importTypes = Collections.asSet( type );
-        if ( isAnnotatedMapper ) {
+        if ( isAnnotatedMapper && !isSingleton) {
             importTypes.add( typeFactory.getType( "org.mapstruct.factory.Mappers" ) );
         }
 
@@ -42,7 +45,7 @@ public class DefaultMapperReference extends MapperReference {
             otherMapperReferences
         );
 
-        return new DefaultMapperReference( type, isAnnotatedMapper, importTypes, variableName );
+        return new DefaultMapperReference( type, isAnnotatedMapper, isSingleton, importTypes, variableName );
     }
 
     @Override
@@ -53,4 +56,9 @@ public class DefaultMapperReference extends MapperReference {
     public boolean isAnnotatedMapper() {
         return isAnnotatedMapper;
     }
+
+    public boolean isSingleton() {
+      return isSingleton;
+    }
+
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/DefaultMapperReference.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/DefaultMapperReference.ftl
@@ -6,4 +6,4 @@
 
 -->
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.DefaultMapperReference" -->
-private final <@includeModel object=type/> ${variableName} = <#if annotatedMapper>Mappers.getMapper( <@includeModel object=type/>.class );<#else>new <@includeModel object=type/>();</#if>
+private final <@includeModel object=type/> ${variableName} = <#if singleton><@includeModel object=type/>.INSTANCE;<#else><#if annotatedMapper>Mappers.getMapper( <@includeModel object=type/>.class );<#else>new <@includeModel object=type/>();</#if></#if>

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/OrganizationMapper1Impl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/OrganizationMapper1Impl.java
@@ -9,7 +9,6 @@ import javax.annotation.Generated;
 import org.mapstruct.ap.test.updatemethods.CompanyDto;
 import org.mapstruct.ap.test.updatemethods.CompanyEntity;
 import org.mapstruct.ap.test.updatemethods.DepartmentEntityFactory;
-import org.mapstruct.factory.Mappers;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
@@ -18,7 +17,7 @@ import org.mapstruct.factory.Mappers;
 )
 public class OrganizationMapper1Impl implements OrganizationMapper1 {
 
-    private final ExternalMapper externalMapper = Mappers.getMapper( ExternalMapper.class );
+    private final ExternalMapper externalMapper = ExternalMapper.INSTANCE;
     private final DepartmentEntityFactory departmentEntityFactory = new DepartmentEntityFactory();
 
     @Override

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/OrganizationMapper3Impl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/OrganizationMapper3Impl.java
@@ -9,7 +9,6 @@ import javax.annotation.Generated;
 import org.mapstruct.ap.test.updatemethods.BossDto;
 import org.mapstruct.ap.test.updatemethods.BossEntity;
 import org.mapstruct.ap.test.updatemethods.ConstructableDepartmentEntity;
-import org.mapstruct.factory.Mappers;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
@@ -18,7 +17,7 @@ import org.mapstruct.factory.Mappers;
 )
 public class OrganizationMapper3Impl implements OrganizationMapper3 {
 
-    private final ExternalMapper externalMapper = Mappers.getMapper( ExternalMapper.class );
+    private final ExternalMapper externalMapper = ExternalMapper.INSTANCE;
 
     @Override
     public void toBossEntity(BossDto dto, BossEntity entity) {


### PR DESCRIPTION
…t exists

This allows to easily avoid the runtime dependency on mapstruct.jar:
we can avoid Mappers.getMapper(...) for instantiating used mappers if
the code follows the conventionnal pattern for creating mapper singletons.

Fix #2277.