### PR TITLE
CaseEnumTransformationStrategy

### DIFF
--- a/core/src/main/java/org/mapstruct/EnumMapping.java
+++ b/core/src/main/java/org/mapstruct/EnumMapping.java
@@ -104,6 +104,8 @@ public @interface EnumMapping {
      *     prefix to the source enum</li>
      *     <li>{@link MappingConstants#STRIP_PREFIX_TRANSFORMATION} - strips the given {@link #configuration()} from
      *     the start of the source enum</li>
+     *     <li>{@link MappingConstants#CASE_TRANSFORMATION} - applies the given {@link #configuration()} case
+     *     transformation to the source enum</li>
      * </ul>
      *
      * It is possible to use custom name transformation strategies by implementing the {@code

--- a/core/src/main/java/org/mapstruct/MappingConstants.java
+++ b/core/src/main/java/org/mapstruct/MappingConstants.java
@@ -75,6 +75,13 @@ public final class MappingConstants {
     public static final String STRIP_PREFIX_TRANSFORMATION = "stripPrefix";
 
     /**
+     * In an {@link EnumMapping} this represent the enum transformation strategy that applies case transformation at the source
+     *
+     * @since 1.5
+     */
+    public static final String CASE_TRANSFORMATION = "case";
+
+    /**
     * Specifies the component model constants to which the generated mapper should adhere.
     * It can be used with the annotation {@link Mapper#componentModel()} or {@link MapperConfig#componentModel()}
     *

--- a/core/src/main/java/org/mapstruct/MappingConstants.java
+++ b/core/src/main/java/org/mapstruct/MappingConstants.java
@@ -75,7 +75,8 @@ public final class MappingConstants {
     public static final String STRIP_PREFIX_TRANSFORMATION = "stripPrefix";
 
     /**
-     * In an {@link EnumMapping} this represent the enum transformation strategy that applies case transformation at the source
+     * In an {@link EnumMapping} this represent the enum transformation strategy that applies case transformation
+     * at the source.
      *
      * @since 1.5
      */

--- a/documentation/src/main/asciidoc/chapter-8-mapping-values.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-8-mapping-values.asciidoc
@@ -259,6 +259,7 @@ MapStruct provides the following out of the box enum name transformation strateg
 * _stripSuffix_ - Strips a suffix from the source enum
 * _prefix_ - Applies a prefix on the source enum
 * _stripPrefix_ - Strips a prefix from the source enum
+* _case_ - Applies case transformation to the source enum
 
 It is also possible to register custom strategies.
 For more information on how to do that have a look at <<custom-enum-transformation-strategy>>

--- a/processor/src/main/java/org/mapstruct/ap/internal/gem/MappingConstantsGem.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/gem/MappingConstantsGem.java
@@ -31,6 +31,8 @@ public final class MappingConstantsGem {
 
     public static final String STRIP_PREFIX_TRANSFORMATION = "stripPrefix";
 
+    public static final String CASE_TRANSFORMATION = "case";
+
     /**
      * Gem for the class {@link org.mapstruct.MappingConstants.ComponentModel}
      *

--- a/processor/src/main/java/org/mapstruct/ap/spi/CaseEnumTransformationStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/CaseEnumTransformationStrategy.java
@@ -1,0 +1,53 @@
+package org.mapstruct.ap.spi;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Applies case transformation to the source enum
+ *
+ * @author jpbassinello
+ *
+ * @since 1.5
+ */
+public class CaseEnumTransformationStrategy implements EnumTransformationStrategy {
+
+    private static final String UPPER = "upper";
+    private static final String LOWER = "lower";
+    private static final String CAPITAL = "capital";
+
+    @Override
+    public String getStrategyName() {
+        return "case";
+    }
+
+    @Override
+    public String transform(String value, String configuration) {
+        switch (configuration.toLowerCase()) {
+            case UPPER:
+                return value.toUpperCase();
+            case LOWER:
+                return value.toLowerCase();
+            case CAPITAL:
+                return capitalize(value);
+            default:
+                return value;
+        }
+    }
+
+    private static String capitalize(String value) {
+        return Arrays.stream(value.split("_"))
+                .map(CaseEnumTransformationStrategy::upperCaseFirst)
+                .collect(Collectors.joining("_"));
+    }
+
+    private static String upperCaseFirst(String value) {
+        char[] array = value.toCharArray();
+        array[0] = Character.toUpperCase(array[0]);
+        for (int i = 1; i < array.length; i++) {
+            array[i] = Character.toLowerCase(array[i]);
+        }
+        return new String(array);
+    }
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/spi/CaseEnumTransformationStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/CaseEnumTransformationStrategy.java
@@ -1,6 +1,7 @@
 package org.mapstruct.ap.spi;
 
 import java.util.Arrays;
+import java.util.Locale;
 import java.util.stream.Collectors;
 
 /**
@@ -25,13 +26,13 @@ public class CaseEnumTransformationStrategy implements EnumTransformationStrateg
     public String transform(String value, String configuration) {
         switch (configuration.toLowerCase()) {
             case UPPER:
-                return value.toUpperCase();
+                return value.toUpperCase(Locale.ROOT);
             case LOWER:
-                return value.toLowerCase();
+                return value.toLowerCase(Locale.ROOT);
             case CAPITAL:
                 return capitalize(value);
             default:
-                return value;
+                throw new IllegalArgumentException( "Unexpected configuration for enum case transformation: " + configuration );
         }
     }
 

--- a/processor/src/main/resources/META-INF/services/org.mapstruct.ap.spi.EnumTransformationStrategy
+++ b/processor/src/main/resources/META-INF/services/org.mapstruct.ap.spi.EnumTransformationStrategy
@@ -6,3 +6,4 @@ org.mapstruct.ap.spi.PrefixEnumTransformationStrategy
 org.mapstruct.ap.spi.StripPrefixEnumTransformationStrategy
 org.mapstruct.ap.spi.StripSuffixEnumTransformationStrategy
 org.mapstruct.ap.spi.SuffixEnumTransformationStrategy
+org.mapstruct.ap.spi.CaseEnumTransformationStrategy

--- a/processor/src/test/java/org/mapstruct/ap/test/gem/ConstantTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/gem/ConstantTest.java
@@ -30,6 +30,7 @@ public class ConstantTest {
         assertThat( MappingConstants.PREFIX_TRANSFORMATION ).isEqualTo( MappingConstantsGem.PREFIX_TRANSFORMATION );
         assertThat( MappingConstants.STRIP_PREFIX_TRANSFORMATION )
             .isEqualTo( MappingConstantsGem.STRIP_PREFIX_TRANSFORMATION );
+        assertThat( MappingConstants.CASE_TRANSFORMATION ).isEqualTo( MappingConstantsGem.CASE_TRANSFORMATION );
     }
 
     @Test

--- a/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseCaseMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseCaseMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.value.nametransformation;
+
+import org.mapstruct.EnumMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author jpbassinello
+ */
+@Mapper
+public interface CheeseCaseMapper {
+
+    CheeseCaseMapper INSTANCE = Mappers.getMapper( CheeseCaseMapper.class );
+
+    @EnumMapping(nameTransformationStrategy = MappingConstants.CASE_TRANSFORMATION, configuration = "lower")
+    CheeseTypeLower mapToLower(CheeseType cheese);
+
+    @EnumMapping(nameTransformationStrategy = MappingConstants.CASE_TRANSFORMATION, configuration = "lower")
+    CheeseTypeLower mapToLower(CheeseTypeCapital cheese);
+
+    @EnumMapping(nameTransformationStrategy = MappingConstants.CASE_TRANSFORMATION, configuration = "upper")
+    CheeseType mapToUpper(CheeseTypeLower cheese);
+
+    @EnumMapping(nameTransformationStrategy = MappingConstants.CASE_TRANSFORMATION, configuration = "upper")
+    CheeseType mapToUpper(CheeseTypeCapital cheese);
+
+    @EnumMapping(nameTransformationStrategy = MappingConstants.CASE_TRANSFORMATION, configuration = "capital")
+    CheeseTypeCapital mapToCapital(CheeseTypeLower cheese);
+
+    @EnumMapping(nameTransformationStrategy = MappingConstants.CASE_TRANSFORMATION, configuration = "capital")
+    CheeseTypeCapital mapToCapital(CheeseType cheese);
+
+    @EnumMapping(nameTransformationStrategy = MappingConstants.CASE_TRANSFORMATION, configuration = "lower")
+    String mapToLowerString(CheeseType cheese);
+
+    @EnumMapping(nameTransformationStrategy = MappingConstants.CASE_TRANSFORMATION, configuration = "upper")
+    String mapToUpperString(CheeseType cheese);
+
+    @EnumMapping(nameTransformationStrategy = MappingConstants.CASE_TRANSFORMATION, configuration = "capital")
+    String mapToCapitalString(CheeseType cheese);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseType.java
@@ -11,5 +11,6 @@ package org.mapstruct.ap.test.value.nametransformation;
 public enum CheeseType {
 
     BRIE,
-    ROQUEFORT
+    ROQUEFORT,
+    COLBY_JACK
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseTypeCapital.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseTypeCapital.java
@@ -6,12 +6,11 @@
 package org.mapstruct.ap.test.value.nametransformation;
 
 /**
- * @author Filip Hrisafov
+ * @author jpbassinello
  */
-public enum CheeseTypeSuffixed {
+public enum CheeseTypeCapital {
 
-    DEFAULT,
-    BRIE_CHEESE_TYPE,
-    ROQUEFORT_CHEESE_TYPE,
-    COLBY_JACK_CHEESE_TYPE
+    Brie,
+    Roquefort,
+    Colby_Jack
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseTypeCustomSuffix.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseTypeCustomSuffix.java
@@ -12,4 +12,5 @@ public enum CheeseTypeCustomSuffix {
 
     brie_TYPE,
     roquefort_TYPE,
+    colby_jack_TYPE
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseTypeLower.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseTypeLower.java
@@ -6,12 +6,11 @@
 package org.mapstruct.ap.test.value.nametransformation;
 
 /**
- * @author Filip Hrisafov
+ * @author jpbassinello
  */
-public enum CheeseTypeSuffixed {
+public enum CheeseTypeLower {
 
-    DEFAULT,
-    BRIE_CHEESE_TYPE,
-    ROQUEFORT_CHEESE_TYPE,
-    COLBY_JACK_CHEESE_TYPE
+    brie,
+    roquefort,
+    colby_jack
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseTypePrefixed.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/CheeseTypePrefixed.java
@@ -13,4 +13,5 @@ public enum CheeseTypePrefixed {
     DEFAULT,
     SWISS_BRIE,
     SWISS_ROQUEFORT,
+    SWISS_COLBY_JACK
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/EnumNameTransformationStrategyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/nametransformation/EnumNameTransformationStrategyTest.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
     CheeseTypeSuffixed.class,
     CheeseTypePrefixed.class,
     CheeseTypeCustomSuffix.class,
+    CheeseTypeLower.class,
+    CheeseTypeCapital.class
 })
 public class EnumNameTransformationStrategyTest {
 
@@ -92,7 +94,7 @@ public class EnumNameTransformationStrategyTest {
                 kind = javax.tools.Diagnostic.Kind.ERROR,
                 line = 20,
                 message = "There is no registered EnumTransformationStrategy for 'custom'. Registered strategies are:" +
-                    " prefix, stripPrefix, stripSuffix, suffix."
+                    " prefix, stripPrefix, stripSuffix, suffix, case."
             )
         }
     )
@@ -109,4 +111,60 @@ public class EnumNameTransformationStrategyTest {
             .isEqualTo( CheeseTypeCustomSuffix.brie_TYPE );
     }
 
+    @ProcessorTest
+    @WithClasses({
+            CheeseCaseMapper.class
+    })
+    public void shouldConvertCaseOnEnumToEnumMapping() {
+        CheeseCaseMapper mapper = CheeseCaseMapper.INSTANCE;
+
+        assertThat( mapper.mapToLower( CheeseType.BRIE ) )
+            .isEqualTo( CheeseTypeLower.brie );
+
+        assertThat( mapper.mapToLower( CheeseTypeCapital.Colby_Jack) )
+                .isEqualTo( CheeseTypeLower.colby_jack );
+
+        assertThat( mapper.mapToUpper( CheeseTypeLower.roquefort ) )
+            .isEqualTo( CheeseType.ROQUEFORT );
+
+        assertThat( mapper.mapToUpper( CheeseTypeCapital.Colby_Jack) )
+                .isEqualTo( CheeseType.COLBY_JACK );
+
+        assertThat( mapper.mapToCapital( CheeseTypeLower.brie ) )
+            .isEqualTo( CheeseTypeCapital.Brie );
+
+        assertThat( mapper.mapToCapital( CheeseType.ROQUEFORT ) )
+            .isEqualTo( CheeseTypeCapital.Roquefort );
+
+        assertThat( mapper.mapToCapital( CheeseType.COLBY_JACK) )
+                .isEqualTo( CheeseTypeCapital.Colby_Jack );
+
+        assertThat( mapper.mapToCapital( CheeseTypeLower.colby_jack ) )
+            .isEqualTo( CheeseTypeCapital.Colby_Jack );
+
+    }
+
+    @ProcessorTest
+    @WithClasses({
+            CheeseCaseMapper.class
+    })
+    public void shouldConvertCaseOnEnumToStringMapping() {
+        CheeseCaseMapper mapper = CheeseCaseMapper.INSTANCE;
+
+        assertThat( mapper.mapToLowerString( CheeseType.BRIE ) )
+                .isEqualTo( "brie" );
+        assertThat( mapper.mapToLowerString( CheeseType.COLBY_JACK ) )
+                .isEqualTo( "colby_jack" );
+
+        assertThat( mapper.mapToUpperString( CheeseType.ROQUEFORT ) )
+                .isEqualTo( "ROQUEFORT" );
+        assertThat( mapper.mapToUpperString( CheeseType.COLBY_JACK ) )
+                .isEqualTo( "COLBY_JACK" );
+
+        assertThat( mapper.mapToCapitalString( CheeseType.ROQUEFORT ) )
+                .isEqualTo( "Roquefort" );
+        assertThat( mapper.mapToCapitalString( CheeseType.COLBY_JACK ) )
+                .isEqualTo( "Colby_Jack" );
+
+    }
 }


### PR DESCRIPTION
A new enum transformation strategy that applies case conversion to the source enum.

LOWER:

`SourceEnum.VALUE1 -> TargetEnum.value1`

UPPER:

`SourceEnum.value1 -> TargetEnum.VALUE1`

CAPITAL:

`SourceEnum.ENUM_VALUE -> TargetEnum.Enum_Value`

Fixes: #2445