### PR TITLE
Ignore source properties if ignoreByDefault = true (closes #2560)

### DIFF
--- a/core/src/main/java/org/mapstruct/BeanMapping.java
+++ b/core/src/main/java/org/mapstruct/BeanMapping.java
@@ -118,7 +118,7 @@ public @interface BeanMapping {
 
     /**
      * Default ignore all mappings. All mappings have to be defined manually. No automatic mapping will take place. No
-     * warning will be issued on missing target properties.
+     * warning will be issued on missing source or target properties.
      *
      * @return The ignore strategy (default false).
      *

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -1514,13 +1514,17 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             if ( mappingReferences.isForForgedMethods() ) {
                 return ReportingPolicyGem.IGNORE;
             }
+            // If we have ignoreByDefault = true, unprocessed source properties are not an issue.
+            if ( method.getOptions().getBeanMapping().isignoreByDefault() ) {
+                return ReportingPolicyGem.IGNORE;
+            }
             return method.getOptions().getMapper().unmappedSourcePolicy();
         }
 
         private void reportErrorForUnmappedSourcePropertiesIfRequired() {
             ReportingPolicyGem unmappedSourcePolicy = getUnmappedSourcePolicy();
 
-            if ( !unprocessedSourceProperties.isEmpty() && unmappedSourcePolicy.requiresReport() ) {
+            if ( !unprocessedSourceProperties.isEmpty() && unmappedSourcePolicy.requiresReport()) {
 
                 Message msg = unmappedSourcePolicy.getDiagnosticKind() == Diagnostic.Kind.ERROR ?
                     Message.BEANMAPPING_UNMAPPED_SOURCES_ERROR : Message.BEANMAPPING_UNMAPPED_SOURCES_WARNING;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2544/Issue2544Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2544/Issue2544Test.java
@@ -5,13 +5,13 @@
  */
 package org.mapstruct.ap.test.bugs._2544;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.math.BigDecimal;
 
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Ben Zegveld

--- a/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/ErroneousSourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/ErroneousSourceTargetMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.ignorebydefaultsource;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(
+    unmappedTargetPolicy = ReportingPolicy.IGNORE,
+    unmappedSourcePolicy = ReportingPolicy.ERROR)
+public interface ErroneousSourceTargetMapper {
+    ErroneousSourceTargetMapper INSTANCE = Mappers.getMapper( ErroneousSourceTargetMapper.class );
+
+    @Mapping(source = "one", target = "one")
+    Target sourceToTarget(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/IgnoreByDefaultSourcesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/IgnoreByDefaultSourcesTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.ignorebydefaultsource;
+
+import javax.tools.Diagnostic.Kind;
+
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+
+public class IgnoreByDefaultSourcesTest {
+
+    @ProcessorTest
+    @WithClasses({ SourceTargetMapper.class, Source.class, Target.class })
+    public void shouldSucceed() {
+    }
+
+    @ProcessorTest
+    @WithClasses({ ErroneousSourceTargetMapper.class, Source.class, Target.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousSourceTargetMapper.class,
+                kind = Kind.ERROR,
+                line = 20,
+                message = "Unmapped source property: \"other\".")
+        }
+    )
+    public void shouldRaiseErrorDueToNonIgnoredSourceProperty() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/Source.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.ignorebydefaultsource;
+
+class Source {
+    private int one;
+    private int other;
+
+    public int getOne() {
+        return one;
+    }
+
+    public void setOne(int one) {
+        this.one = one;
+    }
+
+    public int getOther() {
+        return other;
+    }
+
+    public void setOther(int other) {
+        this.other = other;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/SourceTargetMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.ignorebydefaultsource;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(
+    unmappedTargetPolicy = ReportingPolicy.IGNORE,
+    unmappedSourcePolicy = ReportingPolicy.ERROR)
+public interface SourceTargetMapper {
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    @Mapping(source = "one", target = "one")
+    @BeanMapping(ignoreByDefault = true)
+    Target sourceToTarget(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/Target.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.ignorebydefaultsource;
+
+class Target {
+    private int one;
+
+    public int getOne() {
+        return one;
+    }
+
+    public void setOne(int one) {
+        this.one = one;
+    }
+}


### PR DESCRIPTION
I implemented this at the "check" level - `unprocessedSourceProperties` is still populated, only throwing the error is suppressed.

BTW: On my machine, `org.mapstruct.ap.test.bugs._2544.Issue2544Test` fails when I run all tests, but this hasn't changed.

Fixes #2560 