### PR TITLE
#2668: Added support for collections and maps with a no-args constructor

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
@@ -267,7 +267,7 @@ public class CollectionAssignmentBuilder {
     }
 
     private boolean hasCopyConstructor() {
-        return checkConstructorForPredicate( element -> hasCopyConstructor( element ) );
+        return checkConstructorForPredicate( this::hasCopyConstructor );
     }
 
     private boolean hasNoArgsConstructor() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
@@ -15,6 +15,7 @@ import org.mapstruct.ap.internal.model.assignment.SetterWrapperForCollectionsAnd
 import org.mapstruct.ap.internal.model.assignment.SetterWrapperForCollectionsAndMapsWithNullCheck;
 import org.mapstruct.ap.internal.model.assignment.UpdateWrapper;
 import org.mapstruct.ap.internal.model.common.Assignment;
+import org.mapstruct.ap.internal.model.common.Assignment.AssignmentType;
 import org.mapstruct.ap.internal.model.common.SourceRHS;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
@@ -171,7 +172,7 @@ public class CollectionAssignmentBuilder {
                 );
             }
             else if ( setterWrapperNeedsSourceNullCheck( result )
-                && ( targetType.hasCopyConstructor() || targetType.isEnumSet() ) ) {
+                && canBeMappedOrDirectlyAssigned( result ) ) {
 
                 result = new SetterWrapperForCollectionsAndMapsWithNullCheck(
                     result,
@@ -181,7 +182,7 @@ public class CollectionAssignmentBuilder {
                     targetAccessorType.isFieldAssignment()
                 );
             }
-            else if ( targetType.hasCopyConstructor() || targetType.isEnumSet() ) {
+            else if ( canBeMappedOrDirectlyAssigned( result ) ) {
                 //TODO init default value
 
                 // target accessor is setter, so wrap the setter in setter map/ collection handling
@@ -199,7 +200,8 @@ public class CollectionAssignmentBuilder {
                     targetType,
                     ctx.getTypeFactory(),
                     targetAccessorType.isFieldAssignment() );
-            }else {
+            }
+            else {
                 ctx.getMessager().printMessage(
                     method.getExecutable(),
                     Message.PROPERTYMAPPING_NO_SUITABLE_COLLECTION_OR_MAP_CONSTRUCTOR,
@@ -226,6 +228,12 @@ public class CollectionAssignmentBuilder {
         }
 
         return result;
+    }
+
+    private boolean canBeMappedOrDirectlyAssigned(Assignment result) {
+        return result.getType() != AssignmentType.DIRECT
+                  || targetType.hasCopyConstructor()
+                  || targetType.isEnumSet();
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/NewInstanceSetterWrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/NewInstanceSetterWrapperForCollectionsAndMaps.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model.assignment;
+
+import java.util.List;
+
+import org.mapstruct.ap.internal.model.common.Assignment;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.common.TypeFactory;
+
+/**
+ * This wrapper handles the situation where an assignment is done via the setter, while creating the collection or map
+ * using a no-args constructor.
+ *
+ * @author Ben Zegveld
+ */
+public class NewInstanceSetterWrapperForCollectionsAndMaps extends SetterWrapperForCollectionsAndMapsWithNullCheck {
+
+    private String instanceVar;
+
+    public NewInstanceSetterWrapperForCollectionsAndMaps(Assignment decoratedAssignment,
+        List<Type> thrownTypesToExclude,
+        Type targetType,
+        TypeFactory typeFactory,
+        boolean fieldAssignment) {
+
+        super(
+            decoratedAssignment,
+            thrownTypesToExclude,
+            targetType,
+            typeFactory,
+            fieldAssignment
+        );
+        this.instanceVar = decoratedAssignment.createUniqueVarName( targetType.getName() );
+    }
+
+    public String getInstanceVar() {
+        return instanceVar;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.java
@@ -68,7 +68,7 @@ public class SetterWrapperForCollectionsAndMapsWithNullCheck extends WrapperForC
     }
 
     public boolean isEnumSet() {
-        return "java.util.EnumSet".equals( targetType.getFullyQualifiedName() );
+        return targetType.isEnumSet();
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -176,13 +176,24 @@ public class Type extends ModelElement implements Comparable<Type> {
         }
 
         if ( isCollectionType || isMapType ) {
-            for ( Element element : typeElement.getEnclosedElements() ) {
-                if ( element.getKind() == ElementKind.CONSTRUCTOR && element.getModifiers().contains( Modifier.PUBLIC ) ) {
-                    if (isCopyConstructor( (ExecutableElement) element ) ) {
-                        this.hasCopyConstructor = true;
-                    }
-                    else if ( ( (ExecutableElement) element ).getParameters().isEmpty() ) {
-                        this.hasNoArgsConstructor = true;
+            if ( "java.util".equals( packageName ) ) {
+                hasCopyConstructor = true;
+                hasNoArgsConstructor = true;
+            }
+            else {
+                Element sourceElement =
+                    implementationType != null ? implementationType.getType().getTypeElement() : typeElement;
+                if ( sourceElement != null ) {
+                    for ( Element element : sourceElement.getEnclosedElements() ) {
+                        if ( element.getKind() == ElementKind.CONSTRUCTOR
+                            && element.getModifiers().contains( Modifier.PUBLIC ) ) {
+                            if ( isCopyConstructor( (ExecutableElement) element ) ) {
+                                this.hasCopyConstructor = true;
+                            }
+                            else if ( ( (ExecutableElement) element ).getParameters().isEmpty() ) {
+                                this.hasNoArgsConstructor = true;
+                            }
+                        }
                     }
                 }
             }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -110,15 +110,12 @@ public class Type extends ModelElement implements Comparable<Type> {
     private List<Accessor> setters = null;
     private List<Accessor> adders = null;
     private List<Accessor> alternativeTargetAccessors = null;
-    private Map<String, Accessor> constructorAccessors = null;
 
     private Type boundingBase = null;
 
     private Type boxedEquivalent = null;
 
     private Boolean hasAccessibleConstructor;
-    private boolean hasCopyConstructor;
-    private boolean hasNoArgsConstructor;
 
     private final Filters filters;
 
@@ -175,30 +172,6 @@ public class Type extends ModelElement implements Comparable<Type> {
             enumConstants = Collections.emptyList();
         }
 
-        if ( isCollectionType || isMapType ) {
-            if ( "java.util".equals( packageName ) ) {
-                hasCopyConstructor = true;
-                hasNoArgsConstructor = true;
-            }
-            else {
-                Element sourceElement =
-                    implementationType != null ? implementationType.getType().getTypeElement() : typeElement;
-                if ( sourceElement != null ) {
-                    for ( Element element : sourceElement.getEnclosedElements() ) {
-                        if ( element.getKind() == ElementKind.CONSTRUCTOR
-                            && element.getModifiers().contains( Modifier.PUBLIC ) ) {
-                            if ( isCopyConstructor( (ExecutableElement) element ) ) {
-                                this.hasCopyConstructor = true;
-                            }
-                            else if ( ( (ExecutableElement) element ).getParameters().isEmpty() ) {
-                                this.hasNoArgsConstructor = true;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
         this.isToBeImported = isToBeImported;
         this.toBeImportedTypes = toBeImportedTypes;
         this.notToBeImportedTypes = notToBeImportedTypes;
@@ -208,11 +181,6 @@ public class Type extends ModelElement implements Comparable<Type> {
 
         this.topLevelType = topLevelType( this.typeElement, this.typeFactory );
         this.nameWithTopLevelTypeName = nameWithTopLevelTypeName( this.typeElement );
-    }
-
-    private boolean isCopyConstructor(ExecutableElement ee) {
-        return ee.getParameters().size() == 1
-            && typeUtils.isAssignable( typeMirror, ee.getParameters().get( 0 ).asType() );
     }
     //CHECKSTYLE:ON
 
@@ -1637,20 +1605,6 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     public boolean isEnumSet() {
         return "java.util.EnumSet".equals( getFullyQualifiedName() );
-    }
-
-    /**
-     * Only set for collections and maps.
-     */
-    public boolean hasCopyConstructor() {
-        return hasCopyConstructor;
-    }
-
-    /**
-     * Only set for collections and maps.
-     */
-    public boolean hasNoArgsConstructor() {
-        return hasNoArgsConstructor;
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -80,6 +80,7 @@ public enum Message {
     PROPERTYMAPPING_WHITESPACE_TRIMMED( "The property named \"%s\" has whitespaces, using trimmed property \"%s\" instead.", Diagnostic.Kind.WARNING ),
     PROPERTYMAPPING_CANNOT_DETERMINE_SOURCE_PROPERTY_FROM_TARGET("The type of parameter \"%s\" has no property named \"%s\". Please define the source property explicitly."),
     PROPERTYMAPPING_CANNOT_DETERMINE_SOURCE_PARAMETER_FROM_TARGET("No property named \"%s\" exists in source parameter(s). Please define the source explicitly."),
+    PROPERTYMAPPING_NO_SUITABLE_COLLECTION_OR_MAP_CONSTRUCTOR( "%s does not have an accessible copy or no-args constructor." ),
 
     CONVERSION_LOSSY_WARNING( "%s has a possibly lossy conversion from %s to %s.", Diagnostic.Kind.WARNING ),
     CONVERSION_LOSSY_ERROR( "Can't map %s. It has a possibly lossy conversion from %s to %s." ),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/NewInstanceSetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/NewInstanceSetterWrapperForCollectionsAndMaps.ftl
@@ -1,0 +1,23 @@
+<#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.SetterWrapperForCollectionsAndMapsWithNullCheck" -->
+<#import "../macro/CommonMacros.ftl" as lib>
+<@lib.sourceLocalVarAssignment/>
+<@lib.handleExceptions>
+  <@callTargetWriteAccessor/>
+</@lib.handleExceptions>
+<#--
+  assigns the target via the regular target write accessor (usually the setter)
+-->
+<#macro callTargetWriteAccessor>
+  <@lib.handleLocalVarNullCheck needs_explicit_local_var=directAssignment>
+      <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if> ${instanceVar} = new <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if>();
+      ${instanceVar}.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( ${nullCheckLocalVarName} );
+      <#if ext.targetBeanName?has_content>${ext.targetBeanName}.</#if>${ext.targetWriteAccessorName}<@lib.handleWrite>${instanceVar}</@lib.handleWrite>;
+  </@lib.handleLocalVarNullCheck>
+</#macro>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2668/Erroneous2668ListMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2668/Erroneous2668ListMapper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2668;
+
+import java.util.ArrayList;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Ben Zegveld
+ */
+@Mapper
+public interface Erroneous2668ListMapper {
+
+    Erroneous2668ListMapper INSTANCE = Mappers.getMapper( Erroneous2668ListMapper.class );
+
+    CollectionTarget map(CollectionSource source);
+
+    class CollectionTarget {
+        MyArrayList list;
+
+        public MyArrayList getList() {
+            return list;
+        }
+
+        public void setList(MyArrayList list) {
+            this.list = list;
+        }
+    }
+
+    class CollectionSource {
+        MyArrayList list;
+
+        public MyArrayList getList() {
+            return list;
+        }
+
+        public void setList(MyArrayList list) {
+            this.list = list;
+        }
+    }
+
+    class MyArrayList extends ArrayList<String> {
+        private String unusable;
+
+        public MyArrayList(String unusable) {
+            this.unusable = unusable;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2668/Erroneous2668MapMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2668/Erroneous2668MapMapper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2668;
+
+import java.util.HashMap;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Ben Zegveld
+ */
+@Mapper
+public interface Erroneous2668MapMapper {
+
+    Erroneous2668MapMapper INSTANCE = Mappers.getMapper( Erroneous2668MapMapper.class );
+
+    CollectionTarget map(CollectionSource source);
+
+    class CollectionTarget {
+        MyHashMap map;
+
+        public MyHashMap getMap() {
+            return map;
+        }
+
+        public void setMap(MyHashMap map) {
+            this.map = map;
+        }
+    }
+
+    class CollectionSource {
+        MyHashMap map;
+
+        public MyHashMap getMap() {
+            return map;
+        }
+
+        public void setMap(MyHashMap map) {
+            this.map = map;
+        }
+    }
+
+    class MyHashMap extends HashMap<String, String> {
+        private String unusable;
+
+        public MyHashMap(String unusable) {
+            this.unusable = unusable;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2668/Issue2668Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2668/Issue2668Mapper.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2668;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Ben Zegveld
+ */
+@Mapper
+public interface Issue2668Mapper {
+
+    Issue2668Mapper INSTANCE = Mappers.getMapper( Issue2668Mapper.class );
+
+    CollectionTarget map(CollectionSource source);
+
+    class CollectionTarget {
+        MyArrayList list;
+        MyHashMap map;
+        MyCopyArrayList copyList;
+        MyCopyHashMap copyMap;
+
+        public MyArrayList getList() {
+            return list;
+        }
+
+        public MyHashMap getMap() {
+            return map;
+        }
+
+        public void setList(MyArrayList list) {
+            this.list = list;
+        }
+
+        public void setMap(MyHashMap map) {
+            this.map = map;
+        }
+
+        public MyCopyArrayList getCopyList() {
+            return copyList;
+        }
+
+        public MyCopyHashMap getCopyMap() {
+            return copyMap;
+        }
+
+        public void setCopyList(MyCopyArrayList copyList) {
+            this.copyList = copyList;
+        }
+
+        public void setCopyMap(MyCopyHashMap copyMap) {
+            this.copyMap = copyMap;
+        }
+    }
+
+    class CollectionSource {
+        MyArrayList list;
+        MyHashMap map;
+        MyCopyArrayList copyList;
+        MyCopyHashMap copyMap;
+
+        public MyArrayList getList() {
+            return list;
+        }
+
+        public MyHashMap getMap() {
+            return map;
+        }
+
+        public void setList(MyArrayList list) {
+            this.list = list;
+        }
+
+        public void setMap(MyHashMap map) {
+            this.map = map;
+        }
+
+        public MyCopyArrayList getCopyList() {
+            return copyList;
+        }
+
+        public MyCopyHashMap getCopyMap() {
+            return copyMap;
+        }
+
+        public void setCopyList(MyCopyArrayList copyList) {
+            this.copyList = copyList;
+        }
+
+        public void setCopyMap(MyCopyHashMap copyMap) {
+            this.copyMap = copyMap;
+        }
+    }
+
+    class MyArrayList extends ArrayList<String> {
+    }
+
+    class MyHashMap extends HashMap<String, String> {
+    }
+
+    class MyCopyArrayList extends ArrayList<String> {
+        public MyCopyArrayList(Collection<String> copy) {
+            super( copy );
+        }
+    }
+
+    class MyCopyHashMap extends HashMap<String, String> {
+        public MyCopyHashMap(HashMap<String, String> copy) {
+            super( copy );
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2668/Issue2668Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2668/Issue2668Test.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2668;
+
+import javax.tools.Diagnostic.Kind;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+
+/**
+ * @author Ben Zegveld
+ */
+class Issue2668Test {
+
+    @ProcessorTest
+    @IssueKey( "2668" )
+    @WithClasses( Issue2668Mapper.class )
+    void shouldCompileCorrectlyWithAvailableConstructors() {
+    }
+
+    @ProcessorTest
+    @IssueKey( "2668" )
+    @WithClasses( Erroneous2668ListMapper.class )
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(
+                kind = Kind.ERROR,
+                line = 21,
+                message = "org.mapstruct.ap.test.bugs._2668.Erroneous2668ListMapper.MyArrayList"
+                        + " does not have an accessible copy or no-args constructor."
+                )
+            }
+        )
+    void errorExpectedBecauseCollectionIsNotUsable() {
+    }
+
+    @ProcessorTest
+    @IssueKey( "2668" )
+    @WithClasses( Erroneous2668MapMapper.class )
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(
+                kind = Kind.ERROR,
+                line = 21,
+                message = "org.mapstruct.ap.test.bugs._2668.Erroneous2668MapMapper.MyHashMap"
+                        + " does not have an accessible copy or no-args constructor."
+                )
+            }
+        )
+    void errorExpectedBecauseMapIsNotUsable() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2668/Issue2668Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2668/Issue2668Test.java
@@ -17,16 +17,15 @@ import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutco
 /**
  * @author Ben Zegveld
  */
+@IssueKey( "2668" )
 class Issue2668Test {
 
     @ProcessorTest
-    @IssueKey( "2668" )
     @WithClasses( Issue2668Mapper.class )
     void shouldCompileCorrectlyWithAvailableConstructors() {
     }
 
     @ProcessorTest
-    @IssueKey( "2668" )
     @WithClasses( Erroneous2668ListMapper.class )
     @ExpectedCompilationOutcome(
         value = CompilationResult.FAILED,
@@ -43,7 +42,6 @@ class Issue2668Test {
     }
 
     @ProcessorTest
-    @IssueKey( "2668" )
     @WithClasses( Erroneous2668MapMapper.class )
     @ExpectedCompilationOutcome(
         value = CompilationResult.FAILED,


### PR DESCRIPTION
Added support for collections and maps with a no-args constructor
Added a compiler error in case of a collection or map without either a no-arg constructor or a copy constructor.

Fixes #2668 