### PR TITLE
2696: Invert `@SubclassMappings` with `@InheritInverseConfiguration`.

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -157,6 +157,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             return this;
         }
 
+        @Override
         public BeanMappingMethod build() {
 
             BeanMappingOptions beanMapping = method.getOptions().getBeanMapping();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
@@ -189,7 +189,7 @@ public class MappingMethodOptions {
             }
             else {
                 if ( templateOptions.getValueMappings() != null ) {
-                    // iff there are also inherited mappings, we inverse and add them.
+                    // if there are also inherited mappings, we inverse and add them.
                     for ( ValueMappingOptions inheritedValueMapping : templateOptions.getValueMappings() ) {
                         ValueMappingOptions valueMapping =
                             isInverse ? inheritedValueMapping.inverse() : inheritedValueMapping;
@@ -202,6 +202,7 @@ public class MappingMethodOptions {
             }
 
             if ( isInverse ) {
+                // normal inheritence of subclass mappings will result runtime in infinite loops.
                 setSubclassMapping( SubclassMappingOptions.copyForInverseInheritance(
                           templateOptions.getSubclassMappings(),
                           sourceMethod,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
@@ -130,10 +130,6 @@ public class MappingMethodOptions {
         this.valueMappings = valueMappings;
     }
 
-    public void setSubclassMapping(Set<SubclassMappingOptions> subclassMappings) {
-        this.subclassMappings = subclassMappings;
-    }
-
     public MapperOptions getMapper() {
         return mapper;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
@@ -125,6 +125,10 @@ public class MappingMethodOptions {
         this.valueMappings = valueMappings;
     }
 
+    public void setSubclassMapping(Set<SubclassMappingOptions> subclassMapping) {
+        this.subclassMapping = subclassMapping;
+    }
+
     public MapperOptions getMapper() {
         return mapper;
     }
@@ -144,10 +148,11 @@ public class MappingMethodOptions {
     /**
      * Merges in all the mapping options configured, giving the already defined options precedence.
      *
+     * @param sourceMethod the method which inherits the options.
      * @param templateMethod the template method with the options to inherit, may be {@code null}
      * @param isInverse if {@code true}, the specified options are from an inverse method
      */
-    public void applyInheritedOptions(SourceMethod templateMethod, boolean isInverse) {
+    public void applyInheritedOptions(SourceMethod sourceMethod, SourceMethod templateMethod, boolean isInverse) {
         MappingMethodOptions templateOptions = templateMethod.getOptions();
         if ( null != templateOptions ) {
             if ( !getIterableMapping().hasAnnotation() && templateOptions.getIterableMapping().hasAnnotation() ) {
@@ -196,7 +201,12 @@ public class MappingMethodOptions {
                 }
             }
 
-            // Do NOT inherit subclass mapping options!!!
+            if ( isInverse ) {
+                setSubclassMapping( SubclassMappingOptions.copyForInverseInheritance(
+                          templateOptions.getSubclassMappings(),
+                          sourceMethod,
+                          getBeanMapping() ) );
+            }
 
             Set<MappingOptions> newMappings = new LinkedHashSet<>();
             for ( MappingOptions mapping : templateOptions.getMappings() ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -16,15 +16,14 @@ import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 
 import org.mapstruct.ap.internal.gem.ConditionGem;
-import org.mapstruct.ap.internal.util.TypeUtils;
-
+import org.mapstruct.ap.internal.gem.ObjectFactoryGem;
 import org.mapstruct.ap.internal.model.common.Accessibility;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
-import org.mapstruct.ap.internal.gem.ObjectFactoryGem;
 import org.mapstruct.ap.internal.util.Executables;
 import org.mapstruct.ap.internal.util.Strings;
+import org.mapstruct.ap.internal.util.TypeUtils;
 
 import static org.mapstruct.ap.internal.model.source.MappingMethodUtils.isEnumMapping;
 import static org.mapstruct.ap.internal.util.Collections.first;
@@ -98,6 +97,7 @@ public class SourceMethod implements Method {
         private Set<SubclassMappingOptions> subclassMappings;
 
         private boolean verboseLogging;
+        private SubclassValidator subclassValidator;
 
         public Builder setDeclaringMapper(Type declaringMapper) {
             this.declaringMapper = declaringMapper;
@@ -159,6 +159,11 @@ public class SourceMethod implements Method {
             return this;
         }
 
+        public Builder setSubclassValidator(SubclassValidator subclassValidator) {
+            this.subclassValidator = subclassValidator;
+            return this;
+        }
+
         public Builder setTypeUtils(TypeUtils typeUtils) {
             this.typeUtils = typeUtils;
             return this;
@@ -212,7 +217,8 @@ public class SourceMethod implements Method {
                 beanMapping,
                 enumMappingOptions,
                 valueMappings,
-                subclassMappings
+                subclassMappings,
+                subclassValidator
             );
 
             this.typeParameters = this.executable.getTypeParameters()

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
@@ -5,7 +5,7 @@
  */
 package org.mapstruct.ap.internal.model.source;
 
-import java.util.LinkedHashSet;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.ExecutableElement;
@@ -32,11 +32,13 @@ public class SubclassMappingOptions extends DelegatingOptions {
 
     private final TypeMirror source;
     private final TypeMirror target;
+    private final TypeUtils typeUtils;
 
-    public SubclassMappingOptions(TypeMirror source, TypeMirror target, DelegatingOptions next) {
+    public SubclassMappingOptions(TypeMirror source, TypeMirror target, TypeUtils typeUtils, DelegatingOptions next) {
         super( next );
         this.source = source;
         this.target = target;
+        this.typeUtils = typeUtils;
     }
 
     @Override
@@ -158,20 +160,36 @@ public class SubclassMappingOptions extends DelegatingOptions {
                     new SubclassMappingOptions(
                         sourceSubclass,
                         targetSubclass,
+                        typeUtils,
                         beanMappingOptions ) );
     }
 
-    public static Set<SubclassMappingOptions> copyForInverseInheritance(Set<SubclassMappingOptions> subclassMappings,
+    public static List<SubclassMappingOptions> copyForInverseInheritance(Set<SubclassMappingOptions> subclassMappings,
                                                                         BeanMappingOptions beanMappingOptions) {
-        // we want to keep the order of the mappings, so we are using a LinkedHashSet.
-        Set<SubclassMappingOptions> mappings = new LinkedHashSet<>();
+        // we are not interested in keeping it unique at this point.
+        List<SubclassMappingOptions> mappings = new ArrayList<>();
         for ( SubclassMappingOptions subclassMapping : subclassMappings ) {
             mappings.add(
-                    new SubclassMappingOptions(
+                        new SubclassMappingOptions(
                                    subclassMapping.target,
                                    subclassMapping.source,
+                                   subclassMapping.typeUtils,
                                    beanMappingOptions ) );
         }
         return mappings;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( obj == null || !( obj instanceof SubclassMappingOptions ) ) {
+            return false;
+        }
+        SubclassMappingOptions other = (SubclassMappingOptions) obj;
+        return typeUtils.isSameType( source, other.source );
+    }
+
+    @Override
+    public int hashCode() {
+        return 1; // use a stable value because TypeMirror is not safe to use for hashCode.
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
@@ -5,7 +5,7 @@
  */
 package org.mapstruct.ap.internal.model.source;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import javax.lang.model.element.ExecutableElement;
@@ -188,7 +188,8 @@ public class SubclassMappingOptions extends DelegatingOptions {
     public static Set<SubclassMappingOptions> copyForInverseInheritance(Set<SubclassMappingOptions> subclassMappings,
                                                                         SourceMethod sourceMethod,
                                                                         BeanMappingOptions beanMappingOptions) {
-        HashSet<SubclassMappingOptions> mappings = new HashSet<>();
+        // we want to keep the order of the mappings, so we are using a LinkedHashSet.
+        Set<SubclassMappingOptions> mappings = new LinkedHashSet<>();
         SubclassValidator validator = null;
         for ( SubclassMappingOptions subclassMapping : subclassMappings ) {
             if ( validator == null ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
@@ -86,7 +86,9 @@ public class SubclassMappingOptions extends DelegatingOptions {
                         targetSubclass.toString() );
             isConsistent = false;
         }
-        isConsistent = isConsistent & subclassValidator.isValidUsage( method, gem.mirror(), targetSubclass );
+        if ( !subclassValidator.isValidUsage( method, gem.mirror(), targetSubclass ) ) {
+            isConsistent = false;
+        }
         return isConsistent;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
@@ -8,7 +8,6 @@ package org.mapstruct.ap.internal.model.source;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
-import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.type.TypeMirror;
 
@@ -86,7 +85,7 @@ public class SubclassMappingOptions extends DelegatingOptions {
                         targetSubclass.toString() );
             isConsistent = false;
         }
-        if ( !subclassValidator.isValidUsage( method, gem.mirror(), targetSubclass ) ) {
+        if ( !subclassValidator.isValidUsage( method, gem.mirror(), sourceSubclass ) ) {
             isConsistent = false;
         }
         return isConsistent;
@@ -163,23 +162,15 @@ public class SubclassMappingOptions extends DelegatingOptions {
     }
 
     public static Set<SubclassMappingOptions> copyForInverseInheritance(Set<SubclassMappingOptions> subclassMappings,
-                                                                        SourceMethod sourceMethod,
-                                                                        BeanMappingOptions beanMappingOptions,
-                                                                        SubclassValidator validator,
-                                                                        AnnotationMirror mirror) {
+                                                                        BeanMappingOptions beanMappingOptions) {
         // we want to keep the order of the mappings, so we are using a LinkedHashSet.
         Set<SubclassMappingOptions> mappings = new LinkedHashSet<>();
         for ( SubclassMappingOptions subclassMapping : subclassMappings ) {
-            if ( validator.isValidUsage(
-                         sourceMethod.getExecutable(),
-                         mirror,
-                         subclassMapping.target ) ) {
-                mappings.add(
-                        new SubclassMappingOptions(
-                                       subclassMapping.target,
-                                       subclassMapping.source,
-                                       beanMappingOptions ) );
-            }
+            mappings.add(
+                    new SubclassMappingOptions(
+                                   subclassMapping.target,
+                                   subclassMapping.source,
+                                   beanMappingOptions ) );
         }
         return mappings;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassValidator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassValidator.java
@@ -31,8 +31,17 @@ class SubclassValidator {
         this.typeUtils = typeUtils;
     }
 
-    public boolean isInCorrectOrder(Element e, AnnotationMirror annotation, TypeMirror sourceType) {
+    public boolean isValidUsage(Element e, AnnotationMirror annotation, TypeMirror sourceType) {
         for ( TypeMirror typeMirror : handledSubclasses ) {
+            if ( typeUtils.isSameType( sourceType, typeMirror ) ) {
+                messager
+                        .printMessage(
+                            e,
+                            annotation,
+                            Message.SUBCLASSMAPPING_DOUBLE_SOURCE_SUBCLASS,
+                            sourceType );
+                return false;
+            }
             if ( typeUtils.isAssignable( sourceType, typeMirror ) ) {
                 messager
                         .printMessage(
@@ -43,11 +52,11 @@ class SubclassValidator {
                             typeMirror,
                             sourceType,
                             typeMirror );
-                return true;
+                return false;
             }
         }
         handledSubclasses.add( sourceType );
-        return false;
+        return true;
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassValidator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassValidator.java
@@ -20,13 +20,13 @@ import org.mapstruct.ap.internal.util.TypeUtils;
  *
  * @author Ben Zegveld
  */
-class SubclassValidator {
+public class SubclassValidator {
 
     private final FormattingMessager messager;
     private final List<TypeMirror> handledSubclasses = new ArrayList<>();
     private final TypeUtils typeUtils;
 
-    SubclassValidator(FormattingMessager messager, TypeUtils typeUtils) {
+    public SubclassValidator(FormattingMessager messager, TypeUtils typeUtils) {
         this.messager = messager;
         this.typeUtils = typeUtils;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -497,10 +497,10 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
 
         // apply defined (@InheritConfiguration, @InheritInverseConfiguration) mappings
         if ( forwardTemplateMethod != null ) {
-            mappingOptions.applyInheritedOptions( forwardTemplateMethod, false );
+            mappingOptions.applyInheritedOptions( method, forwardTemplateMethod, false );
         }
         if ( inverseTemplateMethod != null ) {
-            mappingOptions.applyInheritedOptions( inverseTemplateMethod, true );
+            mappingOptions.applyInheritedOptions( method, inverseTemplateMethod, true );
         }
 
         // apply auto inherited options
@@ -510,7 +510,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
             // but.. there should not be an @InheritedConfiguration
             if ( forwardTemplateMethod == null && inheritanceStrategy.isApplyForward() ) {
                 if ( applicablePrototypeMethods.size() == 1 ) {
-                    mappingOptions.applyInheritedOptions( first( applicablePrototypeMethods ), false );
+                    mappingOptions.applyInheritedOptions( method, first( applicablePrototypeMethods ), false );
                 }
                 else if ( applicablePrototypeMethods.size() > 1 ) {
                     messager.printMessage(
@@ -523,7 +523,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
             // or no @InheritInverseConfiguration
             if ( inverseTemplateMethod == null && inheritanceStrategy.isApplyReverse() ) {
                 if ( applicableReversePrototypeMethods.size() == 1 ) {
-                    mappingOptions.applyInheritedOptions( first( applicableReversePrototypeMethods ), true );
+                    mappingOptions.applyInheritedOptions( method, first( applicableReversePrototypeMethods ), true );
                 }
                 else if ( applicableReversePrototypeMethods.size() > 1 ) {
                     messager.printMessage(

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -116,6 +116,7 @@ public enum Message {
     ENUMMAPPING_NO_ELEMENTS( "'nameTransformationStrategy', 'configuration' and 'unexpectedValueMappingException' are undefined in @EnumMapping, define at least one of them." ),
     ENUMMAPPING_ILLEGAL_TRANSFORMATION( "Illegal transformation for '%s' EnumTransformationStrategy. Error: '%s'." ),
 
+    SUBCLASSMAPPING_DOUBLE_SOURCE_SUBCLASS( "Subclass '%s' is already defined as a source." ),
     SUBCLASSMAPPING_ILLEGAL_SUBCLASS( "Class '%s' is not a subclass of '%s'." ),
     SUBCLASSMAPPING_NO_VALID_SUPERCLASS( "Could not find a parameter that is a superclass for '%s'." ),
     SUBCLASSMAPPING_UPDATE_METHODS_NOT_SUPPORTED( "SubclassMapping annotation can not be used for update methods." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/ErroneousInverseSubclassMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/ErroneousInverseSubclassMapper.java
@@ -10,27 +10,19 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.SubclassMapping;
 import org.mapstruct.ap.test.subclassmapping.mappables.Bike;
-import org.mapstruct.ap.test.subclassmapping.mappables.BikeDto;
 import org.mapstruct.ap.test.subclassmapping.mappables.Car;
-import org.mapstruct.ap.test.subclassmapping.mappables.CarDto;
 import org.mapstruct.ap.test.subclassmapping.mappables.Vehicle;
-import org.mapstruct.ap.test.subclassmapping.mappables.VehicleCollection;
-import org.mapstruct.ap.test.subclassmapping.mappables.VehicleCollectionDto;
 import org.mapstruct.ap.test.subclassmapping.mappables.VehicleDto;
 import org.mapstruct.factory.Mappers;
 
 @Mapper
-public interface SimpleSubclassMapper {
-    SimpleSubclassMapper INSTANCE = Mappers.getMapper( SimpleSubclassMapper.class );
+public interface ErroneousInverseSubclassMapper {
+    ErroneousInverseSubclassMapper INSTANCE = Mappers.getMapper( ErroneousInverseSubclassMapper.class );
 
-    VehicleCollectionDto map(VehicleCollection vehicles);
-
-    @SubclassMapping( source = Car.class, target = CarDto.class )
-    @SubclassMapping( source = Bike.class, target = BikeDto.class )
-    @Mapping( source = "vehicleManufacturingCompany", target = "maker")
+    @SubclassMapping( source = Bike.class, target = VehicleDto.class )
+    @SubclassMapping( source = Car.class, target = VehicleDto.class )
+    @Mapping( target = "maker", source = "vehicleManufacturingCompany" )
     VehicleDto map(Vehicle vehicle);
-
-    VehicleCollection mapInverse(VehicleCollectionDto vehicles);
 
     @InheritInverseConfiguration
     Vehicle mapInverse(VehicleDto dto);

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/InverseOrderSubclassMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/InverseOrderSubclassMapper.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.SubclassMapping;
+import org.mapstruct.ap.test.subclassmapping.mappables.Bike;
+import org.mapstruct.ap.test.subclassmapping.mappables.BikeDto;
+import org.mapstruct.ap.test.subclassmapping.mappables.Car;
+import org.mapstruct.ap.test.subclassmapping.mappables.CarDto;
+import org.mapstruct.ap.test.subclassmapping.mappables.HatchBack;
+import org.mapstruct.ap.test.subclassmapping.mappables.Vehicle;
+import org.mapstruct.ap.test.subclassmapping.mappables.VehicleCollection;
+import org.mapstruct.ap.test.subclassmapping.mappables.VehicleCollectionDto;
+import org.mapstruct.ap.test.subclassmapping.mappables.VehicleDto;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface InverseOrderSubclassMapper {
+    InverseOrderSubclassMapper INSTANCE = Mappers.getMapper( InverseOrderSubclassMapper.class );
+
+    VehicleCollectionDto map(VehicleCollection vehicles);
+
+    @SubclassMapping( source = HatchBack.class, target = CarDto.class )
+    @SubclassMapping( source = Car.class, target = CarDto.class )
+    @SubclassMapping( source = Bike.class, target = BikeDto.class )
+    @Mapping( source = "vehicleManufacturingCompany", target = "maker")
+    VehicleDto map(Vehicle vehicle);
+
+    VehicleCollection mapInverse(VehicleCollectionDto vehicles);
+
+    @SubclassMapping( source = CarDto.class, target = Car.class )
+    @InheritInverseConfiguration
+    Vehicle mapInverse(VehicleDto dto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassMappingTest.java
@@ -82,13 +82,31 @@ public class SubclassMappingTest {
 
     @ProcessorTest
     @WithClasses( SimpleSubclassMapper.class )
-    void subclassMappingInheritsMapping() {
+    void subclassMappingInheritsInverseMapping() {
         VehicleCollection vehicles = new VehicleCollection();
         Car car = new Car();
         car.setVehicleManufacturingCompany( "BenZ" );
         vehicles.getVehicles().add( car );
 
         VehicleCollectionDto result = SimpleSubclassMapper.INSTANCE.map( vehicles );
+
+        assertThat( result.getVehicles() )
+            .extracting( VehicleDto::getMaker )
+            .containsExactly( "BenZ" );
+    }
+
+    @ProcessorTest
+    @WithClasses( {
+        HatchBack.class,
+        InverseOrderSubclassMapper.class
+    } )
+    void subclassMappingOverridesInverseInheritsMapping() {
+        VehicleCollection vehicles = new VehicleCollection();
+        Car car = new Car();
+        car.setVehicleManufacturingCompany( "BenZ" );
+        vehicles.getVehicles().add( car );
+
+        VehicleCollectionDto result = InverseOrderSubclassMapper.INSTANCE.map( vehicles );
 
         assertThat( result.getVehicles() )
             .extracting( VehicleDto::getMaker )
@@ -107,11 +125,11 @@ public class SubclassMappingTest {
             line = 28,
             alternativeLine = 30,
             message = "SubclassMapping annotation for "
-                + "'org.mapstruct.ap.test.subclassmapping.mappables.HatchBackDto' found after "
-                + "'org.mapstruct.ap.test.subclassmapping.mappables.CarDto', but all "
-                + "'org.mapstruct.ap.test.subclassmapping.mappables.HatchBackDto' "
+                + "'org.mapstruct.ap.test.subclassmapping.mappables.HatchBack' found after "
+                + "'org.mapstruct.ap.test.subclassmapping.mappables.Car', but all "
+                + "'org.mapstruct.ap.test.subclassmapping.mappables.HatchBack' "
                 + "objects are also instances of "
-                + "'org.mapstruct.ap.test.subclassmapping.mappables.CarDto'.")
+                + "'org.mapstruct.ap.test.subclassmapping.mappables.Car'.")
     })
     void subclassOrderWarning() {
     }
@@ -158,8 +176,7 @@ public class SubclassMappingTest {
     @ExpectedCompilationOutcome( value = CompilationResult.FAILED, diagnostics = {
         @Diagnostic(type = ErroneousInverseSubclassMapper.class,
             kind = javax.tools.Diagnostic.Kind.ERROR,
-            line = 25,
-            alternativeLine = 23,
+            line = 28,
             message = "Subclass "
                 + "'org.mapstruct.ap.test.subclassmapping.mappables.VehicleDto'"
                 + " is already defined as a source."

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassMappingTest.java
@@ -163,13 +163,6 @@ public class SubclassMappingTest {
             message = "Subclass "
                 + "'org.mapstruct.ap.test.subclassmapping.mappables.VehicleDto'"
                 + " is already defined as a source."
-        ),
-        @Diagnostic(type = ErroneousInverseSubclassMapper.class,
-            kind = javax.tools.Diagnostic.Kind.ERROR,
-            line = 28,
-            message = "Subclass "
-                + "'org.mapstruct.ap.test.subclassmapping.mappables.VehicleDto'"
-                + " is already defined as a source."
         )
     })
     void inverseSubclassMappingNotPossible() {

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassMappingTest.java
@@ -83,15 +83,15 @@ public class SubclassMappingTest {
     @ProcessorTest
     @WithClasses( SimpleSubclassMapper.class )
     void subclassMappingInheritsInverseMapping() {
-        VehicleCollection vehicles = new VehicleCollection();
-        Car car = new Car();
-        car.setVehicleManufacturingCompany( "BenZ" );
-        vehicles.getVehicles().add( car );
+        VehicleCollectionDto vehiclesDto = new VehicleCollectionDto();
+        CarDto carDto = new CarDto();
+        carDto.setMaker( "BenZ" );
+        vehiclesDto.getVehicles().add( carDto );
 
-        VehicleCollectionDto result = SimpleSubclassMapper.INSTANCE.map( vehicles );
+        VehicleCollection result = SimpleSubclassMapper.INSTANCE.mapInverse( vehiclesDto );
 
         assertThat( result.getVehicles() )
-            .extracting( VehicleDto::getMaker )
+            .extracting( Vehicle::getVehicleManufacturingCompany )
             .containsExactly( "BenZ" );
     }
 
@@ -101,16 +101,16 @@ public class SubclassMappingTest {
         InverseOrderSubclassMapper.class
     } )
     void subclassMappingOverridesInverseInheritsMapping() {
-        VehicleCollection vehicles = new VehicleCollection();
-        Car car = new Car();
-        car.setVehicleManufacturingCompany( "BenZ" );
-        vehicles.getVehicles().add( car );
+        VehicleCollectionDto vehicleDtos = new VehicleCollectionDto();
+        CarDto carDto = new CarDto();
+        carDto.setMaker( "BenZ" );
+        vehicleDtos.getVehicles().add( carDto );
 
-        VehicleCollectionDto result = InverseOrderSubclassMapper.INSTANCE.map( vehicles );
+        VehicleCollection result = InverseOrderSubclassMapper.INSTANCE.mapInverse( vehicleDtos );
 
-        assertThat( result.getVehicles() )
-            .extracting( VehicleDto::getMaker )
-            .containsExactly( "BenZ" );
+        assertThat( result.getVehicles() ) // remove generic so that test works.
+            .extracting( vehicle -> (Class) vehicle.getClass() )
+            .containsExactly( Car.class );
     }
 
     @ProcessorTest

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/fixture/SubSourceOverride.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/fixture/SubSourceOverride.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.fixture;
+
+public class SubSourceOverride extends ImplementedParentSource implements InterfaceParentSource {
+    private final String finalValue;
+
+    public SubSourceOverride(String finalValue) {
+        this.finalValue = finalValue;
+    }
+
+    public String getFinalValue() {
+        return finalValue;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/fixture/SubSourceSeparate.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/fixture/SubSourceSeparate.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.fixture;
+
+public class SubSourceSeparate extends ImplementedParentSource implements InterfaceParentSource {
+    private final String separateValue;
+
+    public SubSourceSeparate(String separateValue) {
+        this.separateValue = separateValue;
+    }
+
+    public String getSeparateValue() {
+        return separateValue;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/fixture/SubTargetSeparate.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/fixture/SubTargetSeparate.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.fixture;
+
+public class SubTargetSeparate extends ImplementedParentTarget implements InterfaceParentTarget {
+    private final String separateValue;
+
+    public SubTargetSeparate(String separateValue) {
+        this.separateValue = separateValue;
+    }
+
+    public String getSeparateValue() {
+        return separateValue;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/fixture/SubclassAbstractMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/fixture/SubclassAbstractMapper.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.test.subclassmapping.fixture;
 
 import org.mapstruct.BeanMapping;
+import org.mapstruct.InheritInverseConfiguration;
 import org.mapstruct.Mapper;
 import org.mapstruct.SubclassMapping;
 
@@ -18,4 +19,9 @@ public interface SubclassAbstractMapper {
     @SubclassMapping( source = SubSource.class, target = SubTarget.class )
     @SubclassMapping( source = SubSourceOther.class, target = SubTargetOther.class )
     AbstractParentTarget map(AbstractParentSource item);
+
+    @SubclassMapping( source = SubTargetSeparate.class, target = SubSourceSeparate.class )
+    @InheritInverseConfiguration
+    @SubclassMapping( source = SubTargetOther.class, target = SubSourceOverride.class )
+    AbstractParentSource map(AbstractParentTarget item);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/fixture/SubclassFixtureTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/fixture/SubclassFixtureTest.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.test.subclassmapping.fixture;
 
 import org.junit.jupiter.api.extension.RegisterExtension;
+
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
@@ -37,6 +38,9 @@ public class SubclassFixtureTest {
 
     @ProcessorTest
     @WithClasses( {
+        SubSourceOverride.class,
+        SubSourceSeparate.class,
+        SubTargetSeparate.class,
         SubclassAbstractMapper.class,
     } )
     void subclassAbstractParentFixture() {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/subclassmapping/fixture/SubclassAbstractMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/subclassmapping/fixture/SubclassAbstractMapperImpl.java
@@ -9,7 +9,7 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2021-09-12T14:37:10+0200",
+    date = "2022-01-31T19:35:15+0100",
     comments = "version: , compiler: Eclipse JDT (Batch) 3.20.0.v20191203-2131, environment: Java 11.0.12 (Azul Systems, Inc.)"
 )
 public class SubclassAbstractMapperImpl implements SubclassAbstractMapper {
@@ -25,6 +25,26 @@ public class SubclassAbstractMapperImpl implements SubclassAbstractMapper {
         }
         else if (item instanceof SubSourceOther) {
             return subSourceOtherToSubTargetOther( (SubSourceOther) item );
+        }
+        else {
+            throw new IllegalArgumentException("Not all subclasses are supported for this mapping. Missing for " + item.getClass());
+        }
+    }
+
+    @Override
+    public AbstractParentSource map(AbstractParentTarget item) {
+        if ( item == null ) {
+            return null;
+        }
+
+        if (item instanceof SubTargetSeparate) {
+            return subTargetSeparateToSubSourceSeparate( (SubTargetSeparate) item );
+        }
+        else if (item instanceof SubTargetOther) {
+            return subTargetOtherToSubSourceOverride( (SubTargetOther) item );
+        }
+        else if (item instanceof SubTarget) {
+            return subTargetToSubSource( (SubTarget) item );
         }
         else {
             throw new IllegalArgumentException("Not all subclasses are supported for this mapping. Missing for " + item.getClass());
@@ -55,5 +75,45 @@ public class SubclassAbstractMapperImpl implements SubclassAbstractMapper {
         SubTargetOther subTargetOther = new SubTargetOther( finalValue );
 
         return subTargetOther;
+    }
+
+    protected SubSourceSeparate subTargetSeparateToSubSourceSeparate(SubTargetSeparate subTargetSeparate) {
+        if ( subTargetSeparate == null ) {
+            return null;
+        }
+
+        String separateValue = null;
+
+        separateValue = subTargetSeparate.getSeparateValue();
+
+        SubSourceSeparate subSourceSeparate = new SubSourceSeparate( separateValue );
+
+        return subSourceSeparate;
+    }
+
+    protected SubSourceOverride subTargetOtherToSubSourceOverride(SubTargetOther subTargetOther) {
+        if ( subTargetOther == null ) {
+            return null;
+        }
+
+        String finalValue = null;
+
+        finalValue = subTargetOther.getFinalValue();
+
+        SubSourceOverride subSourceOverride = new SubSourceOverride( finalValue );
+
+        return subSourceOverride;
+    }
+
+    protected SubSource subTargetToSubSource(SubTarget subTarget) {
+        if ( subTarget == null ) {
+            return null;
+        }
+
+        SubSource subSource = new SubSource();
+
+        subSource.setValue( subTarget.getValue() );
+
+        return subSource;
     }
 }


### PR DESCRIPTION
`@InheritConfiguration` still not possible with `@SubclassMapping`'s, but `@InheritInverseConfiguration` is possible with `@SubclassMapping`'s.

Added a new error in case of identical source classes in the `@SubclassMapping`'s.
For normal `@SubclassMapping`'s this was easy to spot, but with the `@InheritInverseConfiguration` it was suddenly possible, and you would end up with unreachable code.
```java
if ( A instanceof B ) {
  // do mapping
} else if ( A instanceof B ) { // <--- will never be true
  // do different mapping //  <--- unreachable code
}
```

Fixes #2696 