### PR TITLE
#2682 Change RetentionPolicy of `@DecoratedWith` to `CLASS`

### DIFF
--- a/core/src/main/java/org/mapstruct/DecoratedWith.java
+++ b/core/src/main/java/org/mapstruct/DecoratedWith.java
@@ -145,7 +145,7 @@ import java.lang.annotation.Target;
  * @author Gunnar Morling
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface DecoratedWith {
 
     /**


### PR DESCRIPTION
In some circumstances (used with other types of aggregating processors, e.g. Spring)
the Gradle incremental compilation works correctly only for classes annotated with the `CLASS` or `RUNTIME`
retention policy.

The `@DecoratedWith` is the only annotation from MapStruct that was `SOURCE` retention.
With this commit we are changing its retention policy in order for better compatibility with the Gradle Incremental compilation

Fixes #2682 