### PR TITLE
#2629 Use ModuleElement when getting type element

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [11, 13, 16, 17]
+        java: [13, 16, 17]
     name: 'Linux JDK ${{ matrix.java }}'
     runs-on: ubuntu-latest
     steps:
@@ -25,15 +25,15 @@ jobs:
       - name: 'Test'
         run: ./mvnw ${MAVEN_ARGS} -Djacoco.skip=true install -DskipDistribution=true
   linux:
-    name: 'Linux JDK 8'
+    name: 'Linux JDK 11'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v2
-      - name: 'Set up JDK 8'
+      - name: 'Set up JDK 11'
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: 'Test'
         run: ./mvnw ${MAVEN_ARGS} install
       - name: 'Generate coverage report'
@@ -43,25 +43,43 @@ jobs:
       - name: 'Publish Snapshots'
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'mapstruct/mapstruct'
         run: ./mvnw -s etc/ci-settings.xml -DskipTests=true -DskipDistribution=true deploy
+  linux-jdk-8:
+    name: 'Linux JDK 8'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout'
+        uses: actions/checkout@v2
+      - name: 'Set up JDK 11 for building everything'
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: 'Install Processor'
+        run: ./mvnw ${MAVEN_ARGS} -DskipTests install -pl processor -am
+      - name: 'Set up JDK 8 for running integration tests'
+        uses: actions/setup-java@v1
+        with:
+          java-version: 8
+      - name: 'Run integration tests'
+        run: ./mvnw ${MAVEN_ARGS} verify -pl integrationtest
   windows:
     name: 'Windows'
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v2
-      - name: 'Set up JDK 8'
+      - name: 'Set up JDK 11'
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: 'Test'
-        run: ./mvnw ${MAVEN_ARGS} install
+        run: ./mvnw %MAVEN_ARGS% install
   mac:
     name: 'Mac OS'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v2
-      - name: 'Set up JDK 8'
+      - name: 'Set up JDK 11'
         uses: actions/setup-java@v1
         with:
-          java-version: 8
+          java-version: 11
       - name: 'Test'
         run: ./mvnw ${MAVEN_ARGS} install

