### PR TITLE
#2466 Update dependencies so tests run on Java 16+

### DIFF
--- a/.github/workflows/java-ea.yml
+++ b/.github/workflows/java-ea.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [16-ea]
+        java: [17-ea]
     name: 'Linux JDK ${{ matrix.java }}'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 13, 15]
+        java: [11, 13, 16]
     name: 'Linux JDK ${{ matrix.java }}'
     runs-on: ubuntu-latest
     steps:

--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct.itest.tests;
 
+import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.parallel.Execution;
@@ -25,6 +26,7 @@ public class MavenIntegrationTest {
     }
 
     @ProcessorTest(baseDir = "cdiTest")
+    @DisabledForJreRange(min = JRE.JAVA_16)
     void cdiTest() {
     }
 

--- a/integrationtest/src/test/resources/jaxbTest/pom.xml
+++ b/integrationtest/src/test/resources/jaxbTest/pom.xml
@@ -47,6 +47,13 @@
                     <verbose>true</verbose>
                     <specVersion>2.1</specVersion>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.glassfish.jaxb</groupId>
+                        <artifactId>jaxb-runtime</artifactId>
+                        <version>2.3.2</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -202,7 +202,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.16</version>
+                <version>1.18.20</version>
             </dependency>
             <dependency>
                 <groupId>org.immutables</groupId>


### PR DESCRIPTION
Update GitHub Actions for tests to run on Java 11, 13, 16 and 17-ea.
Update Lombok so tests can run on 16+
Add jaxb-runtime dependency to the maven-jaxb2-plugin see https://github.com/highsource/maven-jaxb2-plugin/issues/148
Disable cdi integration test on Java 16+ until we find a solution for them

Fixes #2466