### PR TITLE
Issue 1617: Add empty constructor with @inject annotation to mapper on  jsr330 componentmodel

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -25,7 +25,7 @@
         <org.apache.maven.plugins.enforcer.version>3.0.0-M3</org.apache.maven.plugins.enforcer.version>
         <org.apache.maven.plugins.surefire.version>3.0.0-M5</org.apache.maven.plugins.surefire.version>
         <org.apache.maven.plugins.javadoc.version>3.1.0</org.apache.maven.plugins.javadoc.version>
-        <org.springframework.version>4.0.3.RELEASE</org.springframework.version>
+        <org.springframework.version>4.3.5.RELEASE</org.springframework.version>
         <org.eclipse.tycho.compiler-jdt.version>1.6.0</org.eclipse.tycho.compiler-jdt.version>
         <com.puppycrawl.tools.checkstyle.version>8.36.1</com.puppycrawl.tools.checkstyle.version>
         <org.junit.jupiter.version>5.7.0</org.junit.jupiter.version>

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/AnnotationBasedComponentModelProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/AnnotationBasedComponentModelProcessor.java
@@ -111,10 +111,12 @@ public abstract class AnnotationBasedComponentModelProcessor implements ModelEle
     }
 
     private void buildConstructors(Mapper mapper) {
-        if ( !toMapperReferences( mapper.getFields() ).isEmpty() ) {
+        final boolean allowEmptyConstructor = allowEmptyConstructor();
+
+        if ( allowEmptyConstructor || !toMapperReferences( mapper.getFields() ).isEmpty() ) {
             AnnotatedConstructor annotatedConstructor = buildAnnotatedConstructorForMapper( mapper );
 
-            if ( !annotatedConstructor.getMapperReferences().isEmpty() ) {
+            if ( allowEmptyConstructor || !annotatedConstructor.getMapperReferences().isEmpty() ) {
                 mapper.setConstructor( annotatedConstructor );
             }
         }
@@ -123,7 +125,7 @@ public abstract class AnnotationBasedComponentModelProcessor implements ModelEle
 
         if ( decorator != null ) {
             AnnotatedConstructor decoratorConstructor = buildAnnotatedConstructorForDecorator( decorator );
-            if ( !decoratorConstructor.getMapperReferences().isEmpty() ) {
+            if ( allowEmptyConstructor || !decoratorConstructor.getMapperReferences().isEmpty() ) {
                 decorator.setConstructor( decoratorConstructor );
             }
         }
@@ -265,6 +267,13 @@ public abstract class AnnotationBasedComponentModelProcessor implements ModelEle
      * @return if a decorator (sub-)class needs to be generated or not
      */
     protected abstract boolean requiresGenerationOfDecoratorClass();
+
+    /**
+     * @return if empty constructor needs to be generated or not
+     */
+    protected boolean allowEmptyConstructor() {
+        return false;
+    }
 
     @Override
     public int getPriority() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/Jsr330ComponentProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/Jsr330ComponentProcessor.java
@@ -57,6 +57,11 @@ public class Jsr330ComponentProcessor extends AnnotationBasedComponentModelProce
         return true;
     }
 
+    @Override
+    protected boolean allowEmptyConstructor() {
+        return true;
+    }
+
     private Annotation singleton() {
         return new Annotation( getTypeFactory().getType( "javax.inject.Singleton" ) );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/constructor/Jsr330ConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/constructor/Jsr330ConstructorMapperTest.java
@@ -91,4 +91,12 @@ public class Jsr330ConstructorMapperTest {
             .contains( "@Inject" + lineSeparator() +
                 "    public CustomerJsr330ConstructorMapperImpl(GenderJsr330ConstructorMapper" );
     }
+
+    @Test
+    public void shouldHaveEmptyConstructorInjection() {
+        generatedSource.forMapper( GenderJsr330ConstructorMapper.class )
+            .content()
+            .contains( "@Inject" + lineSeparator() +
+                "    public GenderJsr330ConstructorMapperImpl() {" );
+    }
 }


### PR DESCRIPTION
Fixes #1617 

I had to upgrade spring to 4.3.5 to tolerate empty constructors (see https://github.com/spring-projects/spring-framework/issues/19572)