### PR TITLE
#2250, #2324 Do not throw error when qualifier is missing on iterable mapping

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
@@ -22,6 +22,8 @@ import org.mapstruct.ap.internal.util.Strings;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
 
+import javax.lang.model.element.AnnotationMirror;
+
 /**
  * Builder that can be used to build {@link ContainerMappingMethod}(s).
  *
@@ -37,6 +39,7 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
     private FormattingParameters formattingParameters;
     private String errorMessagePart;
     private String callingContextTargetPropertyName;
+    private AnnotationMirror positionHint;
 
     ContainerMappingMethodBuilder(Class<B> selfType, String errorMessagePart) {
         super( selfType );
@@ -55,6 +58,11 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
 
     public B callingContextTargetPropertyName(String callingContextTargetPropertyName) {
         this.callingContextTargetPropertyName = callingContextTargetPropertyName;
+        return myself;
+    }
+
+    public B positionHint(AnnotationMirror positionHint) {
+        this.positionHint = positionHint;
         return myself;
     }
 
@@ -88,7 +96,7 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
             formattingParameters,
             criteria,
             sourceRHS,
-            null,
+            positionHint,
             () -> forge( sourceRHS, sourceElementType, targetElementType )
         );
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -656,6 +656,7 @@ public class PropertyMapping extends ModelElement {
                 .method( methodRef )
                 .selectionParameters( selectionParameters )
                 .callingContextTargetPropertyName( targetPropertyName )
+                .positionHint( positionHint )
                 .build();
 
             return createForgedAssignment( source, methodRef, iterableMappingMethod );

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
@@ -298,7 +298,13 @@ public class MappingResolverImpl implements MappingResolver {
             }
 
             if ( hasQualfiers() ) {
-                printQualifierMessage( selectionCriteria );
+                if ((sourceType.isCollectionType() || sourceType.isArrayType()) && targetType.isIterableType()) {
+                    // Allow forging iterable mapping when no iterable mapping already found
+                    return forger.get();
+                }
+                else {
+                    printQualifierMessage( selectionCriteria );
+                }
             }
             else if ( allowMappingMethod() ) {
                 // only forge if we would allow mapping method

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/ErroneousMessageByNamedWithIterableMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/ErroneousMessageByNamedWithIterableMapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.selection.qualifier.errors;
+
+import java.util.Collection;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper
+public interface ErroneousMessageByNamedWithIterableMapper {
+
+    @Mapping(target = "elements", qualifiedByName = "SelectMe")
+    Target map(Source source);
+
+    // CHECKSTYLE:OFF
+    class Source {
+
+        public Collection<String> elements;
+    }
+
+    class Target {
+
+        public Collection<String> elements;
+    }
+    // CHECKSTYLE ON
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/QualfierMessageTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/errors/QualfierMessageTest.java
@@ -87,4 +87,27 @@ public class QualfierMessageTest {
     )
     public void testNoQualifyingMethodByAnnotationAndNamedFound() {
     }
+
+    @Test
+    @WithClasses(ErroneousMessageByNamedWithIterableMapper.class)
+    @ExpectedCompilationOutcome(
+            value = CompilationResult.FAILED,
+            diagnostics = {
+                    @Diagnostic(
+                            type = ErroneousMessageByNamedWithIterableMapper.class,
+                            kind = ERROR,
+                            line = 16,
+                            message = "Qualifier error. No method found annotated with @Named#value: [ SelectMe ]. " +
+                                    "See https://mapstruct.org/faq/#qualifier for more info."),
+                    @Diagnostic(
+                            type = ErroneousMessageByNamedWithIterableMapper.class,
+                            kind = ERROR,
+                            line = 16,
+                            messageRegExp = "Can't map property.*"),
+
+            }
+    )
+    public void testNoQualifyingMethodByNamedForForgedIterableFound() {
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/iterable/Cities.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/iterable/Cities.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.selection.qualifier.iterable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.mapstruct.Qualifier;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Qualifier
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface Cities {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/iterable/IterableAndQualifiersTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/iterable/IterableAndQualifiersTest.java
@@ -15,6 +15,7 @@ import org.junit.runner.RunWith;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+import org.mapstruct.factory.Mappers;
 
 /**
  *
@@ -22,20 +23,22 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
  */
 @IssueKey( "707" )
 @WithClasses( {
+    Cities.class,
     CityDto.class,
     CityEntity.class,
     RiverDto.class,
     RiverEntity.class,
+    Rivers.class,
     TopologyDto.class,
     TopologyEntity.class,
     TopologyFeatureDto.class,
     TopologyFeatureEntity.class,
-    TopologyMapper.class
 } )
 @RunWith( AnnotationProcessorTestRunner.class )
 public class IterableAndQualifiersTest {
 
     @Test
+    @WithClasses(TopologyMapper.class)
     public void testGenerationBasedOnQualifier() {
 
         TopologyDto topologyDto1 = new TopologyDto();
@@ -66,5 +69,40 @@ public class IterableAndQualifiersTest {
         assertThat( result2.getTopologyFeatures().get( 0 ) ).isInstanceOf( CityEntity.class );
         assertThat( ( (CityEntity) result2.getTopologyFeatures().get( 0 ) ).getPopulation() ).isEqualTo( 800000 );
 
+    }
+
+    @Test
+    @WithClasses(TopologyWithoutIterableMappingMapper.class)
+    public void testIterableGeneratorBasedOnQualifier() {
+
+        TopologyWithoutIterableMappingMapper mapper = Mappers.getMapper( TopologyWithoutIterableMappingMapper.class );
+
+        TopologyDto riverTopologyDto = new TopologyDto();
+        List<TopologyFeatureDto> topologyFeatures1 = new ArrayList<>();
+        RiverDto riverDto = new RiverDto();
+        riverDto.setName( "Rhine" );
+        riverDto.setLength( 5 );
+        topologyFeatures1.add( riverDto );
+        riverTopologyDto.setTopologyFeatures( topologyFeatures1 );
+
+        TopologyEntity riverTopology = mapper.mapTopologyAsRiver( riverTopologyDto );
+        assertThat( riverTopology.getTopologyFeatures() ).hasSize( 1 );
+        assertThat( riverTopology.getTopologyFeatures().get( 0 ).getName() ).isEqualTo( "Rhine" );
+        assertThat( riverTopology.getTopologyFeatures().get( 0 ) ).isInstanceOf( RiverEntity.class );
+        assertThat( ( (RiverEntity) riverTopology.getTopologyFeatures().get( 0 ) ).getLength() ).isEqualTo( 5 );
+
+        TopologyDto cityTopologyDto = new TopologyDto();
+        List<TopologyFeatureDto> topologyFeatures2 = new ArrayList<>();
+        CityDto cityDto = new CityDto();
+        cityDto.setName( "Amsterdam" );
+        cityDto.setPopulation( 800000 );
+        topologyFeatures2.add( cityDto );
+        cityTopologyDto.setTopologyFeatures( topologyFeatures2 );
+
+        TopologyEntity cityTopology = mapper.mapTopologyAsCity( cityTopologyDto );
+        assertThat( cityTopology.getTopologyFeatures() ).hasSize( 1 );
+        assertThat( cityTopology.getTopologyFeatures().get( 0 ).getName() ).isEqualTo( "Amsterdam" );
+        assertThat( cityTopology.getTopologyFeatures().get( 0 ) ).isInstanceOf( CityEntity.class );
+        assertThat( ( (CityEntity) cityTopology.getTopologyFeatures().get( 0 ) ).getPopulation() ).isEqualTo( 800000 );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/iterable/Rivers.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/iterable/Rivers.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.selection.qualifier.iterable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.mapstruct.Qualifier;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Qualifier
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface Rivers {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/iterable/TopologyWithoutIterableMappingMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/qualifier/iterable/TopologyWithoutIterableMappingMapper.java
@@ -5,38 +5,23 @@
  */
 package org.mapstruct.ap.test.selection.qualifier.iterable;
 
-import java.util.List;
-
-import org.mapstruct.IterableMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.factory.Mappers;
 
 /**
- *
- * @author Sjaak Derksen
+ * @author Filip Hrisafov
  */
 @Mapper
-public abstract class TopologyMapper {
-
-    public static final TopologyMapper INSTANCE = Mappers.getMapper( TopologyMapper.class );
+public interface TopologyWithoutIterableMappingMapper {
 
     @Mapping( target = "topologyFeatures", qualifiedBy = Rivers.class )
-    public abstract TopologyEntity mapTopologyAsRiver(TopologyDto dto);
+    TopologyEntity mapTopologyAsRiver(TopologyDto dto);
 
     @Mapping( target = "topologyFeatures", qualifiedBy = Cities.class )
-    public abstract TopologyEntity mapTopologyAsCity(TopologyDto dto);
+    TopologyEntity mapTopologyAsCity(TopologyDto dto);
 
     @Rivers
-    @IterableMapping( qualifiedBy = Rivers.class )
-    public abstract List<TopologyFeatureEntity> mapTopologiesAsRiver(List<TopologyFeatureDto> in);
-
-    @Cities
-    @IterableMapping( qualifiedBy = Cities.class )
-    public abstract List<TopologyFeatureEntity> mapTopologiesAsCities(List<TopologyFeatureDto> in);
-
-    @Rivers
-    protected TopologyFeatureEntity mapRiver( TopologyFeatureDto dto ) {
+    default TopologyFeatureEntity mapRiver( TopologyFeatureDto dto ) {
         TopologyFeatureEntity topologyFeatureEntity = null;
         if ( dto instanceof RiverDto ) {
             RiverEntity riverEntity = new RiverEntity();
@@ -48,7 +33,7 @@ public abstract class TopologyMapper {
     }
 
     @Cities
-    protected TopologyFeatureEntity mapCity( TopologyFeatureDto dto ) {
+    default TopologyFeatureEntity mapCity( TopologyFeatureDto dto ) {
         TopologyFeatureEntity topologyFeatureEntity = null;
         if ( dto instanceof CityDto ) {
             CityEntity cityEntity = new CityEntity();


### PR DESCRIPTION

With this change we are relaxing the error handling when qualifiers are used in `@Mapping`
and we allow defining qualifiers for collections / array mapping to mean the same as if it was defined on `@IterableMapping`
i.e. apply the qualifier on the element mapping

Fixes #2250
Fixes #2324