### PR TITLE
2329 Optimization: Caching DateTimeFormatter instances

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/GetDateTimeFormatter.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/GetDateTimeFormatter.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.conversion;
+
+import static org.mapstruct.ap.internal.util.Collections.asSet;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.HelperMethod;
+import org.mapstruct.ap.internal.model.common.Parameter;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.common.TypeFactory;
+import org.mapstruct.ap.internal.model.source.MappingMethodOptions;
+import org.mapstruct.ap.internal.util.Strings;
+
+/**
+ * HelperMethod that returns a static {@link DateTimeFormatter} instance for given dateFormat (or
+ * defaultFormatterSuffix).
+ *
+ * @author Ewald Volkert
+ */
+public class GetDateTimeFormatter extends HelperMethod {
+
+    private final Type returnType;
+    private final Set<Type> importTypes;
+
+    private final String name;
+    private final String dateFormat;
+    private final String defaultFormatterSuffix;
+
+    public GetDateTimeFormatter(TypeFactory typeFactory, String dateFormat, String defaultFormatterSuffix) {
+        this.returnType = typeFactory.getType( DateTimeFormatter.class );
+        this.importTypes = asSet( returnType );
+        this.dateFormat = Strings.isEmpty( dateFormat ) ? null : dateFormat;
+        this.defaultFormatterSuffix = defaultFormatterSuffix;
+        this.name = getDateTimeFormatterMethodName( dateFormat, defaultFormatterSuffix );
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return importTypes;
+    }
+
+    @Override
+    public Parameter getParameter() {
+        return null;
+    }
+
+    @Override
+    public List<Parameter> getParameters() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Type getReturnType() {
+        return returnType;
+    }
+
+    @Override
+    public MappingMethodOptions getOptions() {
+        return MappingMethodOptions.empty();
+    }
+
+    @Override
+    public String describe() {
+        return null;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Map<String, Object> getTemplateParameter() {
+        Map<String, Object> parameter = new HashMap<>();
+        parameter.put( "dateFormat", dateFormat );
+        parameter.put( "defaultFormatterSuffix", defaultFormatterSuffix );
+        parameter.put( "className", Strings.capitalize( name ) );
+        return parameter;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = super.hashCode();
+        result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( !super.equals( obj ) ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        GetDateTimeFormatter other = (GetDateTimeFormatter) obj;
+        if ( name == null ) {
+            if ( other.name != null ) {
+                return false;
+            }
+        }
+        else if ( !name.equals( other.name ) ) {
+            return false;
+        }
+        return true;
+    }
+
+    public static String getDateTimeFormatterMethodName(String dateFormat, String defaultFormatterSuffix) {
+        String name;
+        if ( !Strings.isEmpty( dateFormat ) ) {
+            name = "getDateTimeFormatterWithPattern_" + safeMethodNamePart( dateFormat );
+        }
+        else {
+            name = "getDateTimeFormatterWithSuffix_" + safeMethodNamePart( defaultFormatterSuffix );
+        }
+
+        return name;
+    }
+
+    private static String safeMethodNamePart(String dateFormat) {
+        StringBuilder sb = new StringBuilder();
+
+        dateFormat.codePoints().forEach( cp -> {
+            if ( Character.isJavaIdentifierPart( cp ) ) {
+                // safe to character to method name as is
+                sb.append( Character.toChars( cp ) );
+            }
+            else {
+                // could not be used in method name
+                // thus just show code point instead with some pre/post fix
+                sb.append( "$" ).append( cp ).append( "_" );
+            }
+        } );
+
+        return sb.toString();
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/HelperMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/HelperMethod.java
@@ -9,7 +9,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+
 import javax.lang.model.element.ExecutableElement;
 
 import org.mapstruct.ap.internal.model.common.Accessibility;
@@ -21,22 +23,19 @@ import org.mapstruct.ap.internal.model.source.ParameterProvidedMethods;
 import org.mapstruct.ap.internal.util.Strings;
 
 /**
- * A non mapping method to be generated.
- *
- * Can be called from for instance conversions or built-in methods as shared helper method.
- *
- * One example of such method is the creation of a decimal formatter
- * {@link org.mapstruct.ap.internal.conversion.CreateDecimalFormat}, which is used in 2 conversions
- * (BigInteger to String and BigDecimal to String)
+ * A non mapping method to be generated. Can be called from for instance conversions or built-in methods as shared
+ * helper method. One example of such method is the creation of a decimal formatter
+ * {@link org.mapstruct.ap.internal.conversion.CreateDecimalFormat}, which is used in 2 conversions (BigInteger to
+ * String and BigDecimal to String)
  *
  * @author Sjaak Derksen
  */
 public abstract class HelperMethod implements Method {
-   /**
-    * {@inheritDoc }
-    *
-    * @return default method name is equal to class name of build in method name
-    */
+    /**
+     * {@inheritDoc }
+     *
+     * @return default method name is equal to class name of build in method name
+     */
     @Override
     public String getName() {
         return Strings.decapitalize( this.getClass().getSimpleName() );
@@ -56,12 +55,12 @@ public abstract class HelperMethod implements Method {
     /**
      * {@inheritDoc}
      * <p>
-     * Default the targetType should be assignable to the returnType and the sourceType to the parameter,
-     * excluding generic type variables. When the implementor sees a need for this, this method can be overridden.
+     * Default the targetType should be assignable to the returnType and the sourceType to the parameter, excluding
+     * generic type variables. When the implementor sees a need for this, this method can be overridden.
      */
     @Override
     public boolean matches(List<Type> sourceTypes, Type targetType) {
-           throw new IllegalStateException( "Irrelevant." );
+        throw new IllegalStateException( "Irrelevant." );
 
     }
 
@@ -154,7 +153,6 @@ public abstract class HelperMethod implements Method {
      * equals based on class
      *
      * @param obj other class
-     *
      * @return true when classes are the same
      */
     @Override
@@ -211,7 +209,7 @@ public abstract class HelperMethod implements Method {
 
     @Override
     public boolean overridesMethod() {
-        return  false;
+        return false;
     }
 
     @Override
@@ -242,5 +240,12 @@ public abstract class HelperMethod implements Method {
     @Override
     public boolean isUpdateMethod() {
         return false; // irrelevant
+    }
+
+    /**
+     * @return additional template parameters
+     */
+    public Map<String, Object> getTemplateParameter() {
+        return null;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/SupportingMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/SupportingMappingMethod.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct.ap.internal.model;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
@@ -16,12 +17,10 @@ import org.mapstruct.ap.internal.util.Strings;
 
 /**
  * A mapping method which is not based on an actual method declared in the original mapper interface but is added as
- * private method to map a certain source/target type combination. Based on a {@link BuiltInMethod}.
- *
- * Specific templates all point to this class, for instance:
- * {@link org.mapstruct.ap.internal.model.source.builtin.XmlGregorianCalendarToCalendar},
- * but also used fields and constructor elements, e.g.
- * {@link org.mapstruct.ap.internal.model.source.builtin.FinalField} and
+ * private method to map a certain source/target type combination. Based on a {@link BuiltInMethod}. Specific templates
+ * all point to this class, for instance:
+ * {@link org.mapstruct.ap.internal.model.source.builtin.XmlGregorianCalendarToCalendar}, but also used fields and
+ * constructor elements, e.g. {@link org.mapstruct.ap.internal.model.source.builtin.FinalField} and
  * {@link NewDatatypeFactoryConstructorFragment}
  *
  * @author Gunnar Morling
@@ -32,11 +31,13 @@ public class SupportingMappingMethod extends MappingMethod {
     private final Set<Type> importTypes;
     private final Field supportingField;
     private final SupportingConstructorFragment supportingConstructorFragment;
+    private final Map<String, Object> templateParameter;
 
     public SupportingMappingMethod(BuiltInMethod method, Set<Field> existingFields) {
         super( method );
         this.importTypes = method.getImportTypes();
         this.templateName = getTemplateNameForClass( method.getClass() );
+        this.templateParameter = null;
         if ( method.getFieldReference() != null ) {
             this.supportingField = getSafeField( method.getFieldReference(), existingFields );
         }
@@ -44,10 +45,8 @@ public class SupportingMappingMethod extends MappingMethod {
             this.supportingField = null;
         }
         if ( method.getConstructorFragment() != null ) {
-            this.supportingConstructorFragment = new SupportingConstructorFragment(
-                this,
-                method.getConstructorFragment()
-            );
+            this.supportingConstructorFragment =
+                new SupportingConstructorFragment( this, method.getConstructorFragment() );
         }
         else {
             this.supportingConstructorFragment = null;
@@ -77,6 +76,7 @@ public class SupportingMappingMethod extends MappingMethod {
         this.templateName = getTemplateNameForClass( method.getClass() );
         this.supportingField = null;
         this.supportingConstructorFragment = null;
+        this.templateParameter = method.getTemplateParameter();
     }
 
     @Override
@@ -94,9 +94,7 @@ public class SupportingMappingMethod extends MappingMethod {
      * names of the {@code importTypes}.
      *
      * @param name Fully-qualified or simple name of the type.
-     *
      * @return Found type, never <code>null</code>.
-     *
      * @throws IllegalArgumentException In case no {@link Type} was found for given name.
      */
     public Type findType(String name) {
@@ -120,11 +118,15 @@ public class SupportingMappingMethod extends MappingMethod {
         return supportingConstructorFragment;
     }
 
+    public Map<String, Object> getTemplateParameter() {
+        return templateParameter;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ( ( templateName == null ) ? 0 : templateName.hashCode() );
+        result = prime * result + ( ( getName() == null ) ? 0 : getName().hashCode() );
         return result;
     }
 
@@ -141,7 +143,7 @@ public class SupportingMappingMethod extends MappingMethod {
         }
         SupportingMappingMethod other = (SupportingMappingMethod) obj;
 
-        if ( !Objects.equals( templateName, other.templateName ) ) {
+        if ( !Objects.equals( getName(), other.getName() ) ) {
             return false;
         }
 

--- a/processor/src/main/resources/org/mapstruct/ap/internal/conversion/GetDateTimeFormatter.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/conversion/GetDateTimeFormatter.ftl
@@ -1,0 +1,19 @@
+<#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+
+private static class ${templateParameter['className']} {
+<#if templateParameter['dateFormat']??>
+    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern( "${templateParameter['dateFormat']}" );
+<#else>
+    private static final DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.${templateParameter['defaultFormatterSuffix']};
+</#if>
+}
+
+private DateTimeFormatter ${name}() {
+    return ${templateParameter['className']}.DATETIME_FORMATTER;
+}


### PR DESCRIPTION
* HelperMethod
  extended to supply additional template parameters to
  be more flexible in freemarker templates

* SupportingMappingMethod
** provide templateParameters to freemarker
** hashCode/equals base on name property instead of template name,
   as we use one specific template multiple times with different
   parameters generating multiple methods

* AbstractJavaTimeToStringConversion
  provides GetDateTimeFormatter as HelperMethod
  using cached DateTimeFormatter instance provided by
  GetDateTimeFormatter

* GetDateTimeFormatter
** a HelperMethod that creates cached DateTimeFormatters
   for given dateFormat or defaultFormatterSuffix
** method name and cache class name are created dynamically using
   given dateFormat creating a safe but unique name
** will be reused for multiple conversion fields with same
   dateFormat