### PR TITLE
#2437 Do not visit the same type element twice when retrieving methods

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/Issue2437Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/Issue2437Test.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2437;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2437")
+@WithClasses({
+    Phone.class,
+    PhoneDto.class,
+    PhoneMapper.class,
+    PhoneParent1Mapper.class,
+    PhoneParent2Mapper.class,
+    PhoneSuperMapper.class,
+})
+class Issue2437Test {
+
+    @ProcessorTest
+    void shouldGenerateValidCode() {
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/Phone.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/Phone.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2437;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class Phone {
+
+    private final String number;
+
+    public Phone(String number) {
+        this.number = number;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/PhoneDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/PhoneDto.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2437;
+
+/**
+ * @author Filip Hrisafov
+ */
+public class PhoneDto {
+
+    private final String number;
+
+    public PhoneDto(String number) {
+        this.number = number;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/PhoneMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/PhoneMapper.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2437;
+
+import org.mapstruct.Mapper;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface PhoneMapper extends PhoneParent1Mapper, PhoneParent2Mapper {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/PhoneParent1Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/PhoneParent1Mapper.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2437;
+
+/**
+ * @author Filip Hrisafov
+ */
+public interface PhoneParent1Mapper extends PhoneSuperMapper {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/PhoneParent2Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/PhoneParent2Mapper.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2437;
+
+/**
+ * @author Filip Hrisafov
+ */
+public interface PhoneParent2Mapper extends PhoneSuperMapper {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/PhoneSuperMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2437/PhoneSuperMapper.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2437;
+
+/**
+ * @author Filip Hrisafov
+ */
+public interface PhoneSuperMapper {
+
+    Phone map(PhoneDto dto);
+}


### PR DESCRIPTION
When using the diamond inheritance a TypeElement might be visited twice.
This is however, incorrect. We need to visit a TypeElement exactly once.

Fixes #2437