### PR TITLE
#2728 Add new WithTestDependency annotation for our processor testing

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/Issue1395Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/Issue1395Test.java
@@ -8,6 +8,7 @@ package org.mapstruct.ap.test.bugs._1395;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithSpring;
 
 /**
  * @author Filip Hrisafov
@@ -18,6 +19,7 @@ import org.mapstruct.ap.testutil.WithClasses;
     Source.class,
     Target.class
 } )
+@WithSpring
 @IssueKey( "1395" )
 public class Issue1395Test {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1425/Issue1425Test.java
@@ -9,6 +9,7 @@ import org.joda.time.LocalDate;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJoda;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -21,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     Target.class
 })
 @IssueKey("1425")
+@WithJoda
 public class Issue1425Test {
 
     @ProcessorTest

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Issue1460Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1460/Issue1460Test.java
@@ -12,6 +12,7 @@ import org.joda.time.DateTime;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJoda;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,6 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     Target.class
 })
 @IssueKey("1460")
+@WithJoda
 public class Issue1460Test {
 
     @ProcessorTest

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2145/Issue2145Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2145/Issue2145Test.java
@@ -8,11 +8,13 @@ package org.mapstruct.ap.test.bugs._2145;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxJaxb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @IssueKey("2145")
 @WithClasses(Issue2145Mapper.class)
+@WithJavaxJaxb
 public class Issue2145Test {
 
     @ProcessorTest

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/Issue880Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/Issue880Test.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.MappingConstants;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithSpring;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
@@ -30,6 +31,7 @@ import org.springframework.stereotype.Component;
 @ProcessorOptions({
     @ProcessorOption(name = "mapstruct.defaultComponentModel", value = MappingConstants.ComponentModel.SPRING),
     @ProcessorOption(name = "mapstruct.unmappedTargetPolicy", value = "ignore") })
+@WithSpring
 public class Issue880Test {
     @RegisterExtension
     final GeneratedSource generatedSource = new GeneratedSource();

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/BuiltInTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/BuiltInTest.java
@@ -58,6 +58,7 @@ import org.mapstruct.ap.test.builtin.source.MapSource;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxJaxb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -71,8 +72,6 @@ import static org.assertj.core.api.Assertions.assertThat;
     MapTarget.class,
     CalendarProperty.class,
     DateProperty.class,
-    JaxbElementListProperty.class,
-    JaxbElementProperty.class,
     StringListProperty.class,
     StringProperty.class,
     BigDecimalProperty.class,
@@ -81,13 +80,16 @@ import static org.assertj.core.api.Assertions.assertThat;
     XmlGregorianCalendarProperty.class,
     ZonedDateTimeProperty.class,
     IterableSource.class,
-    MapSource.class
 })
 @DefaultTimeZone("Europe/Berlin")
 public class BuiltInTest {
 
     @ProcessorTest
-    @WithClasses( JaxbMapper.class )
+    @WithClasses( {
+        JaxbMapper.class,
+        JaxbElementProperty.class,
+    } )
+    @WithJavaxJaxb
     public void shouldApplyBuiltInOnJAXBElement()  {
         JaxbElementProperty source = new JaxbElementProperty();
         source.setProp( createJaxb( "TEST" ) );
@@ -100,7 +102,11 @@ public class BuiltInTest {
     }
 
     @ProcessorTest
-    @WithClasses( JaxbMapper.class )
+    @WithClasses( {
+        JaxbMapper.class,
+        JaxbElementProperty.class,
+    } )
+    @WithJavaxJaxb
     @IssueKey( "1698" )
     public void shouldApplyBuiltInOnJAXBElementExtra()  {
         JaxbElementProperty source = new JaxbElementProperty();
@@ -123,7 +129,11 @@ public class BuiltInTest {
     }
 
     @ProcessorTest
-    @WithClasses( JaxbListMapper.class )
+    @WithClasses( {
+        JaxbListMapper.class,
+        JaxbElementListProperty.class,
+    } )
+    @WithJavaxJaxb
     @IssueKey( "141" )
     public void shouldApplyBuiltInOnJAXBElementList() {
 
@@ -347,7 +357,11 @@ public class BuiltInTest {
     }
 
     @ProcessorTest
-    @WithClasses( MapSourceTargetMapper.class )
+    @WithClasses( {
+        MapSourceTargetMapper.class,
+        MapSource.class,
+    } )
+    @WithJavaxJaxb
     public void shouldApplyBuiltInOnMap() throws DatatypeConfigurationException {
 
         MapSource source = new MapSource();

--- a/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/JodaTimeTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builtin/jodatime/JodaTimeTest.java
@@ -30,6 +30,8 @@ import org.mapstruct.ap.test.builtin.jodatime.mapper.XmlGregorianCalendarToLocal
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxJaxb;
+import org.mapstruct.ap.testutil.WithJoda;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,6 +47,8 @@ import static org.assertj.core.api.Assertions.assertThat;
     XmlGregorianCalendarBean.class
 })
 @IssueKey( "689" )
+@WithJoda
+@WithJavaxJaxb
 public class JodaTimeTest {
 
     @ProcessorTest

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/wildcard/WildCardTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/wildcard/WildCardTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxJaxb;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
@@ -133,6 +134,7 @@ public class WildCardTest {
 
     @ProcessorTest
     @WithClasses( { BeanMapper.class, GoodIdea.class, CunningPlan.class } )
+    @WithJavaxJaxb
     public void shouldMapBean() {
 
         GoodIdea aGoodIdea = new GoodIdea();

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/erroneous/InvalidDateFormatTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/erroneous/InvalidDateFormatTest.java
@@ -8,6 +8,7 @@ package org.mapstruct.ap.test.conversion.erroneous;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJoda;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
@@ -19,6 +20,7 @@ import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutco
     Source.class,
     Target.class
 })
+@WithJoda
 @IssueKey("725")
 public class InvalidDateFormatTest {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/jodatime/JodaConversionTest.java
@@ -20,6 +20,7 @@ import org.junitpioneer.jupiter.DefaultLocale;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJoda;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -31,6 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @WithClasses({ Source.class, Target.class, SourceTargetMapper.class })
 @IssueKey("75")
 @DefaultLocale("de")
+@WithJoda
 public class JodaConversionTest {
 
     @ProcessorTest

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/jsr330/Jsr330DecoratorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/jsr330/Jsr330DecoratorTest.java
@@ -19,6 +19,7 @@ import org.mapstruct.ap.test.decorator.PersonDto;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxInject;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -44,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @IssueKey("592")
 @ComponentScan(basePackageClasses = Jsr330DecoratorTest.class)
 @Configuration
+@WithJavaxInject
 public class Jsr330DecoratorTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/spring/constructor/SpringDecoratorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/spring/constructor/SpringDecoratorTest.java
@@ -16,6 +16,7 @@ import org.mapstruct.ap.test.decorator.PersonDto;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithSpring;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -40,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @IssueKey("592")
 @ComponentScan(basePackageClasses = SpringDecoratorTest.class)
 @Configuration
+@WithSpring
 public class SpringDecoratorTest {
 
     @Autowired

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/spring/field/SpringDecoratorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/spring/field/SpringDecoratorTest.java
@@ -16,6 +16,7 @@ import org.mapstruct.ap.test.decorator.PersonDto;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithSpring;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -37,6 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     PersonMapper.class,
     PersonMapperDecorator.class
 })
+@WithSpring
 @IssueKey("592")
 @ComponentScan(basePackageClasses = SpringDecoratorTest.class)
 @Configuration

--- a/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/destination/DestinationClassNameTest.java
@@ -7,6 +7,7 @@ package org.mapstruct.ap.test.destination;
 
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxInject;
 import org.mapstruct.factory.Mappers;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -25,6 +26,7 @@ public class DestinationClassNameTest {
 
     @ProcessorTest
     @WithClasses({ DestinationClassNameWithJsr330Mapper.class })
+    @WithJavaxInject
     public void shouldNotGenerateSpi() throws Exception {
 
         Class<DestinationClassNameWithJsr330Mapper> clazz = DestinationClassNameWithJsr330Mapper.class;

--- a/processor/src/test/java/org/mapstruct/ap/test/imports/ConflictingTypesNamesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/imports/ConflictingTypesNamesTest.java
@@ -15,6 +15,7 @@ import org.mapstruct.ap.test.imports.referenced.Target;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxInject;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     org.mapstruct.ap.test.imports.to.FooWrapper.class,
     SecondSourceTargetMapper.class
 })
+@WithJavaxInject
 public class ConflictingTypesNamesTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/_default/Jsr330DefaultCompileOptionFieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/_default/Jsr330DefaultCompileOptionFieldMapperTest.java
@@ -17,6 +17,7 @@ import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
 import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxInject;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     GenderJsr330DefaultCompileOptionFieldMapper.class
 })
 @ComponentScan(basePackageClasses = CustomerJsr330DefaultCompileOptionFieldMapper.class)
+@WithJavaxInject
 @Configuration
 public class Jsr330DefaultCompileOptionFieldMapperTest {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/compileoptionconstructor/Jsr330CompileOptionConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/compileoptionconstructor/Jsr330CompileOptionConstructorMapperTest.java
@@ -14,6 +14,7 @@ import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
 import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxInject;
 import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ProcessorOption( name = "mapstruct.defaultInjectionStrategy", value = "constructor")
 @ComponentScan(basePackageClasses = CustomerJsr330CompileOptionConstructorMapper.class)
 @Configuration
+@WithJavaxInject
 public class Jsr330CompileOptionConstructorMapperTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/constructor/Jsr330ConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/constructor/Jsr330ConstructorMapperTest.java
@@ -15,6 +15,7 @@ import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxInject;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @IssueKey("571")
 @ComponentScan(basePackageClasses = CustomerJsr330ConstructorMapper.class)
 @Configuration
+@WithJavaxInject
 public class Jsr330ConstructorMapperTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/field/Jsr330FieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/field/Jsr330FieldMapperTest.java
@@ -18,6 +18,7 @@ import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxInject;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -44,6 +45,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @IssueKey("571")
 @ComponentScan(basePackageClasses = CustomerJsr330FieldMapper.class)
 @Configuration
+@WithJavaxInject
 public class Jsr330FieldMapperTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/_default/SpringDefaultMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/_default/SpringDefaultMapperTest.java
@@ -15,6 +15,7 @@ import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithSpring;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -41,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @IssueKey("571")
 @ComponentScan(basePackageClasses = CustomerSpringDefaultMapper.class)
 @Configuration
+@WithSpring
 public class SpringDefaultMapperTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/compileoptionconstructor/SpringCompileOptionConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/compileoptionconstructor/SpringCompileOptionConstructorMapperTest.java
@@ -21,6 +21,7 @@ import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
 import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithSpring;
 import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,6 +53,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ProcessorOption( name = "mapstruct.defaultInjectionStrategy", value = "constructor")
 @ComponentScan(basePackageClasses = CustomerSpringCompileOptionConstructorMapper.class)
 @Configuration
+@WithSpring
 @DefaultTimeZone("Europe/Berlin")
 public class SpringCompileOptionConstructorMapperTest {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/constructor/SpringConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/constructor/SpringConstructorMapperTest.java
@@ -23,6 +23,7 @@ import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithSpring;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -53,6 +54,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @IssueKey( "571" )
 @ComponentScan(basePackageClasses = CustomerSpringConstructorMapper.class)
 @Configuration
+@WithSpring
 @DefaultTimeZone("Europe/Berlin")
 public class SpringConstructorMapperTest {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/field/SpringFieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/field/SpringFieldMapperTest.java
@@ -15,6 +15,7 @@ import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithSpring;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @IssueKey("571")
 @ComponentScan(basePackageClasses = CustomerSpringFieldMapper.class)
 @Configuration
+@WithSpring
 public class SpringFieldMapperTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/NestedMappingMethodInvocationTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nestedmethodcall/NestedMappingMethodInvocationTest.java
@@ -20,6 +20,7 @@ import org.junitpioneer.jupiter.DefaultLocale;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxJaxb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,6 +43,7 @@ public class NestedMappingMethodInvocationTest {
         OrderDetailsType.class,
         OrderType.class
     } )
+    @WithJavaxJaxb
     public void shouldMapViaMethodAndMethod() throws DatatypeConfigurationException {
         OrderTypeToOrderDtoMapper instance = OrderTypeToOrderDtoMapper.INSTANCE;
         OrderDto target = instance.sourceToTarget( createOrderType() );
@@ -62,6 +64,7 @@ public class NestedMappingMethodInvocationTest {
         ObjectFactory.class,
         TargetDto.class
     } )
+    @WithJavaxJaxb
     public void shouldMapViaMethodAndConversion() {
         SourceTypeTargetDtoMapper instance = SourceTypeTargetDtoMapper.INSTANCE;
 
@@ -78,6 +81,7 @@ public class NestedMappingMethodInvocationTest {
         ObjectFactory.class,
         TargetDto.class
     } )
+    @WithJavaxJaxb
     public void shouldMapViaConversionAndMethod() {
         SourceTypeTargetDtoMapper instance = SourceTypeTargetDtoMapper.INSTANCE;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/references/samename/SeveralReferencedMappersWithSameSimpleNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/references/samename/SeveralReferencedMappersWithSameSimpleNameTest.java
@@ -12,6 +12,7 @@ import org.mapstruct.ap.test.references.samename.model.Target;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxInject;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -30,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     Jsr330SourceTargetMapper.class,
     AnotherSourceTargetMapper.class
 })
+@WithJavaxInject
 public class SeveralReferencedMappersWithSameSimpleNameTest {
 
     @ProcessorTest

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/JaxbFactoryMethodSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/JaxbFactoryMethodSelectionTest.java
@@ -13,6 +13,7 @@ import org.mapstruct.ap.test.selection.jaxb.test2.OrderShippingDetailsType;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxJaxb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -28,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     OrderDto.class, OrderShippingDetailsDto.class, OrderType.class, OrderShippingDetailsType.class,
     OrderMapper.class
 })
+@WithJavaxJaxb
 public class JaxbFactoryMethodSelectionTest {
 
     @ProcessorTest

--- a/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/UnderscoreSelectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/jaxb/UnderscoreSelectionTest.java
@@ -13,6 +13,7 @@ import org.mapstruct.ap.test.selection.jaxb.underscores.UnderscoreType;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJavaxJaxb;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @IssueKey( "726" )
 @WithClasses( { UnderscoreType.class, ObjectFactory.class, SuperType.class, SubType.class, UnderscoreMapper.class } )
+@WithJavaxJaxb
 public class UnderscoreSelectionTest {
 
     @ProcessorTest

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithJavaxInject.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithJavaxInject.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta annotation that adds the needed Spring Dependencies
+ *
+ * @author Filip Hrisafov
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@WithTestDependency({
+    "javax.inject",
+})
+public @interface WithJavaxInject {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithJavaxJaxb.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithJavaxJaxb.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta annotation that adds the needed Spring Dependencies
+ *
+ * @author Filip Hrisafov
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@WithTestDependency({
+    "jaxb-api",
+})
+public @interface WithJavaxJaxb {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithJoda.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithJoda.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta annotation that adds the needed Spring Dependencies
+ *
+ * @author Filip Hrisafov
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@WithTestDependency({
+    "joda-time"
+})
+public @interface WithJoda {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithSpring.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithSpring.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta annotation that adds the needed Spring Dependencies
+ *
+ * @author Filip Hrisafov
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@WithTestDependency({
+    "spring-beans",
+    "spring-context"
+})
+public @interface WithSpring {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithTestDependencies.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithTestDependencies.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author Filip Hrisafov
+ * @see WithTestDependency
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+public @interface WithTestDependencies {
+
+    WithTestDependency[] value();
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithTestDependency.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithTestDependency.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies the group id of the additional test dependencies that should be added to the test compile path
+ *
+ * @author Filip Hrisafov
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.METHOD })
+@Repeatable( WithTestDependencies.class )
+public @interface WithTestDependency {
+    /**
+     * @return The group ids of the additional test dependencies for the test compile path
+     */
+    String[] value();
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilationRequest.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilationRequest.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct.ap.testutil.runner;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -17,13 +18,15 @@ public class CompilationRequest {
     private final Set<Class<?>> sourceClasses;
     private final Map<Class<?>, Class<?>> services;
     private final List<String> processorOptions;
+    private final Collection<String> testDependencies;
 
     CompilationRequest(Compiler compiler, Set<Class<?>> sourceClasses, Map<Class<?>, Class<?>> services,
-                       List<String> processorOptions) {
+                       List<String> processorOptions, Collection<String> testDependencies) {
         this.compiler = compiler;
         this.sourceClasses = sourceClasses;
         this.services = services;
         this.processorOptions = processorOptions;
+        this.testDependencies = testDependencies;
     }
 
     @Override
@@ -34,6 +37,7 @@ public class CompilationRequest {
         result = prime * result + ( ( processorOptions == null ) ? 0 : processorOptions.hashCode() );
         result = prime * result + ( ( services == null ) ? 0 : services.hashCode() );
         result = prime * result + ( ( sourceClasses == null ) ? 0 : sourceClasses.hashCode() );
+        result = prime * result + ( ( testDependencies == null ) ? 0 : testDependencies.hashCode() );
         return result;
     }
 
@@ -53,6 +57,7 @@ public class CompilationRequest {
         return compiler.equals( other.compiler )
             && processorOptions.equals( other.processorOptions )
             && services.equals( other.services )
+            && testDependencies.equals( other.testDependencies )
             && sourceClasses.equals( other.sourceClasses );
     }
 
@@ -66,5 +71,9 @@ public class CompilationRequest {
 
     public Map<Class<?>, Class<?>> getServices() {
         return services;
+    }
+
+    public Collection<String> getTestDependencies() {
+        return testDependencies;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
@@ -104,7 +104,7 @@ abstract class CompilingExtension implements BeforeEachCallback {
      * needed for compiling the generated sources once the processor has run.
      */
     private static List<String> buildTestCompilationClasspath() {
-        Collection<String> whitelist =Arrays.asList(
+        Collection<String> whitelist = Arrays.asList(
                 // MapStruct annotations in multi-module reactor build or IDE
                 "core" + File.separator + "target",
                 // MapStruct annotations in single module build

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/EclipseCompilingExtension.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/EclipseCompilingExtension.java
@@ -6,6 +6,9 @@
 package org.mapstruct.ap.testutil.runner;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
@@ -65,11 +68,25 @@ class EclipseCompilingExtension extends CompilingExtension {
 
         return clHelper.compileInOtherClassloader(
             compilationRequest,
-            TEST_COMPILATION_CLASSPATH,
+            getTestCompilationClasspath( compilationRequest ),
             getSourceFiles( compilationRequest.getSourceClasses() ),
             SOURCE_DIR,
             sourceOutputDir,
             classOutputDir );
+    }
+
+    private static List<String> getTestCompilationClasspath(CompilationRequest request) {
+        Collection<String> testDependencies = request.getTestDependencies();
+        if ( testDependencies.isEmpty() ) {
+            return TEST_COMPILATION_CLASSPATH;
+        }
+
+        List<String> testCompilationPaths = new ArrayList<>(
+            TEST_COMPILATION_CLASSPATH.size() + testDependencies.size() );
+
+        testCompilationPaths.addAll( TEST_COMPILATION_CLASSPATH );
+        testCompilationPaths.addAll( filterBootClassPath( testDependencies ) );
+        return testCompilationPaths;
     }
 
     private static FilteringParentClassLoader newFilteringClassLoaderForEclipse() {
@@ -143,12 +160,12 @@ class EclipseCompilingExtension extends CompilingExtension {
     }
 
     private static List<String> buildEclipseCompilerClasspath() {
-        String[] whitelist =
-            new String[] {
+        Collection<String> whitelist = Arrays.asList(
                 "tycho-compiler",
                 "ecj",
                 "plexus-compiler-api",
-                "plexus-component-annotations" };
+                "plexus-component-annotations"
+        );
 
         return filterBootClassPath( whitelist );
     }


### PR DESCRIPTION
Adding this dependency allows us to dynamically pick the dependencies that we want to have on the test compilation classpath.
It would allow us to more granularly test things with different dependencies, such as javax inject and jakarta inject

Fixes #2728 