### PR TITLE
PR for issues #131, #2438, #366

### DIFF
--- a/core/src/main/java/org/mapstruct/SubClassMapping.java
+++ b/core/src/main/java/org/mapstruct/SubClassMapping.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Configures the mapping to handle hierarchy of the source type.
+ * <p>
+ * The subclass to be mapped is to be specified via {@link #sourceClass()}.
+ * The subclass to map to is to be specified via {@link #targetClass()}.
+ * It currently is also required that a mapping method exist that has the {@link #targetClass()}
+ * as the return type and the {@link #sourceClass()} as the only argument.
+ * </p>
+ * <p>
+ * This annotation can be combined with &#64;Mapping annotations.
+ * </p>
+ *
+ * <pre><code class='java'>
+ * &#64;Mapper
+ * public interface MyMapper {
+ *    &#64;SubClassMapping (sourceClass = SourceSubClass.class,
+ *                      targetClass = TargetSubClass.class)
+ *    TargetParent mapParent(SourceParent parent);
+ *
+ *    TargetSubClass mapSubClass(SourceSubClass subInstant);
+ * }
+ * </code></pre>
+ * Below follow examples of the implementation for the mapParent method.
+ * <strong>Example 1:</strong> For parents that cannot be created. (e.g. abstract classes or interfaces)
+ * <pre><code class='java'>
+ * // generates
+ * &#64;Override
+ * public TargetParent mapParent(SourceParent parent) {
+ *     if (parent instanceof SourceSubClass) {
+ *         return mapSubClass( (SourceSubClass) parent );
+ *     }
+ *     else {
+ *         throw new IllegalArgumentException("Not all subclasses are supported for this mapping. Missing for "
+ *                    + parent.getClass());
+ *     }
+ * }
+ * </code></pre>
+ * <strong>Example 2:</strong> For parents that can be created. (e.g. normal classes or interfaces with
+ * &#64;Mappper( uses = ObjectFactory.class ) )
+ * <pre><code class='java'>
+ * // generates
+ * &#64;Override
+ * public TargetParent mapParent(SourceParent parent) {
+ *     TargetParent targetParent1;
+ *     if (parent instanceof SourceSubClass) {
+ *         targetParent1 = mapSubClass( (SourceSubClass) parent );
+ *     }
+ *     else {
+ *         targetParent1 = new TargetParent();
+ *         // ...
+ *     }
+ * }
+ * </code></pre>
+ *
+ * @author Ben Zegveld
+ * @since 1.5
+ */
+@Repeatable( value = SubClassMappings.class )
+@Retention( RetentionPolicy.CLASS )
+@Target( { ElementType.METHOD, ElementType.ANNOTATION_TYPE } )
+public @interface SubClassMapping {
+    /**
+     * @return the source subclass to check for before using the default mapping as fallback.
+     */
+    Class<?> sourceClass();
+
+    /**
+     * @return the target subclass to map the sourceSubClass to.
+     */
+    Class<?> targetClass();
+}

--- a/core/src/main/java/org/mapstruct/SubClassMappings.java
+++ b/core/src/main/java/org/mapstruct/SubClassMappings.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Configures the SubClassMappings of several subclasses.
+ * <p>
+ * <strong>TIP: When using java 8 or later, you can omit the @SubClassMappings
+ * Wrapper annotation and directly specify several @SubClassMapping annotations
+ * on one method.</strong>
+ * </p>
+ * <p>These two examples are equal.
+ * </p>
+ * <pre><code class='java'>
+ * // before java 8
+ * &#64;Mapper
+ * public interface MyMapper {
+ *     &#64;SubClassMappings({
+ *         &#64;SubClassMapping(sourceClass = firstSub.class,
+ *                          targetClass = firstTargetSub.class),
+ *         &#64;SubClassMapping(sourceClass = secondSub.class,
+ *                          targetClass = secondTargetSub.class)
+ *     })
+ *     ParentTarget toParentTarget(Parent parent);
+ * }
+ * </code></pre>
+ * <pre><code class='java'>
+ * // java 8 and later
+ * &#64;Mapper
+ * public interface MyMapper {
+ *     &#64;SubClassMapping(sourceClass = firstSub.class,
+ *                      targetClass = firstTargetSub.class),
+ *     &#64;SubClassMapping(sourceClass = secondSub.class,
+ *                      targetClass = secondTargetSub.class)
+ *     ParentTarget toParentTarget(Parent parent);
+ * }
+ * </code></pre>
+ *
+ * @author Ben Zegveld
+ * @since 1.5
+ */
+@Target( ElementType.METHOD )
+@Retention( RetentionPolicy.CLASS )
+public @interface SubClassMappings {
+
+    /**
+     * @return the subClassMappings to apply.
+     */
+    SubClassMapping[] value();
+
+}

