### PR TITLE
#2301 Implicitly ignore forward inherited mappings from different method types

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -938,6 +938,15 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
 
             if ( targetWriteAccessor == null ) {
                 if ( targetReadAccessor == null ) {
+                    if ( mapping.getInheritContext() != null && mapping.getInheritContext().isForwarded() &&
+                        mapping.getInheritContext().getTemplateMethod().isUpdateMethod() != method.isUpdateMethod() ) {
+                        // When a configuration is inherited and the template method is not same type as the current
+                        // method then we can safely ignore this mapping.
+                        // This means that a property which is inherited might be present for a direct mapping
+                        // via the Builder, but not for an update mapping (directly on the object itself),
+                        // or vice versa
+                        return false;
+                    }
                     Set<String> readAccessors = resultTypeToMap.getPropertyReadAccessors().keySet();
                     String mostSimilarProperty = Strings.getMostSimilarWord( targetPropertyName, readAccessors );
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2301/Artifact.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2301/Artifact.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2301;
+
+import java.util.Set;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Artifact {
+
+    private String name;
+    private Set<String> dependantBuildRecords;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Set<String> getDependantBuildRecords() {
+        return dependantBuildRecords;
+    }
+
+    public void setDependantBuildRecords(Set<String> dependantBuildRecords) {
+        this.dependantBuildRecords = dependantBuildRecords;
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String name;
+        private Set<String> dependantBuildRecords;
+
+        public Artifact build() {
+            Artifact artifact = new Artifact();
+            artifact.setName( name );
+            artifact.setDependantBuildRecords( dependantBuildRecords );
+
+            return artifact;
+        }
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder dependantBuildRecord(String dependantBuildRecord) {
+            this.dependantBuildRecords.add( dependantBuildRecord );
+            return this;
+        }
+
+        public Builder dependantBuildRecords(Set<String> dependantBuildRecords) {
+            this.dependantBuildRecords = dependantBuildRecords;
+            return this;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2301/ArtifactDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2301/ArtifactDto.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2301;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class ArtifactDto {
+
+    private final String name;
+
+    public ArtifactDto(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2301/Issue2301Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2301/Issue2301Mapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2301;
+
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue2301Mapper {
+
+    Issue2301Mapper INSTANCE = Mappers.getMapper( Issue2301Mapper.class );
+
+    @Mapping(target = "dependantBuildRecords", ignore = true)
+    @Mapping(target = "dependantBuildRecord", ignore = true)
+    Artifact map(ArtifactDto dto);
+
+    @InheritConfiguration
+    void update(@MappingTarget Artifact artifact, ArtifactDto dto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2301/Issue2301Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2301/Issue2301Test.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2301;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2301")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    Artifact.class,
+    ArtifactDto.class,
+    Issue2301Mapper.class
+})
+public class Issue2301Test {
+
+    @Test
+    public void shouldCorrectlyIgnoreProperties() {
+        Artifact artifact = Issue2301Mapper.INSTANCE.map( new ArtifactDto( "mapstruct" ) );
+
+        assertThat( artifact ).isNotNull();
+        assertThat( artifact.getName() ).isEqualTo( "mapstruct" );
+        assertThat( artifact.getDependantBuildRecords() ).isNull();
+
+        Issue2301Mapper.INSTANCE.update( artifact, new ArtifactDto( "mapstruct-processor" ) );
+
+        assertThat( artifact.getName() ).isEqualTo( "mapstruct-processor" );
+    }
+}


### PR DESCRIPTION
Fixes #2301

This is a regression from 1.3. In 1.3 it worked correctly because we were checking the `@Mapping` only once, i.e. when they were defined, but not during the creation of the bean mapping method. 