### PR TITLE
implicit source properties now get removed from unprocessedSourceProperties

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -1170,6 +1170,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                             .build();
                         handledTargets.add( targetPropertyName );
                         unprocessedSourceParameters.remove( sourceRef.getParameter() );
+                        unprocessedSourceProperties.remove( sourceRef.getShallowestPropertyName() );
                     }
                     else {
                         errorOccured = true;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2537/ImplicitSourceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2537/ImplicitSourceTest.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2537;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+
+/**
+ * implicit source-target mapping should list the source property as being mapped.
+ *
+ * @author Ben Zegveld
+ */
+@WithClasses( { UnmappedSourcePolicyWithImplicitSourceMapper.class } )
+@IssueKey( "2537" )
+public class ImplicitSourceTest {
+
+    @ProcessorTest
+    @ExpectedCompilationOutcome( value = CompilationResult.SUCCEEDED, diagnostics = {} )
+    public void reportsProperWarningsAndError() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2537/ImplicitSourceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2537/ImplicitSourceTest.java
@@ -8,8 +8,6 @@ package org.mapstruct.ap.test.bugs._2537;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
-import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 
 /**
  * implicit source-target mapping should list the source property as being mapped.

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2537/ImplicitSourceTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2537/ImplicitSourceTest.java
@@ -21,7 +21,6 @@ import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutco
 public class ImplicitSourceTest {
 
     @ProcessorTest
-    @ExpectedCompilationOutcome( value = CompilationResult.SUCCEEDED, diagnostics = {} )
-    public void reportsProperWarningsAndError() {
+    public void situationCompilesWithoutErrors() {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2537/UnmappedSourcePolicyWithImplicitSourceMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2537/UnmappedSourcePolicyWithImplicitSourceMapper.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct.ap.test.bugs._2537;
 
+import org.mapstruct.BeanMapping;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
@@ -14,6 +15,7 @@ import org.mapstruct.ReportingPolicy;
  */
 @Mapper( unmappedSourcePolicy = ReportingPolicy.ERROR )
 public interface UnmappedSourcePolicyWithImplicitSourceMapper {
+    @BeanMapping( ignoreByDefault = true )
     @Mapping( target = "property" )
     Target map(Source source);
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2537/UnmappedSourcePolicyWithImplicitSourceMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2537/UnmappedSourcePolicyWithImplicitSourceMapper.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2537;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+/**
+ * @author Ben Zegveld
+ */
+@Mapper( unmappedSourcePolicy = ReportingPolicy.ERROR )
+public interface UnmappedSourcePolicyWithImplicitSourceMapper {
+    @Mapping( target = "property" )
+    Target map(Source source);
+
+    class Source {
+        private String property;
+
+        public String getProperty() {
+            return property;
+        }
+
+        public void setProperty(String property) {
+            this.property = property;
+        }
+    }
+
+    class Target {
+        private String property;
+
+        public String getProperty() {
+            return property;
+        }
+
+        public void setProperty(String property) {
+            this.property = property;
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2537.
Using the situation as reported in the issue as test.