--- a/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
@@ -110,6 +110,34 @@ public interface SourceTargetMapper {
 
 The example demonstrates how to use defaultExpression to set an `ID` field if the source field is null, this could be used to take the existing `sourceId` from the source object if it is set, or create a new `Id` if it isn't. Please note that the fully qualified package name is specified because MapStruct does not take care of the import of the `UUID` class (unless it’s used otherwise explicitly in the `SourceTargetMapper`). This can be resolved by defining imports on the @Mapper annotation (see <<expressions>>).
 
+[[sub-class-mappings]]
+=== Subclass Mapping
+
+When both input and result types have an inheritance relation, you would want the correct specialization be mapped to the matching specialization. Suppose an Apple and a Banana, which are both specializations of Fruit.
+
+.Specifying the sub class mappings of a fruit mapping
+====
+[source, java, linenums]
+[subs="verbatim,attributes"]
+----
+@Mapper
+public interface FruitMapper {
+
+    @SubClassMapping( sourceClass = AppleDto.class, targetClass = Apple.class )
+    @SubClassMapping( sourceClass = BananaDto.class, targetClass = Banana.class )
+    Fruit map( FruitDto source );
+
+}
+----
+====
+
+If you would just use a normal mapping both the AppleDto and the BananaDto would be made into a Fruit object, instead of an Apple and a Banana object. By using the SubClassMapping an AppleDtoToApple mapping will be done for Apples, and an BananaDtoToBanana mapping will be done for Banana's. If you would try to map a GrapeDto it would still turn into a Fruit. In the case that the Fruit type is an abstract class or an interface, you would get an IllegalArgumentException because it is unknown how to map a GrapeDto. Adding the missing (`@SubClassMapping`) for it will fix that.
+
+[TIP]
+====
+If the mapping method for the subClasses does not exist it will be created and any other annotations on the fruit mapping method are inherited by the newly generated mappings.
+====
+
 [[determining-result-type]]
 === Determining the result type
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/gem/GemGenerator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/gem/GemGenerator.java
@@ -28,6 +28,8 @@ import org.mapstruct.Mappings;
 import org.mapstruct.Named;
 import org.mapstruct.ObjectFactory;
 import org.mapstruct.Qualifier;
+import org.mapstruct.SubClassMapping;
+import org.mapstruct.SubClassMappings;
 import org.mapstruct.TargetType;
 import org.mapstruct.ValueMapping;
 import org.mapstruct.ValueMappings;
@@ -47,6 +49,8 @@ import org.mapstruct.tools.gem.GemDefinition;
 @GemDefinition(BeanMapping.class)
 @GemDefinition(EnumMapping.class)
 @GemDefinition(MapMapping.class)
+@GemDefinition(SubClassMapping.class)
+@GemDefinition(SubClassMappings.class)
 @GemDefinition(TargetType.class)
 @GemDefinition(MappingTarget.class)
 @GemDefinition(DecoratedWith.class)

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ForgedMethod.java
@@ -11,6 +11,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
+
 import javax.lang.model.element.ExecutableElement;
 
 import org.mapstruct.ap.internal.model.beanmapping.MappingReferences;
@@ -347,7 +348,7 @@ public class ForgedMethod implements Method {
 
     @Override
     public MappingMethodOptions getOptions() {
-        return basedOn.getOptions();
+        return MappingMethodOptions.getForgedMethodInheritedOptions( basedOn.getOptions() );
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/SubClassMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/SubClassMapping.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.assignment.AssignmentWrapper;
+import org.mapstruct.ap.internal.model.assignment.ReturnWrapper;
+import org.mapstruct.ap.internal.model.common.Assignment;
+import org.mapstruct.ap.internal.model.common.ModelElement;
+import org.mapstruct.ap.internal.model.common.Parameter;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.util.TypeUtils;
+
+/**
+ * Represents the mapping between a SubClass and its mapping target. This will be used by a {@link BeanMappingMethod}
+ * that has {@link org.mapstruct.SubClassMapping} annotations applied to it. Before doing the normal mapping for that
+ * method it will first check if the source object is of the sourceType if so it will use the assignment instead.
+ *
+ * @author Ben Zegveld
+ */
+public class SubClassMapping extends ModelElement {
+
+    private final Type sourceType;
+    private Type targetType;
+    private Assignment assignment;
+    private String sourceArgument;
+    private TypeUtils typeUtils;
+
+    public SubClassMapping(Type sourceType, Type targetType, Assignment assignment, TypeUtils typeUtils) {
+        this.sourceType = sourceType;
+        this.targetType = targetType;
+        this.assignment = assignment;
+        this.typeUtils = typeUtils;
+    }
+
+    public Type getSourceType() {
+        return sourceType;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return new HashSet<>( Arrays.asList( sourceType, targetType ) );
+    }
+
+    public AssignmentWrapper getAssignment() {
+        return new ReturnWrapper( assignment );
+    }
+
+    public void updateWithParameters(List<Parameter> parameters) {
+        for ( Parameter parameter : parameters ) {
+            if ( typeUtils.isAssignable( sourceType.getTypeMirror(), parameter.getType().getTypeMirror() ) ) {
+                sourceArgument = parameter.getName();
+                assignment.setSourceLocalVarName( "(" + sourceType.createReferenceName() + ") " + sourceArgument );
+            }
+        }
+    }
+
+    public String getSourceArgument() {
+        return sourceArgument;
+    }
+
+    @Override
+    public boolean equals(final Object other) {
+        if ( !( other instanceof SubClassMapping ) ) {
+            return false;
+        }
+        SubClassMapping castOther = (SubClassMapping) other;
+        return Objects.equals( sourceType, castOther.sourceType ) && Objects.equals( targetType, castOther.targetType );
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash( sourceType, targetType );
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ReturnWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ReturnWrapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model.assignment;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.Assignment;
+import org.mapstruct.ap.internal.model.common.Type;
+
+/**
+ * Decorates an assignment as a return variable.
+ *
+ * @author Ben Zegveld
+ */
+public class ReturnWrapper extends AssignmentWrapper {
+
+    public ReturnWrapper(Assignment decoratedAssignment) {
+        super( decoratedAssignment, false );
+    }
+
+    @Override
+    public List<Type> getThrownTypes() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return new HashSet<>( getAssignment().getImportTypes() );
+    }
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
@@ -34,6 +34,7 @@ public class MappingMethodOptions {
         null,
         null,
         null,
+        Collections.emptyList(),
         Collections.emptyList()
     );
 
@@ -45,12 +46,14 @@ public class MappingMethodOptions {
     private EnumMappingOptions enumMappingOptions;
     private List<ValueMappingOptions> valueMappings;
     private boolean fullyInitialized;
+    private List<SubClassMappingOptions> subClassMapping;
 
     public MappingMethodOptions(MapperOptions mapper, Set<MappingOptions> mappings,
                                 IterableMappingOptions iterableMapping,
                                 MapMappingOptions mapMapping, BeanMappingOptions beanMapping,
                                 EnumMappingOptions enumMappingOptions,
-                                List<ValueMappingOptions> valueMappings) {
+                                List<ValueMappingOptions> valueMappings,
+                                List<SubClassMappingOptions> subClassMapping) {
         this.mapper = mapper;
         this.mappings = mappings;
         this.iterableMapping = iterableMapping;
@@ -58,6 +61,7 @@ public class MappingMethodOptions {
         this.beanMapping = beanMapping;
         this.enumMappingOptions = enumMappingOptions;
         this.valueMappings = valueMappings;
+        this.subClassMapping = subClassMapping;
     }
 
     /**
@@ -97,6 +101,10 @@ public class MappingMethodOptions {
         return valueMappings;
     }
 
+    public List<SubClassMappingOptions> getSubClassMappings() {
+        return subClassMapping;
+    }
+
     public void setIterableMapping(IterableMappingOptions iterableMapping) {
         this.iterableMapping = iterableMapping;
     }
@@ -115,6 +123,10 @@ public class MappingMethodOptions {
 
     public void setValueMappings(List<ValueMappingOptions> valueMappings) {
         this.valueMappings = valueMappings;
+    }
+
+    public void setSubClassMappings(List<SubClassMappingOptions> subClassMapping) {
+        this.subClassMapping = subClassMapping;
     }
 
     public MapperOptions getMapper() {
@@ -187,6 +199,8 @@ public class MappingMethodOptions {
                     }
                 }
             }
+
+            // Do NOT inherit subclass mapping options!!!
 
             Set<MappingOptions> newMappings = new LinkedHashSet<>();
             for ( MappingOptions mapping : templateOptions.getMappings() ) {
@@ -313,6 +327,23 @@ public class MappingMethodOptions {
         }
 
         return getPropertyEntries( mapping )[0];
+    }
+
+    /**
+     * SubClassMappingOptions are not inherited to forged methods. They would result in an infinite loop if they were.
+     *
+     * @return a MappingMethodOptions without SubClassMappingOptions.
+     */
+    public static MappingMethodOptions getForgedMethodInheritedOptions(MappingMethodOptions options) {
+        return new MappingMethodOptions(
+            options.mapper,
+            options.mappings,
+            options.iterableMapping,
+            options.mapMapping,
+            options.beanMapping,
+            options.enumMappingOptions,
+            options.valueMappings,
+            Collections.emptyList() );
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -95,6 +95,7 @@ public class SourceMethod implements Method {
         private EnumMappingOptions enumMappingOptions;
         private ParameterProvidedMethods contextProvidedMethods;
         private List<Type> typeParameters;
+        private List<SubClassMappingOptions> subClassMappings = Collections.emptyList();
 
         private boolean verboseLogging;
 
@@ -153,6 +154,11 @@ public class SourceMethod implements Method {
             return this;
         }
 
+        public Builder setSubClassMappings(List<SubClassMappingOptions> subClassMappings) {
+            this.subClassMappings = subClassMappings;
+            return this;
+        }
+
         public Builder setTypeUtils(TypeUtils typeUtils) {
             this.typeUtils = typeUtils;
             return this;
@@ -201,7 +207,8 @@ public class SourceMethod implements Method {
                 mapMapping,
                 beanMapping,
                 enumMappingOptions,
-                valueMappings
+                valueMappings,
+                subClassMappings
             );
 
             this.typeParameters = this.executable.getTypeParameters()

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubClassMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubClassMappingOptions.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model.source;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+import org.mapstruct.ap.internal.gem.SubClassMappingGem;
+import org.mapstruct.ap.internal.gem.SubClassMappingsGem;
+import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.TypeUtils;
+
+import static java.util.Objects.nonNull;
+import static org.mapstruct.ap.internal.util.Message.SUBCLASSMAPPING_ILLEGAL_SUBCLASS;
+import static org.mapstruct.ap.internal.util.Message.SUBCLASSMAPPING_METHOD_SIGNATURE_NOT_SUPPORTED;
+
+/**
+ * Represents a sub class mapping as configured via {@code @SubClassMapping}.
+ *
+ * @author Ben Zegveld
+ */
+public class SubClassMappingOptions extends DelegatingOptions {
+
+    private TypeMirror sourceClass;
+    private TypeMirror targetClass;
+
+    public SubClassMappingOptions(TypeMirror sourceClass, TypeMirror targetClass, DelegatingOptions next) {
+        super( next );
+        this.sourceClass = sourceClass;
+        this.targetClass = targetClass;
+    }
+
+    @Override
+    public boolean hasAnnotation() {
+        return sourceClass != null && targetClass != null;
+    }
+
+    public static List<SubClassMappingOptions> getInstanceOn(ExecutableElement method, MapperOptions mapperOptions,
+                                                       FormattingMessager messager, TypeUtils typeUtils) {
+
+        SubClassMappingsGem subClassMappings = SubClassMappingsGem.instanceOn( method );
+        List<SubClassMappingGem> subClassMappingAnnotations;
+        if ( nonNull( subClassMappings ) ) {
+            subClassMappingAnnotations = subClassMappings.value().get();
+        }
+        else if ( nonNull( SubClassMappingGem.instanceOn( method ) ) ) {
+            subClassMappingAnnotations = Arrays.asList( SubClassMappingGem.instanceOn( method ) );
+        }
+        else {
+            return Collections.emptyList();
+        }
+
+        List<SubClassMappingOptions> subClassMappingOptions = new ArrayList<>();
+
+        for ( SubClassMappingGem subClassMapping : subClassMappingAnnotations ) {
+
+            if ( !isConsistent( subClassMapping, method, messager, typeUtils ) ) {
+                continue;
+            }
+
+            TypeMirror sourceSubClass = subClassMapping.sourceClass().getValue();
+            TypeMirror targetSubClass = subClassMapping.targetClass().getValue();
+
+            subClassMappingOptions
+                                  .add(
+                                      new SubClassMappingOptions(
+                                          sourceSubClass,
+                                          targetSubClass,
+                                          mapperOptions ) );
+        }
+        return subClassMappingOptions;
+    }
+
+    private static boolean isConsistent(SubClassMappingGem gem, ExecutableElement method, FormattingMessager messager,
+                                        TypeUtils typeUtils) {
+
+        if ( method.getParameters().isEmpty() || method.getReturnType().getKind() == TypeKind.VOID ) {
+            messager
+                    .printMessage(
+                        method,
+                        gem.mirror(),
+                        SUBCLASSMAPPING_METHOD_SIGNATURE_NOT_SUPPORTED );
+            return false;
+        }
+
+        TypeMirror sourceSubClass = gem.sourceClass().getValue();
+        TypeMirror targetSubClass = gem.targetClass().getValue();
+        TypeMirror sourceParentType = method.getParameters().get( 0 ).asType();
+        TypeMirror targetParentType = method.getReturnType();
+        boolean isConsistent = true;
+
+        if ( !isChildOfParent( typeUtils, sourceSubClass, sourceParentType ) ) {
+            messager
+                    .printMessage(
+                        method,
+                        gem.mirror(),
+                        SUBCLASSMAPPING_ILLEGAL_SUBCLASS,
+                        sourceParentType.toString(),
+                        sourceSubClass.toString() );
+            isConsistent = false;
+        }
+        if ( !isChildOfParent( typeUtils, targetSubClass, targetParentType ) ) {
+            messager
+                    .printMessage(
+                        method,
+                        gem.mirror(),
+                        SUBCLASSMAPPING_ILLEGAL_SUBCLASS,
+                        targetParentType.toString(),
+                        targetSubClass.toString() );
+            isConsistent = false;
+        }
+        return isConsistent;
+    }
+
+    private static boolean isChildOfParent(TypeUtils typeUtils, TypeMirror childType, TypeMirror parentType) {
+        return typeUtils.isSubtype( childType, parentType );
+    }
+
+    public TypeMirror getSourceClass() {
+        return sourceClass;
+    }
+
+    public TypeMirror getTargetClass() {
+        return targetClass;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -54,6 +54,7 @@ import org.mapstruct.ap.internal.model.source.MappingMethodOptions;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.SourceMethod;
+import org.mapstruct.ap.internal.model.source.SubClassMappingOptions;
 import org.mapstruct.ap.internal.option.Options;
 import org.mapstruct.ap.internal.processor.creation.MappingResolverImpl;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
@@ -198,10 +199,11 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
             .options( options )
             .versionInformation( versionInformation )
             .decorator( getDecorator( element, methods, mapperOptions.implementationName(),
-                mapperOptions.implementationPackage(), getExtraImports( element, mapperOptions ) ) )
+                                                mapperOptions.implementationPackage(),
+                                                getExtraImports( element, mapperOptions, methods ) ) )
             .typeFactory( typeFactory )
             .elementUtils( elementUtils )
-            .extraImports( getExtraImports( element, mapperOptions ) )
+            .extraImports( getExtraImports( element, mapperOptions, methods ) )
             .implName( mapperOptions.implementationName() )
             .implPackage( mapperOptions.implementationPackage() )
             .build();
@@ -294,9 +296,19 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
         return decorator;
     }
 
-    private SortedSet<Type> getExtraImports(TypeElement element,  MapperOptions mapperOptions) {
+    private SortedSet<Type> getExtraImports(TypeElement element, MapperOptions mapperOptions,
+                                            List<SourceMethod> methods) {
         SortedSet<Type> extraImports = new TreeSet<>();
 
+
+        for ( SourceMethod method : methods ) {
+            for ( SubClassMappingOptions subClassMapping : method.getOptions().getSubClassMappings() ) {
+                Type type = typeFactory.getType( subClassMapping.getTargetClass() );
+                extraImports.add( type );
+                type = typeFactory.getType( subClassMapping.getSourceClass() );
+                extraImports.add( type );
+            }
+        }
 
         for ( TypeMirror extraImport : mapperOptions.imports() ) {
             Type type = typeFactory.getType( extraImport );

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -42,6 +42,7 @@ import org.mapstruct.ap.internal.model.source.MapperOptions;
 import org.mapstruct.ap.internal.model.source.MappingOptions;
 import org.mapstruct.ap.internal.model.source.ParameterProvidedMethods;
 import org.mapstruct.ap.internal.model.source.SourceMethod;
+import org.mapstruct.ap.internal.model.source.SubClassMappingOptions;
 import org.mapstruct.ap.internal.model.source.ValueMappingOptions;
 import org.mapstruct.ap.internal.option.Options;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
@@ -299,6 +300,14 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
             messager
         );
 
+        List<SubClassMappingOptions> subClassMappingOptions =
+            SubClassMappingOptions.getInstanceOn(
+                method,
+                mapperOptions,
+                messager,
+                typeUtils
+            );
+
         return new SourceMethod.Builder()
             .setExecutable( method )
             .setParameters( parameters )
@@ -311,6 +320,7 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
             .setMapMappingOptions( mapMappingOptions )
             .setValueMappingOptionss( getValueMappings( method ) )
             .setEnumMappingOptions( enumMappingOptions )
+            .setSubClassMappings( subClassMappingOptions )
             .setTypeUtils( typeUtils )
             .setTypeFactory( typeFactory )
             .setPrototypeMethods( prototypeMethods )

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -114,6 +114,9 @@ public enum Message {
     ENUMMAPPING_NO_ELEMENTS( "'nameTransformationStrategy', 'configuration' and 'unexpectedValueMappingException' are undefined in @EnumMapping, define at least one of them." ),
     ENUMMAPPING_ILLEGAL_TRANSFORMATION( "Illegal transformation for '%s' EnumTransformationStrategy. Error: '%s'." ),
 
+    SUBCLASSMAPPING_ILLEGAL_SUBCLASS("Class '%s' is not a subclass of '%s'."),
+    SUBCLASSMAPPING_METHOD_SIGNATURE_NOT_SUPPORTED("SubClassMapping annotation can not be used on Suppliers and Runnables."),
+
     LIFECYCLEMETHOD_AMBIGUOUS_PARAMETERS( "Lifecycle method has multiple matching parameters (e. g. same type), in this case please ensure to name the parameters in the lifecycle and mapping method identical. This lifecycle method will not be used for the mapping method '%s'.", Diagnostic.Kind.WARNING),
 
     DECORATOR_NO_SUBTYPE( "Specified decorator type is no subtype of the annotated mapper type." ),
@@ -187,7 +190,6 @@ public enum Message {
     MAPTOBEANMAPPING_RAW_MAP( "The Map parameter \"%s\" cannot be used for property mapping. It must be typed with Map<String, ???> but it was raw.", Diagnostic.Kind.WARNING ),
     ;
     // CHECKSTYLE:ON
-
 
     private final String description;
     private final Diagnostic.Kind kind;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -24,6 +24,19 @@
     }
     </#if>
 
+    <#if hasSubClassMappings()>
+        <#assign first = true />
+        <#list constructSubClassMappings(parameters) as subClass>
+            <#if !first>else</#if> if (${subClass.sourceArgument} instanceof <@includeModel object=subClass.sourceType/>) {
+                <@includeModel object=subClass.assignment existingInstanceMapping=existingInstanceMapping/>
+            }
+            <#assign first = false />
+        </#list>
+        else {
+    </#if>
+    <#if isAbstractReturnType()>
+        throw new IllegalArgumentException("Not all subclasses are supported for this mapping. Missing for " + ${parameters[0].name}.getClass());
+    <#else>
     <#if !existingInstanceMapping>
         <#if hasConstructorMappings()>
             <#if (sourceParameters?size > 1)>
@@ -119,6 +132,10 @@
     <#else>
         return ${resultName};
     </#if>
+    </#if>
+    </#if>
+    <#if hasSubClassMappings()>
+        }
     </#if>
 }
 <#macro throws>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ReturnWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ReturnWrapper.ftl
@@ -1,0 +1,17 @@
+<#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.ReturnWrapper" -->
+return <@_assignment/>;
+<#macro _assignment>
+    <@includeModel object=assignment
+               targetBeanName=ext.targetBeanName
+               existingInstanceMapping=ext.existingInstanceMapping
+               targetReadAccessorName=ext.targetReadAccessorName
+               targetWriteAccessorName=ext.targetWriteAccessorName
+               targetType=ext.targetType/>
+</#macro>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/Issue131Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/Issue131Mapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._131;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.SubClassMapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue131Mapper {
+    Issue131Mapper INSTANCE = Mappers.getMapper( Issue131Mapper.class );
+
+    org.mapstruct.ap.test.bugs._131.dto.VehicleCollection
+                    map(org.mapstruct.ap.test.bugs._131.domain.VehicleCollection vehicles);
+
+    org.mapstruct.ap.test.bugs._131.dto.Car mapCar(org.mapstruct.ap.test.bugs._131.domain.Car car);
+
+    @SubClassMapping( sourceClass = org.mapstruct.ap.test.bugs._131.domain.Car.class,
+                    targetClass = org.mapstruct.ap.test.bugs._131.dto.Car.class )
+    @SubClassMapping( sourceClass = org.mapstruct.ap.test.bugs._131.domain.Bike.class,
+                    targetClass = org.mapstruct.ap.test.bugs._131.dto.Bike.class )
+    org.mapstruct.ap.test.bugs._131.dto.Vehicle map(org.mapstruct.ap.test.bugs._131.domain.Vehicle vehicle);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/Issue131Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/Issue131Test.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._131;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+@IssueKey( "131" )
+@WithClasses( { Issue131Mapper.class, org.mapstruct.ap.test.bugs._131.domain.VehicleCollection.class,
+    org.mapstruct.ap.test.bugs._131.domain.Vehicle.class, org.mapstruct.ap.test.bugs._131.domain.Car.class,
+    org.mapstruct.ap.test.bugs._131.domain.Bike.class, org.mapstruct.ap.test.bugs._131.dto.VehicleCollection.class,
+    org.mapstruct.ap.test.bugs._131.dto.Vehicle.class, org.mapstruct.ap.test.bugs._131.dto.Car.class,
+    org.mapstruct.ap.test.bugs._131.dto.Bike.class, } )
+public class Issue131Test {
+
+    @ProcessorTest
+    void issue131MappingTest() {
+        org.mapstruct.ap.test.bugs._131.domain.VehicleCollection vehicles =
+            new org.mapstruct.ap.test.bugs._131.domain.VehicleCollection();
+        vehicles.getVehicles().add( new org.mapstruct.ap.test.bugs._131.domain.Car() );
+        vehicles.getVehicles().add( new org.mapstruct.ap.test.bugs._131.domain.Bike() );
+
+        org.mapstruct.ap.test.bugs._131.dto.VehicleCollection result = Issue131Mapper.INSTANCE.map( vehicles );
+
+        assertThat( result.getVehicles() ).doesNotContainNull();
+        assertThat( result.getVehicles() ) // remove generic so that test works.
+                                          .extracting( vehicle -> (Class) vehicle.getClass() )
+                                          .containsExactly(
+                                              org.mapstruct.ap.test.bugs._131.dto.Car.class,
+                                              org.mapstruct.ap.test.bugs._131.dto.Bike.class );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/domain/Bike.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/domain/Bike.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._131.domain;
+
+public class Bike extends Vehicle {
+    private int numberOfGears;
+
+    public int getNumberOfGears() {
+        return numberOfGears;
+    }
+
+    public void setNumberOfGears(int numberOfGears) {
+        this.numberOfGears = numberOfGears;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/domain/Car.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/domain/Car.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._131.domain;
+
+public class Car extends Vehicle {
+    private boolean manual;
+
+    public boolean isManual() {
+        return manual;
+    }
+
+    public void setManual(boolean manual) {
+        this.manual = manual;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/domain/Vehicle.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/domain/Vehicle.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._131.domain;
+
+public class Vehicle {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/domain/VehicleCollection.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/domain/VehicleCollection.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._131.domain;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class VehicleCollection {
+    private Collection<Vehicle> vehicles = new ArrayList<>();
+
+    public Collection<Vehicle> getVehicles() {
+        return vehicles;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/dto/Bike.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/dto/Bike.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._131.dto;
+
+public class Bike extends Vehicle {
+    private int numberOfGears;
+
+    public int getNumberOfGears() {
+        return numberOfGears;
+    }
+
+    public void setNumberOfGears(int numberOfGears) {
+        this.numberOfGears = numberOfGears;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/dto/Car.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/dto/Car.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._131.dto;
+
+public class Car extends Vehicle {
+    private boolean manual;
+
+    public boolean isManual() {
+        return manual;
+    }
+
+    public void setManual(boolean manual) {
+        this.manual = manual;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/dto/Vehicle.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/dto/Vehicle.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._131.dto;
+
+public class Vehicle {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/dto/VehicleCollection.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_131/dto/VehicleCollection.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._131.dto;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class VehicleCollection {
+    private Collection<Vehicle> vehicles = new ArrayList<>();
+
+    public Collection<Vehicle> getVehicles() {
+        return vehicles;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2438/Issue2438Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2438/Issue2438Test.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2438;
+
+import org.assertj.core.api.Assertions;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.factory.Mappers;
+
+@IssueKey( "2438" )
+@WithClasses( { Source.class, SourceSubclass.class, SubclassMapper.class, Target.class } )
+class Issue2438Test {
+
+    @ProcessorTest
+    void inheretenceTest() {
+        SubclassMapper mapper = Mappers.getMapper( SubclassMapper.class );
+        SourceSubclass sourceSubclass = new SourceSubclass( "f1", "f2", "f3", "f4", "f5" );
+
+        Target result = mapper.mapSuperclass( sourceSubclass );
+
+        Assertions.assertThat( result.getTarget1() ).isEqualTo( "f1" );
+        Assertions.assertThat( result.getTarget2() ).isEqualTo( "f2" );
+        Assertions.assertThat( result.getTarget3() ).isEqualTo( "f3" );
+        Assertions.assertThat( result.getTarget4() ).isEqualTo( "f4" );
+        Assertions.assertThat( result.getTarget5() ).isEqualTo( "f5" );
+    }
+
+    @ProcessorTest
+    void superclassTest() {
+        SubclassMapper mapper = Mappers.getMapper( SubclassMapper.class );
+        Source source = new Source( "f1", "f2", "f3" );
+
+        Target result = mapper.mapSuperclass( source );
+
+        Assertions.assertThat( result.getTarget1() ).isEqualTo( "f1" );
+        Assertions.assertThat( result.getTarget2() ).isEqualTo( "f2" );
+        Assertions.assertThat( result.getTarget3() ).isEqualTo( "f3" );
+        Assertions.assertThat( result.getTarget4() ).isNull();
+        Assertions.assertThat( result.getTarget5() ).isNull();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2438/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2438/Source.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2438;
+
+public class Source {
+    private String property1;
+    private String property2;
+    private String property3;
+
+    public Source(String prop1, String prop2, String prop3) {
+        setProperty1( prop1 );
+        setProperty2( prop2 );
+        setProperty3( prop3 );
+    }
+
+    public String getProperty1() {
+        return property1;
+    }
+
+    public String getProperty2() {
+        return property2;
+    }
+
+    public String getProperty3() {
+        return property3;
+    }
+
+    public void setProperty1(String property1) {
+        this.property1 = property1;
+    }
+
+    public void setProperty2(String property2) {
+        this.property2 = property2;
+    }
+
+    public void setProperty3(String property3) {
+        this.property3 = property3;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2438/SourceSubclass.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2438/SourceSubclass.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2438;
+
+public class SourceSubclass extends Source {
+    private String subclassProperty;
+    private String target5;
+
+    public SourceSubclass(String prop1, String prop2, String prop3, String subProp, String target5) {
+        super( prop1, prop2, prop3 );
+        setSubclassProperty( subProp );
+        setTarget5( target5 );
+    }
+
+    public String getSubclassProperty() {
+        return subclassProperty;
+    }
+
+    public String getTarget5() {
+        return target5;
+    }
+
+    public void setSubclassProperty(String subclassProperty) {
+        this.subclassProperty = subclassProperty;
+    }
+
+    public void setTarget5(String target5) {
+        this.target5 = target5;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2438/SubclassMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2438/SubclassMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2438;
+
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.SubClassMapping;
+
+@Mapper
+public interface SubclassMapper {
+
+    @SubClassMapping( sourceClass = SourceSubclass.class, targetClass = Target.class )
+    @Mapping( target = "target1", source = "property1" )
+    @Mapping( target = "target2", source = "property2" )
+    @Mapping( target = "target3", source = "property3" )
+    @Mapping( target = "target4", expression = "java(null)" )
+    @Mapping( target = "target5", expression = "java(null)" )
+    Target mapSuperclass(Source source);
+
+    @InheritConfiguration( name = "mapSuperclass" )
+    @Mapping( target = "target4", source = "subclassProperty" )
+    @Mapping( target = "target5" ) // Have to declare in order to override with default behavior
+    Target mapSubclass(SourceSubclass source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2438/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2438/Target.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2438;
+
+public class Target {
+    private String target1;
+    private String target2;
+    private String target3;
+    private String target4;
+    private String target5;
+
+    public String getTarget1() {
+        return target1;
+    }
+
+    public String getTarget2() {
+        return target2;
+    }
+
+    public String getTarget3() {
+        return target3;
+    }
+
+    public String getTarget4() {
+        return target4;
+    }
+
+    public String getTarget5() {
+        return target5;
+    }
+
+    public void setTarget1(String target1) {
+        this.target1 = target1;
+    }
+
+    public void setTarget2(String target2) {
+        this.target2 = target2;
+    }
+
+    public void setTarget3(String target3) {
+        this.target3 = target3;
+    }
+
+    public void setTarget4(String target4) {
+        this.target4 = target4;
+    }
+
+    public void setTarget5(String target5) {
+        this.target5 = target5;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/Issue366Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/Issue366Mapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.SubClassMapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue366Mapper {
+    Issue366Mapper INSTANCE = Mappers.getMapper( Issue366Mapper.class );
+
+    org.mapstruct.ap.test.bugs._366.dto.VehicleCollection
+                    map(org.mapstruct.ap.test.bugs._366.domain.VehicleCollection vehicles);
+
+    org.mapstruct.ap.test.bugs._366.dto.Car map(org.mapstruct.ap.test.bugs._366.domain.Car car);
+
+    org.mapstruct.ap.test.bugs._366.dto.Bike map(org.mapstruct.ap.test.bugs._366.domain.Bike bike);
+
+    @SubClassMapping( sourceClass = org.mapstruct.ap.test.bugs._366.domain.Car.class,
+                    targetClass = org.mapstruct.ap.test.bugs._366.dto.Car.class )
+    @SubClassMapping( sourceClass = org.mapstruct.ap.test.bugs._366.domain.Bike.class,
+                    targetClass = org.mapstruct.ap.test.bugs._366.dto.Bike.class )
+    org.mapstruct.ap.test.bugs._366.dto.Vehicle map(org.mapstruct.ap.test.bugs._366.domain.Vehicle vehicle);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/Issue366Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/Issue366Test.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+@IssueKey( "366" )
+@WithClasses( { Issue366Mapper.class, org.mapstruct.ap.test.bugs._366.domain.VehicleCollection.class,
+    org.mapstruct.ap.test.bugs._366.domain.Vehicle.class, org.mapstruct.ap.test.bugs._366.domain.Car.class,
+    org.mapstruct.ap.test.bugs._366.domain.Bike.class, org.mapstruct.ap.test.bugs._366.dto.VehicleCollection.class,
+    org.mapstruct.ap.test.bugs._366.dto.Vehicle.class, org.mapstruct.ap.test.bugs._366.dto.Car.class,
+    org.mapstruct.ap.test.bugs._366.dto.Bike.class, } )
+public class Issue366Test {
+
+    @ProcessorTest
+    void issue366MappingTest() {
+        org.mapstruct.ap.test.bugs._366.domain.VehicleCollection vehicles =
+            new org.mapstruct.ap.test.bugs._366.domain.VehicleCollection();
+        vehicles.getVehicles().add( new org.mapstruct.ap.test.bugs._366.domain.Car() );
+        vehicles.getVehicles().add( new org.mapstruct.ap.test.bugs._366.domain.Bike() );
+
+        org.mapstruct.ap.test.bugs._366.dto.VehicleCollection result = Issue366Mapper.INSTANCE.map( vehicles );
+
+        assertThat( result.getVehicles() ).doesNotContainNull();
+        assertThat( result.getVehicles() ) // remove generic so that test works.
+                                          .extracting( vehicle -> (Class) vehicle.getClass() )
+                                          .containsExactly(
+                                              org.mapstruct.ap.test.bugs._366.dto.Car.class,
+                                              org.mapstruct.ap.test.bugs._366.dto.Bike.class );
+    }
+
+    @ProcessorTest
+    void mappingOfUnknownChildThrowsIllegalArgumentException() {
+        org.mapstruct.ap.test.bugs._366.domain.VehicleCollection vehicles =
+            new org.mapstruct.ap.test.bugs._366.domain.VehicleCollection();
+        vehicles.getVehicles().add( new org.mapstruct.ap.test.bugs._366.domain.Car() );
+        vehicles.getVehicles().add( new org.mapstruct.ap.test.bugs._366.domain.Motorcycle() );
+
+        IllegalArgumentException thrown =
+            assertThrows( IllegalArgumentException.class, () -> Issue366Mapper.INSTANCE.map( vehicles ) );
+
+        String expectedMessage = "Not all subclasses are supported for this mapping. "
+            + "Missing for class org.mapstruct.ap.test.bugs._366.domain.Motorcycle";
+        assertThat( thrown.getMessage() ).isEqualTo( expectedMessage );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/domain/Bike.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/domain/Bike.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366.domain;
+
+public class Bike extends Vehicle {
+    private int numberOfGears;
+
+    public int getNumberOfGears() {
+        return numberOfGears;
+    }
+
+    public void setNumberOfGears(int numberOfGears) {
+        this.numberOfGears = numberOfGears;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/domain/Car.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/domain/Car.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366.domain;
+
+public class Car extends Vehicle {
+    private boolean manual;
+
+    public boolean isManual() {
+        return manual;
+    }
+
+    public void setManual(boolean manual) {
+        this.manual = manual;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/domain/Motorcycle.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/domain/Motorcycle.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366.domain;
+
+public class Motorcycle extends Vehicle {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/domain/Vehicle.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/domain/Vehicle.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366.domain;
+
+public abstract class Vehicle {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/domain/VehicleCollection.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/domain/VehicleCollection.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366.domain;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class VehicleCollection {
+    private Collection<Vehicle> vehicles = new ArrayList<>();
+
+    public Collection<Vehicle> getVehicles() {
+        return vehicles;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/dto/Bike.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/dto/Bike.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366.dto;
+
+public class Bike extends Vehicle {
+    private int numberOfGears;
+
+    public int getNumberOfGears() {
+        return numberOfGears;
+    }
+
+    public void setNumberOfGears(int numberOfGears) {
+        this.numberOfGears = numberOfGears;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/dto/Car.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/dto/Car.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366.dto;
+
+public class Car extends Vehicle {
+    private boolean manual;
+
+    public boolean isManual() {
+        return manual;
+    }
+
+    public void setManual(boolean manual) {
+        this.manual = manual;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/dto/Motorcycle.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/dto/Motorcycle.java
@@ -1,0 +1,10 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366.dto;
+
+public class Motorcycle extends Vehicle {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/dto/Vehicle.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/dto/Vehicle.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366.dto;
+
+public abstract class Vehicle {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/dto/VehicleCollection.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_366/dto/VehicleCollection.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._366.dto;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+public class VehicleCollection {
+    private Collection<Vehicle> vehicles = new ArrayList<>();
+
+    public Collection<Vehicle> getVehicles() {
+        return vehicles;
+    }
+}


### PR DESCRIPTION
#131 #2438 #366 : Added support for SubClassMapping annotations. This will allow for hierarchy mappings.

if a parent mapping method is annotated with @SubClassMapping it will now generate an instanceof check inside the parent mapping and generate the subclass mappings if they are not manually defined. See issues #131 #2438 and #366 for more information.