### PR TITLE
Return null if all mapped values are null which is controlled by ValueMappingStrategy.RETURN_NULL_ON_ALL_NULL_VALUE

### DIFF
--- a/core/src/main/java/org/mapstruct/NullValueMappingStrategy.java
+++ b/core/src/main/java/org/mapstruct/NullValueMappingStrategy.java
@@ -30,5 +30,12 @@ public enum NullValueMappingStrategy {
      * <li>For map mapping methods an empty map will be returned.</li>
      * </ul>
      */
-    RETURN_DEFAULT;
+    RETURN_DEFAULT,
+
+    /**
+     * If {@code null} is passed to a mapping method, or if all the mapped values from the passed object are null, then
+     * {@code null} will be returned.
+     */
+    RETURN_NULL_ON_ALL_NULL_VALUES;
+
 }

--- a/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
@@ -212,6 +212,50 @@ However, by specifying `nullValueMappingStrategy = NullValueMappingStrategy.RETU
 
 The strategy works in a hierarchical fashion. Setting `nullValueMappingStrategy` on mapping method level will override `@Mapper#nullValueMappingStrategy`, and `@Mapper#nullValueMappingStrategy` will override `@MapperConfig#nullValueMappingStrategy`.
 
+[[mapping-result-for-all-null-mapping-values]
+=== Controlling mapping result for all-'null' properties in source bean mappings (excludes update mapping methods)
+
+Mapstruct offers control over the object to create when the value of all source argument mapping methods equal 'null'.  By default the value returned wis controlled only considers whether the source object is null and returns 'null' if the object is 'null'.
+
+By specifying 'nullValueMappingStrategy = NullValueMappingStrategy.RETURN_NULL_ON_ALL_NULL_VALUES` on `@BeanMapping`, `@IterableMapping`, `@MapMapping`, or globally on `@Mapper` or `@MapperConfig`, the mapping result can be altered to a 'null' value.  This means for:
+
+* *Bean mappings*: an 'null' target bean will be returned if all mapping methods are null.
+* *Iterables / Arrays*: an empty iterable will be returned.
+* *Maps*: an empty map will be returned.
+
+The strategy works in a hierarchical fashion. Setting `nullValueMappingStrategy` on mapping method level will override `@Mapper#nullValueMappingStrategy`, and `@Mapper#nullValueMappingStrategy` will override `@MapperConfig#nullValueMappingStrategy`.
+
+.generated all mapped value null check
+====
+[source, java, linenums]
+[subs="verbatim,attributes"]
+----
+protected Address orderDTOToAddress(OrderDTO orderDTO) {
+    if ( orderDTO == null ) {
+        return null;
+    }
+
+    Address address = new Address();
+
+    address.setLine1( orderDTO.getLine1() );
+    address.setLine2( orderDTO.getLine2() );
+    address.setLine3( orderDTO.getLine3() );
+
+    if (   ( address . getLine1() == null )
+        && ( address . getLine2() == null )
+        && ( address . getLine3() == null )
+    ) return null;
+
+    return address;
+}
+----
+====
+
+[NOTE]
+====
+Any default value assigned, or any primitive value that can not be part of a null check, will result in the all-value null check not being performed.
+====
+
 
 [[mapping-result-for-null-properties]]
 === Controlling mapping result for 'null' properties in bean mappings (update mapping methods only).

--- a/processor/src/main/java/org/mapstruct/ap/internal/gem/NullValueMappingStrategyGem.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/gem/NullValueMappingStrategyGem.java
@@ -12,16 +12,25 @@ package org.mapstruct.ap.internal.gem;
  */
 public enum NullValueMappingStrategyGem {
 
-    RETURN_NULL( false ),
-    RETURN_DEFAULT( true );
+    RETURN_NULL( false , false),
+    RETURN_DEFAULT( true, false ),
+    RETURN_NULL_ON_ALL_NULL_VALUES ( false , true);
 
     private final boolean returnDefault;
 
-    NullValueMappingStrategyGem(boolean returnDefault) {
+    private final boolean returnNullOnAllNullValues;
+
+    NullValueMappingStrategyGem(boolean returnDefault, boolean returnNullOnAllNull) {
         this.returnDefault = returnDefault;
+        this.returnNullOnAllNullValues = returnNullOnAllNull;
     }
 
     public boolean isReturnDefault() {
         return returnDefault;
     }
+
+    public boolean isReturnNullOnAllNullValues() {
+        return returnNullOnAllNullValues;
+    }
+
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
@@ -33,11 +33,11 @@ public abstract class ContainerMappingMethod extends NormalTypeMappingMethod {
     private IterableCreation iterableCreation;
 
     ContainerMappingMethod(Method method, Collection<String> existingVariables, Assignment parameterAssignment,
-        MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
+        MethodReference factoryMethod, boolean mapNullToDefault, boolean mapAllNullValuesToNull, String loopVariableName,
         List<LifecycleCallbackMethodReference> beforeMappingReferences,
         List<LifecycleCallbackMethodReference> afterMappingReferences,
         SelectionParameters selectionParameters) {
-        super( method, existingVariables, factoryMethod, mapNullToDefault, beforeMappingReferences,
+        super( method, existingVariables, factoryMethod, mapNullToDefault, mapAllNullValuesToNull, beforeMappingReferences,
             afterMappingReferences );
         this.elementAssignment = parameterAssignment;
         this.loopVariableName = loopVariableName;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
@@ -131,6 +131,11 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
             .getNullValueMappingStrategy()
             .isReturnDefault();
 
+        boolean mapAllNullValuesToNull = method.getOptions()
+                .getIterableMapping()
+                .getNullValueMappingStrategy()
+                .isReturnNullOnAllNullValues();
+
         MethodReference factoryMethod = null;
         if ( !method.isUpdateMethod() ) {
             factoryMethod = ObjectFactoryMethodResolver.getFactoryMethod( method, null, ctx );
@@ -158,6 +163,7 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
             assignment,
             factoryMethod,
             mapNullToDefault,
+            mapAllNullValuesToNull,
             loopVariableName,
             beforeMappingMethods,
             afterMappingMethods,
@@ -175,7 +181,7 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
 
     protected abstract M instantiateMappingMethod(Method method, Collection<String> existingVariables,
                                                   Assignment assignment, MethodReference factoryMethod,
-                                                  boolean mapNullToDefault, String loopVariableName,
+                                                  boolean mapNullToDefault, boolean mapAllNullValuesToNull, String loopVariableName,
                                                   List<LifecycleCallbackMethodReference> beforeMappingMethods,
                                                   List<LifecycleCallbackMethodReference> afterMappingMethods,
         SelectionParameters selectionParameters);

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -52,7 +52,7 @@ public class IterableMappingMethod extends ContainerMappingMethod {
 
         @Override
         protected IterableMappingMethod instantiateMappingMethod(Method method, Collection<String> existingVariables,
-            Assignment assignment, MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
+            Assignment assignment, MethodReference factoryMethod, boolean mapNullToDefault, boolean mapAllNullValuesToNull, String loopVariableName,
             List<LifecycleCallbackMethodReference> beforeMappingMethods,
             List<LifecycleCallbackMethodReference> afterMappingMethods, SelectionParameters selectionParameters) {
             return new IterableMappingMethod(
@@ -61,6 +61,7 @@ public class IterableMappingMethod extends ContainerMappingMethod {
                 assignment,
                 factoryMethod,
                 mapNullToDefault,
+                mapAllNullValuesToNull,
                 loopVariableName,
                 beforeMappingMethods,
                 afterMappingMethods,
@@ -70,7 +71,7 @@ public class IterableMappingMethod extends ContainerMappingMethod {
     }
 
     private IterableMappingMethod(Method method, Collection<String> existingVariables, Assignment parameterAssignment,
-                                  MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
+                                  MethodReference factoryMethod, boolean mapNullToDefault, boolean mapAllNullValuesToNull, String loopVariableName,
                                   List<LifecycleCallbackMethodReference> beforeMappingReferences,
                                   List<LifecycleCallbackMethodReference> afterMappingReferences,
         SelectionParameters selectionParameters) {
@@ -80,6 +81,7 @@ public class IterableMappingMethod extends ContainerMappingMethod {
             parameterAssignment,
             factoryMethod,
             mapNullToDefault,
+            mapAllNullValuesToNull,
             loopVariableName,
             beforeMappingReferences,
             afterMappingReferences,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -182,6 +182,9 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
             boolean mapNullToDefault =
                 method.getOptions().getMapMapping().getNullValueMappingStrategy().isReturnDefault();
 
+            boolean mapAllNullValuesToNull =
+                    method.getOptions().getMapMapping().getNullValueMappingStrategy().isReturnNullOnAllNullValues();
+
             MethodReference factoryMethod = null;
             if ( !method.isUpdateMethod() ) {
                 factoryMethod = ObjectFactoryMethodResolver
@@ -204,6 +207,7 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
                 valueAssignment,
                 factoryMethod,
                 mapNullToDefault,
+                mapAllNullValuesToNull,
                 beforeMappingMethods,
                 afterMappingMethods
             );
@@ -225,10 +229,10 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
     }
 
     private MapMappingMethod(Method method, Collection<String> existingVariableNames, Assignment keyAssignment,
-                             Assignment valueAssignment, MethodReference factoryMethod, boolean mapNullToDefault,
+                             Assignment valueAssignment, MethodReference factoryMethod, boolean mapNullToDefault, boolean mapAllNullValuesToNull,
                              List<LifecycleCallbackMethodReference> beforeMappingReferences,
                              List<LifecycleCallbackMethodReference> afterMappingReferences) {
-        super( method, existingVariableNames, factoryMethod, mapNullToDefault, beforeMappingReferences,
+        super( method, existingVariableNames, factoryMethod, mapNullToDefault, mapAllNullValuesToNull, beforeMappingReferences,
             afterMappingReferences );
 
         this.keyAssignment = keyAssignment;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NormalTypeMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NormalTypeMappingMethod.java
@@ -23,15 +23,17 @@ public abstract class NormalTypeMappingMethod extends MappingMethod {
     private final MethodReference factoryMethod;
     private final boolean overridden;
     private final boolean mapNullToDefault;
+    private final boolean mapAllNullValuesToNull;
 
     NormalTypeMappingMethod(Method method, Collection<String> existingVariableNames, MethodReference factoryMethod,
-        boolean mapNullToDefault,
+        boolean mapNullToDefault,boolean mapAllNullValuesToNull,
         List<LifecycleCallbackMethodReference> beforeMappingReferences,
         List<LifecycleCallbackMethodReference> afterMappingReferences) {
         super( method, existingVariableNames, beforeMappingReferences, afterMappingReferences );
         this.factoryMethod = factoryMethod;
         this.overridden = method.overridesMethod();
         this.mapNullToDefault = mapNullToDefault;
+        this.mapAllNullValuesToNull = mapAllNullValuesToNull;
     }
 
     @Override
@@ -50,6 +52,10 @@ public abstract class NormalTypeMappingMethod extends MappingMethod {
 
     public boolean isMapNullToDefault() {
         return mapNullToDefault;
+    }
+
+    public boolean isMapAllNullValuesToNull() {
+        return mapAllNullValuesToNull;
     }
 
     public boolean isOverridden() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
@@ -49,7 +49,7 @@ public class StreamMappingMethod extends ContainerMappingMethod {
 
         @Override
         protected StreamMappingMethod instantiateMappingMethod(Method method, Collection<String> existingVariables,
-            Assignment assignment, MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
+            Assignment assignment, MethodReference factoryMethod, boolean mapNullToDefault, boolean mapAllNullValuesToNull, String loopVariableName,
             List<LifecycleCallbackMethodReference> beforeMappingMethods,
             List<LifecycleCallbackMethodReference> afterMappingMethods, SelectionParameters selectionParameters) {
 
@@ -70,6 +70,7 @@ public class StreamMappingMethod extends ContainerMappingMethod {
                 assignment,
                 factoryMethod,
                 mapNullToDefault,
+                mapAllNullValuesToNull,
                 loopVariableName,
                 beforeMappingMethods,
                 afterMappingMethods,
@@ -80,7 +81,7 @@ public class StreamMappingMethod extends ContainerMappingMethod {
     }
 
     private StreamMappingMethod(Method method, Collection<String> existingVariables, Assignment parameterAssignment,
-                                MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
+                                MethodReference factoryMethod, boolean mapNullToDefault, boolean mapAllNullValuesToNull, String loopVariableName,
                                 List<LifecycleCallbackMethodReference> beforeMappingReferences,
                                 List<LifecycleCallbackMethodReference> afterMappingReferences,
         SelectionParameters selectionParameters, Set<Type> helperImports) {
@@ -90,6 +91,7 @@ public class StreamMappingMethod extends ContainerMappingMethod {
             parameterAssignment,
             factoryMethod,
             mapNullToDefault,
+            mapAllNullValuesToNull,
             loopVariableName,
             beforeMappingReferences,
             afterMappingReferences,

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -123,6 +123,16 @@
     	</#if>
     	<@includeModel object=callback targetBeanName=resultName targetType=targetType/>
     </#list>
+
+    <#if returnType.name != "void" && collapseObjectsWithNullValuesToNull>
+            <#assign outputWritten = false/>
+            if (   <#list sourceParameters as sourceParam><#if (propertyMappingsByParameter(sourceParam)?size > 0)><#list propertyMappingsByParameter(sourceParam) as propertyMapping><#if outputWritten> && </#if>( <#if propertyMapping.assignment.sourceLocalVarName??>${propertyMapping.assignment.sourceLocalVarName}<#else>${resultName}.${propertyMapping.targetReadAccessorName}</#if> == null ) <#assign outputWritten=true/>
+                        </#list>
+                    </#if>
+                </#list>
+            ) return null;
+    </#if>
+
     <#if returnType.name != "void">
 
     <#if finalizerMethod??>


### PR DESCRIPTION
This will return null if all mapped values are null which is controlled by ValueMappingStrategy.RETURN_NULL_ON_ALL_NULL_VALUE.   Issue is #1166 .


The solution generates a null check after processing for bean mapping and map mapping like:


```
  protected Address orderDTOToAddress(OrderDTO orderDTO) {
        if ( orderDTO == null ) {
            return null;
        }

        Address address = new Address();

        address.setLine1( orderDTO.getLine1() );
        address.setLine2( orderDTO.getLine2() );
        address.setLine3( orderDTO.getLine3() );

        if ( address.getLine1() == null
            && address.getLine2()== null
            && address.getLine3() == null)
            return null;

        return address;
    }
```


and 


```
    protected NestedMiddle orderDTOToNestedMiddle(OrderDTO orderDTO) {
        if ( orderDTO == null ) {
            return null;
        }

        NestedMiddle nestedMiddle = new NestedMiddle();
        nestedMiddle.setLeaf( orderDTOToNestedLeaf( orderDTO ) );

        if ( nestedMiddle.getLeaf() == null )
            return null;

        return nestedMiddle;
    }
```

This is the least disruptive change.  As seen in my comments #1166 the solution to avoid the creation of the object (check in advance of the object assignment) will require major changes for which I am not yet suitable to make.

 

