### PR TITLE
#2318 Fix missing mapping when source is redefined

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
@@ -137,7 +137,7 @@ public class MappingMethodOptions {
      * Merges in all the mapping options configured, giving the already defined options precedence.
      *
      * @param templateMethod the template method with the options to inherit, may be {@code null}
-     * @param isInverse if {@code true}, the specified options are from an inverse method
+     * @param isInverse      if {@code true}, the specified options are from an inverse method
      */
     public void applyInheritedOptions(SourceMethod templateMethod, boolean isInverse) {
         MappingMethodOptions templateOptions = templateMethod.getOptions();
@@ -151,7 +151,7 @@ public class MappingMethodOptions {
             }
 
             if ( !getBeanMapping().hasAnnotation() && templateOptions.getBeanMapping().hasAnnotation() ) {
-                setBeanMapping( BeanMappingOptions.forInheritance( templateOptions.getBeanMapping( ) ) );
+                setBeanMapping( BeanMappingOptions.forInheritance( templateOptions.getBeanMapping() ) );
             }
 
             if ( !getEnumMappingOptions().hasAnnotation() && templateOptions.getEnumMappingOptions().hasAnnotation() ) {
@@ -181,7 +181,7 @@ public class MappingMethodOptions {
                         ValueMappingOptions valueMapping =
                             isInverse ? inheritedValueMapping.inverse() : inheritedValueMapping;
                         if ( valueMapping != null
-                            && !getValueMappings().contains(  valueMapping ) ) {
+                            && !getValueMappings().contains( valueMapping ) ) {
                             getValueMappings().add( valueMapping );
                         }
                     }
@@ -221,15 +221,14 @@ public class MappingMethodOptions {
         }
         for ( MappingOptions inheritedMapping : inheritedMappings ) {
             if ( inheritedMapping.isIgnored()
-                || ( !isRedefined( redefinedSources, inheritedMapping.getSourceName() )
-                && !isRedefined( redefinedTargets, inheritedMapping.getTargetName() ) )
+                || !isRedefined( redefinedTargets, inheritedMapping.getTargetName() )
             ) {
                 mappings.add( inheritedMapping );
             }
         }
     }
 
-    private boolean isRedefined(Set<String> redefinedNames, String inheritedName ) {
+    private boolean isRedefined(Set<String> redefinedNames, String inheritedName) {
         for ( String redefinedName : redefinedNames ) {
             if ( elementsAreContainedIn( redefinedName, inheritedName ) ) {
                 return true;
@@ -238,7 +237,7 @@ public class MappingMethodOptions {
         return false;
     }
 
-    private boolean elementsAreContainedIn( String redefinedName, String inheritedName ) {
+    private boolean elementsAreContainedIn(String redefinedName, String inheritedName) {
         if ( inheritedName != null && redefinedName.startsWith( inheritedName ) ) {
             // it is possible to redefine an exact matching source name, because the same source can be mapped to
             // multiple targets. It is not possible for target, but caught by the Set and equals methoded in
@@ -288,7 +287,7 @@ public class MappingMethodOptions {
         }
     }
 
-    private void filterNestedTargetIgnores( Set<MappingOptions> mappings) {
+    private void filterNestedTargetIgnores(Set<MappingOptions> mappings) {
 
         // collect all properties to ignore, and safe their target name ( == same name as first ref target property)
         Set<String> ignored = getMappingTargetNamesBy( MappingOptions::isIgnored, mappings );
@@ -297,10 +296,10 @@ public class MappingMethodOptions {
 
     private boolean isToBeIgnored(Set<String> ignored, MappingOptions mapping) {
         String[] propertyEntries = getPropertyEntries( mapping );
-        return propertyEntries.length > 1 && ignored.contains( propertyEntries[ 0 ] );
+        return propertyEntries.length > 1 && ignored.contains( propertyEntries[0] );
     }
 
-    private String[] getPropertyEntries( MappingOptions mapping ) {
+    private String[] getPropertyEntries(MappingOptions mapping) {
         return mapping.getTargetName().split( "\\." );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2318/Issue2318Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2318/Issue2318Mapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2318;
+
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(config = Issue2318Mapper.Config.class)
+public interface Issue2318Mapper {
+
+    Issue2318Mapper INSTANCE = Mappers.getMapper( Issue2318Mapper.class );
+
+    @MapperConfig
+    interface Config {
+
+        @Mapping(target = "parentValue1", source = "holder")
+        Model.TargetParent mapParent(Model.SourceParent parent);
+
+        @InheritConfiguration(name = "mapParent")
+        @Mapping(target = "childValue", source = "value")
+        @Mapping(target = "parentValue2", source = "holder.parentValue2")
+        Model.TargetChild mapChild(Model.SourceChild child);
+    }
+
+    @InheritConfiguration(name = "mapChild")
+    Model.TargetChild mapChild(Model.SourceChild child);
+
+    default String parentValue1(Model.SourceParent.Holder holder) {
+        return holder.getParentValue1();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2318/Issue2318Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2318/Issue2318Test.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2318;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.bugs._2318.Model.SourceChild;
+import org.mapstruct.ap.test.bugs._2318.Model.TargetChild;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("2318")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({ Issue2318Mapper.class, Model.class })
+public class Issue2318Test {
+
+    @Test
+    public void shouldMap() {
+
+        SourceChild source = new SourceChild();
+        source.setValue( "From child" );
+        source.setHolder( new Model.SourceParent.Holder() );
+        source.getHolder().setParentValue1( "From parent" );
+        source.getHolder().setParentValue2( 12 );
+
+        TargetChild target = Issue2318Mapper.INSTANCE.mapChild( source );
+
+        assertThat( target.getParentValue1() ).isEqualTo( "From parent" );
+        assertThat( target.getParentValue2() ).isEqualTo( 12 );
+        assertThat( target.getChildValue() ).isEqualTo( "From child" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2318/Model.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2318/Model.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2318;
+
+public interface Model {
+
+    class SourceParent {
+        private Holder holder;
+
+        public Holder getHolder() {
+            return holder;
+        }
+
+        public void setHolder(Holder holder) {
+            this.holder = holder;
+        }
+
+        public static class Holder {
+            private String parentValue1;
+            private Integer parentValue2;
+
+            public String getParentValue1() {
+                return parentValue1;
+            }
+
+            public void setParentValue1(String parentValue1) {
+                this.parentValue1 = parentValue1;
+            }
+
+            public Integer getParentValue2() {
+                return parentValue2;
+            }
+
+            public void setParentValue2(Integer parentValue2) {
+                this.parentValue2 = parentValue2;
+            }
+        }
+    }
+
+    class SourceChild extends SourceParent {
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+
+    class TargetParent {
+        private String parentValue1;
+        private Integer parentValue2;
+
+        public String getParentValue1() {
+            return parentValue1;
+        }
+
+        public void setParentValue1(String parentValue1) {
+            this.parentValue1 = parentValue1;
+        }
+
+        public Integer getParentValue2() {
+            return parentValue2;
+        }
+
+        public void setParentValue2(Integer parentValue2) {
+            this.parentValue2 = parentValue2;
+        }
+    }
+
+    class TargetChild extends TargetParent {
+        private String childValue;
+
+        public String getChildValue() {
+            return childValue;
+        }
+
+        public void setChildValue(String childValue) {
+            this.childValue = childValue;
+        }
+    }
+}


### PR DESCRIPTION
Naive attempt at fixing #2318 by not considering redefined source mappings for exclusion. 
I am absolutely not sure if this is the right way to do it but at least it fixes the problem without breaking the unit tests of related issue #2101.