### PR TITLE
#2446 Use DefaultLocale and DefaultTimeZone from JUnit Pioneer

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -29,6 +29,7 @@
         <org.eclipse.tycho.compiler-jdt.version>1.6.0</org.eclipse.tycho.compiler-jdt.version>
         <com.puppycrawl.tools.checkstyle.version>8.36.1</com.puppycrawl.tools.checkstyle.version>
         <org.junit.jupiter.version>5.8.0-M1</org.junit.jupiter.version>
+        <junit-pioneer.version>1.4.2</junit-pioneer.version>
         <add.release.arguments />
         <forkCount>1</forkCount>
         <assertj.version>3.17.2</assertj.version>
@@ -140,6 +141,11 @@
                 <version>${org.junit.jupiter.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit-pioneer</groupId>
+                <artifactId>junit-pioneer</artifactId>
+                <version>${junit-pioneer.version}</version>
             </dependency>
 
             <!-- CDI, Weld, Arquillian -->

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -115,6 +115,12 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.junit-pioneer</groupId>
+            <artifactId>junit-pioneer</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- There is no compile dependency to Joda-Time; It's only required for testing the Joda conversions -->
         <dependency>
             <groupId>joda-time</groupId>

--- a/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
@@ -9,29 +9,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Locale;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
  * @author Filip Hrisafov
  */
 public class StringsTest {
-
-    private static final Locale TURKEY_LOCALE = getTurkeyLocale();
-    private Locale defaultLocale;
-
-    @BeforeEach
-    public void before() {
-        defaultLocale = Locale.getDefault();
-    }
-
-    @AfterEach
-    public void after() {
-        Locale.setDefault( defaultLocale );
-    }
 
     @Test
     public void testCapitalize() {
@@ -137,40 +122,31 @@ public class StringsTest {
     }
 
     @Test
+    @DefaultLocale("en")
     public void capitalizeEnglish() {
-        Locale.setDefault( Locale.ENGLISH );
         String international = Strings.capitalize( "international" );
         assertThat( international ).isEqualTo( "International" );
     }
 
     @Test
+    @DefaultLocale("en")
     public void decapitalizeEnglish() {
-        Locale.setDefault( Locale.ENGLISH );
         String international = Strings.decapitalize( "International" );
         assertThat( international ).isEqualTo( "international" );
     }
 
     @Test
+    @DefaultLocale("tr")
     public void capitalizeTurkish() {
-        Locale.setDefault( TURKEY_LOCALE );
         String international = Strings.capitalize( "international" );
         assertThat( international ).isEqualTo( "International" );
     }
 
     @Test
+    @DefaultLocale("tr")
     public void decapitalizeTurkish() {
-        Locale.setDefault( TURKEY_LOCALE );
         String international = Strings.decapitalize( "International" );
         assertThat( international ).isEqualTo( "international" );
     }
 
-    private static Locale getTurkeyLocale() {
-        Locale turkeyLocale = Locale.forLanguageTag( "tr" );
-
-        if ( turkeyLocale == null ) {
-            throw new IllegalStateException( "Can't find Turkey locale." );
-        }
-
-        return turkeyLocale;
-    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1523/java8/Issue1523Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1523/java8/Issue1523Test.java
@@ -9,8 +9,7 @@ import java.time.ZonedDateTime;
 import java.util.Calendar;
 import java.util.TimeZone;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junitpioneer.jupiter.DefaultTimeZone;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
@@ -31,23 +30,11 @@ import static org.assertj.core.api.Assertions.assertThat;
     Target.class
 })
 @IssueKey("1523")
+// we want to test that the timezone will correctly be used in mapped XMLGregorianCalendar and not the
+// default one, so we must ensure that we use a different timezone than the default one -> set the default
+// one explicitly to UTC
+@DefaultTimeZone("UTC")
 public class Issue1523Test {
-
-    private static final TimeZone DEFAULT_TIMEZONE = TimeZone.getDefault();
-
-    @BeforeAll
-    public static void before() {
-        // we want to test that the timezone will correctly be used in mapped XMLGregorianCalendar and not the
-        // default one, so we must ensure that we use a different timezone than the default one -> set the default
-        // one explicitly to UTC
-        TimeZone.setDefault( TimeZone.getTimeZone( "UTC" ) );
-    }
-
-    @AfterAll
-    public static void after() {
-        // revert the changed default TZ
-        TimeZone.setDefault( DEFAULT_TIMEZONE );
-    }
 
     @ProcessorTest
     public void testThatCorrectTimeZoneWillBeUsedInTarget() {

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/BuiltInTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/BuiltInTest.java
@@ -17,15 +17,13 @@ import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
-import java.util.TimeZone;
 import javax.xml.bind.JAXBElement;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+import org.junitpioneer.jupiter.DefaultTimeZone;
 import org.mapstruct.ap.test.builtin._target.IterableTarget;
 import org.mapstruct.ap.test.builtin._target.MapTarget;
 import org.mapstruct.ap.test.builtin.bean.BigDecimalProperty;
@@ -85,20 +83,8 @@ import static org.assertj.core.api.Assertions.assertThat;
     IterableSource.class,
     MapSource.class
 })
+@DefaultTimeZone("Europe/Berlin")
 public class BuiltInTest {
-
-    private static TimeZone originalTimeZone;
-
-    @BeforeAll
-    public static void setDefaultTimeZoneToCet() {
-        originalTimeZone = TimeZone.getDefault();
-        TimeZone.setDefault( TimeZone.getTimeZone( "Europe/Berlin" ) );
-    }
-
-    @AfterAll
-    public static void restoreOriginalTimeZone() {
-        TimeZone.setDefault( originalTimeZone );
-    }
 
     @ProcessorTest
     @WithClasses( JaxbMapper.class )

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/DatatypeFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/DatatypeFactoryTest.java
@@ -10,10 +10,8 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
-import java.util.TimeZone;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junitpioneer.jupiter.DefaultTimeZone;
 import org.mapstruct.ap.test.builtin.bean.CalendarProperty;
 import org.mapstruct.ap.test.builtin.bean.DatatypeFactory;
 import org.mapstruct.ap.test.builtin.bean.DateProperty;
@@ -32,20 +30,8 @@ import static org.assertj.core.api.Assertions.assertThat;
     DateProperty.class
 
 } )
+@DefaultTimeZone("Europe/Berlin")
 public class DatatypeFactoryTest {
-
-    private TimeZone originalTimeZone;
-
-    @BeforeEach
-    public void setUp() {
-        originalTimeZone = TimeZone.getDefault();
-        TimeZone.setDefault( TimeZone.getTimeZone( "Europe/Berlin" ) );
-    }
-
-    @AfterEach
-    public void tearDown() {
-        TimeZone.setDefault( originalTimeZone );
-    }
 
     @ProcessorTest
     public void testNoConflictsWithOwnDatatypeFactory() throws ParseException {

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/date/DateConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/date/DateConversionTest.java
@@ -12,13 +12,11 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.Locale;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
+import org.junitpioneer.jupiter.DefaultLocale;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
@@ -36,20 +34,8 @@ import static org.assertj.core.api.Assertions.assertThat;
     SourceTargetMapper.class
 })
 @IssueKey("43")
+@DefaultLocale("de")
 public class DateConversionTest {
-
-    private Locale originalLocale;
-
-    @BeforeEach
-    public void setDefaultLocale() {
-        originalLocale = Locale.getDefault();
-        Locale.setDefault( Locale.GERMAN );
-    }
-
-    @AfterEach
-    public void tearDown() {
-        Locale.setDefault( originalLocale );
-    }
 
     @ProcessorTest
     @EnabledOnJre( JRE.JAVA_8 )

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/java8time/Java8TimeConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/java8time/Java8TimeConversionTest.java
@@ -17,8 +17,7 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junitpioneer.jupiter.DefaultTimeZone;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
@@ -36,18 +35,6 @@ public class Java8TimeConversionTest {
 
     @RegisterExtension
     GeneratedSource generatedSource = new GeneratedSource().addComparisonToFixtureFor( SourceTargetMapper.class );
-
-    private TimeZone originalTimeZone;
-
-    @BeforeEach
-    public void setUp() {
-        originalTimeZone = TimeZone.getDefault();
-    }
-
-    @AfterEach
-    public void tearDown() {
-        TimeZone.setDefault( originalTimeZone );
-    }
 
     @ProcessorTest
     public void testDateTimeToString() {
@@ -226,8 +213,8 @@ public class Java8TimeConversionTest {
     }
 
     @ProcessorTest
+    @DefaultTimeZone("UTC")
     public void testZonedDateTimeToDateMapping() {
-        TimeZone.setDefault( TimeZone.getTimeZone( "UTC" ) );
         Source source = new Source();
         ZonedDateTime dateTime = ZonedDateTime.of( LocalDateTime.of( 2014, 1, 1, 0, 0 ), ZoneId.of( "UTC" ) );
         source.setForDateConversionWithZonedDateTime(
@@ -266,8 +253,8 @@ public class Java8TimeConversionTest {
     }
 
     @ProcessorTest
+    @DefaultTimeZone("Australia/Melbourne")
     public void testLocalDateTimeToDateMapping() {
-        TimeZone.setDefault( TimeZone.getTimeZone( "Australia/Melbourne" ) );
 
         Source source = new Source();
         LocalDateTime dateTime = LocalDateTime.of( 2014, 1, 1, 0, 0 );
@@ -292,8 +279,8 @@ public class Java8TimeConversionTest {
     }
 
     @ProcessorTest
+    @DefaultTimeZone("Australia/Melbourne")
     public void testLocalDateToDateMapping() {
-        TimeZone.setDefault( TimeZone.getTimeZone( "Australia/Melbourne" ) );
 
         Source source = new Source();
         LocalDate localDate = LocalDate.of( 2016, 3, 1 );
@@ -316,8 +303,8 @@ public class Java8TimeConversionTest {
     }
 
     @ProcessorTest
+    @DefaultTimeZone("Australia/Melbourne")
     public void testLocalDateToSqlDateMapping() {
-        TimeZone.setDefault( TimeZone.getTimeZone( "Australia/Melbourne" ) );
 
         Source source = new Source();
         LocalDate localDate = LocalDate.of( 2016, 3, 1 );

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
@@ -6,7 +6,6 @@
 package org.mapstruct.ap.test.conversion.jodatime;
 
 import java.util.Calendar;
-import java.util.Locale;
 import java.util.TimeZone;
 
 import org.joda.time.DateTime;
@@ -14,11 +13,10 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.LocalDate;
 import org.joda.time.LocalDateTime;
 import org.joda.time.LocalTime;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.EnabledOnJre;
 import org.junit.jupiter.api.condition.JRE;
+import org.junitpioneer.jupiter.DefaultLocale;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
@@ -32,20 +30,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @WithClasses({ Source.class, Target.class, SourceTargetMapper.class })
 @IssueKey("75")
+@DefaultLocale("de")
 public class JodaConversionTest {
-
-    private Locale originalLocale;
-
-    @BeforeEach
-    public void setDefaultLocale() {
-        originalLocale = Locale.getDefault();
-        Locale.setDefault( Locale.GERMAN );
-    }
-
-    @AfterEach
-    public void tearDown() {
-        Locale.setDefault( originalLocale );
-    }
 
     @ProcessorTest
     public void testDateTimeToString() {

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/numbers/NumberFormatConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/numbers/NumberFormatConversionTest.java
@@ -10,11 +10,9 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junitpioneer.jupiter.DefaultLocale;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
 
@@ -26,20 +24,8 @@ import static org.assertj.core.api.Assertions.entry;
         Target.class,
         SourceTargetMapper.class
 })
+@DefaultLocale("en")
 public class NumberFormatConversionTest {
-
-    private Locale originalLocale;
-
-    @BeforeEach
-    public void setDefaultLocale() {
-        originalLocale = Locale.getDefault();
-        Locale.setDefault( Locale.ENGLISH );
-    }
-
-    @AfterEach
-    public void tearDown() {
-        Locale.setDefault( originalLocale );
-    }
 
     @ProcessorTest
     public void shouldApplyStringConversions() {

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/compileoptionconstructor/SpringCompileOptionConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/compileoptionconstructor/SpringCompileOptionConstructorMapperTest.java
@@ -8,13 +8,11 @@ package org.mapstruct.ap.test.injectionstrategy.spring.compileoptionconstructor;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.TimeZone;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.DefaultTimeZone;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerRecordDto;
@@ -54,9 +52,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ProcessorOption( name = "mapstruct.defaultInjectionStrategy", value = "constructor")
 @ComponentScan(basePackageClasses = CustomerSpringCompileOptionConstructorMapper.class)
 @Configuration
+@DefaultTimeZone("Europe/Berlin")
 public class SpringCompileOptionConstructorMapperTest {
-
-    private static TimeZone originalTimeZone;
 
     @RegisterExtension
     final GeneratedSource generatedSource = new GeneratedSource();
@@ -64,17 +61,6 @@ public class SpringCompileOptionConstructorMapperTest {
     @Autowired
     private CustomerRecordSpringCompileOptionConstructorMapper customerRecordMapper;
     private ConfigurableApplicationContext context;
-
-    @BeforeAll
-    public static void setDefaultTimeZoneToCet() {
-        originalTimeZone = TimeZone.getDefault();
-        TimeZone.setDefault( TimeZone.getTimeZone( "Europe/Berlin" ) );
-    }
-
-    @AfterAll
-    public static void restoreOriginalTimeZone() {
-        TimeZone.setDefault( originalTimeZone );
-    }
 
     @BeforeEach
     public void springUp() {

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/constructor/SpringConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/constructor/SpringConstructorMapperTest.java
@@ -10,11 +10,10 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junitpioneer.jupiter.DefaultTimeZone;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerRecordDto;
@@ -54,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @IssueKey( "571" )
 @ComponentScan(basePackageClasses = CustomerSpringConstructorMapper.class)
 @Configuration
+@DefaultTimeZone("Europe/Berlin")
 public class SpringConstructorMapperTest {
 
     private static TimeZone originalTimeZone;
@@ -64,17 +64,6 @@ public class SpringConstructorMapperTest {
     @Autowired
     private CustomerRecordSpringConstructorMapper customerRecordMapper;
     private ConfigurableApplicationContext context;
-
-    @BeforeAll
-    public static void setDefaultTimeZoneToCet() {
-        originalTimeZone = TimeZone.getDefault();
-        TimeZone.setDefault( TimeZone.getTimeZone( "Europe/Berlin" ) );
-    }
-
-    @AfterAll
-    public static void restoreOriginalTimeZone() {
-        TimeZone.setDefault( originalTimeZone );
-    }
 
     @BeforeEach
     public void springUp() {

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/NestedMappingMethodInvocationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/NestedMappingMethodInvocationTest.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.List;
-import java.util.Locale;
 import javax.xml.bind.JAXBElement;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeConstants;
@@ -17,8 +16,7 @@ import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junitpioneer.jupiter.DefaultLocale;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
@@ -31,22 +29,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Sjaak Derksen
  */
 @IssueKey("134")
+@DefaultLocale("de")
 public class NestedMappingMethodInvocationTest {
 
     public static final QName QNAME = new QName( "dont-care" );
-
-    private Locale originalLocale;
-
-    @BeforeEach
-    public void setDefaultLocale() {
-        originalLocale = Locale.getDefault();
-        Locale.setDefault( Locale.GERMAN );
-    }
-
-    @AfterEach
-    public void tearDown() {
-        Locale.setDefault( originalLocale );
-    }
 
     @ProcessorTest
     @WithClasses( {

--- a/processor/src/test/resources/junit-platform.properties
+++ b/processor/src/test/resources/junit-platform.properties
@@ -1,0 +1,3 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default = same_thread
+junit.jupiter.execution.parallel.mode.classes.default = concurrent


### PR DESCRIPTION
Configure the JUnit Platform to run the processor tests in parallel by running different test classes in concurrent threads

Fixes #2446 