### PR TITLE
#2611 Scope org.eclipse.tycho:tycho-compiler-jdt under test

### DIFF
--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -44,8 +44,7 @@
         <dependency>
             <groupId>org.eclipse.tycho</groupId>
             <artifactId>tycho-compiler-jdt</artifactId>
-            <scope>provided</scope>
-            <optional>true</optional>
+            <scope>test</scope>
         </dependency>
         <!-- Test -->
         <dependency>


### PR DESCRIPTION
Since the removal of the Eclipse Specific compiler workarounds in c2e803403027f3fae92bd15b0ba50ab7df5063e6
the org.eclipse.tycho:tycho-compiler-jdt dependency is no longer needed in the compile code, we only need it for tests

Fixes #2611