### PR TITLE
#2351 NullValueMappingStrategy for Maps and Iterables

### DIFF
--- a/core/src/main/java/org/mapstruct/Mapper.java
+++ b/core/src/main/java/org/mapstruct/Mapper.java
@@ -204,6 +204,32 @@ public @interface Mapper {
     NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.RETURN_NULL;
 
     /**
+     * The strategy to be applied when {@code null} is passed as source argument value to an {@link IterableMapping} of
+     * this mapper. If unset, the strategy set with {@link #nullValueMappingStrategy()} will be applied. If neither
+     * strategy is configured, the strategy given via {@link MapperConfig#nullValueIterableMappingStrategy()} will be
+     * applied, using {@link NullValueMappingStrategy#RETURN_NULL} by default.
+     *
+     * @since 1.5
+     *
+     * @return The strategy to be applied when {@code null} is passed as source value to an {@link IterableMapping} of
+     * this mapper.
+     */
+    NullValueMappingStrategy nullValueIterableMappingStrategy() default NullValueMappingStrategy.RETURN_NULL;
+
+    /**
+     * The strategy to be applied when {@code null} is passed as source argument value to a {@link MapMapping} of this
+     * mapper. If unset, the strategy set with {@link #nullValueMappingStrategy()} will be applied. If neither strategy
+     * is configured, the strategy given via {@link MapperConfig#nullValueMapMappingStrategy()} will be applied, using
+     * {@link NullValueMappingStrategy#RETURN_NULL} by default.
+     *
+     * @since 1.5
+     *
+     * @return The strategy to be applied when {@code null} is passed as source value to a {@link MapMapping} of this
+     * mapper.
+     */
+    NullValueMappingStrategy nullValueMapMappingStrategy() default NullValueMappingStrategy.RETURN_NULL;
+
+    /**
      * The strategy to be applied when a source bean property is {@code null} or not present. If no strategy is
      * configured, the strategy given via {@link MapperConfig#nullValuePropertyMappingStrategy()} will be applied,
      * {@link NullValuePropertyMappingStrategy#SET_TO_NULL} will be used by default.

--- a/core/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core/src/main/java/org/mapstruct/MapperConfig.java
@@ -178,6 +178,28 @@ public @interface MapperConfig {
     NullValueMappingStrategy nullValueMappingStrategy() default NullValueMappingStrategy.RETURN_NULL;
 
     /**
+     * The strategy to be applied when {@code null} is passed as source argument value to an {@link IterableMapping}.
+     * If no strategy is configured, the strategy given via {@link #nullValueMappingStrategy()} will be applied, using
+     * {@link NullValueMappingStrategy#RETURN_NULL} by default.
+     *
+     * @since 1.5
+     *
+     * @return The strategy to be applied when {@code null} is passed as source value to an {@link IterableMapping}.
+     */
+    NullValueMappingStrategy nullValueIterableMappingStrategy() default NullValueMappingStrategy.RETURN_NULL;
+
+    /**
+     * The strategy to be applied when {@code null} is passed as source argument value to a {@link MapMapping}.
+     * If no strategy is configured, the strategy given via {@link #nullValueMappingStrategy()} will be applied, using
+     * {@link NullValueMappingStrategy#RETURN_NULL} by default.
+     *
+     * @since 1.5
+     *
+     * @return The strategy to be applied when {@code null} is passed as source value to a {@link MapMapping}.
+     */
+    NullValueMappingStrategy nullValueMapMappingStrategy() default NullValueMappingStrategy.RETURN_NULL;
+
+    /**
      * The strategy to be applied when a source bean property is {@code null} or not present. If no strategy is
      * configured, {@link NullValuePropertyMappingStrategy#SET_TO_NULL} will be used by default.
      *

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/DefaultOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/DefaultOptions.java
@@ -124,6 +124,14 @@ public class DefaultOptions extends DelegatingOptions {
         return SubclassExhaustiveStrategyGem.valueOf( mapper.subclassExhaustiveStrategy().getDefaultValue() );
     }
 
+    public NullValueMappingStrategyGem getNullValueIterableMappingStrategy() {
+        return NullValueMappingStrategyGem.valueOf( mapper.nullValueIterableMappingStrategy().getDefaultValue() );
+    }
+
+    public NullValueMappingStrategyGem getNullValueMapMappingStrategy() {
+        return NullValueMappingStrategyGem.valueOf( mapper.nullValueMapMappingStrategy().getDefaultValue() );
+    }
+
     public BuilderGem getBuilder() {
         // TODO: I realized this is not correct, however it needs to be null in order to keep downward compatibility
         // but assuming a default @Builder will make testcases fail. Not having a default means that you need to

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/DelegatingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/DelegatingOptions.java
@@ -102,6 +102,14 @@ public abstract class DelegatingOptions {
         return next.getSubclassExhaustiveStrategy();
     }
 
+    public NullValueMappingStrategyGem getNullValueIterableMappingStrategy() {
+        return next.getNullValueIterableMappingStrategy();
+    }
+
+    public NullValueMappingStrategyGem getNullValueMapMappingStrategy() {
+        return next.getNullValueMapMappingStrategy();
+    }
+
     public BuilderGem getBuilder() {
         return next.getBuilder();
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/IterableMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/IterableMappingOptions.java
@@ -30,11 +30,11 @@ public class IterableMappingOptions extends DelegatingOptions {
     private final IterableMappingGem iterableMapping;
 
     public static IterableMappingOptions fromGem(IterableMappingGem iterableMapping,
-                                                 MapperOptions mappperOptions, ExecutableElement method,
+                                                 MapperOptions mapperOptions, ExecutableElement method,
                                                  FormattingMessager messager, TypeUtils typeUtils) {
 
         if ( iterableMapping == null || !isConsistent( iterableMapping, method, messager ) ) {
-            IterableMappingOptions options = new IterableMappingOptions( null, null, null, mappperOptions );
+            IterableMappingOptions options = new IterableMappingOptions( null, null, null, mapperOptions );
             return options;
         }
 
@@ -54,7 +54,7 @@ public class IterableMappingOptions extends DelegatingOptions {
         );
 
         IterableMappingOptions options =
-            new IterableMappingOptions( formatting, selection, iterableMapping, mappperOptions );
+            new IterableMappingOptions( formatting, selection, iterableMapping, mapperOptions );
         return options;
     }
 
@@ -99,7 +99,7 @@ public class IterableMappingOptions extends DelegatingOptions {
             .filter( GemValue::hasValue )
             .map( GemValue::getValue )
             .map( NullValueMappingStrategyGem::valueOf )
-            .orElse( next().getNullValueMappingStrategy() );
+            .orElse( next().getNullValueIterableMappingStrategy() );
     }
 
     public MappingControl getElementMappingControl(ElementUtils elementUtils) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapMappingOptions.java
@@ -144,7 +144,7 @@ public class MapMappingOptions extends DelegatingOptions {
             .filter( GemValue::hasValue )
             .map( GemValue::getValue )
             .map( NullValueMappingStrategyGem::valueOf )
-            .orElse( next().getNullValueMappingStrategy() );
+            .orElse( next().getNullValueMapMappingStrategy() );
     }
 
     public MappingControl getKeyMappingControl(ElementUtils elementUtils) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperConfigOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperConfigOptions.java
@@ -135,6 +135,28 @@ public class MapperConfigOptions extends DelegatingOptions {
     }
 
     @Override
+    public NullValueMappingStrategyGem getNullValueIterableMappingStrategy() {
+        if ( mapperConfig.nullValueIterableMappingStrategy().hasValue() ) {
+            return NullValueMappingStrategyGem.valueOf( mapperConfig.nullValueIterableMappingStrategy().get() );
+        }
+        if ( mapperConfig.nullValueMappingStrategy().hasValue() ) {
+            return NullValueMappingStrategyGem.valueOf( mapperConfig.nullValueMappingStrategy().get() );
+        }
+        return next().getNullValueIterableMappingStrategy();
+    }
+
+    @Override
+    public NullValueMappingStrategyGem getNullValueMapMappingStrategy() {
+        if ( mapperConfig.nullValueMapMappingStrategy().hasValue() ) {
+            return NullValueMappingStrategyGem.valueOf( mapperConfig.nullValueMapMappingStrategy().get() );
+        }
+        if ( mapperConfig.nullValueMappingStrategy().hasValue() ) {
+            return NullValueMappingStrategyGem.valueOf( mapperConfig.nullValueMappingStrategy().get() );
+        }
+        return next().getNullValueMapMappingStrategy();
+    }
+
+    @Override
     public BuilderGem getBuilder() {
         return mapperConfig.builder().hasValue() ? mapperConfig.builder().get() : next().getBuilder();
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperOptions.java
@@ -164,6 +164,28 @@ public class MapperOptions extends DelegatingOptions {
     }
 
     @Override
+    public NullValueMappingStrategyGem getNullValueIterableMappingStrategy() {
+        if ( mapper.nullValueIterableMappingStrategy().hasValue() ) {
+            return NullValueMappingStrategyGem.valueOf( mapper.nullValueIterableMappingStrategy().get() );
+        }
+        if ( mapper.nullValueMappingStrategy().hasValue() ) {
+            return NullValueMappingStrategyGem.valueOf( mapper.nullValueMappingStrategy().get() );
+        }
+        return next().getNullValueIterableMappingStrategy();
+    }
+
+    @Override
+    public NullValueMappingStrategyGem getNullValueMapMappingStrategy() {
+        if ( mapper.nullValueMapMappingStrategy().hasValue() ) {
+            return NullValueMappingStrategyGem.valueOf( mapper.nullValueMapMappingStrategy().get() );
+        }
+        if ( mapper.nullValueMappingStrategy().hasValue() ) {
+            return NullValueMappingStrategyGem.valueOf( mapper.nullValueMappingStrategy().get() );
+        }
+        return next().getNullValueMapMappingStrategy();
+    }
+
+    @Override
     public BuilderGem getBuilder() {
         return mapper.builder().hasValue() ? mapper.builder().get() : next().getBuilder();
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapper.java
@@ -16,7 +16,6 @@ import org.mapstruct.IterableMapping;
 import org.mapstruct.MapMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Mappings;
 import org.mapstruct.ap.test.nullvaluemapping._target.CarDto;
 import org.mapstruct.ap.test.nullvaluemapping._target.DriverAndCarDto;
 import org.mapstruct.ap.test.nullvaluemapping.source.Car;
@@ -29,18 +28,14 @@ public interface CarMapper {
     CarMapper INSTANCE = Mappers.getMapper( CarMapper.class );
 
     @BeanMapping(nullValueMappingStrategy = RETURN_DEFAULT)
-    @Mappings({
-        @Mapping(target = "seatCount", source = "numberOfSeats"),
-        @Mapping(target = "model", constant = "ModelT"),
-        @Mapping(target = "catalogId", expression = "java( UUID.randomUUID().toString() )")
-    })
+    @Mapping(target = "seatCount", source = "numberOfSeats")
+    @Mapping(target = "model", constant = "ModelT")
+    @Mapping(target = "catalogId", expression = "java( UUID.randomUUID().toString() )")
     CarDto carToCarDto(Car car);
 
     @BeanMapping(nullValueMappingStrategy = RETURN_DEFAULT)
-    @Mappings({
-        @Mapping(target = "seatCount", source = "car.numberOfSeats"),
-        @Mapping(target = "catalogId", expression = "java( UUID.randomUUID().toString() )")
-    })
+    @Mapping(target = "seatCount", source = "car.numberOfSeats")
+    @Mapping(target = "catalogId", expression = "java( UUID.randomUUID().toString() )")
     CarDto carToCarDto(Car car, String model);
 
     @IterableMapping(nullValueMappingStrategy = RETURN_DEFAULT)

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperIterableSettingOnConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperIterableSettingOnConfig.java
@@ -13,24 +13,23 @@ import org.mapstruct.IterableMapping;
 import org.mapstruct.MapMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.NullValueMappingStrategy;
 import org.mapstruct.ap.test.nullvaluemapping._target.CarDto;
 import org.mapstruct.ap.test.nullvaluemapping.source.Car;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(imports = UUID.class, nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
-public interface CarMapperSettingOnMapper {
+@Mapper(imports = UUID.class, config = CentralIterableMappingConfig.class)
+public interface CarMapperIterableSettingOnConfig {
 
-    CarMapperSettingOnMapper INSTANCE = Mappers.getMapper( CarMapperSettingOnMapper.class );
+    CarMapperIterableSettingOnConfig INSTANCE = Mappers.getMapper( CarMapperIterableSettingOnConfig.class );
 
     @Mapping(target = "seatCount", source = "numberOfSeats")
     @Mapping(target = "model", constant = "ModelT")
     @Mapping(target = "catalogId", expression = "java( UUID.randomUUID().toString() )")
     CarDto carToCarDto(Car car);
 
-    @IterableMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+    @IterableMapping(dateFormat = "dummy")
     List<CarDto> carsToCarDtos(List<Car> cars);
 
-    @MapMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_NULL)
+    @MapMapping(valueDateFormat = "dummy")
     Map<Integer, CarDto> carsToCarDtoMap(Map<Integer, Car> cars);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperIterableSettingOnMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperIterableSettingOnMapper.java
@@ -18,19 +18,23 @@ import org.mapstruct.ap.test.nullvaluemapping._target.CarDto;
 import org.mapstruct.ap.test.nullvaluemapping.source.Car;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(imports = UUID.class, nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
-public interface CarMapperSettingOnMapper {
+@Mapper(
+    imports = UUID.class,
+    nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
+    nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_NULL
+)
+public interface CarMapperIterableSettingOnMapper {
 
-    CarMapperSettingOnMapper INSTANCE = Mappers.getMapper( CarMapperSettingOnMapper.class );
+    CarMapperIterableSettingOnMapper INSTANCE = Mappers.getMapper( CarMapperIterableSettingOnMapper.class );
 
     @Mapping(target = "seatCount", source = "numberOfSeats")
     @Mapping(target = "model", constant = "ModelT")
     @Mapping(target = "catalogId", expression = "java( UUID.randomUUID().toString() )")
     CarDto carToCarDto(Car car);
 
-    @IterableMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+    @IterableMapping(dateFormat = "dummy")
     List<CarDto> carsToCarDtos(List<Car> cars);
 
-    @MapMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_NULL)
+    @MapMapping(valueDateFormat = "dummy")
     Map<Integer, CarDto> carsToCarDtoMap(Map<Integer, Car> cars);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperMapSettingOnConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperMapSettingOnConfig.java
@@ -13,24 +13,23 @@ import org.mapstruct.IterableMapping;
 import org.mapstruct.MapMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.NullValueMappingStrategy;
 import org.mapstruct.ap.test.nullvaluemapping._target.CarDto;
 import org.mapstruct.ap.test.nullvaluemapping.source.Car;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(imports = UUID.class, nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
-public interface CarMapperSettingOnMapper {
+@Mapper(imports = UUID.class, config = CentralMapMappingConfig.class)
+public interface CarMapperMapSettingOnConfig {
 
-    CarMapperSettingOnMapper INSTANCE = Mappers.getMapper( CarMapperSettingOnMapper.class );
+    CarMapperMapSettingOnConfig INSTANCE = Mappers.getMapper( CarMapperMapSettingOnConfig.class );
 
     @Mapping(target = "seatCount", source = "numberOfSeats")
     @Mapping(target = "model", constant = "ModelT")
     @Mapping(target = "catalogId", expression = "java( UUID.randomUUID().toString() )")
     CarDto carToCarDto(Car car);
 
-    @IterableMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+    @IterableMapping(dateFormat = "dummy")
     List<CarDto> carsToCarDtos(List<Car> cars);
 
-    @MapMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_NULL)
+    @MapMapping(valueDateFormat = "dummy")
     Map<Integer, CarDto> carsToCarDtoMap(Map<Integer, Car> cars);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperMapSettingOnMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperMapSettingOnMapper.java
@@ -18,19 +18,23 @@ import org.mapstruct.ap.test.nullvaluemapping._target.CarDto;
 import org.mapstruct.ap.test.nullvaluemapping.source.Car;
 import org.mapstruct.factory.Mappers;
 
-@Mapper(imports = UUID.class, nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
-public interface CarMapperSettingOnMapper {
+@Mapper(
+    imports = UUID.class,
+    nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
+    nullValueMapMappingStrategy = NullValueMappingStrategy.RETURN_NULL
+)
+public interface CarMapperMapSettingOnMapper {
 
-    CarMapperSettingOnMapper INSTANCE = Mappers.getMapper( CarMapperSettingOnMapper.class );
+    CarMapperMapSettingOnMapper INSTANCE = Mappers.getMapper( CarMapperMapSettingOnMapper.class );
 
     @Mapping(target = "seatCount", source = "numberOfSeats")
     @Mapping(target = "model", constant = "ModelT")
     @Mapping(target = "catalogId", expression = "java( UUID.randomUUID().toString() )")
     CarDto carToCarDto(Car car);
 
-    @IterableMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+    @IterableMapping(dateFormat = "dummy")
     List<CarDto> carsToCarDtos(List<Car> cars);
 
-    @MapMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_NULL)
+    @MapMapping(valueDateFormat = "dummy")
     Map<Integer, CarDto> carsToCarDtoMap(Map<Integer, Car> cars);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperSettingOnConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CarMapperSettingOnConfig.java
@@ -13,7 +13,6 @@ import org.mapstruct.IterableMapping;
 import org.mapstruct.MapMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
-import org.mapstruct.Mappings;
 import org.mapstruct.NullValueMappingStrategy;
 import org.mapstruct.ap.test.nullvaluemapping._target.CarDto;
 import org.mapstruct.ap.test.nullvaluemapping.source.Car;
@@ -24,11 +23,9 @@ public interface CarMapperSettingOnConfig {
 
     CarMapperSettingOnConfig INSTANCE = Mappers.getMapper( CarMapperSettingOnConfig.class );
 
-    @Mappings({
-        @Mapping(target = "seatCount", source = "numberOfSeats"),
-        @Mapping(target = "model", constant = "ModelT"),
-        @Mapping(target = "catalogId", expression = "java( UUID.randomUUID().toString() )")
-    })
+    @Mapping(target = "seatCount", source = "numberOfSeats")
+    @Mapping(target = "model", constant = "ModelT")
+    @Mapping(target = "catalogId", expression = "java( UUID.randomUUID().toString() )")
     CarDto carToCarDto(Car car);
 
     @IterableMapping(dateFormat = "dummy")

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CentralIterableMappingConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CentralIterableMappingConfig.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullvaluemapping;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.NullValueMappingStrategy;
+
+@MapperConfig(
+    nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
+    nullValueIterableMappingStrategy = NullValueMappingStrategy.RETURN_NULL
+)
+public class CentralIterableMappingConfig {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CentralMapMappingConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/CentralMapMappingConfig.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullvaluemapping;
+
+import org.mapstruct.MapperConfig;
+import org.mapstruct.NullValueMappingStrategy;
+
+@MapperConfig(
+    nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
+    nullValueMapMappingStrategy = NullValueMappingStrategy.RETURN_NULL
+)
+public class CentralMapMappingConfig {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/NullValueMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluemapping/NullValueMappingTest.java
@@ -33,8 +33,14 @@ import static org.assertj.core.api.Assertions.assertThat;
     DriverAndCarDto.class,
     CarMapper.class,
     CarMapperSettingOnMapper.class,
+    CarMapperIterableSettingOnMapper.class,
+    CarMapperMapSettingOnMapper.class,
     CentralConfig.class,
-    CarMapperSettingOnConfig.class
+    CarMapperSettingOnConfig.class,
+    CentralIterableMappingConfig.class,
+    CarMapperIterableSettingOnConfig.class,
+    CentralMapMappingConfig.class,
+    CarMapperMapSettingOnConfig.class,
 })
 public class NullValueMappingTest {
 
@@ -161,8 +167,7 @@ public class NullValueMappingTest {
         List<CarDto> carDtos = CarMapperSettingOnMapper.INSTANCE.carsToCarDtos( null );
 
         //then
-        assertThat( carDtos ).isNotNull();
-        assertThat( carDtos.isEmpty() ).isTrue();
+        assertThat( carDtos ).isEmpty();
     }
 
     @ProcessorTest
@@ -170,6 +175,74 @@ public class NullValueMappingTest {
 
         //when
         Map<Integer, CarDto> carDtoMap = CarMapperSettingOnMapper.INSTANCE.carsToCarDtoMap( null );
+
+        //then
+        assertThat( carDtoMap ).isNull();
+    }
+
+    @ProcessorTest
+    public void shouldMapExpressionAndConstantRegardlessOfIterableNullArgOnMapper() {
+
+        //when
+        CarDto carDto = CarMapperIterableSettingOnMapper.INSTANCE.carToCarDto( null );
+
+        //then
+        assertThat( carDto ).isNotNull();
+        assertThat( carDto.getMake() ).isNull();
+        assertThat( carDto.getSeatCount() ).isEqualTo( 0 );
+        assertThat( carDto.getModel() ).isEqualTo( "ModelT" );
+        assertThat( carDto.getCatalogId() ).isNotEmpty();
+    }
+
+    @ProcessorTest
+    public void shouldMapIterableToNullWithIterableNullArgOnMapper() {
+
+        //when
+        List<CarDto> carDtos = CarMapperIterableSettingOnMapper.INSTANCE.carsToCarDtos( null );
+
+        //then
+        assertThat( carDtos ).isNull();
+    }
+
+    @ProcessorTest
+    public void shouldMapMapRegardlessOfIterableNullArgOnMapper() {
+
+        //when
+        Map<Integer, CarDto> carDtoMap = CarMapperIterableSettingOnMapper.INSTANCE.carsToCarDtoMap( null );
+
+        //then
+        assertThat( carDtoMap ).isEmpty();
+    }
+
+    @ProcessorTest
+    public void shouldMapExpressionAndConstantRegardlessMapNullArgOnMapper() {
+
+        //when
+        CarDto carDto = CarMapperMapSettingOnMapper.INSTANCE.carToCarDto( null );
+
+        //then
+        assertThat( carDto ).isNotNull();
+        assertThat( carDto.getMake() ).isNull();
+        assertThat( carDto.getSeatCount() ).isEqualTo( 0 );
+        assertThat( carDto.getModel() ).isEqualTo( "ModelT" );
+        assertThat( carDto.getCatalogId() ).isNotEmpty();
+    }
+
+    @ProcessorTest
+    public void shouldMapIterableRegardlessOfMapNullArgOnMapper() {
+
+        //when
+        List<CarDto> carDtos = CarMapperMapSettingOnMapper.INSTANCE.carsToCarDtos( null );
+
+        //then
+        assertThat( carDtos ).isEmpty();
+    }
+
+    @ProcessorTest
+    public void shouldMapMapToWithMapNullArgOnMapper() {
+
+        //when
+        Map<Integer, CarDto> carDtoMap = CarMapperMapSettingOnMapper.INSTANCE.carsToCarDtoMap( null );
 
         //then
         assertThat( carDtoMap ).isNull();
@@ -196,8 +269,7 @@ public class NullValueMappingTest {
         List<CarDto> carDtos = CarMapperSettingOnConfig.INSTANCE.carsToCarDtos( null );
 
         //then
-        assertThat( carDtos ).isNotNull();
-        assertThat( carDtos.isEmpty() ).isTrue();
+        assertThat( carDtos ).isEmpty();
     }
 
     @ProcessorTest
@@ -205,6 +277,74 @@ public class NullValueMappingTest {
 
         //when
         Map<Integer, CarDto> carDtoMap = CarMapperSettingOnConfig.INSTANCE.carsToCarDtoMap( null );
+
+        //then
+        assertThat( carDtoMap ).isNull();
+    }
+
+    @ProcessorTest
+    public void shouldMapExpressionAndConstantRegardlessOfIterableNullArgOnConfig() {
+
+        //when
+        CarDto carDto = CarMapperIterableSettingOnConfig.INSTANCE.carToCarDto( null );
+
+        //then
+        assertThat( carDto ).isNotNull();
+        assertThat( carDto.getMake() ).isNull();
+        assertThat( carDto.getSeatCount() ).isEqualTo( 0 );
+        assertThat( carDto.getModel() ).isEqualTo( "ModelT" );
+        assertThat( carDto.getCatalogId() ).isNotEmpty();
+    }
+
+    @ProcessorTest
+    public void shouldMapIterableToNullWithIterableNullArgOnConfig() {
+
+        //when
+        List<CarDto> carDtos = CarMapperIterableSettingOnConfig.INSTANCE.carsToCarDtos( null );
+
+        //then
+        assertThat( carDtos ).isNull();
+    }
+
+    @ProcessorTest
+    public void shouldMapMapRegardlessOfIterableNullArgOnConfig() {
+
+        //when
+        Map<Integer, CarDto> carDtoMap = CarMapperIterableSettingOnConfig.INSTANCE.carsToCarDtoMap( null );
+
+        //then
+        assertThat( carDtoMap ).isEmpty();
+    }
+
+    @ProcessorTest
+    public void shouldMapExpressionAndConstantRegardlessOfMapNullArgOnConfig() {
+
+        //when
+        CarDto carDto = CarMapperMapSettingOnConfig.INSTANCE.carToCarDto( null );
+
+        //then
+        assertThat( carDto ).isNotNull();
+        assertThat( carDto.getMake() ).isNull();
+        assertThat( carDto.getSeatCount() ).isEqualTo( 0 );
+        assertThat( carDto.getModel() ).isEqualTo( "ModelT" );
+        assertThat( carDto.getCatalogId() ).isNotEmpty();
+    }
+
+    @ProcessorTest
+    public void shouldMapIterableRegardlessOfMapNullArgOnConfig() {
+
+        //when
+        List<CarDto> carDtos = CarMapperMapSettingOnConfig.INSTANCE.carsToCarDtos( null );
+
+        //then
+        assertThat( carDtos ).isEmpty();
+    }
+
+    @ProcessorTest
+    public void shouldMapMapToNullWithMapNullArgOnConfig() {
+
+        //when
+        Map<Integer, CarDto> carDtoMap = CarMapperMapSettingOnConfig.INSTANCE.carsToCarDtoMap( null );
 
         //then
         assertThat( carDtoMap ).isNull();


### PR DESCRIPTION
With two new parameters for Mapper and MapperConfig, it is now possible to override the nullValueMappingStrategy specifically for MapMapping and IterableMapping.

Fixes #2351