### PR TITLE
Small fixes for Java 16

### DIFF
--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -65,7 +65,6 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.6</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrationtest/src/test/resources/lombokBuilderTest/pom.xml
+++ b/integrationtest/src/test/resources/lombokBuilderTest/pom.xml
@@ -25,5 +25,11 @@
             <artifactId>lombok</artifactId>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok-mapstruct-binding</artifactId>
+            <version>0.2.0</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -25,7 +25,7 @@
         <org.apache.maven.plugins.enforcer.version>3.0.0-M3</org.apache.maven.plugins.enforcer.version>
         <org.apache.maven.plugins.surefire.version>3.0.0-M5</org.apache.maven.plugins.surefire.version>
         <org.apache.maven.plugins.javadoc.version>3.1.0</org.apache.maven.plugins.javadoc.version>
-        <org.springframework.version>4.0.3.RELEASE</org.springframework.version>
+        <org.springframework.version>5.3.3</org.springframework.version>
         <org.eclipse.tycho.compiler-jdt.version>1.6.0</org.eclipse.tycho.compiler-jdt.version>
         <com.puppycrawl.tools.checkstyle.version>8.36.1</com.puppycrawl.tools.checkstyle.version>
         <org.junit.jupiter.version>5.7.0</org.junit.jupiter.version>
@@ -202,7 +202,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.10</version>
+                <version>1.18.16</version>
             </dependency>
             <dependency>
                 <groupId>org.immutables</groupId>
@@ -261,7 +261,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.5</version>
+                <version>2.6</version>
             </dependency>
 
             <!-- Project modules -->
@@ -553,7 +553,7 @@
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.13.1</version>
+                    <version>0.15.2</version>
                     <executions>
                         <execution>
                             <phase>verify</phase>

--- a/processor/src/test/java/org/mapstruct/ap/test/exceptions/ExceptionTestMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/exceptions/ExceptionTestMapper.java
@@ -20,6 +20,6 @@ public class ExceptionTestMapper  {
         else if ( size == 2 ) {
             throw new TestException2();
         }
-        return new Long(size);
+        return Long.valueOf( size );
     }
 }


### PR DESCRIPTION
* Upgrade japicmp-maven-plugin to 0.15.2
* Do not use deprecated for removal Long constructor
* Update Spring to 5.3.3
* Upgrade Lombok to 1.18.16