### PR TITLE
#2366 remove java 9 specific documentation

### DIFF
--- a/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
@@ -248,7 +248,7 @@ If a policy is given for a specific mapper via `@Mapper#unmappedTargetPolicy()`,
 |`WARN`
 |===
 
-=== Using MapStruct on Java 9 and higher versions
+=== Using MapStruct with the Java Module System
 
 MapStruct can be used with Java 9 and higher versions.
 

--- a/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
@@ -248,13 +248,11 @@ If a policy is given for a specific mapper via `@Mapper#unmappedTargetPolicy()`,
 |`WARN`
 |===
 
-=== Using MapStruct on Java 9
+=== Using MapStruct on Java 9 and higher versions
 
-MapStruct can be used with Java 9 (JPMS), support for it is experimental.
+MapStruct can be used with Java 9 and higher versions.
 
-A core theme of Java 9 is the modularization of the JDK. One effect of this is that a specific module needs	to be enabled for a project in order to use the `javax.annotation.Generated` annotation. `@Generated` is added by MapStruct to generated mapper classes to tag them as generated code, stating the date of generation, the generator version etc.
-
-To allow usage of the `@Generated` annotation the module _java.xml.ws.annotation_ must be enabled. When using Maven, this can be done like this:
+To allow usage of the `@Generated` annotation the module _java.xml.ws.annotation_ can be enabled. When using Maven, this can be done like this:
 
     export MAVEN_OPTS="--add-modules java.xml.ws.annotation"
 

--- a/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
@@ -252,14 +252,4 @@ If a policy is given for a specific mapper via `@Mapper#unmappedTargetPolicy()`,
 
 MapStruct can be used with Java 9 and higher versions.
 
-To allow usage of the `@Generated` annotation the module _java.xml.ws.annotation_ can be enabled. When using Maven, this can be done like this:
-
-    export MAVEN_OPTS="--add-modules java.xml.ws.annotation"
-
-If the `@Generated` annotation is not available, MapStruct will detect this situation and not add it to generated mappers.
-
-[NOTE]
-=====
-In Java 9 `java.annotation.processing.Generated` was added (part of the `java.compiler` module),
-if this annotation is available then it will be used.
-=====
+To allow usage of the `@Generated` annotation `java.annotation.processing.Generated` (part of the `java.compiler` module) can be enabled.


### PR DESCRIPTION
## Description

### Fixes: #2366

Removed Java 9 specific documentation as we are already in Java 15 and Java 11 LTS.