### PR TITLE
#2567 Add support for Jakarta Injection

### DIFF
--- a/core/src/main/java/org/mapstruct/DecoratedWith.java
+++ b/core/src/main/java/org/mapstruct/DecoratedWith.java
@@ -103,12 +103,12 @@ import java.lang.annotation.Target;
  * private PersonMapper personMapper; // injects the decorator, with the injected original mapper
  * </pre>
  *
- * <h3>3. Component model 'jsr330'</h3>
+ * <h3>3. Component model 'jsr330' or 'jakarta'</h3>
  * <h4>Referencing the original mapper</h4>
  * <p>
- * JSR 330 doesn't specify qualifiers and only allows to specifically name the beans. Hence, the generated
- * implementation of the original mapper is annotated with
- * {@code @javax.inject.Named("fully-qualified-name-of-generated-impl")} and {@code @Singleton} (please note that when
+ * JSR 330 / Jakarta Inject doesn't specify qualifiers and only allows to specifically name the beans. Hence,
+ * the generated implementation of the original mapper is annotated with
+ * {@code @Named("fully-qualified-name-of-generated-impl")} and {@code @Singleton} (please note that when
  * using a decorator, the class name of the mapper implementation ends with an underscore). To inject that bean in your
  * decorator, add the same annotation to the delegate field (e.g. by copy/pasting it from the generated class):
  *

--- a/core/src/main/java/org/mapstruct/InjectionStrategy.java
+++ b/core/src/main/java/org/mapstruct/InjectionStrategy.java
@@ -7,7 +7,7 @@ package org.mapstruct;
 
 /**
  * Strategy for handling injection. This is only used on annotated based component models such as CDI, Spring and
- * JSR330.
+ * JSR330 / Jakarta.
  *
  * @author Kevin Grüneberg
  */

--- a/core/src/main/java/org/mapstruct/Mapper.java
+++ b/core/src/main/java/org/mapstruct/Mapper.java
@@ -142,7 +142,12 @@ public @interface Mapper {
      * can be retrieved via {@code @Autowired}</li>
      * <li>
      * {@code jsr330}: the generated mapper is annotated with {@code @javax.inject.Named} and
-     * {@code @Singleton}, and can be retrieved via {@code @Inject}</li>
+     * {@code @Singleton}, and can be retrieved via {@code @Inject}.
+     * The annotations will either be from javax.inject or jakarta.inject,
+     * depending on which one is available, with javax.inject having precedence.</li>
+     * <li>
+     * {@code jakarta}: the generated mapper is annotated with {@code @jakarta.inject.Named} and
+     * {@code @Singleton}, and can be retrieved via {@code @Inject}.</li>
      * </ul>
      * The method overrides a componentModel set in a central configuration set
      * by {@link #config() }

--- a/core/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core/src/main/java/org/mapstruct/MapperConfig.java
@@ -131,7 +131,12 @@ public @interface MapperConfig {
      * can be retrieved via {@code @Autowired}</li>
      * <li>
      * {@code jsr330}: the generated mapper is annotated with {@code @javax.inject.Named} and
-     * {@code @Singleton}, and can be retrieved via {@code @Inject}</li>
+     * {@code @Singleton}, and can be retrieved via {@code @Inject}.
+     * The annotations will either be from javax.inject or jakarta.inject,
+     * depending on which one is available, with javax.inject having precedence.</li>
+     * <li>
+     * {@code jakarta}: the generated mapper is annotated with {@code @jakarta.inject.Named} and
+     * {@code @Singleton}, and can be retrieved via {@code @Inject}.</li>
      * </ul>
      *
      * @return The component model for the generated mapper.

--- a/core/src/main/java/org/mapstruct/MappingConstants.java
+++ b/core/src/main/java/org/mapstruct/MappingConstants.java
@@ -120,10 +120,23 @@ public final class MappingConstants {
         public static final String SPRING = "spring";
 
         /**
-         * The generated mapper is annotated with @javax.inject.Named and @Singleton, and can be retrieved via @Inject
+         * The generated mapper is annotated with @Named and @Singleton, and can be retrieved via @Inject.
+         * The annotations are either from {@code javax.inject} or {@code jakarta.inject}.
+         * Priority have the {@code javax.inject} annotations.
+         * In case you want to only use Jakarta then use {@link #JAKARTA}.
          *
+         * @see #JAKARTA
          */
         public static final String JSR330 = "jsr330";
+
+        /**
+         * The generated mapper is annotated with @Named and @Singleton, and can be retrieved via @Inject.
+         * The annotations are from {@code jakarta.inject}.
+         * In case you want to use {@code javax.inject} then use {@link #JSR330}.
+         *
+         * @see #JSR330
+         */
+        public static final String JAKARTA = "jakarta";
 
     }
 

--- a/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
@@ -217,7 +217,8 @@ Supported values are:
 * `default`: the mapper uses no component model, instances are typically retrieved via `Mappers#getMapper(Class)`
 * `cdi`: the generated mapper is an application-scoped CDI bean and can be retrieved via `@Inject`
 * `spring`: the generated mapper is a singleton-scoped Spring bean and can be retrieved via `@Autowired`
-* `jsr330`: the generated mapper is annotated with {@code @Named} and can be retrieved via `@Inject`, e.g. using Spring
+* `jsr330`: the generated mapper is annotated with {@code @Named} and can be retrieved via `@Inject` (from javax.inject or jakarta.inject, depending which one is available with javax.inject having priority), e.g. using Spring
+* `jakarta`: the generated mapper is annotated with {@code @Named} and can be retrieved via `@Inject` (from jakarta.inject), e.g. using Spring
 
 If a component model is given for a specific mapper via `@Mapper#componentModel()`, the value from the annotation takes precedence.
 |`default`

--- a/integrationtest/src/test/resources/fullFeatureTest/pom.xml
+++ b/integrationtest/src/test/resources/fullFeatureTest/pom.xml
@@ -60,6 +60,10 @@
             <groupId>javax.inject</groupId>
             <artifactId>javax.inject</artifactId>
         </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+        </dependency>
 
         <!-- Spring -->
         <dependency>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -160,6 +160,11 @@
                 <version>1</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>2.0.1</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
                 <version>1.6.0.Final</version>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -83,6 +83,11 @@
             <artifactId>javax.inject</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
 
         <!-- plexus-container-default is a runtime-dependency of the tycho-compiler -->
         <dependency>

--- a/processor/src/main/java/org/mapstruct/ap/internal/gem/MappingConstantsGem.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/gem/MappingConstantsGem.java
@@ -49,6 +49,8 @@ public final class MappingConstantsGem {
         public static final String SPRING = "spring";
 
         public static final String JSR330 = "jsr330";
+
+        public static final String JAKARTA = "jakarta";
      }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/JakartaComponentProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/JakartaComponentProcessor.java
@@ -12,21 +12,18 @@ import java.util.List;
 import org.mapstruct.ap.internal.gem.MappingConstantsGem;
 import org.mapstruct.ap.internal.model.Annotation;
 import org.mapstruct.ap.internal.model.Mapper;
-import org.mapstruct.ap.internal.model.common.Type;
-import org.mapstruct.ap.internal.util.AnnotationProcessingException;
 
 /**
  * A {@link ModelElementProcessor} which converts the given {@link Mapper}
- * object into a JSR 330 style bean in case "jsr330" is configured as the
+ * object into a Jakarta Inject style bean in case "jakarta" is configured as the
  * target component model for this mapper.
  *
- * @author Gunnar Morling
- * @author Andreas Gudian
+ * @author Filip Hrisafov
  */
-public class Jsr330ComponentProcessor extends AnnotationBasedComponentModelProcessor {
+public class JakartaComponentProcessor extends AnnotationBasedComponentModelProcessor {
     @Override
     protected String getComponentModelIdentifier() {
-        return MappingConstantsGem.ComponentModelGem.JSR330;
+        return MappingConstantsGem.ComponentModelGem.JAKARTA;
     }
 
     @Override
@@ -60,35 +57,22 @@ public class Jsr330ComponentProcessor extends AnnotationBasedComponentModelProce
     }
 
     private Annotation singleton() {
-        return new Annotation( getType( "Singleton" ) );
+        return new Annotation( getTypeFactory().getType( "jakarta.inject.Singleton" ) );
     }
 
     private Annotation named() {
-        return new Annotation( getType( "Named" ) );
+        return new Annotation( getTypeFactory().getType( "jakarta.inject.Named" ) );
     }
 
     private Annotation namedDelegate(Mapper mapper) {
         return new Annotation(
-            getType( "Named" ),
+            getTypeFactory().getType( "jakarta.inject.Named" ),
             Collections.singletonList( '"' + mapper.getPackageName() + "." + mapper.getName() + '"' )
         );
     }
 
     private Annotation inject() {
-        return new Annotation( getType( "Inject" ) );
+        return new Annotation( getTypeFactory().getType( "jakarta.inject.Inject" ) );
     }
 
-    private Type getType(String simpleName) {
-        if ( getTypeFactory().isTypeAvailable( "javax.inject." + simpleName ) ) {
-            return getTypeFactory().getType( "javax.inject." + simpleName );
-        }
-
-        if ( getTypeFactory().isTypeAvailable( "jakarta.inject." + simpleName ) ) {
-            return getTypeFactory().getType( "jakarta.inject." + simpleName );
-        }
-
-        throw new AnnotationProcessingException(
-            "Couldn't find any of the JSR330 or Jakarta Dependency Inject types." +
-                " Are you missing a dependency on your classpath?" );
-    }
 }

--- a/processor/src/main/resources/META-INF/services/org.mapstruct.ap.internal.processor.ModelElementProcessor
+++ b/processor/src/main/resources/META-INF/services/org.mapstruct.ap.internal.processor.ModelElementProcessor
@@ -4,6 +4,7 @@
 
 org.mapstruct.ap.internal.processor.CdiComponentProcessor
 org.mapstruct.ap.internal.processor.Jsr330ComponentProcessor
+org.mapstruct.ap.internal.processor.JakartaComponentProcessor
 org.mapstruct.ap.internal.processor.MapperCreationProcessor
 org.mapstruct.ap.internal.processor.MapperRenderingProcessor
 org.mapstruct.ap.internal.processor.MethodRetrievalProcessor

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/jakarta/jsr330/JakartaJsr330DecoratorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/jakarta/jsr330/JakartaJsr330DecoratorTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.decorator.jakarta.jsr330;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.decorator.Address;
+import org.mapstruct.ap.test.decorator.AddressDto;
+import org.mapstruct.ap.test.decorator.Person;
+import org.mapstruct.ap.test.decorator.PersonDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJakartaInject;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static java.lang.System.lineSeparator;
+
+@WithClasses({
+    Person.class,
+    PersonDto.class,
+    Address.class,
+    AddressDto.class,
+    PersonMapper.class,
+    PersonMapperDecorator.class
+})
+@IssueKey("2567")
+@WithJakartaInject
+// We can't use Spring for testing since Spring 5 does not support Jakarta Inject
+// However, we can test the generated source code
+public class JakartaJsr330DecoratorTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void hasCorrectImports() {
+        // check the decorator
+        generatedSource.forMapper( PersonMapper.class )
+            .content()
+            .contains( "import jakarta.inject.Inject;" )
+            .contains( "import jakarta.inject.Named;" )
+            .contains( "import jakarta.inject.Singleton;" )
+            .contains( "@Singleton" + lineSeparator() + "@Named" )
+            .doesNotContain( "javax.inject" );
+        // check the plain mapper
+        generatedSource.forDecoratedMapper( PersonMapper.class ).content()
+            .contains( "import jakarta.inject.Named;" )
+            .contains( "import jakarta.inject.Singleton;" )
+            .contains( "@Singleton" + lineSeparator() + "@Named" )
+            .doesNotContain( "javax.inject" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/jakarta/jsr330/PersonMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/jakarta/jsr330/PersonMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.decorator.jakarta.jsr330;
+
+import org.mapstruct.DecoratedWith;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ap.test.decorator.Address;
+import org.mapstruct.ap.test.decorator.AddressDto;
+import org.mapstruct.ap.test.decorator.Person;
+import org.mapstruct.ap.test.decorator.PersonDto;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.JSR330)
+@DecoratedWith(PersonMapperDecorator.class)
+public interface PersonMapper {
+
+    @Mapping( target = "name", ignore = true )
+    PersonDto personToPersonDto(Person person);
+
+    AddressDto addressToAddressDto(Address address);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/jakarta/jsr330/PersonMapperDecorator.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/jakarta/jsr330/PersonMapperDecorator.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.decorator.jakarta.jsr330;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+
+import org.mapstruct.ap.test.decorator.Person;
+import org.mapstruct.ap.test.decorator.PersonDto;
+
+public abstract class PersonMapperDecorator implements PersonMapper {
+
+    @Inject
+    @Named("org.mapstruct.ap.test.decorator.jakarta.jsr330.PersonMapperImpl_")
+    private PersonMapper delegate;
+
+    @Override
+    public PersonDto personToPersonDto(Person person) {
+        PersonDto dto = delegate.personToPersonDto( person );
+        dto.setName( person.getFirstName() + " " + person.getLastName() );
+
+        return dto;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/gem/ConstantTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/gem/ConstantTest.java
@@ -40,5 +40,7 @@ public class ConstantTest {
         assertThat( MappingConstants.ComponentModel.CDI ).isEqualTo( MappingConstantsGem.ComponentModelGem.CDI );
         assertThat( MappingConstants.ComponentModel.SPRING ).isEqualTo( MappingConstantsGem.ComponentModelGem.SPRING );
         assertThat( MappingConstants.ComponentModel.JSR330 ).isEqualTo( MappingConstantsGem.ComponentModelGem.JSR330 );
+        assertThat( MappingConstants.ComponentModel.JAKARTA )
+            .isEqualTo( MappingConstantsGem.ComponentModelGem.JAKARTA );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/_default/CustomerJakartaDefaultCompileOptionFieldMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/_default/CustomerJakartaDefaultCompileOptionFieldMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta._default;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(componentModel = MappingConstants.ComponentModel.JAKARTA,
+    uses = GenderJakartaDefaultCompileOptionFieldMapper.class)
+public interface CustomerJakartaDefaultCompileOptionFieldMapper {
+
+    CustomerDto asTarget(CustomerEntity customerEntity);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/_default/GenderJakartaDefaultCompileOptionFieldMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/_default/GenderJakartaDefaultCompileOptionFieldMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta._default;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(componentModel = MappingConstants.ComponentModel.JAKARTA)
+public interface GenderJakartaDefaultCompileOptionFieldMapper {
+
+    @ValueMappings({
+        @ValueMapping(source = "MALE", target = "M"),
+        @ValueMapping(source = "FEMALE", target = "F")
+    })
+    GenderDto mapToDto(Gender gender);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/_default/JakartaAndJsr330DefaultCompileOptionFieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/_default/JakartaAndJsr330DefaultCompileOptionFieldMapperTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta._default;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJakartaInject;
+import org.mapstruct.ap.testutil.WithJavaxInject;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static java.lang.System.lineSeparator;
+
+/**
+ * Test field injection for component model jakarta.
+ * Default value option mapstruct.defaultInjectionStrategy is "field"
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("2567")
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerJakartaDefaultCompileOptionFieldMapper.class,
+    GenderJakartaDefaultCompileOptionFieldMapper.class
+})
+@WithJakartaInject
+@WithJavaxInject
+public class JakartaAndJsr330DefaultCompileOptionFieldMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveJakartaInjection() {
+        generatedSource.forMapper( CustomerJakartaDefaultCompileOptionFieldMapper.class )
+            .content()
+            .contains( "import jakarta.inject.Inject;" )
+            .contains( "import jakarta.inject.Named;" )
+            .contains( "import jakarta.inject.Singleton;" )
+            .contains( "@Inject" + lineSeparator() + "    private GenderJakartaDefaultCompileOptionFieldMapper" )
+            .doesNotContain( "public CustomerJakartaDefaultCompileOptionFieldMapperImpl(" )
+            .doesNotContain( "javax.inject" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/_default/JakartaDefaultCompileOptionFieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/_default/JakartaDefaultCompileOptionFieldMapperTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta._default;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJakartaInject;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static java.lang.System.lineSeparator;
+
+/**
+ * Test field injection for component model jakarta.
+ * Default value option mapstruct.defaultInjectionStrategy is "field"
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("2567")
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerJakartaDefaultCompileOptionFieldMapper.class,
+    GenderJakartaDefaultCompileOptionFieldMapper.class
+})
+@WithJakartaInject
+public class JakartaDefaultCompileOptionFieldMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveJakartaInjection() {
+        generatedSource.forMapper( CustomerJakartaDefaultCompileOptionFieldMapper.class )
+            .content()
+            .contains( "import jakarta.inject.Inject;" )
+            .contains( "import jakarta.inject.Named;" )
+            .contains( "import jakarta.inject.Singleton;" )
+            .contains( "@Inject" + lineSeparator() + "    private GenderJakartaDefaultCompileOptionFieldMapper" )
+            .doesNotContain( "public CustomerJakartaDefaultCompileOptionFieldMapperImpl(" )
+            .doesNotContain( "javax.inject" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/compileoptionconstructor/CustomerJakartaCompileOptionConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/compileoptionconstructor/CustomerJakartaCompileOptionConstructorMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.compileoptionconstructor;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper( componentModel = MappingConstants.ComponentModel.JAKARTA,
+    uses = GenderJakartaCompileOptionConstructorMapper.class )
+public interface CustomerJakartaCompileOptionConstructorMapper {
+
+    @Mapping(target = "gender", source = "gender")
+    CustomerDto asTarget(CustomerEntity customerEntity);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/compileoptionconstructor/GenderJakartaCompileOptionConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/compileoptionconstructor/GenderJakartaCompileOptionConstructorMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.compileoptionconstructor;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(componentModel = MappingConstants.ComponentModel.JAKARTA)
+public interface GenderJakartaCompileOptionConstructorMapper {
+
+    @ValueMappings({
+        @ValueMapping(source = "MALE", target = "M"),
+        @ValueMapping(source = "FEMALE", target = "F")
+    })
+    GenderDto mapToDto(Gender gender);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/compileoptionconstructor/JakartaAndJsr330CompileOptionConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/compileoptionconstructor/JakartaAndJsr330CompileOptionConstructorMapperTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.compileoptionconstructor;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJakartaInject;
+import org.mapstruct.ap.testutil.WithJavaxInject;
+import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static java.lang.System.lineSeparator;
+
+/**
+ * Test constructor injection for component model jakarta with compile option
+ * mapstruct.defaultInjectionStrategy=constructor
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("2567")
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerJakartaCompileOptionConstructorMapper.class,
+    GenderJakartaCompileOptionConstructorMapper.class
+})
+@ProcessorOption(name = "mapstruct.defaultInjectionStrategy", value = "constructor")
+@WithJakartaInject
+@WithJavaxInject
+public class JakartaAndJsr330CompileOptionConstructorMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveJakartaInjection() {
+        generatedSource.forMapper( CustomerJakartaCompileOptionConstructorMapper.class )
+            .content()
+            .contains( "import jakarta.inject.Inject;" )
+            .contains( "import jakarta.inject.Named;" )
+            .contains( "import jakarta.inject.Singleton;" )
+            .contains( "private final GenderJakartaCompileOptionConstructorMapper" )
+            .contains( "@Inject" + lineSeparator() +
+                "    public CustomerJakartaCompileOptionConstructorMapperImpl" +
+                "(GenderJakartaCompileOptionConstructorMapper" )
+            .doesNotContain( "javax.inject" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/compileoptionconstructor/JakartaCompileOptionConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/compileoptionconstructor/JakartaCompileOptionConstructorMapperTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.compileoptionconstructor;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJakartaInject;
+import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static java.lang.System.lineSeparator;
+
+/**
+ * Test constructor injection for component model jakarta with compile option
+ * mapstruct.defaultInjectionStrategy=constructor
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("2567")
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerJakartaCompileOptionConstructorMapper.class,
+    GenderJakartaCompileOptionConstructorMapper.class
+})
+@ProcessorOption(name = "mapstruct.defaultInjectionStrategy", value = "constructor")
+@WithJakartaInject
+public class JakartaCompileOptionConstructorMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveJakartaInjection() {
+        generatedSource.forMapper( CustomerJakartaCompileOptionConstructorMapper.class )
+            .content()
+            .contains( "import jakarta.inject.Inject;" )
+            .contains( "import jakarta.inject.Named;" )
+            .contains( "import jakarta.inject.Singleton;" )
+            .contains( "private final GenderJakartaCompileOptionConstructorMapper" )
+            .contains( "@Inject" + lineSeparator() +
+                "    public CustomerJakartaCompileOptionConstructorMapperImpl" +
+                "(GenderJakartaCompileOptionConstructorMapper" )
+            .doesNotContain( "javax.inject" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/constructor/ConstructorJakartaConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/constructor/ConstructorJakartaConfig.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.constructor;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.MappingConstants;
+
+/**
+ * @author Filip Hrisafov
+ */
+@MapperConfig(componentModel = MappingConstants.ComponentModel.JAKARTA,
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface ConstructorJakartaConfig {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/constructor/CustomerJakartaConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/constructor/CustomerJakartaConstructorMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.constructor;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper( componentModel = MappingConstants.ComponentModel.JAKARTA,
+    uses = GenderJakartaConstructorMapper.class,
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR )
+public interface CustomerJakartaConstructorMapper {
+
+    @Mapping(target = "gender", source = "gender")
+    CustomerDto asTarget(CustomerEntity customerEntity);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/constructor/GenderJakartaConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/constructor/GenderJakartaConstructorMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.constructor;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(config = ConstructorJakartaConfig.class)
+public interface GenderJakartaConstructorMapper {
+
+    @ValueMappings({
+        @ValueMapping(source = "MALE", target = "M"),
+        @ValueMapping(source = "FEMALE", target = "F")
+    })
+    GenderDto mapToDto(Gender gender);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/constructor/JakartaAndJsr330ConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/constructor/JakartaAndJsr330ConstructorMapperTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.constructor;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJakartaInject;
+import org.mapstruct.ap.testutil.WithJavaxInject;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import static java.lang.System.lineSeparator;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2567")
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerJakartaConstructorMapper.class,
+    GenderJakartaConstructorMapper.class,
+    ConstructorJakartaConfig.class
+})
+@ComponentScan(basePackageClasses = CustomerJakartaConstructorMapper.class)
+@Configuration
+@WithJakartaInject
+@WithJavaxInject
+public class JakartaAndJsr330ConstructorMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveJakartaInjection() {
+        generatedSource.forMapper( CustomerJakartaConstructorMapper.class )
+            .content()
+            .contains( "import jakarta.inject.Inject;" )
+            .contains( "import jakarta.inject.Named;" )
+            .contains( "import jakarta.inject.Singleton;" )
+            .contains( "private final GenderJakartaConstructorMapper" )
+            .contains( "@Inject" + lineSeparator() +
+                "    public CustomerJakartaConstructorMapperImpl(GenderJakartaConstructorMapper" )
+            .doesNotContain( "javax.inject" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/constructor/JakartaConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/constructor/JakartaConstructorMapperTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.constructor;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJakartaInject;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import static java.lang.System.lineSeparator;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2567")
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerJakartaConstructorMapper.class,
+    GenderJakartaConstructorMapper.class,
+    ConstructorJakartaConfig.class
+})
+@ComponentScan(basePackageClasses = CustomerJakartaConstructorMapper.class)
+@Configuration
+@WithJakartaInject
+public class JakartaConstructorMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveJakartaInjection() {
+        generatedSource.forMapper( CustomerJakartaConstructorMapper.class )
+            .content()
+            .contains( "import jakarta.inject.Inject;" )
+            .contains( "import jakarta.inject.Named;" )
+            .contains( "import jakarta.inject.Singleton;" )
+            .contains( "private final GenderJakartaConstructorMapper" )
+            .contains( "@Inject" + lineSeparator() +
+                "    public CustomerJakartaConstructorMapperImpl(GenderJakartaConstructorMapper" )
+            .doesNotContain( "javax.inject" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/field/CustomerFieldMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/field/CustomerFieldMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.field;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(componentModel = MappingConstants.ComponentModel.JAKARTA, uses = GenderJakartaFieldMapper.class,
+    injectionStrategy = InjectionStrategy.FIELD)
+public interface CustomerFieldMapper {
+
+    CustomerDto asTarget(CustomerEntity customerEntity);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/field/FieldJakartaConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/field/FieldJakartaConfig.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.field;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.MappingConstants;
+
+/**
+ * @author Filip Hrisafov
+ */
+@MapperConfig(componentModel = MappingConstants.ComponentModel.JAKARTA, injectionStrategy = InjectionStrategy.FIELD)
+public interface FieldJakartaConfig {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/field/GenderJakartaFieldMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/field/GenderJakartaFieldMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.field;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(config = FieldJakartaConfig.class)
+public interface GenderJakartaFieldMapper {
+
+    @ValueMappings({
+        @ValueMapping(source = "MALE", target = "M"),
+        @ValueMapping(source = "FEMALE", target = "F")
+    })
+    GenderDto mapToDto(Gender gender);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/field/JakartaAndJsr330FieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/field/JakartaAndJsr330FieldMapperTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.field;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJakartaInject;
+import org.mapstruct.ap.testutil.WithJavaxInject;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static java.lang.System.lineSeparator;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerFieldMapper.class,
+    GenderJakartaFieldMapper.class,
+    FieldJakartaConfig.class
+})
+@IssueKey("2567")
+@WithJakartaInject
+@WithJavaxInject
+public class JakartaAndJsr330FieldMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveJakartaInjection() {
+        generatedSource.forMapper( CustomerFieldMapper.class )
+            .content()
+            .contains( "import jakarta.inject.Inject;" )
+            .contains( "import jakarta.inject.Named;" )
+            .contains( "import jakarta.inject.Singleton;" )
+            .contains( "@Inject" + lineSeparator() + "    private GenderJakartaFieldMapper" )
+            .doesNotContain( "public CustomerJakartaFieldMapperImpl(" )
+            .doesNotContain( "javax.inject" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/field/JakartaFieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jakarta/field/JakartaFieldMapperTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jakarta.field;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJakartaInject;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static java.lang.System.lineSeparator;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerFieldMapper.class,
+    GenderJakartaFieldMapper.class,
+    FieldJakartaConfig.class
+})
+@IssueKey("2567")
+@WithJakartaInject
+public class JakartaFieldMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveJakartaInjection() {
+        generatedSource.forMapper( CustomerFieldMapper.class )
+            .content()
+            .contains( "import jakarta.inject.Inject;" )
+            .contains( "import jakarta.inject.Named;" )
+            .contains( "import jakarta.inject.Singleton;" )
+            .contains( "@Inject" + lineSeparator() + "    private GenderJakartaFieldMapper" )
+            .doesNotContain( "public CustomerJakartaFieldMapperImpl(" )
+            .doesNotContain( "javax.inject" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/_default/Jsr330DefaultCompileOptionFieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/_default/Jsr330DefaultCompileOptionFieldMapperTest.java
@@ -87,6 +87,9 @@ public class Jsr330DefaultCompileOptionFieldMapperTest {
     public void shouldHaveFieldInjection() {
         generatedSource.forMapper( CustomerJsr330DefaultCompileOptionFieldMapper.class )
             .content()
+            .contains( "import javax.inject.Inject;" )
+            .contains( "import javax.inject.Named;" )
+            .contains( "import javax.inject.Singleton;" )
             .contains( "@Inject" + lineSeparator() + "    private GenderJsr330DefaultCompileOptionFieldMapper" )
             .doesNotContain( "public CustomerJsr330DefaultCompileOptionFieldMapperImpl(" );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/compileoptionconstructor/Jsr330CompileOptionConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/compileoptionconstructor/Jsr330CompileOptionConstructorMapperTest.java
@@ -86,6 +86,9 @@ public class Jsr330CompileOptionConstructorMapperTest {
     public void shouldHaveConstructorInjectionFromCompileOption() {
         generatedSource.forMapper( CustomerJsr330CompileOptionConstructorMapper.class )
             .content()
+            .contains( "import javax.inject.Inject;" )
+            .contains( "import javax.inject.Named;" )
+            .contains( "import javax.inject.Singleton;" )
             .contains( "private final GenderJsr330CompileOptionConstructorMapper" )
             .contains( "@Inject" + lineSeparator() +
                 "    public CustomerJsr330CompileOptionConstructorMapperImpl" +

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/constructor/Jsr330ConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/constructor/Jsr330ConstructorMapperTest.java
@@ -86,6 +86,9 @@ public class Jsr330ConstructorMapperTest {
     public void shouldHaveConstructorInjection() {
         generatedSource.forMapper( CustomerJsr330ConstructorMapper.class )
             .content()
+            .contains( "import javax.inject.Inject;" )
+            .contains( "import javax.inject.Named;" )
+            .contains( "import javax.inject.Singleton;" )
             .contains( "private final GenderJsr330ConstructorMapper" )
             .contains( "@Inject" + lineSeparator() +
                 "    public CustomerJsr330ConstructorMapperImpl(GenderJsr330ConstructorMapper" );

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/field/Jsr330FieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/field/Jsr330FieldMapperTest.java
@@ -89,6 +89,9 @@ public class Jsr330FieldMapperTest {
     public void shouldHaveFieldInjection() {
         generatedSource.forMapper( CustomerJsr330FieldMapper.class )
             .content()
+            .contains( "import javax.inject.Inject;" )
+            .contains( "import javax.inject.Named;" )
+            .contains( "import javax.inject.Singleton;" )
             .contains( "@Inject" + lineSeparator() + "    private GenderJsr330FieldMapper" )
             .doesNotContain( "public CustomerJsr330FieldMapperImpl(" );
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/jakarta/CustomerJsr330DefaultCompileOptionFieldMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/jakarta/CustomerJsr330DefaultCompileOptionFieldMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jsr330.jakarta;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+
+/**
+ * @author Andrei Arlou
+ */
+@Mapper(componentModel = MappingConstants.ComponentModel.JSR330,
+    uses = GenderJsr330DefaultCompileOptionFieldMapper.class)
+public interface CustomerJsr330DefaultCompileOptionFieldMapper {
+
+    CustomerDto asTarget(CustomerEntity customerEntity);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/jakarta/GenderJsr330DefaultCompileOptionFieldMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/jakarta/GenderJsr330DefaultCompileOptionFieldMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jsr330.jakarta;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+
+/**
+ * @author Andrei Arlou
+ */
+@Mapper(componentModel = MappingConstants.ComponentModel.JSR330)
+public interface GenderJsr330DefaultCompileOptionFieldMapper {
+
+    @ValueMappings({
+        @ValueMapping(source = "MALE", target = "M"),
+        @ValueMapping(source = "FEMALE", target = "F")
+    })
+    GenderDto mapToDto(Gender gender);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/jakarta/JakartaAndJsr330DefaultCompileOptionFieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/jakarta/JakartaAndJsr330DefaultCompileOptionFieldMapperTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jsr330.jakarta;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJakartaInject;
+import org.mapstruct.ap.testutil.WithJavaxInject;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static java.lang.System.lineSeparator;
+
+/**
+ * Test field injection for component model jsr330.
+ * Default value option mapstruct.defaultInjectionStrategy is "field"
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("2567")
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerJsr330DefaultCompileOptionFieldMapper.class,
+    GenderJsr330DefaultCompileOptionFieldMapper.class
+})
+@WithJakartaInject
+@WithJavaxInject
+public class JakartaAndJsr330DefaultCompileOptionFieldMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveJavaxInjection() {
+        generatedSource.forMapper( CustomerJsr330DefaultCompileOptionFieldMapper.class )
+            .content()
+            .contains( "import javax.inject.Inject;" )
+            .contains( "import javax.inject.Named;" )
+            .contains( "import javax.inject.Singleton;" )
+            .contains( "@Inject" + lineSeparator() + "    private GenderJsr330DefaultCompileOptionFieldMapper" )
+            .doesNotContain( "public CustomerJsr330DefaultCompileOptionFieldMapperImpl(" )
+            .doesNotContain( "jakarta.inject" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/jakarta/JakartaJsr330DefaultCompileOptionFieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/jakarta/JakartaJsr330DefaultCompileOptionFieldMapperTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.jsr330.jakarta;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJakartaInject;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static java.lang.System.lineSeparator;
+
+/**
+ * Test field injection for component model jsr330.
+ * Default value option mapstruct.defaultInjectionStrategy is "field"
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("2567")
+@WithClasses({
+    CustomerDto.class,
+    CustomerEntity.class,
+    Gender.class,
+    GenderDto.class,
+    CustomerJsr330DefaultCompileOptionFieldMapper.class,
+    GenderJsr330DefaultCompileOptionFieldMapper.class
+})
+@WithJakartaInject
+public class JakartaJsr330DefaultCompileOptionFieldMapperTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveJakartaInjection() {
+        generatedSource.forMapper( CustomerJsr330DefaultCompileOptionFieldMapper.class )
+            .content()
+            .contains( "import jakarta.inject.Inject;" )
+            .contains( "import jakarta.inject.Named;" )
+            .contains( "import jakarta.inject.Singleton;" )
+            .contains( "@Inject" + lineSeparator() + "    private GenderJsr330DefaultCompileOptionFieldMapper" )
+            .doesNotContain( "public CustomerJsr330DefaultCompileOptionFieldMapperImpl(" )
+            .doesNotContain( "javax.inject" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithJakartaInject.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithJakartaInject.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta annotation that adds the needed Spring Dependencies
+ *
+ * @author Filip Hrisafov
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@WithTestDependency({
+    "jakarta.inject-api",
+})
+public @interface WithJakartaInject {
+
+}


### PR DESCRIPTION
Support for Jakarta is done in 2 ways:

* current jsr330 component model - In this case Jakarta Inject will be used if javax.inject is not available
* new jakarta component model - In this case Jakarta Inject will always be used

Fixes #2567