### PR TITLE
[DOCS] Fixed reference variable

### DIFF
--- a/documentation/src/main/asciidoc/chapter-3-defining-a-mapper.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-3-defining-a-mapper.asciidoc
@@ -696,7 +696,7 @@ public class CustomerMapperImpl implements CustomerMapper {
             customer.setId( Integer.parseInt( map.get( "id" ) ) );
         }
         if ( map.containsKey( "customerName" ) ) {
-            customer.setName( source.get( "customerName" ) );
+            customer.setName( map.get( "customerName" ) );
         }
         // ...
     }


### PR DESCRIPTION
The documentation for the new feature for mapping Maps to Beans contains a wrong variable reference in the generated example code.