### PR TITLE
#2339 Enum mapping option for runtime exception

### DIFF
--- a/core/src/main/java/org/mapstruct/MappingConstants.java
+++ b/core/src/main/java/org/mapstruct/MappingConstants.java
@@ -37,6 +37,14 @@ public final class MappingConstants {
     public static final String ANY_UNMAPPED = "<ANY_UNMAPPED>";
 
     /**
+     * In an {@link ValueMapping} this represents any target that will be mapped to an
+     * {@link java.lang.IllegalArgumentException} which will be thrown at runtime.
+     * <p>
+     * NOTE: The value is only applicable to {@link ValueMapping#target()} and not to {@link ValueMapping#source()}.
+     */
+    public static final String THROW_EXCEPTION = "<THROW_EXCEPTION>";
+
+    /**
      * In an {@link EnumMapping} this represent the enum transformation strategy that adds a suffix to the source enum.
      *
      * @since 1.4

--- a/core/src/main/java/org/mapstruct/ValueMapping.java
+++ b/core/src/main/java/org/mapstruct/ValueMapping.java
@@ -23,7 +23,8 @@ import java.lang.annotation.Target;
  *
  * <pre>
  * <code>
- * public enum OrderType { RETAIL, B2B, EXTRA, STANDARD, NORMAL }
+ *
+ * public enum OrderType { RETAIL, B2B, C2C, EXTRA, STANDARD, NORMAL }
  *
  * public enum ExternalOrderType { RETAIL, B2B, SPECIAL, DEFAULT }
  *
@@ -45,13 +46,12 @@ import java.lang.annotation.Target;
  * +---------------------+----------------------------+
  * </pre>
  *
- * MapStruct will <B>WARN</B> on incomplete mappings. However, if for some reason no match is found an
- * {@link java.lang.IllegalStateException} will be thrown.
  * <p>
  * <B>Example 2:</B>
  *
  * <pre>
  * <code>
+ *
  * &#64;ValueMapping( source = MappingConstants.NULL, target = "DEFAULT" ),
  * &#64;ValueMapping( source = "STANDARD", target = MappingConstants.NULL ),
  * &#64;ValueMapping( source = MappingConstants.ANY_REMAINING, target = "SPECIAL" )
@@ -68,6 +68,26 @@ import java.lang.annotation.Target;
  * | OrderType.NORMAL    | ExternalOrderType.SPECIAL  |
  * | OrderType.EXTRA     | ExternalOrderType.SPECIAL  |
  * +---------------------+----------------------------+
+ * </pre>
+ *
+ * <p>
+ * <B>Example 3:</B>
+ * </p>
+ *
+ * <p></p>MapStruct will <B>WARN</B> on incomplete mappings. However, if for some reason no match is found, an
+ * {@link java.lang.IllegalStateException} will be thrown. This compile-time error can be avoided by
+ * using {@link MappingConstants#THROW_EXCEPTION} for {@link ValueMapping#target()}. It will result an
+ * {@link java.lang.IllegalArgumentException} at runtime.
+ * <pre>
+ * <code>
+ *
+ * &#64;ValueMapping( source = "STANDARD", target = "DEFAULT" ),
+ * &#64;ValueMapping( source = "C2C", target = MappingConstants.THROW_EXCEPTION )
+ * ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
+ * </code>
+ * Mapping result:
+ * {@link java.lang.IllegalArgumentException} with the error message:
+ * Unexpected enum constant: C2C
  * </pre>
  *
  * @author Sjaak Derksen
@@ -104,6 +124,7 @@ public @interface ValueMapping {
      * <ol>
      * <li>enum constant name</li>
      * <li>{@link MappingConstants#NULL}</li>
+     * <li>{@link MappingConstants#THROW_EXCEPTION}</li>
      * </ol>
      *
      * @return The target value.

--- a/processor/src/main/java/org/mapstruct/ap/internal/gem/MappingConstantsGem.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/gem/MappingConstantsGem.java
@@ -21,6 +21,8 @@ public final class MappingConstantsGem {
 
     public static final String ANY_UNMAPPED = "<ANY_UNMAPPED>";
 
+    public static final String THROW_EXCEPTION = "<THROW_EXCEPTION>";
+
     public static final String SUFFIX_TRANSFORMATION = "suffix";
 
     public static final String STRIP_SUFFIX_TRANSFORMATION = "stripSuffix";

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
-import org.mapstruct.ap.internal.util.TypeUtils;
 
 import org.mapstruct.ap.internal.gem.BeanMappingGem;
 import org.mapstruct.ap.internal.model.common.Parameter;
@@ -25,11 +24,13 @@ import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.ValueMappingOptions;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.Strings;
+import org.mapstruct.ap.internal.util.TypeUtils;
 import org.mapstruct.ap.spi.EnumTransformationStrategy;
 
 import static org.mapstruct.ap.internal.gem.MappingConstantsGem.ANY_REMAINING;
 import static org.mapstruct.ap.internal.gem.MappingConstantsGem.ANY_UNMAPPED;
 import static org.mapstruct.ap.internal.gem.MappingConstantsGem.NULL;
+import static org.mapstruct.ap.internal.gem.MappingConstantsGem.THROW_EXCEPTION;
 import static org.mapstruct.ap.internal.util.Collections.first;
 
 /**
@@ -313,7 +314,17 @@ public class ValueMappingMethod extends MappingMethod {
 
             for ( ValueMappingOptions mappedConstant : valueMappings.regularValueMappings ) {
 
-                if ( !sourceEnumConstants.contains( mappedConstant.getSource() ) ) {
+                if ( THROW_EXCEPTION.equals( mappedConstant.getSource() ) ) {
+                    ctx.getMessager().printMessage(
+                        method.getExecutable(),
+                        mappedConstant.getMirror(),
+                        mappedConstant.getSourceAnnotationValue(),
+                        Message.VALUEMAPPING_THROW_EXCEPTION_SOURCE
+                    );
+                    foundIncorrectMapping = true;
+                }
+                else if ( !sourceEnumConstants.contains( mappedConstant.getSource() ) ) {
+
                     ctx.getMessager().printMessage(
                         method.getExecutable(),
                         mappedConstant.getMirror(),
@@ -361,6 +372,7 @@ public class ValueMappingMethod extends MappingMethod {
 
             for ( ValueMappingOptions mappedConstant : valueMappings.regularValueMappings ) {
                 if ( !NULL.equals( mappedConstant.getTarget() )
+                    && !THROW_EXCEPTION.equals( mappedConstant.getTarget() )
                     && !targetEnumConstants.contains( mappedConstant.getTarget() ) ) {
                     ctx.getMessager().printMessage(
                         method.getExecutable(),

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
@@ -386,7 +386,9 @@ public class ValueMappingMethod extends MappingMethod {
                 }
             }
 
-            if ( valueMappings.defaultTarget != null && !NULL.equals( valueMappings.defaultTarget.getTarget() )
+            if ( valueMappings.defaultTarget != null
+                && !THROW_EXCEPTION.equals( valueMappings.defaultTarget.getTarget() )
+                && !NULL.equals( valueMappings.defaultTarget.getTarget() )
                 && !targetEnumConstants.contains( valueMappings.defaultTarget.getTarget() ) ) {
                 ctx.getMessager().printMessage(
                     method.getExecutable(),
@@ -427,7 +429,8 @@ public class ValueMappingMethod extends MappingMethod {
         }
 
         private Type determineUnexpectedValueMappingException() {
-            if ( !valueMappings.hasDefaultValue ) {
+            boolean noDefaultValueForSwitchCase = !valueMappings.hasDefaultValue;
+            if ( noDefaultValueForSwitchCase || valueMappings.defaultTargetValue.equals( THROW_EXCEPTION ) ) {
                 TypeMirror unexpectedValueMappingException = enumMapping.getUnexpectedValueMappingException();
                 if ( unexpectedValueMappingException != null ) {
                     return ctx.getTypeFactory().getType( unexpectedValueMappingException );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/ValueMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/ValueMappingOptions.java
@@ -18,6 +18,7 @@ import org.mapstruct.ap.internal.util.Message;
 
 import static org.mapstruct.ap.internal.gem.MappingConstantsGem.ANY_REMAINING;
 import static org.mapstruct.ap.internal.gem.MappingConstantsGem.ANY_UNMAPPED;
+import static org.mapstruct.ap.internal.gem.MappingConstantsGem.THROW_EXCEPTION;
 
 /**
  * Represents the mapping between one value constant and another.
@@ -112,7 +113,7 @@ public class ValueMappingOptions {
 
     public ValueMappingOptions inverse() {
         ValueMappingOptions result;
-        if ( !(ANY_REMAINING.equals( source ) || ANY_UNMAPPED.equals( source ) ) ) {
+        if ( !(ANY_REMAINING.equals( source ) || ANY_UNMAPPED.equals( source ) || THROW_EXCEPTION.equals( target ) ) ) {
             result = new ValueMappingOptions(
                 target,
                 source,

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -176,8 +176,7 @@ public enum Message {
     VALUEMAPPING_ANY_REMAINING_OR_UNMAPPED_MISSING( "Source = \"<ANY_REMAINING>\" or \"<ANY_UNMAPPED>\" is advisable for mapping of type String to an enum type.", Diagnostic.Kind.WARNING  ),
     VALUEMAPPING_NON_EXISTING_CONSTANT_FROM_SPI( "Constant %s doesn't exist in enum type %s. Constant was returned from EnumMappingStrategy: %s"),
     VALUEMAPPING_NON_EXISTING_CONSTANT( "Constant %s doesn't exist in enum type %s." ),
-    VALUEMAPPING_THROW_EXCEPTION_SOURCE(
-        "Source = \"<THROW_EXCEPTION>\" is not allowed. Target = \"<THROW_EXCEPTION>\" can only be used." );
+    VALUEMAPPING_THROW_EXCEPTION_SOURCE( "Source = \"<THROW_EXCEPTION>\" is not allowed. Target = \"<THROW_EXCEPTION>\" can only be used." );
     // CHECKSTYLE:ON
 
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -175,7 +175,9 @@ public enum Message {
     VALUEMAPPING_ANY_REMAINING_FOR_NON_ENUM( "Source = \"<ANY_REMAINING>\" can only be used on targets of type enum and not for %s." ),
     VALUEMAPPING_ANY_REMAINING_OR_UNMAPPED_MISSING( "Source = \"<ANY_REMAINING>\" or \"<ANY_UNMAPPED>\" is advisable for mapping of type String to an enum type.", Diagnostic.Kind.WARNING  ),
     VALUEMAPPING_NON_EXISTING_CONSTANT_FROM_SPI( "Constant %s doesn't exist in enum type %s. Constant was returned from EnumMappingStrategy: %s"),
-    VALUEMAPPING_NON_EXISTING_CONSTANT( "Constant %s doesn't exist in enum type %s." );
+    VALUEMAPPING_NON_EXISTING_CONSTANT( "Constant %s doesn't exist in enum type %s." ),
+    VALUEMAPPING_THROW_EXCEPTION_SOURCE(
+        "Source = \"<THROW_EXCEPTION>\" is not allowed. Target = \"<THROW_EXCEPTION>\" can only be used." );
     // CHECKSTYLE:ON
 
 

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
@@ -22,10 +22,10 @@
 
     switch ( ${sourceParameter.name} ) {
     <#list valueMappings as valueMapping>
-        case <@writeSource source=valueMapping.source/>: <#if unexpectedValueMappingException?? && valueMapping.target?? && valueMapping.target="<THROW_EXCEPTION>">throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} );<#else>${resultName} = <@writeTarget target=valueMapping.target/>;
+        case <@writeSource source=valueMapping.source/>: <#if valueMapping.targetAsException >throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} );<#else>${resultName} = <@writeTarget target=valueMapping.target/>;
         break;</#if>
     </#list>
-    default: <#if unexpectedValueMappingException?? || (unexpectedValueMappingException?? && defaultTarget?? && defaultTarget="<THROW_EXCEPTION>")>throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} )<#else>${resultName} = <@writeTarget target=defaultTarget/></#if>;
+    default: <#if defaultAsException >throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} )<#else>${resultName} = <@writeTarget target=defaultTarget/></#if>;
     }
     <#list beforeMappingReferencesWithMappingTarget as callback>
         <#if callback_index = 0>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
@@ -22,8 +22,8 @@
 
     switch ( ${sourceParameter.name} ) {
     <#list valueMappings as valueMapping>
-        case <@writeSource source=valueMapping.source/>: ${resultName} = <@writeTarget target=valueMapping.target/>;
-        break;
+        case <@writeSource source=valueMapping.source/>: <#if unexpectedValueMappingException?? && valueMapping.target?? && valueMapping.target="<THROW_EXCEPTION>">throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} );<#else>${resultName} = <@writeTarget target=valueMapping.target/>;
+        break;</#if>
     </#list>
     default: <#if unexpectedValueMappingException??>throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} )<#else>${resultName} = <@writeTarget target=defaultTarget/></#if>;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
@@ -15,7 +15,7 @@
         </#if>
     </#list>
     if ( ${sourceParameter.name} == null ) {
-        return <@writeTarget target=nullTarget/>;
+        <#if nullAsException >throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} );<#else>return <@writeTarget target=nullTarget/>;</#if>
     }
 
     <@includeModel object=resultType/> ${resultName};

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
@@ -25,7 +25,7 @@
         case <@writeSource source=valueMapping.source/>: <#if unexpectedValueMappingException?? && valueMapping.target?? && valueMapping.target="<THROW_EXCEPTION>">throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} );<#else>${resultName} = <@writeTarget target=valueMapping.target/>;
         break;</#if>
     </#list>
-    default: <#if unexpectedValueMappingException??>throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} )<#else>${resultName} = <@writeTarget target=defaultTarget/></#if>;
+    default: <#if unexpectedValueMappingException?? || (unexpectedValueMappingException?? && defaultTarget?? && defaultTarget="<THROW_EXCEPTION>")>throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} )<#else>${resultName} = <@writeTarget target=defaultTarget/></#if>;
     }
     <#list beforeMappingReferencesWithMappingTarget as callback>
         <#if callback_index = 0>

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/DefaultOrderThrowExceptionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/DefaultOrderThrowExceptionMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.ap.test.value.enum2enum;
 
 import org.mapstruct.Mapper;

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/DefaultOrderThrowExceptionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/DefaultOrderThrowExceptionMapper.java
@@ -12,7 +12,7 @@ import org.mapstruct.factory.Mappers;
 public interface DefaultOrderThrowExceptionMapper {
     DefaultOrderThrowExceptionMapper INSTANCE = Mappers.getMapper( DefaultOrderThrowExceptionMapper.class );
 
-    @Named("orderTypeToExternalOrderTypeWithException")
+    @Named("orderTypeToExternalOrderTypeAnyUnmappedToException")
     @ValueMapping(source = MappingConstants.ANY_UNMAPPED, target = MappingConstants.THROW_EXCEPTION)
-    ExternalOrderType orderTypeToExternalOrderTypeWithException(OrderType orderType);
+    ExternalOrderType orderTypeToExternalOrderTypeAnyUnmappedToException(OrderType orderType);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/DefaultOrderThrowExceptionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/DefaultOrderThrowExceptionMapper.java
@@ -1,0 +1,18 @@
+package org.mapstruct.ap.test.value.enum2enum;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.Named;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ap.test.value.ExternalOrderType;
+import org.mapstruct.ap.test.value.OrderType;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface DefaultOrderThrowExceptionMapper {
+    DefaultOrderThrowExceptionMapper INSTANCE = Mappers.getMapper( DefaultOrderThrowExceptionMapper.class );
+
+    @Named("orderTypeToExternalOrderTypeWithException")
+    @ValueMapping(source = MappingConstants.ANY_UNMAPPED, target = MappingConstants.THROW_EXCEPTION)
+    ExternalOrderType orderTypeToExternalOrderTypeWithException(OrderType orderType);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/DefaultOrderThrowExceptionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/DefaultOrderThrowExceptionMapper.java
@@ -13,6 +13,9 @@ import org.mapstruct.ap.test.value.ExternalOrderType;
 import org.mapstruct.ap.test.value.OrderType;
 import org.mapstruct.factory.Mappers;
 
+/**
+ * @author Jude Niroshan
+ */
 @Mapper
 public interface DefaultOrderThrowExceptionMapper {
     DefaultOrderThrowExceptionMapper INSTANCE = Mappers.getMapper( DefaultOrderThrowExceptionMapper.class );

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumMappingTest.java
@@ -5,8 +5,6 @@
  */
 package org.mapstruct.ap.test.value.enum2enum;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import javax.tools.Diagnostic.Kind;
 
 import org.junit.Rule;
@@ -22,14 +20,19 @@ import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutco
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 /**
  * Test for the generation and invocation of enum mapping methods.
  *
  * @author Gunnar Morling, Sjaak Derksen
  */
 @IssueKey("128")
-@WithClasses({  OrderMapper.class, SpecialOrderMapper.class, DefaultOrderMapper.class, OrderEntity.class,
-    OrderType.class, OrderDto.class, ExternalOrderType.class })
+@WithClasses({
+    OrderMapper.class, SpecialOrderMapper.class, DefaultOrderMapper.class, OrderEntity.class,
+    OrderType.class, OrderDto.class, ExternalOrderType.class
+})
 @RunWith(AnnotationProcessorTestRunner.class)
 public class EnumToEnumMappingTest {
 
@@ -74,16 +77,16 @@ public class EnumToEnumMappingTest {
     @Test
     public void shouldApplyReverseMappings() {
 
-        OrderType result =  OrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.SPECIAL );
+        OrderType result = OrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.SPECIAL );
         assertThat( result ).isEqualTo( OrderType.EXTRA );
 
-        result =  OrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.DEFAULT );
+        result = OrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.DEFAULT );
         assertThat( result ).isEqualTo( OrderType.STANDARD );
 
-        result =  OrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.RETAIL );
+        result = OrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.RETAIL );
         assertThat( result ).isEqualTo( OrderType.RETAIL );
 
