### PR TITLE
Added new componentModel to improve Dagger2 support

### DIFF
--- a/core/src/main/java/org/mapstruct/MappingConstants.java
+++ b/core/src/main/java/org/mapstruct/MappingConstants.java
@@ -125,6 +125,11 @@ public final class MappingConstants {
          */
         public static final String JSR330 = "jsr330";
 
+        /**
+         * The generated mapper is annotated with @javax.inject.Named and @Singleton, and can be retrieved via @Inject
+         */
+        public static final String DAGGER2 = "dagger2";
+
     }
 
 }

--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
@@ -180,4 +180,8 @@ public class MavenIntegrationTest {
     void faultyAstModifyingProcessor() {
     }
 
+    @ProcessorTest(baseDir = "dagger2Test")
+    void dagger2Test() {
+    }
+
 }

--- a/integrationtest/src/test/resources/dagger2Test/pom.xml
+++ b/integrationtest/src/test/resources/dagger2Test/pom.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.mapstruct</groupId>
+        <artifactId>mapstruct-it-parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>dagger2Test</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <dagger.version>2.37</dagger.version>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>com.google.dagger</groupId>
+            <artifactId>dagger</artifactId>
+            <version>${dagger.version}</version>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.mapstruct</groupId>
+                            <artifactId>mapstruct-processor</artifactId>
+                            <version>${mapstruct.version}</version>
+                        </path>
+                        <path>
+                            <groupId>com.google.dagger</groupId>
+                            <artifactId>dagger-compiler</artifactId>
+                            <version>${dagger.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/AppComponent.java
+++ b/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/AppComponent.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.dagger2;
+
+import dagger.Component;
+import javax.inject.Singleton;
+
+@Singleton
+@Component(modules = {AppModule.class})
+public interface AppComponent {
+
+    SourceTargetMapper sourceTargetMapper();
+
+    DecoratedSourceTargetMapper decoratedSourceTargetMapper();
+
+    SecondDecoratedSourceTargetMapper secondDecoratedSourceTargetMapper();
+
+}

--- a/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/AppModule.java
+++ b/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/AppModule.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.dagger2;
+
+import javax.inject.Named;
+
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class AppModule {
+
+    @Provides
+    public static SourceTargetMapper sourceTargetMapper(SourceTargetMapperImpl impl) {
+        return impl;
+    }
+
+    @Provides
+    @Named("org.mapstruct.itest.dagger2.DecoratedSourceTargetMapperImpl_")
+    public static DecoratedSourceTargetMapper decoratedSourceTargetMapper_(
+        DecoratedSourceTargetMapperImpl_ impl) {
+        return impl;
+    }
+
+    @Provides
+    public static DecoratedSourceTargetMapper decoratedSourceTargetMapper(DecoratedSourceTargetMapperImpl impl) {
+        return impl;
+    }
+
+    @Provides
+    @Named("org.mapstruct.itest.dagger2.SecondDecoratedSourceTargetMapperImpl_")
+    public static SecondDecoratedSourceTargetMapper secondDecoratedSourceTargetMapper_(SecondDecoratedSourceTargetMapperImpl_ impl) {
+        return impl;
+    }
+
+    @Provides
+    public static SecondDecoratedSourceTargetMapper secondDecoratedSourceTargetMapper(SecondDecoratedSourceTargetMapperImpl impl) {
+        return impl;
+    }
+
+}

--- a/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/DecoratedSourceTargetMapper.java
+++ b/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/DecoratedSourceTargetMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.dagger2;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.DecoratedWith;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.itest.dagger2.other.DateMapper;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.DAGGER2, uses = DateMapper.class, injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+@DecoratedWith(SourceTargetMapperDecorator.class)
+public interface DecoratedSourceTargetMapper {
+
+    Target sourceToTarget(Source source);
+
+    Target undecoratedSourceToTarget(Source source);
+}

--- a/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/SecondDecoratedSourceTargetMapper.java
+++ b/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/SecondDecoratedSourceTargetMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.dagger2;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.DecoratedWith;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.itest.dagger2.other.DateMapper;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.DAGGER2, uses = DateMapper.class, injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+@DecoratedWith(SecondSourceTargetMapperDecorator.class)
+public interface SecondDecoratedSourceTargetMapper {
+
+    Target sourceToTarget(Source source);
+
+    Target undecoratedSourceToTarget(Source source);
+}

--- a/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/SecondSourceTargetMapperDecorator.java
+++ b/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/SecondSourceTargetMapperDecorator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.dagger2;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+public abstract class SecondSourceTargetMapperDecorator implements SecondDecoratedSourceTargetMapper {
+
+    @Inject
+    @Named("org.mapstruct.itest.dagger2.SecondDecoratedSourceTargetMapperImpl_")
+    SecondDecoratedSourceTargetMapper delegate;
+
+    @Override
+    public Target sourceToTarget(Source source) {
+        Target t = delegate.sourceToTarget( source );
+        t.setFoo( 43L );
+        return t;
+    }
+}

--- a/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/Source.java
+++ b/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/Source.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.dagger2;
+
+import java.util.Date;
+import java.util.GregorianCalendar;
+
+public class Source {
+
+    private int foo = 42;
+
+    private Date date = new GregorianCalendar( 1980, 0, 1 ).getTime();
+
+    public int getFoo() {
+        return foo;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+}

--- a/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/SourceTargetMapper.java
+++ b/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/SourceTargetMapper.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.dagger2;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.itest.dagger2.other.DateMapper;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.DAGGER2, uses = DateMapper.class, injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface SourceTargetMapper {
+
+    Target sourceToTarget(Source source);
+}

--- a/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/SourceTargetMapperDecorator.java
+++ b/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/SourceTargetMapperDecorator.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.dagger2;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+public abstract class SourceTargetMapperDecorator implements DecoratedSourceTargetMapper {
+
+    @Inject
+    @Named("org.mapstruct.itest.dagger2.DecoratedSourceTargetMapperImpl_")
+    DecoratedSourceTargetMapper delegate;
+
+    @Override
+    public Target sourceToTarget(Source source) {
+        Target t = delegate.sourceToTarget( source );
+        t.setFoo( 43L );
+        return t;
+    }
+}

--- a/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/Target.java
+++ b/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/Target.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.dagger2;
+
+public class Target {
+
+    private Long foo;
+
+    private String date;
+
+    public void setFoo(Long foo) {
+        this.foo = foo;
+    }
+
+    public Long getFoo() {
+        return foo;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public void setDate(String date) {
+        this.date = date;
+    }
+}

--- a/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/other/DateMapper.java
+++ b/integrationtest/src/test/resources/dagger2Test/src/main/java/org/mapstruct/itest/dagger2/other/DateMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.dagger2.other;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class DateMapper {
+
+    @Inject
+    public DateMapper() {
+
+    }
+
+    public String asString(Date date) {
+        return date != null ? new SimpleDateFormat( "yyyy" ).format( date ) : null;
+    }
+
+    public Date asDate(String date) {
+        try {
+            return date != null ? new SimpleDateFormat( "yyyy" ).parse( date ) : null;
+        }
+        catch ( ParseException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+}

--- a/integrationtest/src/test/resources/dagger2Test/src/test/java/org/mapstruct/itest/dagger2/Dagger2BasedMapperTest.java
+++ b/integrationtest/src/test/resources/dagger2Test/src/test/java/org/mapstruct/itest/dagger2/Dagger2BasedMapperTest.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.dagger2;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for generation of Dagger2-based Mapper implementations
+ */
+public class Dagger2BasedMapperTest {
+
+    SourceTargetMapper mapper;
+
+    DecoratedSourceTargetMapper decoratedMapper;
+
+    SecondDecoratedSourceTargetMapper secondDecoratedMapper;
+
+    @Before
+    public void init() {
+        AppComponent appComponent = DaggerAppComponent.create();
+        mapper = appComponent.sourceTargetMapper();
+        decoratedMapper = appComponent.decoratedSourceTargetMapper();
+        secondDecoratedMapper = appComponent.secondDecoratedSourceTargetMapper();
+    }
+
+    @Test
+    public void shouldInjectDagger2BasedMapper() {
+        Source source = new Source();
+
+        Target target = mapper.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFoo() ).isEqualTo( Long.valueOf( 42 ) );
+        assertThat( target.getDate() ).isEqualTo( "1980" );
+    }
+
+    @Test
+    public void shouldInjectDecorator() {
+        Source source = new Source();
+
+        Target target = decoratedMapper.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFoo() ).isEqualTo( Long.valueOf( 43 ) );
+        assertThat( target.getDate() ).isEqualTo( "1980" );
+
+        target = decoratedMapper.undecoratedSourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFoo() ).isEqualTo( Long.valueOf( 42 ) );
+        assertThat( target.getDate() ).isEqualTo( "1980" );
+    }
+
+    @Test
+    public void shouldInjectSecondDecorator() {
+        Source source = new Source();
+
+        Target target = secondDecoratedMapper.sourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFoo() ).isEqualTo( Long.valueOf( 43 ) );
+        assertThat( target.getDate() ).isEqualTo( "1980" );
+
+        target = secondDecoratedMapper.undecoratedSourceToTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getFoo() ).isEqualTo( Long.valueOf( 42 ) );
+        assertThat( target.getDate() ).isEqualTo( "1980" );
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/gem/MappingConstantsGem.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/gem/MappingConstantsGem.java
@@ -49,6 +49,8 @@ public final class MappingConstantsGem {
         public static final String SPRING = "spring";
 
         public static final String JSR330 = "jsr330";
+
+        public static final String DAGGER2 = "dagger2";
      }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AnnotationMapperReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AnnotationMapperReference.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.mapstruct.ap.internal.model.common.Accessibility;
 import org.mapstruct.ap.internal.model.common.Type;
 
 /**
@@ -28,12 +29,16 @@ public class AnnotationMapperReference extends MapperReference {
 
     private final boolean includeAnnotationsOnField;
 
+    private final Accessibility accessibility;
+
     public AnnotationMapperReference(Type type, String variableName, List<Annotation> annotations, boolean isUsed,
-                                     boolean fieldFinal, boolean includeAnnotationsOnField) {
+                                     boolean fieldFinal, boolean includeAnnotationsOnField,
+                                     Accessibility accessibility) {
         super( type, variableName, isUsed );
         this.annotations = annotations;
         this.fieldFinal = fieldFinal;
         this.includeAnnotationsOnField = includeAnnotationsOnField;
+        this.accessibility = accessibility;
     }
 
     public List<Annotation> getAnnotations() {
@@ -60,6 +65,10 @@ public class AnnotationMapperReference extends MapperReference {
         return includeAnnotationsOnField;
     }
 
+    public Accessibility getAccessibility() {
+        return accessibility;
+    }
+
     public AnnotationMapperReference withNewAnnotations(List<Annotation> annotations) {
         return new AnnotationMapperReference(
             getType(),
@@ -67,6 +76,7 @@ public class AnnotationMapperReference extends MapperReference {
             annotations,
             isUsed(),
             isFieldFinal(),
-            isIncludeAnnotationsOnField() );
+            isIncludeAnnotationsOnField(),
+            getAccessibility() );
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/AnnotationBasedComponentModelProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/AnnotationBasedComponentModelProcessor.java
@@ -111,10 +111,12 @@ public abstract class AnnotationBasedComponentModelProcessor implements ModelEle
     }
 
     private void buildConstructors(Mapper mapper) {
-        if ( !toMapperReferences( mapper.getFields() ).isEmpty() ) {
+        boolean constructorIsRequired = requiresGenerationOfConstructor();
+
+        if ( constructorIsRequired || !toMapperReferences( mapper.getFields() ).isEmpty() ) {
             AnnotatedConstructor annotatedConstructor = buildAnnotatedConstructorForMapper( mapper );
 
-            if ( !annotatedConstructor.getMapperReferences().isEmpty() ) {
+            if ( constructorIsRequired || !annotatedConstructor.getMapperReferences().isEmpty() ) {
                 mapper.setConstructor( annotatedConstructor );
             }
         }
@@ -209,6 +211,10 @@ public abstract class AnnotationBasedComponentModelProcessor implements ModelEle
     }
 
     protected boolean additionalPublicEmptyConstructor() {
+        return false;
+    }
+
+    protected boolean requiresGenerationOfConstructor() {
         return false;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/AnnotationBasedComponentModelProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/AnnotationBasedComponentModelProcessor.java
@@ -21,6 +21,7 @@ import org.mapstruct.ap.internal.model.Decorator;
 import org.mapstruct.ap.internal.model.Field;
 import org.mapstruct.ap.internal.model.Mapper;
 import org.mapstruct.ap.internal.model.MapperReference;
+import org.mapstruct.ap.internal.model.common.Accessibility;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.gem.InjectionStrategyGem;
@@ -241,7 +242,8 @@ public abstract class AnnotationBasedComponentModelProcessor implements ModelEle
             annotations,
             originalReference.isUsed(),
             finalField,
-            includeAnnotationsOnField );
+            includeAnnotationsOnField,
+            getMapperReferenceAccessibility( injectionStrategy ) );
     }
 
     /**
@@ -266,6 +268,14 @@ public abstract class AnnotationBasedComponentModelProcessor implements ModelEle
      * @return the annotation of the field for the mapper reference
      */
     protected abstract List<Annotation> getMapperReferenceAnnotations();
+
+    /**
+     * @param injectionStrategy the injection strategy
+     * @return the mapper reference field's accessibility
+     */
+    protected Accessibility getMapperReferenceAccessibility(InjectionStrategyGem injectionStrategy) {
+        return Accessibility.PRIVATE;
+    }
 
     /**
      * @return if a decorator (sub-)class needs to be generated or not

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/Dagger2ComponentProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/Dagger2ComponentProcessor.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.processor;
+
+import org.mapstruct.ap.internal.gem.MappingConstantsGem;
+import org.mapstruct.ap.internal.model.Mapper;
+
+/**
+ * A {@link ModelElementProcessor} which converts the given {@link Mapper}
+ * object into a Dagger2 style bean in case "dagger2" is configured as the
+ * target component model for this mapper.
+ *
+ * @author Leonardo Lima
+ */
+public class Dagger2ComponentProcessor extends Jsr330ComponentProcessor {
+    @Override
+    protected String getComponentModelIdentifier() {
+        return MappingConstantsGem.ComponentModelGem.DAGGER2;
+    }
+
+    @Override
+    protected boolean requiresGenerationOfConstructor() {
+        return true;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/Dagger2ComponentProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/Dagger2ComponentProcessor.java
@@ -5,8 +5,10 @@
  */
 package org.mapstruct.ap.internal.processor;
 
+import org.mapstruct.ap.internal.gem.InjectionStrategyGem;
 import org.mapstruct.ap.internal.gem.MappingConstantsGem;
 import org.mapstruct.ap.internal.model.Mapper;
+import org.mapstruct.ap.internal.model.common.Accessibility;
 
 /**
  * A {@link ModelElementProcessor} which converts the given {@link Mapper}
@@ -24,5 +26,10 @@ public class Dagger2ComponentProcessor extends Jsr330ComponentProcessor {
     @Override
     protected boolean requiresGenerationOfConstructor() {
         return true;
+    }
+
+    @Override
+    protected Accessibility getMapperReferenceAccessibility(InjectionStrategyGem injectionStrategy) {
+        return injectionStrategy == InjectionStrategyGem.CONSTRUCTOR ? Accessibility.PRIVATE : Accessibility.DEFAULT;
     }
 }

--- a/processor/src/main/resources/META-INF/services/org.mapstruct.ap.internal.processor.ModelElementProcessor
+++ b/processor/src/main/resources/META-INF/services/org.mapstruct.ap.internal.processor.ModelElementProcessor
@@ -9,3 +9,4 @@ org.mapstruct.ap.internal.processor.MapperRenderingProcessor
 org.mapstruct.ap.internal.processor.MethodRetrievalProcessor
 org.mapstruct.ap.internal.processor.SpringComponentProcessor
 org.mapstruct.ap.internal.processor.MapperServiceProcessor
+org.mapstruct.ap.internal.processor.Dagger2ComponentProcessor

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/AnnotationMapperReference.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/AnnotationMapperReference.ftl
@@ -11,4 +11,4 @@
         <#nt><@includeModel object=annotation/>
     </#list>
 </#if>
-private <#if fieldFinal>final </#if><@includeModel object=type/> ${variableName};
+${accessibility.keyword} <#if fieldFinal>final </#if><@includeModel object=type/> ${variableName};

--- a/processor/src/test/java/org/mapstruct/ap/test/gem/ConstantTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/gem/ConstantTest.java
@@ -40,5 +40,7 @@ public class ConstantTest {
         assertThat( MappingConstants.ComponentModel.CDI ).isEqualTo( MappingConstantsGem.ComponentModelGem.CDI );
         assertThat( MappingConstants.ComponentModel.SPRING ).isEqualTo( MappingConstantsGem.ComponentModelGem.SPRING );
         assertThat( MappingConstants.ComponentModel.JSR330 ).isEqualTo( MappingConstantsGem.ComponentModelGem.JSR330 );
+        assertThat( MappingConstants.ComponentModel.DAGGER2 )
+            .isEqualTo( MappingConstantsGem.ComponentModelGem.DAGGER2 );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/_default/CustomerDagger2DefaultCompileOptionFieldMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/_default/CustomerDagger2DefaultCompileOptionFieldMapper.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2._default;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.DAGGER2,
+    uses = GenderDagger2DefaultCompileOptionFieldMapper.class)
+public interface CustomerDagger2DefaultCompileOptionFieldMapper {
+
+    CustomerDto asTarget(CustomerEntity customerEntity);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/_default/Dagger2DefaultCompileOptionFieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/_default/Dagger2DefaultCompileOptionFieldMapperTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2._default;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import static java.lang.System.lineSeparator;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test default injection for component model dagger2.
+ */
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerDagger2DefaultCompileOptionFieldMapper.class,
+    GenderDagger2DefaultCompileOptionFieldMapper.class
+})
+@ComponentScan(basePackageClasses = CustomerDagger2DefaultCompileOptionFieldMapper.class)
+@Configuration
+public class Dagger2DefaultCompileOptionFieldMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @Inject
+    @Named
+    private CustomerDagger2DefaultCompileOptionFieldMapper customerMapper;
+    private ConfigurableApplicationContext context;
+
+    @BeforeEach
+    public void springUp() {
+        context = new AnnotationConfigApplicationContext( getClass() );
+        context.getAutowireCapableBeanFactory().autowireBean( this );
+    }
+
+    @AfterEach
+    public void springDown() {
+        if ( context != null ) {
+            context.close();
+        }
+    }
+
+    @ProcessorTest
+    public void shouldConvertToTarget() {
+        // given
+        CustomerEntity customerEntity = new CustomerEntity();
+        customerEntity.setName( "Samuel" );
+        customerEntity.setGender( Gender.MALE );
+
+        // when
+        CustomerDto customerDto = customerMapper.asTarget( customerEntity );
+
+        // then
+        assertThat( customerDto ).isNotNull();
+        assertThat( customerDto.getName() ).isEqualTo( "Samuel" );
+        assertThat( customerDto.getGender() ).isEqualTo( GenderDto.M );
+    }
+
+    @ProcessorTest
+    public void shouldHaveFieldInjection() {
+        generatedSource.forMapper( CustomerDagger2DefaultCompileOptionFieldMapper.class )
+            .content()
+            .contains( "@Inject" + lineSeparator() + "    private GenderDagger2DefaultCompileOptionFieldMapper" )
+            .doesNotContain( "public CustomerDagger2DefaultCompileOptionFieldMapperImpl(" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/_default/GenderDagger2DefaultCompileOptionFieldMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/_default/GenderDagger2DefaultCompileOptionFieldMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2._default;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.DAGGER2)
+public interface GenderDagger2DefaultCompileOptionFieldMapper {
+
+    @ValueMappings({
+        @ValueMapping(source = "MALE", target = "M"),
+        @ValueMapping(source = "FEMALE", target = "F")
+    })
+    GenderDto mapToDto(Gender gender);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/constructor/ConstructorDagger2Config.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/constructor/ConstructorDagger2Config.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2.constructor;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.MappingConstants;
+
+@MapperConfig(componentModel = MappingConstants.ComponentModel.DAGGER2,
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface ConstructorDagger2Config {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/constructor/CustomerDagger2ConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/constructor/CustomerDagger2ConstructorMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2.constructor;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+
+@Mapper( componentModel = MappingConstants.ComponentModel.DAGGER2,
+    uses = GenderDagger2ConstructorMapper.class,
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR )
+public interface CustomerDagger2ConstructorMapper {
+
+    @Mapping(target = "gender", source = "gender")
+    CustomerDto asTarget(CustomerEntity customerEntity);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/constructor/Dagger2ConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/constructor/Dagger2ConstructorMapperTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2.constructor;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import static java.lang.System.lineSeparator;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test constructor injection for component model dagger2.
+ */
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerDagger2ConstructorMapper.class,
+    GenderDagger2ConstructorMapper.class,
+    ConstructorDagger2Config.class
+})
+@ComponentScan(basePackageClasses = CustomerDagger2ConstructorMapper.class)
+@Configuration
+public class Dagger2ConstructorMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @Inject
+    @Named
+    private CustomerDagger2ConstructorMapper customerMapper;
+    private ConfigurableApplicationContext context;
+
+    @BeforeEach
+    public void springUp() {
+        context = new AnnotationConfigApplicationContext( getClass() );
+        context.getAutowireCapableBeanFactory().autowireBean( this );
+    }
+
+    @AfterEach
+    public void springDown() {
+        if ( context != null ) {
+            context.close();
+        }
+    }
+
+    @ProcessorTest
+    public void shouldConvertToTarget() {
+        // given
+        CustomerEntity customerEntity = new CustomerEntity();
+        customerEntity.setName( "Samuel" );
+        customerEntity.setGender( Gender.MALE );
+
+        // when
+        CustomerDto customerDto = customerMapper.asTarget( customerEntity );
+
+        // then
+        assertThat( customerDto ).isNotNull();
+        assertThat( customerDto.getName() ).isEqualTo( "Samuel" );
+        assertThat( customerDto.getGender() ).isEqualTo( GenderDto.M );
+    }
+
+    @ProcessorTest
+    public void shouldHaveConstructorInjection() {
+        generatedSource.forMapper( CustomerDagger2ConstructorMapper.class )
+            .content()
+            .contains( "private final GenderDagger2ConstructorMapper" )
+            .contains( "@Inject" + lineSeparator() +
+                "    public CustomerDagger2ConstructorMapperImpl(GenderDagger2ConstructorMapper" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/constructor/GenderDagger2ConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/constructor/GenderDagger2ConstructorMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2.constructor;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+
+@Mapper(config = ConstructorDagger2Config.class)
+public interface GenderDagger2ConstructorMapper {
+
+    @ValueMappings({
+        @ValueMapping(source = "MALE", target = "M"),
+        @ValueMapping(source = "FEMALE", target = "F")
+    })
+    GenderDto mapToDto(Gender gender);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/emptyconstructor/ConstructorDagger2Config.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/emptyconstructor/ConstructorDagger2Config.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2.emptyconstructor;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.MappingConstants;
+
+@MapperConfig(componentModel = MappingConstants.ComponentModel.DAGGER2,
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface ConstructorDagger2Config {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/emptyconstructor/Dagger2EmptyConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/emptyconstructor/Dagger2EmptyConstructorMapperTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2.emptyconstructor;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import static java.lang.System.lineSeparator;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test constructor injection for component model dagger2, when a mapper has no extra dependencies.
+ */
+@WithClasses({
+    Gender.class,
+    GenderDto.class,
+    ConstructorDagger2Config.class,
+    GenderDagger2EmptyConstructorMapper.class
+})
+@ComponentScan(basePackageClasses = GenderDagger2EmptyConstructorMapper.class)
+@Configuration
+public class Dagger2EmptyConstructorMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @Inject
+    @Named
+    private GenderDagger2EmptyConstructorMapper customerMapper;
+    private ConfigurableApplicationContext context;
+
+    @BeforeEach
+    public void springUp() {
+        context = new AnnotationConfigApplicationContext( getClass() );
+        context.getAutowireCapableBeanFactory().autowireBean( this );
+
+        ConfigurableListableBeanFactory beanFactory = context.getBeanFactory();
+    }
+
+    @AfterEach
+    public void springDown() {
+        if ( context != null ) {
+            context.close();
+        }
+    }
+
+    @ProcessorTest
+    public void shouldMapToDto() {
+        // given
+        Gender gender = Gender.MALE;
+
+        // when
+        GenderDto genderDto = customerMapper.mapToDto( gender );
+
+        // then
+        assertThat( genderDto ).isEqualTo( GenderDto.M );
+    }
+
+    @ProcessorTest
+    public void shouldHaveConstructorInjection() {
+        generatedSource.forMapper( GenderDagger2EmptyConstructorMapper.class )
+            .content()
+            .contains( "@Inject" + lineSeparator() + "    public GenderDagger2EmptyConstructorMapperImpl()" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/emptyconstructor/GenderDagger2EmptyConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/emptyconstructor/GenderDagger2EmptyConstructorMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2.emptyconstructor;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+
+@Mapper(config = ConstructorDagger2Config.class)
+public interface GenderDagger2EmptyConstructorMapper {
+
+    @ValueMappings({
+        @ValueMapping(source = "MALE", target = "M"),
+        @ValueMapping(source = "FEMALE", target = "F")
+    })
+    GenderDto mapToDto(Gender gender);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/field/CustomerDagger2FieldMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/field/CustomerDagger2FieldMapper.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2.field;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.DAGGER2, uses = GenderDagger2FieldMapper.class,
+    injectionStrategy = InjectionStrategy.FIELD)
+public interface CustomerDagger2FieldMapper {
+
+    CustomerDto asTarget(CustomerEntity customerEntity);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/field/Dagger2FieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/field/Dagger2FieldMapperTest.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.injectionstrategy.dagger2._default;
+package org.mapstruct.ap.test.injectionstrategy.dagger2.field;
 
 import javax.inject.Inject;
 import javax.inject.Named;
@@ -27,26 +27,27 @@ import static java.lang.System.lineSeparator;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Test default injection for component model dagger2.
+ * Test field injection for component model dagger2.
  */
 @WithClasses({
     CustomerDto.class,
     CustomerEntity.class,
     Gender.class,
     GenderDto.class,
-    CustomerDagger2DefaultCompileOptionFieldMapper.class,
-    GenderDagger2DefaultCompileOptionFieldMapper.class
+    CustomerDagger2FieldMapper.class,
+    GenderDagger2FieldMapper.class,
+    FieldDagger2Config.class
 })
-@ComponentScan(basePackageClasses = CustomerDagger2DefaultCompileOptionFieldMapper.class)
+@ComponentScan(basePackageClasses = CustomerDagger2FieldMapper.class)
 @Configuration
-public class Dagger2DefaultCompileOptionFieldMapperTest {
+public class Dagger2FieldMapperTest {
 
     @RegisterExtension
     final GeneratedSource generatedSource = new GeneratedSource();
 
     @Inject
     @Named
-    private CustomerDagger2DefaultCompileOptionFieldMapper customerMapper;
+    private CustomerDagger2FieldMapper customerMapper;
     private ConfigurableApplicationContext context;
 
     @BeforeEach
@@ -80,9 +81,9 @@ public class Dagger2DefaultCompileOptionFieldMapperTest {
 
     @ProcessorTest
     public void shouldHaveFieldInjection() {
-        generatedSource.forMapper( CustomerDagger2DefaultCompileOptionFieldMapper.class )
+        generatedSource.forMapper( CustomerDagger2FieldMapper.class )
             .content()
-            .contains( "@Inject" + lineSeparator() + "    GenderDagger2DefaultCompileOptionFieldMapper" )
-            .doesNotContain( "public CustomerDagger2DefaultCompileOptionFieldMapperImpl(" );
+            .contains( "@Inject" + lineSeparator() + "    GenderDagger2FieldMapper" )
+            .doesNotContain( "public CustomerDagger2FieldMapperImpl(" );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/field/FieldDagger2Config.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/field/FieldDagger2Config.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2.field;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.MappingConstants;
+
+@MapperConfig(componentModel = MappingConstants.ComponentModel.DAGGER2, injectionStrategy = InjectionStrategy.FIELD)
+public interface FieldDagger2Config {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/field/GenderDagger2FieldMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/dagger2/field/GenderDagger2FieldMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.dagger2.field;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+
+@Mapper(config = FieldDagger2Config.class)
+public interface GenderDagger2FieldMapper {
+
+    @ValueMappings({
+        @ValueMapping(source = "MALE", target = "M"),
+        @ValueMapping(source = "FEMALE", target = "F")
+    })
+    GenderDto mapToDto(Gender gender);
+}


### PR DESCRIPTION
Added a new componentModel for Dagger2, as suggested in #1617 and #2337

Dagger2 is mostly compatible with the existing `jsr330` componentModel, but it has 2 issues:

1. For constructor injection, a constructor annotated with `@Inject` should always be present, even if the constructor is empty
2. For field injection, it requires the fields to be package private (no access modifiers)

Issue 1 should be fixed by the current state of this PR
Issue 2 would involve changing more stuff,  and I'm not sure if you'd be interested in supporting it, since constructor injection is preferred with Dagger



Also, I'd like some help fixing the integration tests, if possible. I'm having trouble making both dagger and mapstruct annotation processing work during testing

