### PR TITLE
Example uses wrong maven plugin configuration

### DIFF
--- a/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
@@ -187,15 +187,15 @@ When invoking javac directly, these options are passed to the compiler in the fo
         <!-- due to problem in maven-compiler-plugin, for verbose mode add showWarnings -->
         <showWarnings>true</showWarnings>
         <compilerArgs>
-            <compilerArg>
+            <arg>
                 -Amapstruct.suppressGeneratorTimestamp=true
-            </compilerArg>
-            <compilerArg>
+            </arg>
+            <arg>
                 -Amapstruct.suppressGeneratorVersionInfoComment=true
-            </compilerArg>
-            <compilerArg>
+            </arg>
+            <arg>
                 -Amapstruct.verbose=true
-            </compilerArg>
+            </arg>
         </compilerArgs>
     </configuration>
 </plugin>


### PR DESCRIPTION
See official maven doc on this: https://maven.apache.org/plugins/maven-compiler-plugin/examples/pass-compiler-arguments.html
Otherwise for example intellij doesn't recognize the compiler options on maven import