-        result =  OrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.B2B );
+        result = OrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.B2B );
         assertThat( result ).isEqualTo( OrderType.B2B );
 
     }
@@ -141,16 +144,16 @@ public class EnumToEnumMappingTest {
     @Test
     public void shouldApplyDefaultReverseMappings() {
 
-        OrderType result =  SpecialOrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.SPECIAL );
+        OrderType result = SpecialOrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.SPECIAL );
         assertThat( result ).isEqualTo( OrderType.EXTRA );
 
-        result =  SpecialOrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.DEFAULT );
+        result = SpecialOrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.DEFAULT );
         assertThat( result ).isNull();
 
-        result =  SpecialOrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.RETAIL );
+        result = SpecialOrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.RETAIL );
         assertThat( result ).isEqualTo( OrderType.RETAIL );
 
-        result =  SpecialOrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.B2B );
+        result = SpecialOrderMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.B2B );
         assertThat( result ).isEqualTo( OrderType.B2B );
 
     }
@@ -186,7 +189,7 @@ public class EnumToEnumMappingTest {
 
     }
 
-    @IssueKey( "1091" )
+    @IssueKey("1091")
     @Test
     public void shouldMapAnyRemainingToNullCorrectly() {
         ExternalOrderType externalOrderType = SpecialOrderMapper.INSTANCE.anyRemainingToNull( OrderType.RETAIL );
@@ -207,6 +210,32 @@ public class EnumToEnumMappingTest {
 
         externalOrderType = SpecialOrderMapper.INSTANCE.anyRemainingToNull( OrderType.NORMAL );
         assertThat( externalOrderType ).isNull();
+    }
+
+    @IssueKey("2339")
+    @Test
+    public void shouldThrowExceptionWhenRequestingEnumsWithExpectedExceptions() {
+
+        assertThatThrownBy( () ->
+            SpecialOrderMapper.INSTANCE.orderTypeToExternalOrderTypeWithException( OrderType.EXTRA ) )
+            .isInstanceOf( IllegalArgumentException.class )
+            .hasMessage( "Unexpected enum constant: EXTRA" );
+    }
+
+    @IssueKey("2339")
+    @Test
+    @WithClasses(ErroneousOrderMapperThrowExceptionAsSourceType.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousOrderMapperThrowExceptionAsSourceType.class,
+                kind = Kind.ERROR,
+                line = 29,
+                message = "Source = \"<THROW_EXCEPTION>\" is not allowed. " +
+                    "Target = \"<THROW_EXCEPTION>\" can only be used.")
+        }
+    )
+    public void shouldRaiseErrorWhenThrowExceptionUsedAsSourceType() {
     }
 
     @Test
