### PR TITLE
#2402 Always add source parameter name when constructing the source references for target this

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/SourceReference.java
@@ -421,8 +421,13 @@ public class SourceReference extends AbstractReference {
         if ( deepestProperty != null ) {
             Type type = deepestProperty.getType();
             Map<String, Accessor> newDeepestReadAccessors = type.getPropertyReadAccessors();
+            String parameterName = getParameter().getName();
+            String deepestPropertyFullName = deepestProperty.getFullName();
             for ( Map.Entry<String, Accessor> newDeepestReadAccessorEntry : newDeepestReadAccessors.entrySet() ) {
-                String newFullName = deepestProperty.getFullName() + "." + newDeepestReadAccessorEntry.getKey();
+                // Always include the parameter name in the new full name.
+                // Otherwise multi source parameters might be reported incorrectly
+                String newFullName =
+                    parameterName + "." + deepestPropertyFullName + "." + newDeepestReadAccessorEntry.getKey();
                 SourceReference sourceReference = new BuilderFromMapping()
                     .sourceName( newFullName )
                     .method( method )

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2042/Issue2402Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2042/Issue2402Mapper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2042;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue2402Mapper {
+
+    Issue2402Mapper INSTANCE = Mappers.getMapper( Issue2402Mapper.class );
+
+    @Mapping(target = ".", source = "source.info")
+    Target map(Source source, String other);
+
+    class Target {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    class Source {
+
+        private final Info info;
+
+        public Source(Info info) {
+            this.info = info;
+        }
+
+        public Info getInfo() {
+            return info;
+        }
+    }
+
+    class Info {
+        private final String name;
+
+        public Info(String name) {
+            this.name = name;
+        }
+
+        public String getName() {
+            return name;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2042/Issue2402Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2042/Issue2402Test.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2042;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.AnnotationProcessorTestRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2402")
+@RunWith(AnnotationProcessorTestRunner.class)
+@WithClasses({
+    Issue2402Mapper.class
+})
+public class Issue2402Test {
+
+    @Test
+    public void shouldCompile() {
+        Issue2402Mapper.Target target = Issue2402Mapper.INSTANCE.
+            map(
+                new Issue2402Mapper.Source( new Issue2402Mapper.Info( "test" ) ),
+                "other test"
+            );
+
+        assertThat( target.getName() ).isEqualTo( "test" );
+    }
+}


### PR DESCRIPTION
Fixes #2402