### PR TITLE
fix(pom): fix gradle repo url 404

### DIFF
--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -28,7 +28,7 @@
     <repositories>
         <repository>
             <id>gradle</id>
-            <url>https://repo.gradle.org/gradle/libs-releases</url>
+            <url>https://repo.gradle.org/artifactory/libs-releases/</url>
             <releases>
                 <enabled>true</enabled>
             </releases>


### PR DESCRIPTION
original url is 404 replace with new url
because https://repo.gradle.org/artifactory/libs-releases/ is 404 now
reference to https://repo.gradle.org/ui/repos/tree/General/libs-releases
```
[ERROR] Failed to execute goal on project mapstruct-integrationtest: Could not resolve dependencies for project org.mapstruct:mapstruct-integrationtest:jar:1.5.0-SNAPSHOT: Failed to collect dependencies at org.gradle:gradle-test-kit:jar:5.6.4: Failed to read artifact descriptor for org.gradle:gradle-test-kit:jar:5.6.4: Could not transfer artifact org.gradle:gradle-test-kit:pom:5.6.4 from/to gradle (https://repo.gradle.org/gradle/libs-releases): Transfer failed for https://repo.gradle.org/gradle/libs-releases/org/gradle/gradle-test-kit/5.6.4/gradle-test-kit-5.6.4.pom 503 Service Temporarily Unavailable -> [Help 1]
```