--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
@@ -87,6 +87,14 @@ public class MavenIntegrationTest {
     void lombokBuilderTest() {
     }
 
+    @ProcessorTest(baseDir = "lombokModuleTest", processorTypes = {
+        ProcessorTest.ProcessorType.JAVAC,
+        ProcessorTest.ProcessorType.JAVAC_WITH_PATHS
+    })
+    @EnabledForJreRange(min = JRE.JAVA_11)
+    void lombokModuleTest() {
+    }
+
     @ProcessorTest(baseDir = "namingStrategyTest", processorTypes = {
         ProcessorTest.ProcessorType.JAVAC
     })

--- a/integrationtest/src/test/resources/lombokModuleTest/pom.xml
+++ b/integrationtest/src/test/resources/lombokModuleTest/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.mapstruct</groupId>
+        <artifactId>mapstruct-it-parent</artifactId>
+        <version>1.0.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>lombokModuleIntegrationTest</artifactId>
+    <packaging>jar</packaging>
+
+    <properties>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
+    </properties>
+    
+    <dependencies>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok-mapstruct-binding</artifactId>
+            <version>0.2.0</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <profiles>
+        <profile>
+            <id>generate-via-compiler-plugin-with-annotation-processor-paths</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgument combine.self="override"></compilerArgument>
+                            <compilerId>\${compiler-id}</compilerId>
+                            <annotationProcessorPaths>
+                                <annotationProcessorPath>
+                                    <groupId>${project.groupId}</groupId>
+                                    <artifactId>mapstruct-processor</artifactId>
+                                    <version>${mapstruct.version}</version>
+                                </annotationProcessorPath>
+                                <annotationProcessorPath>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok</artifactId>
+                                    <version>1.18.22</version>
+                                </annotationProcessorPath>
+                                <annotationProcessorPath>
+                                    <groupId>org.projectlombok</groupId>
+                                    <artifactId>lombok-mapstruct-binding</artifactId>
+                                    <version>0.2.0</version>
+                                </annotationProcessorPath>
+                            </annotationProcessorPaths>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.eclipse.tycho</groupId>
+                                <artifactId>tycho-compiler-jdt</artifactId>
+                                <version>${org.eclipse.tycho.compiler-jdt.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/integrationtest/src/test/resources/lombokModuleTest/src/main/java/module-info.java
+++ b/integrationtest/src/test/resources/lombokModuleTest/src/main/java/module-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+module org.example {
+    requires org.mapstruct;
+    requires lombok;
+}

--- a/integrationtest/src/test/resources/lombokModuleTest/src/main/java/org/mapstruct/itest/lombok/Address.java
+++ b/integrationtest/src/test/resources/lombokModuleTest/src/main/java/org/mapstruct/itest/lombok/Address.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.lombok;
+
+public class Address {
+    private final String addressLine;
+
+    public Address(String addressLine) {
+        this.addressLine = addressLine;
+    }
+
+    public String getAddressLine() {
+        return addressLine;
+    }
+}

--- a/integrationtest/src/test/resources/lombokModuleTest/src/main/java/org/mapstruct/itest/lombok/AddressDto.java
+++ b/integrationtest/src/test/resources/lombokModuleTest/src/main/java/org/mapstruct/itest/lombok/AddressDto.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.lombok;
+
+public class AddressDto {
+
+    private final String addressLine;
+
+    public AddressDto(String addressLine) {
+        this.addressLine = addressLine;
+    }
+
+    public String getAddressLine() {
+        return addressLine;
+    }
+}

--- a/integrationtest/src/test/resources/lombokModuleTest/src/main/java/org/mapstruct/itest/lombok/Person.java
+++ b/integrationtest/src/test/resources/lombokModuleTest/src/main/java/org/mapstruct/itest/lombok/Person.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.lombok;
+
+public class Person {
+    private final String name;
+    private final int age;
+    private final Address address;
+
+    public Person(String name, int age, Address address) {
+        this.name = name;
+        this.age = age;
+        this.address = address;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public Address getAddress() {
+        return address;
+    }
+}

--- a/integrationtest/src/test/resources/lombokModuleTest/src/main/java/org/mapstruct/itest/lombok/PersonDto.java
+++ b/integrationtest/src/test/resources/lombokModuleTest/src/main/java/org/mapstruct/itest/lombok/PersonDto.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.lombok;
+
+public class PersonDto {
+    private final String name;
+    private final int age;
+    private final AddressDto address;
+
+    public PersonDto(String name, int age, AddressDto address) {
+        this.name = name;
+        this.age = age;
+        this.address = address;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public AddressDto getAddress() {
+        return address;
+    }
+}

--- a/integrationtest/src/test/resources/lombokModuleTest/src/main/java/org/mapstruct/itest/lombok/PersonMapper.java
+++ b/integrationtest/src/test/resources/lombokModuleTest/src/main/java/org/mapstruct/itest/lombok/PersonMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.lombok;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ */
+@Mapper(unmappedTargetPolicy = ReportingPolicy.ERROR)
+public interface PersonMapper {
+
+    PersonMapper INSTANCE = Mappers.getMapper( PersonMapper.class );
+
+    Person fromDto(PersonDto personDto);
+    PersonDto toDto(Person personDto);
+}

--- a/integrationtest/src/test/resources/lombokModuleTest/src/test/java/org/mapstruct/itest/lombok/LombokMapperTest.java
+++ b/integrationtest/src/test/resources/lombokModuleTest/src/test/java/org/mapstruct/itest/lombok/LombokMapperTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.lombok;
+
+import org.junit.Test;
+import org.mapstruct.factory.Mappers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for generation of Lombok Builder Mapper implementations
+ *
+ * @author Eric Martineau
+ */
+public class LombokMapperTest {
+
+    @Test
+    public void testSimpleImmutableBuilderHappyPath() {
+        PersonDto personDto = PersonMapper.INSTANCE.toDto( new Person( "Bob", 33, new Address( "Wild Drive" ) ) );
+        assertThat( personDto.getAge() ).isEqualTo( 33 );
+        assertThat( personDto.getName() ).isEqualTo( "Bob" );
+        assertThat( personDto.getAddress() ).isNotNull();
+        assertThat( personDto.getAddress().getAddressLine() ).isEqualTo( "Wild Drive" );
+    }
+
+    @Test
+    public void testLombokToImmutable() {
+        Person person = PersonMapper.INSTANCE.fromDto( new PersonDto( "Bob", 33, new AddressDto( "Wild Drive" ) ) );
+        assertThat( person.getAge() ).isEqualTo( 33 );
+        assertThat( person.getName() ).isEqualTo( "Bob" );
+        assertThat( person.getAddress() ).isNotNull();
+        assertThat( person.getAddress().getAddressLine() ).isEqualTo( "Wild Drive" );
+    }
+}

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -208,7 +208,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.20</version>
+                <version>1.18.22</version>
             </dependency>
             <dependency>
                 <groupId>org.immutables</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -36,6 +36,11 @@
         <!-- automatically run annotation processors within the incremental compilation -->
         <!-- Needed for the gem tools processor-->
         <m2e.apt.activation>jdt_apt</m2e.apt.activation>
+        <!--
+            The minimum Java Version that is needed to build a module in MapStruct.
+            The processor module needs at least Java 11.
+         -->
+        <minimum.java.version>1.8</minimum.java.version>
     </properties>
 
     <licenses>
@@ -660,6 +665,9 @@
                                 <artifactId>java18</artifactId>
                                 <version>1.0</version>
                             </signature>
+                            <annotations>
+                                <annotation>org.mapstruct.ap.internal.util.IgnoreJRERequirement</annotation>
+                            </annotations>
                         </configuration>
                     </execution>
                 </executions>
@@ -679,7 +687,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8,)</version>
+                                    <version>[${minimum.java.version},)</version>
                                 </requireJavaVersion>
                                 <DependencyConvergence />
                                 <requirePluginVersions />

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -24,6 +24,7 @@
         <!-- Netbeans has a problem when we use late binding with @ in the surefire arg line.
             Therefore we set this empty property here-->
         <jacocoArgLine />
+        <minimum.java.version>11</minimum.java.version>
     </properties>
 
     <dependencies>

--- a/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
@@ -265,7 +265,11 @@ public class MappingProcessor extends AbstractProcessor {
                 // of one outer interface
                 List<? extends Element> tst = mapperElement.getEnclosedElements();
                 ProcessorContext context = new DefaultModelElementProcessorContext(
-                        processingEnv, options, roundContext, getDeclaredTypesNotToBeImported( mapperElement )
+                    processingEnv,
+                    options,
+                    roundContext,
+                    getDeclaredTypesNotToBeImported( mapperElement ),
+                    mapperElement
                 );
 
                 processMapperTypeElement( context, mapperElement );

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/DefaultModelElementProcessorContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/DefaultModelElementProcessorContext.java
@@ -13,6 +13,7 @@ import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.TypeElement;
 import javax.tools.Diagnostic.Kind;
 
 import org.mapstruct.ap.internal.model.common.TypeFactory;
@@ -46,14 +47,14 @@ public class DefaultModelElementProcessorContext implements ProcessorContext {
     private final RoundContext roundContext;
 
     public DefaultModelElementProcessorContext(ProcessingEnvironment processingEnvironment, Options options,
-            RoundContext roundContext, Map<String, String> notToBeImported) {
+            RoundContext roundContext, Map<String, String> notToBeImported, TypeElement mapperElement) {
 
         this.processingEnvironment = processingEnvironment;
         this.messager = new DelegatingMessager( processingEnvironment.getMessager(), options.isVerbose() );
         this.accessorNaming = roundContext.getAnnotationProcessorContext().getAccessorNaming();
         this.versionInformation = DefaultVersionInformation.fromProcessingEnvironment( processingEnvironment );
         this.delegatingTypes = TypeUtils.create( processingEnvironment, versionInformation );
-        this.delegatingElements = ElementUtils.create( processingEnvironment, versionInformation );
+        this.delegatingElements = ElementUtils.create( processingEnvironment, versionInformation, mapperElement );
         this.roundContext = roundContext;
         this.typeFactory = new TypeFactory(
             delegatingElements,

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/AbstractElementUtilsDecorator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/AbstractElementUtilsDecorator.java
@@ -46,7 +46,7 @@ public abstract class AbstractElementUtilsDecorator implements ElementUtils {
     @IgnoreJRERequirement
     AbstractElementUtilsDecorator(ProcessingEnvironment processingEnv, TypeElement mapperElement) {
         this.delegate = processingEnv.getElementUtils();
-        if ( SourceVersion.RELEASE_8.compareTo( processingEnv.getSourceVersion() ) <= 0 ) {
+        if ( SourceVersion.RELEASE_8.compareTo( processingEnv.getSourceVersion() ) >= 0 ) {
             // We are running with Java 8 or lower
             this.moduleElement = null;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/EclipseElementUtilsDecorator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/EclipseElementUtilsDecorator.java
@@ -13,8 +13,8 @@ public class EclipseElementUtilsDecorator extends AbstractElementUtilsDecorator 
 
     private final Elements delegate;
 
-    EclipseElementUtilsDecorator(ProcessingEnvironment processingEnv) {
-        super( processingEnv );
+    EclipseElementUtilsDecorator(ProcessingEnvironment processingEnv, TypeElement mapperElement) {
+        super( processingEnv, mapperElement );
         this.delegate = processingEnv.getElementUtils();
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/ElementUtils.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/ElementUtils.java
@@ -16,12 +16,13 @@ import org.mapstruct.ap.internal.version.VersionInformation;
 
 public interface ElementUtils extends Elements {
 
-     static ElementUtils create(ProcessingEnvironment processingEnvironment, VersionInformation info ) {
+     static ElementUtils create(ProcessingEnvironment processingEnvironment, VersionInformation info,
+                                TypeElement mapperElement) {
         if ( info.isEclipseJDTCompiler() ) {
-            return new EclipseElementUtilsDecorator( processingEnvironment );
+            return new EclipseElementUtilsDecorator( processingEnvironment, mapperElement );
         }
         else {
-            return new JavacElementUtilsDecorator( processingEnvironment );
+            return new JavacElementUtilsDecorator( processingEnvironment, mapperElement );
         }
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/IgnoreJRERequirement.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/IgnoreJRERequirement.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.util;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.CLASS)
+@Target({ ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.TYPE })
+public @interface IgnoreJRERequirement {
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/JavacElementUtilsDecorator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/JavacElementUtilsDecorator.java
@@ -10,8 +10,8 @@ import javax.lang.model.element.TypeElement;
 
 public class JavacElementUtilsDecorator extends AbstractElementUtilsDecorator {
 
-    JavacElementUtilsDecorator(ProcessingEnvironment processingEnv) {
-        super( processingEnv );
+    JavacElementUtilsDecorator(ProcessingEnvironment processingEnv, TypeElement mapperElement) {
+        super( processingEnv, mapperElement );
     }
 
     @Override


### PR DESCRIPTION
Prior to this MapStruct would only use `Elements#getTypeElement`.
With this PR if the mapper being generated is within a module MapStruct will use that module
for the methods that are needed (getTypeElement and getPackageElement)

Fixes #2629.

I have to say that I am not the proudest of this piece of code. However, it does it's job. Everything works fine now when running with the module system.