### PR TITLE
#2553 Support source property paths for maps

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -504,7 +504,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                         .build();
 
                     Accessor targetPropertyReadAccessor =
-                        method.getResultType().getPropertyReadAccessors().get( propertyName );
+                        method.getResultType().getReadAccessor( propertyName );
                     MappingReferences mappingRefs = extractMappingReferences( propertyName, true );
                     PropertyMapping propertyMapping = new PropertyMappingBuilder()
                         .mappingContext( ctx )
@@ -1047,7 +1047,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             }
 
             Accessor targetWriteAccessor = unprocessedTargetProperties.get( targetPropertyName );
-            Accessor targetReadAccessor = resultTypeToMap.getPropertyReadAccessors().get( targetPropertyName );
+            Accessor targetReadAccessor = resultTypeToMap.getReadAccessor( targetPropertyName );
 
             if ( targetWriteAccessor == null ) {
                 if ( targetReadAccessor == null ) {
@@ -1389,7 +1389,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 }
 
                 Accessor targetPropertyReadAccessor =
-                    method.getResultType().getPropertyReadAccessors().get( targetPropertyName );
+                    method.getResultType().getReadAccessor( targetPropertyName );
                 MappingReferences mappingRefs = extractMappingReferences( targetPropertyName, false );
                 PropertyMapping propertyMapping = new PropertyMappingBuilder().mappingContext( ctx )
                     .sourceMethod( method )
@@ -1432,7 +1432,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                             .build();
 
                         Accessor targetPropertyReadAccessor =
-                            method.getResultType().getPropertyReadAccessors().get( targetProperty.getKey() );
+                            method.getResultType().getReadAccessor( targetProperty.getKey() );
                         MappingReferences mappingRefs = extractMappingReferences( targetProperty.getKey(), false );
                         PropertyMapping propertyMapping = new PropertyMappingBuilder()
                             .mappingContext( ctx )
@@ -1473,22 +1473,11 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 return sourceRef;
             }
 