@@ -265,7 +294,7 @@ public class EnumToEnumMappingTest {
             @Diagnostic(type = ErroneousOrderMapperDuplicateANY.class,
                 kind = Kind.ERROR,
                 line = 28,
-                message = "Source = \"<ANY_REMAINING>\" or \"<ANY_UNMAPPED>\" can only be used once." )
+                message = "Source = \"<ANY_REMAINING>\" or \"<ANY_UNMAPPED>\" can only be used once.")
         }
     )
     public void shouldRaiseErrorIfMappingsContainDuplicateANY() {

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumMappingTest.java
@@ -21,7 +21,6 @@ import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 /**
  * Test for the generation and invocation of enum mapping methods.
@@ -210,32 +209,6 @@ public class EnumToEnumMappingTest {
 
         externalOrderType = SpecialOrderMapper.INSTANCE.anyRemainingToNull( OrderType.NORMAL );
         assertThat( externalOrderType ).isNull();
-    }
-
-    @IssueKey("2339")
-    @Test
-    public void shouldThrowExceptionWhenRequestingEnumsWithExpectedExceptions() {
-
-        assertThatThrownBy( () ->
-            SpecialOrderMapper.INSTANCE.orderTypeToExternalOrderTypeWithException( OrderType.EXTRA ) )
-            .isInstanceOf( IllegalArgumentException.class )
-            .hasMessage( "Unexpected enum constant: EXTRA" );
-    }
-
-    @IssueKey("2339")
-    @Test
-    @WithClasses(ErroneousOrderMapperThrowExceptionAsSourceType.class)
-    @ExpectedCompilationOutcome(
-        value = CompilationResult.FAILED,
-        diagnostics = {
-            @Diagnostic(type = ErroneousOrderMapperThrowExceptionAsSourceType.class,
-                kind = Kind.ERROR,
-                line = 29,
-                message = "Source = \"<THROW_EXCEPTION>\" is not allowed. " +
-                    "Target = \"<THROW_EXCEPTION>\" can only be used.")
-        }
-    )
-    public void shouldRaiseErrorWhenThrowExceptionUsedAsSourceType() {
     }
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumThrowExceptionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumThrowExceptionMappingTest.java
@@ -15,7 +15,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @IssueKey("2339")
 @WithClasses({
-    DefaultOrderThrowExceptionMapper.class, OrderEntity.class,
+    OrderEntity.class,
     OrderType.class, ExternalOrderType.class
 })
 @RunWith(AnnotationProcessorTestRunner.class)
@@ -23,17 +23,18 @@ public class EnumToEnumThrowExceptionMappingTest {
 
     @IssueKey("2339")
     @Test
-    public void shouldThrowExceptionWhenRequestingEnumsWithExpectedExceptions() {
+    @WithClasses(DefaultOrderThrowExceptionMapper.class)
+    public void shouldThrowExceptionWhenRequestingAnyEnumWithExpectedExceptions() {
 
         assertThatThrownBy( () ->
-            DefaultOrderThrowExceptionMapper.INSTANCE.orderTypeToExternalOrderTypeWithException( OrderType.EXTRA ) )
+            DefaultOrderThrowExceptionMapper.INSTANCE.orderTypeToExternalOrderTypeAnyUnmappedToException( OrderType.EXTRA ) )
             .isInstanceOf( IllegalArgumentException.class )
             .hasMessage( "Unexpected enum constant: EXTRA" );
     }
 
     @IssueKey("2339")
     @Test
-    @WithClasses(ErroneousOrderMapperThrowExceptionAsSourceType.class)
+    @WithClasses({ DefaultOrderThrowExceptionMapper.class, ErroneousOrderMapperThrowExceptionAsSourceType.class })
     @ExpectedCompilationOutcome(
         value = CompilationResult.FAILED,
         diagnostics = {

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumThrowExceptionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumThrowExceptionMappingTest.java
@@ -16,8 +16,12 @@ import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+/**
+ * @author Jude Niroshan
+ */
 @IssueKey("2339")
 @WithClasses({
     OrderEntity.class,
@@ -29,7 +33,7 @@ public class EnumToEnumThrowExceptionMappingTest {
     @IssueKey("2339")
     @Test
     @WithClasses(DefaultOrderThrowExceptionMapper.class)
-    public void shouldThrowExceptionWhenRequestingAnyEnumWithExpectedExceptions() {
+    public void shouldBeAbleToMapAnyUnmappedToThrowException() {
 
         assertThatThrownBy( () ->
             DefaultOrderThrowExceptionMapper.INSTANCE
@@ -52,5 +56,38 @@ public class EnumToEnumThrowExceptionMappingTest {
         }
     )
     public void shouldRaiseErrorWhenThrowExceptionUsedAsSourceType() {
+    }
+
+    @IssueKey("2339")
+    @Test
+    @WithClasses({OrderThrowExceptionMapper.class, OrderDto.class})
+    public void shouldIgnoreThrowExceptionWhenInverseValueMappings() {
+
+        OrderType target = OrderThrowExceptionMapper.INSTANCE.externalOrderTypeToOrderType( ExternalOrderType.B2B );
+        assertThat( target ).isEqualTo( OrderType.B2B );
+    }
+
+    @IssueKey("2339")
+    @Test
+    @WithClasses({SpecialThrowExceptionMapper.class, OrderDto.class})
+    public void shouldBeAbleToMapAnyRemainingToThrowException() {
+
+        assertThatThrownBy( () ->
+            SpecialThrowExceptionMapper.INSTANCE
+                .orderTypeToExternalOrderType( OrderType.EXTRA ) )
+            .isInstanceOf( IllegalArgumentException.class )
+            .hasMessage( "Unexpected enum constant: EXTRA" );
+    }
+
+    @IssueKey("2339")
+    @Test
+    @WithClasses({SpecialThrowExceptionMapper.class, OrderDto.class})
+    public void shouldBeAbleToMapNullToThrowException() {
+
+        assertThatThrownBy( () ->
+            SpecialThrowExceptionMapper.INSTANCE
+                .anyRemainingToNullToException( null ) )
+            .isInstanceOf( IllegalArgumentException.class )
+            .hasMessage( "Unexpected enum constant: null" );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumThrowExceptionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumThrowExceptionMappingTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.ap.test.value.enum2enum;
 
 import org.junit.Test;
@@ -27,7 +32,8 @@ public class EnumToEnumThrowExceptionMappingTest {
     public void shouldThrowExceptionWhenRequestingAnyEnumWithExpectedExceptions() {
 
         assertThatThrownBy( () ->
-            DefaultOrderThrowExceptionMapper.INSTANCE.orderTypeToExternalOrderTypeAnyUnmappedToException( OrderType.EXTRA ) )
+            DefaultOrderThrowExceptionMapper.INSTANCE
+                .orderTypeToExternalOrderTypeAnyUnmappedToException( OrderType.EXTRA ) )
             .isInstanceOf( IllegalArgumentException.class )
             .hasMessage( "Unexpected enum constant: EXTRA" );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumThrowExceptionMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/EnumToEnumThrowExceptionMappingTest.java
@@ -1,0 +1,49 @@
+package org.mapstruct.ap.test.value.enum2enum;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.test.value.ExternalOrderType;
+import org.mapstruct.ap.test.value.OrderType;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@IssueKey("2339")
+@WithClasses({
+    DefaultOrderThrowExceptionMapper.class, OrderEntity.class,
+    OrderType.class, ExternalOrderType.class
+})
+@RunWith(AnnotationProcessorTestRunner.class)
+public class EnumToEnumThrowExceptionMappingTest {
+
+    @IssueKey("2339")
+    @Test
+    public void shouldThrowExceptionWhenRequestingEnumsWithExpectedExceptions() {
+
+        assertThatThrownBy( () ->
+            DefaultOrderThrowExceptionMapper.INSTANCE.orderTypeToExternalOrderTypeWithException( OrderType.EXTRA ) )
+            .isInstanceOf( IllegalArgumentException.class )
+            .hasMessage( "Unexpected enum constant: EXTRA" );
+    }
+
+    @IssueKey("2339")
+    @Test
+    @WithClasses(ErroneousOrderMapperThrowExceptionAsSourceType.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousOrderMapperThrowExceptionAsSourceType.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 29,
+                message = "Source = \"<THROW_EXCEPTION>\" is not allowed. " +
+                    "Target = \"<THROW_EXCEPTION>\" can only be used.")
+        }
+    )
+    public void shouldRaiseErrorWhenThrowExceptionUsedAsSourceType() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/ErroneousOrderMapperThrowExceptionAsSourceType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/ErroneousOrderMapperThrowExceptionAsSourceType.java
@@ -28,5 +28,5 @@ public interface ErroneousOrderMapperThrowExceptionAsSourceType {
         @ValueMapping(source = "<ANY_REMAINING>", target = "DEFAULT"),
         @ValueMapping(source = "<THROW_EXCEPTION>", target = "DEFAULT")
     })
-    ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
+    ExternalOrderType orderTypeToExternalOrderTypeWithErroneousSourceMapping(OrderType orderType);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/ErroneousOrderMapperThrowExceptionAsSourceType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/ErroneousOrderMapperThrowExceptionAsSourceType.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.value.enum2enum;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.value.ExternalOrderType;
+import org.mapstruct.ap.test.value.OrderType;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Jude Niroshan
+ */
+@Mapper
+public interface ErroneousOrderMapperThrowExceptionAsSourceType {
+
+    ErroneousOrderMapperThrowExceptionAsSourceType INSTANCE = Mappers.getMapper(
+        ErroneousOrderMapperThrowExceptionAsSourceType.class );
+
+    @ValueMappings({
+        @ValueMapping(source = "EXTRA", target = "SPECIAL"),
+        @ValueMapping(source = "STANDARD", target = "DEFAULT"),
+        @ValueMapping(source = "NORMAL", target = "DEFAULT"),
+        @ValueMapping(source = "<ANY_REMAINING>", target = "DEFAULT"),
+        @ValueMapping(source = "<THROW_EXCEPTION>", target = "DEFAULT")
+    })
+    ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/OrderThrowExceptionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/OrderThrowExceptionMapper.java
@@ -14,6 +14,9 @@ import org.mapstruct.ap.test.value.ExternalOrderType;
 import org.mapstruct.ap.test.value.OrderType;
 import org.mapstruct.factory.Mappers;
 
+/**
+ * @author Jude Niroshan
+ */
 @Mapper
 public interface OrderThrowExceptionMapper {
     OrderThrowExceptionMapper INSTANCE = Mappers.getMapper( OrderThrowExceptionMapper.class );

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/OrderThrowExceptionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/OrderThrowExceptionMapper.java
@@ -1,0 +1,28 @@
+package org.mapstruct.ap.test.value.enum2enum;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.value.ExternalOrderType;
+import org.mapstruct.ap.test.value.OrderType;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface OrderThrowExceptionMapper {
+    OrderThrowExceptionMapper INSTANCE = Mappers.getMapper( OrderThrowExceptionMapper.class );
+
+
+    OrderDto orderEntityToDto(OrderEntity order);
+
+    @ValueMappings({
+        @ValueMapping(source = "EXTRA", target = "SPECIAL"),
+        @ValueMapping(source = "STANDARD", target = "DEFAULT"),
+        @ValueMapping(source = "NORMAL", target = MappingConstants.THROW_EXCEPTION)
+    })
+    ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
+
+    @InheritInverseConfiguration
+    OrderType externalOrderTypeToOrderType(ExternalOrderType orderType);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/OrderThrowExceptionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/OrderThrowExceptionMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.ap.test.value.enum2enum;
 
 import org.mapstruct.InheritInverseConfiguration;
@@ -12,7 +17,6 @@ import org.mapstruct.factory.Mappers;
 @Mapper
 public interface OrderThrowExceptionMapper {
     OrderThrowExceptionMapper INSTANCE = Mappers.getMapper( OrderThrowExceptionMapper.class );
-
 
     OrderDto orderEntityToDto(OrderEntity order);
 

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/SpecialOrderMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/SpecialOrderMapper.java
@@ -29,14 +29,24 @@ public interface SpecialOrderMapper {
 
     @Named("orderTypeToExternalOrderType")
     @ValueMappings({
-        @ValueMapping( source = MappingConstants.NULL, target = "DEFAULT" ),
-        @ValueMapping( source = "STANDARD", target = MappingConstants.NULL ),
-        @ValueMapping( source = MappingConstants.ANY_REMAINING, target = "SPECIAL" )
+        @ValueMapping(source = MappingConstants.NULL, target = "DEFAULT"),
+        @ValueMapping(source = "STANDARD", target = MappingConstants.NULL),
+        @ValueMapping(source = MappingConstants.ANY_REMAINING, target = "SPECIAL")
     })
     ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
 
+    @Named("orderTypeToExternalOrderTypeWithException")
+    @ValueMappings({
+        @ValueMapping(source = "RETAIL", target = "RETAIL"),
+        @ValueMapping(source = "B2B", target = "B2B"),
+        @ValueMapping(source = "STANDARD", target = "SPECIAL"),
+        @ValueMapping(source = "NORMAL", target = "DEFAULT"),
+        @ValueMapping(source = "EXTRA", target = MappingConstants.THROW_EXCEPTION)
+    })
+    ExternalOrderType orderTypeToExternalOrderTypeWithException(OrderType orderType);
+
     @InheritInverseConfiguration(name = "orderTypeToExternalOrderType")
-    @ValueMapping( target = "EXTRA", source = "SPECIAL" )
+    @ValueMapping(target = "EXTRA", source = "SPECIAL")
     OrderType externalOrderTypeToOrderType(ExternalOrderType orderType);
 
     @ValueMappings({

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/SpecialThrowExceptionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/SpecialThrowExceptionMapper.java
@@ -1,8 +1,3 @@
-/*
- * Copyright MapStruct Authors.
- *
- * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
- */
 package org.mapstruct.ap.test.value.enum2enum;
 
 import org.mapstruct.InheritInverseConfiguration;
@@ -16,13 +11,9 @@ import org.mapstruct.ap.test.value.ExternalOrderType;
 import org.mapstruct.ap.test.value.OrderType;
 import org.mapstruct.factory.Mappers;
 
-/**
- * @author Sjaak Derksen
- */
 @Mapper
-public interface SpecialOrderMapper {
-
-    SpecialOrderMapper INSTANCE = Mappers.getMapper( SpecialOrderMapper.class );
+public interface SpecialThrowExceptionMapper {
+    SpecialThrowExceptionMapper INSTANCE = Mappers.getMapper( SpecialThrowExceptionMapper.class );
 
     @Mapping(target = "orderType", source = "orderType", qualifiedByName = "orderTypeToExternalOrderType")
     OrderDto orderEntityToDto(OrderEntity order);
@@ -31,7 +22,7 @@ public interface SpecialOrderMapper {
     @ValueMappings({
         @ValueMapping(source = MappingConstants.NULL, target = "DEFAULT"),
         @ValueMapping(source = "STANDARD", target = MappingConstants.NULL),
-        @ValueMapping(source = MappingConstants.ANY_REMAINING, target = "SPECIAL")
+        @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.THROW_EXCEPTION)
     })
     ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
 
@@ -40,7 +31,7 @@ public interface SpecialOrderMapper {
     OrderType externalOrderTypeToOrderType(ExternalOrderType orderType);
 
     @ValueMappings({
-        @ValueMapping(source = MappingConstants.NULL, target = "DEFAULT"),
+        @ValueMapping(source = MappingConstants.NULL, target = MappingConstants.THROW_EXCEPTION),
         @ValueMapping(source = "STANDARD", target = MappingConstants.NULL),
         @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)
     })

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/SpecialThrowExceptionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/SpecialThrowExceptionMapper.java
@@ -16,6 +16,9 @@ import org.mapstruct.ap.test.value.ExternalOrderType;
 import org.mapstruct.ap.test.value.OrderType;
 import org.mapstruct.factory.Mappers;
 
+/**
+ * @author Jude Niroshan
+ */
 @Mapper
 public interface SpecialThrowExceptionMapper {
     SpecialThrowExceptionMapper INSTANCE = Mappers.getMapper( SpecialThrowExceptionMapper.class );
@@ -40,5 +43,5 @@ public interface SpecialThrowExceptionMapper {
         @ValueMapping(source = "STANDARD", target = MappingConstants.NULL),
         @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)
     })
-    ExternalOrderType anyRemainingToNull(OrderType orderType);
+    ExternalOrderType anyRemainingToNullToException(OrderType orderType);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/SpecialThrowExceptionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/enum2enum/SpecialThrowExceptionMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.ap.test.value.enum2enum;
 
 import org.mapstruct.InheritInverseConfiguration;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/enum2enum/SpecialOrderMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/enum2enum/SpecialOrderMapperImpl.java
@@ -11,8 +11,8 @@ import org.mapstruct.ap.test.value.OrderType;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2017-02-20T21:25:45+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+    date = "2021-02-19T21:20:19+0100",
+    comments = "version: , compiler: javac, environment: Java 1.8.0_191 (Oracle Corporation)"
 )
 public class SpecialOrderMapperImpl implements SpecialOrderMapper {
 
@@ -45,6 +45,30 @@ public class SpecialOrderMapperImpl implements SpecialOrderMapper {
             case B2B: externalOrderType = ExternalOrderType.B2B;
             break;
             default: externalOrderType = ExternalOrderType.SPECIAL;
+        }
+
+        return externalOrderType;
+    }
+
+    @Override
+    public ExternalOrderType orderTypeToExternalOrderTypeWithException(OrderType orderType) {
+        if ( orderType == null ) {
+            return null;
+        }
+
+        ExternalOrderType externalOrderType;
+
+        switch ( orderType ) {
+            case RETAIL: externalOrderType = ExternalOrderType.RETAIL;
+            break;
+            case B2B: externalOrderType = ExternalOrderType.B2B;
+            break;
+            case STANDARD: externalOrderType = ExternalOrderType.SPECIAL;
+            break;
+            case NORMAL: externalOrderType = ExternalOrderType.DEFAULT;
+            break;
+            case EXTRA: throw new IllegalArgumentException( "Unexpected enum constant: " + orderType );
+            default: throw new IllegalArgumentException( "Unexpected enum constant: " + orderType );
         }
 
         return externalOrderType;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/enum2enum/SpecialOrderMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/enum2enum/SpecialOrderMapperImpl.java
@@ -51,30 +51,6 @@ public class SpecialOrderMapperImpl implements SpecialOrderMapper {
     }
 
     @Override
-    public ExternalOrderType orderTypeToExternalOrderTypeWithException(OrderType orderType) {
-        if ( orderType == null ) {
-            return null;
-        }
-
-        ExternalOrderType externalOrderType;
-
-        switch ( orderType ) {
-            case RETAIL: externalOrderType = ExternalOrderType.RETAIL;
-            break;
-            case B2B: externalOrderType = ExternalOrderType.B2B;
-            break;
-            case STANDARD: externalOrderType = ExternalOrderType.SPECIAL;
-            break;
-            case NORMAL: externalOrderType = ExternalOrderType.DEFAULT;
-            break;
-            case EXTRA: throw new IllegalArgumentException( "Unexpected enum constant: " + orderType );
-            default: throw new IllegalArgumentException( "Unexpected enum constant: " + orderType );
-        }
-
-        return externalOrderType;
-    }
-
-    @Override
     public OrderType externalOrderTypeToOrderType(ExternalOrderType orderType) {
         if ( orderType == null ) {
             return OrderType.STANDARD;


### PR DESCRIPTION
## Description

### Feature PR 🚀

Fixes: #2339 

### Changes

Introduced a new feature that can bypass the compilation error for certain Enum values. 

```
    @ValueMappings({
        @ValueMapping(source = "RETAIL", target = "RETAIL"),
        @ValueMapping(source = "EXTRA", target = MappingConstants.THROW_EXCEPTION)
    })
    ExternalOrderType orderTypeToExternalOrderTypeWithException(OrderType orderType);
```

This will generate the following code:

```
    @Override
    public ExternalOrderType orderTypeToExternalOrderTypeWithException(OrderType orderType) {
        if ( orderType == null ) {
            return null;
        }

        ExternalOrderType externalOrderType;

        switch ( orderType ) {
            case RETAIL: externalOrderType = ExternalOrderType.RETAIL;
            break;
            case EXTRA: throw new IllegalArgumentException( "Unexpected enum constant: " + orderType );
            default: throw new IllegalArgumentException( "Unexpected enum constant: " + orderType );
        }

        return externalOrderType;
    }
```

