### PR TITLE
#2674: Added check if method without implementation doesn’t have  @AfterMapping / @BeforeMapping annotation

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -564,6 +564,16 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
             }
         }
 
+        if ( Executables.isAfterMappingMethod( method ) ) {
+            messager.printMessage( method, Message.RETRIEVAL_AFTER_METHOD_NOT_IMPLEMENTED );
+            return false;
+        }
+
+        if ( Executables.isBeforeMappingMethod( method ) ) {
+            messager.printMessage( method, Message.RETRIEVAL_BEFORE_METHOD_NOT_IMPLEMENTED );
+            return false;
+        }
+
         return true;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -167,6 +167,8 @@ public enum Message {
     RETRIEVAL_WILDCARD_EXTENDS_BOUND_RESULT( "Can't generate mapping method for a wildcard extends bound result." ),
     RETRIEVAL_CONTEXT_PARAMS_WITH_SAME_TYPE( "The types of @Context parameters must be unique." ),
     RETRIEVAL_MAPPER_USES_CYCLE( "The mapper %s is referenced itself in Mapper#uses.", Diagnostic.Kind.WARNING ),
+    RETRIEVAL_AFTER_METHOD_NOT_IMPLEMENTED( "AfterMapping can only be applied to an implemented method." ),
+    RETRIEVAL_BEFORE_METHOD_NOT_IMPLEMENTED( "BeforeMapping can only be applied to an implemented method." ),
 
     INHERITINVERSECONFIGURATION_DUPLICATES( "Several matching inverse methods exist: %s(). Specify a name explicitly." ),
     INHERITINVERSECONFIGURATION_INVALID_NAME( "None of the candidates %s() matches given name: \"%s\"." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2674/ErroneousSourceTargetMapping.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2674/ErroneousSourceTargetMapping.java
@@ -1,0 +1,23 @@
+package org.mapstruct.ap.test.bugs._2674;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.BeforeMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+interface ErroneousSourceTargetMapping {
+
+    ErroneousSourceTargetMapping INSTANCE = Mappers.getMapper( ErroneousSourceTargetMapping.class );
+
+    @BeforeMapping
+    void beforeMappingMethod(Target target, @MappingTarget Source source);
+
+    @AfterMapping
+    void afterMappingMethod(Source source, @MappingTarget Target target);
+
+    Target toTarget (Source source);
+
+    Source toSource (Target target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2674/Issue2674Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2674/Issue2674Test.java
@@ -1,0 +1,35 @@
+package org.mapstruct.ap.test.bugs._2674;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+
+import static javax.tools.Diagnostic.Kind;
+
+/**
+ * @author Justyna Kubica-Ledzion
+ */
+@IssueKey("2674")
+@WithClasses({Source.class, Target.class, ErroneousSourceTargetMapping.class})
+public class Issue2674Test {
+
+    @ProcessorTest
+    @ExpectedCompilationOutcome(
+            value = CompilationResult.FAILED,
+            diagnostics = {
+                    @Diagnostic(type = ErroneousSourceTargetMapping.class,
+                            kind = Kind.ERROR,
+                            line = 15,
+                            message = "BeforeMapping can only be applied to an implemented method."),
+                    @Diagnostic(type = ErroneousSourceTargetMapping.class,
+                            kind = Kind.ERROR,
+                            line = 18,
+                            message = "AfterMapping can only be applied to an implemented method.")
+            }
+    )
+    public void shouldRaiseErrorIfThereIsNoAfterOrBeforeMethodImplementation() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2674/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2674/Source.java
@@ -1,0 +1,23 @@
+package org.mapstruct.ap.test.bugs._2674;
+
+public class Source {
+
+    private int id;
+    private String name;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2674/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2674/Target.java
@@ -1,0 +1,23 @@
+package org.mapstruct.ap.test.bugs._2674;
+
+public class Target {
+
+    private int id;
+    private String name;
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}


### PR DESCRIPTION
#2674: Added check if method without implementation doesn’t have  @AfterMapping / @BeforeMapping annotation.