-            if ( sourceParameter.getType().isMapType() ) {
-                List<Type> typeParameters = sourceParameter.getType().getTypeParameters();
-                if ( typeParameters.size() == 2 && typeParameters.get( 0 ).isString() ) {
-                    return SourceReference.fromMapSource(
-                        new String[] { targetPropertyName },
-                        sourceParameter
-                    );
-                }
-            }
-
-            Accessor sourceReadAccessor =
-                sourceParameter.getType().getPropertyReadAccessors().get( targetPropertyName );
+            Accessor sourceReadAccessor = sourceParameter.getType().getReadAccessor( targetPropertyName );
             if ( sourceReadAccessor != null ) {
                 // property mapping
                 Accessor sourcePresenceChecker =
-                    sourceParameter.getType().getPropertyPresenceCheckers().get( targetPropertyName );
+                    sourceParameter.getType().getPresenceChecker( targetPropertyName );
 
                 DeclaredType declaredSourceType = (DeclaredType) sourceParameter.getType().getTypeMirror();
                 Type returnType = ctx.getTypeFactory().getReturnType( declaredSourceType, sourceReadAccessor );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
@@ -14,9 +14,12 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.beanmapping.PropertyEntry;
+import org.mapstruct.ap.internal.model.presence.SourceReferenceContainsKeyPresenceCheck;
 import org.mapstruct.ap.internal.model.presence.SourceReferenceMethodPresenceCheck;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.ValueProvider;
+import org.mapstruct.ap.internal.util.accessor.Accessor;
+import org.mapstruct.ap.internal.util.accessor.AccessorType;
 
 /**
  * This method is used to convert the nested properties as listed in propertyEntries into a method
@@ -165,11 +168,20 @@ public class NestedPropertyMappingMethod extends MappingMethod {
         public SafePropertyEntry(PropertyEntry entry, String safeName, String previousPropertyName) {
             this.safeName = safeName;
             this.readAccessorName = ValueProvider.of( entry.getReadAccessor() ).getValue();
-            if ( entry.getPresenceChecker() != null ) {
-                this.presenceChecker = new SourceReferenceMethodPresenceCheck(
-                    previousPropertyName,
-                    entry.getPresenceChecker().getSimpleName()
-                );
+            Accessor presenceChecker = entry.getPresenceChecker();
+            if ( presenceChecker != null ) {
+                if ( presenceChecker.getAccessorType() == AccessorType.MAP_CONTAINS ) {
+                    this.presenceChecker = new SourceReferenceContainsKeyPresenceCheck(
+                        previousPropertyName,
+                        presenceChecker.getSimpleName()
+                    );
+                }
+                else {
+                    this.presenceChecker = new SourceReferenceMethodPresenceCheck(
+                        previousPropertyName,
+                        presenceChecker.getSimpleName()
+                    );
+                }
             }
             else {
                 this.presenceChecker = null;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
@@ -642,7 +642,7 @@ public class NestedTargetPropertyMappingHolder {
                                                                      boolean forceUpdateMethod) {
 
             Accessor targetWriteAccessor = targetPropertiesWriteAccessors.get( targetPropertyName );
-            Accessor targetReadAccessor = targetType.getPropertyReadAccessors().get( targetPropertyName );
+            Accessor targetReadAccessor = targetType.getReadAccessor( targetPropertyName );
             if ( targetWriteAccessor == null ) {
                 Set<String> readAccessors = targetType.getPropertyReadAccessors().keySet();
                 String mostSimilarProperty = Strings.getMostSimilarWord( targetPropertyName, readAccessors );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/SourceReference.java
@@ -207,15 +207,6 @@ public class SourceReference extends AbstractReference {
             return new SourceReference( parameter, entries, foundEntryMatch );
         }
 
-        private boolean canBeTreatedAsMapSourceType(Type type) {
-            if ( !type.isMapType() ) {
-                return false;
-            }
-
-            List<Type> typeParameters = type.getTypeParameters();
-            return typeParameters.size() == 2 && typeParameters.get( 0 ).isString();
-        }
-
         /**
          * When there are more than one source parameters, the first segment name of the property
          * needs to match the parameter name to avoid ambiguity

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -48,6 +48,8 @@ import org.mapstruct.ap.internal.util.Nouns;
 import org.mapstruct.ap.internal.util.TypeUtils;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.AccessorType;
+import org.mapstruct.ap.internal.util.accessor.MapValueAccessor;
+import org.mapstruct.ap.internal.util.accessor.MapValuePresenceChecker;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
 
@@ -60,6 +62,7 @@ import static org.mapstruct.ap.internal.util.Collections.first;
  * through {@link TypeFactory}.
  *
  * @author Gunnar Morling
+ * @author Filip Hrisafov
  */
 public class Type extends ModelElement implements Comparable<Type> {
 
@@ -595,6 +598,48 @@ public class Type extends ModelElement implements Comparable<Type> {
         else {
             return this;
         }
+    }
+
+    public Accessor getReadAccessor(String propertyName) {
+        if ( isMapType() ) {
+            List<Type> typeParameters = getTypeParameters();
+            if ( typeParameters.size() == 2 && typeParameters.get( 0 ).isString() ) {
+                ExecutableElement getMethod = getAllMethods()
+                    .stream()
+                    .filter( m -> m.getSimpleName().contentEquals( "get" ) )
+                    .filter( m -> m.getParameters().size() == 1 )
+                    .findAny()
+                    .orElse( null );
+                return new MapValueAccessor( getMethod, typeParameters.get( 1 ).getTypeMirror(), propertyName );
+            }
+        }
+
+        Map<String, Accessor> readAccessors = getPropertyReadAccessors();
+
+        return readAccessors.get( propertyName );
+    }
+
+    public Accessor getPresenceChecker(String propertyName) {
+        if ( isMapType() ) {
+            List<Type> typeParameters = getTypeParameters();
+            if ( typeParameters.size() == 2 && typeParameters.get( 0 ).isString() ) {
+                ExecutableElement containsKeyMethod = getAllMethods()
+                    .stream()
+                    .filter( m -> m.getSimpleName().contentEquals( "containsKey" ) )
+                    .filter( m -> m.getParameters().size() == 1 )
+                    .findAny()
+                    .orElse( null );
+
+                return new MapValuePresenceChecker(
+                    containsKeyMethod,
+                    typeParameters.get( 1 ).getTypeMirror(),
+                    propertyName
+                );
+            }
+        }
+
+        Map<String, Accessor> presenceCheckers = getPropertyPresenceCheckers();
+        return presenceCheckers.get( propertyName );
     }
 
     /**

--- a/processor/src/test/java/org/mapstruct/ap/test/frommap/FromMapMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/frommap/FromMapMappingTest.java
@@ -261,6 +261,20 @@ class FromMapMappingTest {
         assertThat( target.getNestedTarget().getStringFromNestedMap() ).isEqualTo( "valueFromNestedMap" );
     }
 
+    @IssueKey("2553")
+    @ProcessorTest
+    @WithClasses(MapToBeanFromMapAndNestedMapWithDefinedMapping.class)
+    void shouldMapFromNestedMapWithDefinedMapping() {
+
+        MapToBeanFromMapAndNestedMapWithDefinedMapping.Source source =
+            new MapToBeanFromMapAndNestedMapWithDefinedMapping.Source();
+        MapToBeanFromMapAndNestedMapWithDefinedMapping.Target target =
+            MapToBeanFromMapAndNestedMapWithDefinedMapping.INSTANCE.toTarget( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getNested() ).isEqualTo( "valueFromNestedMap" );
+    }
+
     @ProcessorTest
     @WithClasses(ObjectMapToBeanWithQualifierMapper.class)
     void shouldUseObjectQualifiedMethod() {

--- a/processor/src/test/java/org/mapstruct/ap/test/frommap/MapToBeanFromMapAndNestedMapWithDefinedMapping.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/frommap/MapToBeanFromMapAndNestedMapWithDefinedMapping.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.frommap;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface MapToBeanFromMapAndNestedMapWithDefinedMapping {
+
+    MapToBeanFromMapAndNestedMapWithDefinedMapping INSTANCE = Mappers.getMapper(
+        MapToBeanFromMapAndNestedMapWithDefinedMapping.class );
+
+    @Mapping(target = "nested", source = "nestedTarget.nested")
+    Target toTarget(Source source);
+
+    class Source {
+
+        private Map<String, String> nestedTarget = new HashMap<>();
+
+        public Map<String, String> getNestedTarget() {
+            return nestedTarget;
+        }
+
+        public void setNestedTarget(Map<String, String> nestedTarget) {
+            this.nestedTarget = nestedTarget;
+        }
+
+        public Source() {
+            nestedTarget.put( "nested", "valueFromNestedMap" );
+        }
+    }
+
+    class Target {
+
+        private String nested;
+
+        public String getNested() {
+            return nested;
+        }
+
+        public void setNested(String nested) {
+            this.nested = nested;
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #2553 

This PR does some small changes in the way we acquire read accessors. The refactorings in the PR, especially the new methods in the `Type` can open the door for better support for things like Jackson `JsonNode`,  `ResultSet`, etc.