### PR TITLE
#2352 Add source element type for Iterable mappings

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -9,6 +9,7 @@ import static org.mapstruct.ap.internal.util.Collections.first;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 import org.mapstruct.ap.internal.model.assignment.LocalVarWrapper;
 import org.mapstruct.ap.internal.model.assignment.SetterWrapper;
@@ -84,6 +85,14 @@ public class IterableMappingMethod extends ContainerMappingMethod {
             afterMappingReferences,
             selectionParameters
         );
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        Set<Type> types = super.getImportTypes();
+
+        types.add( getSourceElementType() );
+        return types;
     }
 
     public Type getSourceElementType() {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/Issue2352Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/Issue2352Test.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2352;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.bugs._2352.dto.TheDto;
+import org.mapstruct.ap.test.bugs._2352.dto.TheModel;
+import org.mapstruct.ap.test.bugs._2352.dto.TheModels;
+import org.mapstruct.ap.test.bugs._2352.mapper.TheModelMapper;
+import org.mapstruct.ap.test.bugs._2352.mapper.TheModelsMapper;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2352")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    TheDto.class,
+    TheModel.class,
+    TheModels.class,
+    TheModelMapper.class,
+    TheModelsMapper.class,
+})
+public class Issue2352Test {
+
+    @Test
+    public void shouldGenerateValidCode() {
+        TheModels theModels = new TheModels();
+        theModels.add( new TheModel( "1" ) );
+        theModels.add( new TheModel( "2" ) );
+
+        List<TheDto> theDtos = TheModelsMapper.INSTANCE.convert( theModels );
+
+        assertThat( theDtos )
+            .extracting( TheDto::getId )
+            .containsExactly( "1", "2" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/dto/TheDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/dto/TheDto.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2352.dto;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class TheDto {
+
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/dto/TheModel.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/dto/TheModel.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2352.dto;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class TheModel {
+
+    private final String id;
+
+    public TheModel(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/dto/TheModels.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/dto/TheModels.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2352.dto;
+
+import java.util.ArrayList;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class TheModels extends ArrayList<TheModel> {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/mapper/TheModelMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/mapper/TheModelMapper.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2352.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.bugs._2352.dto.TheDto;
+import org.mapstruct.ap.test.bugs._2352.dto.TheModel;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface TheModelMapper {
+
+    TheDto convert(TheModel theModel);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/mapper/TheModelsMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2352/mapper/TheModelsMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2352.mapper;
+
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.bugs._2352.dto.TheDto;
+import org.mapstruct.ap.test.bugs._2352.dto.TheModels;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(uses = TheModelMapper.class)
+public interface TheModelsMapper {
+
+    TheModelsMapper INSTANCE = Mappers.getMapper( TheModelsMapper.class );
+
+    List<TheDto> convert(TheModels theModels);
+}


### PR DESCRIPTION
When the Iterable type we are mapping is not generic
(i.e. it is a custom type extending an Iterable) then the source element type
which is included in the loop was not imported.

Fixes #2352