### PR TITLE
Mapping map keys with invalid chars for methods

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Strings.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Strings.java
@@ -183,7 +183,15 @@ public class Strings {
 
             if ( firstAlphabeticIndex < identifier.length()) {
                 // If it is not consisted of only underscores
-                return identifier.substring( firstAlphabeticIndex ).replace( "[]", "Array" );
+                String firstAlphaString = identifier.substring( firstAlphabeticIndex ).replace( "[]", "Array" );
+
+                return firstAlphaString.codePoints()
+                    .map(codePoint -> Character.isJavaIdentifierPart(codePoint) || codePoint == (int) '.' ? codePoint : (int) '_')
+                    .collect(
+                        StringBuilder::new,
+                        StringBuilder::appendCodePoint,
+                        StringBuilder::append
+                    ).toString();
             }
 
             return identifier.replace( "[]", "Array" );

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Strings.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Strings.java
@@ -185,13 +185,17 @@ public class Strings {
                 // If it is not consisted of only underscores
                 String firstAlphaString = identifier.substring( firstAlphabeticIndex ).replace( "[]", "Array" );
 
-                return firstAlphaString.codePoints()
-                    .map(codePoint -> Character.isJavaIdentifierPart(codePoint) || codePoint == (int) '.' ? codePoint : (int) '_')
-                    .collect(
-                        StringBuilder::new,
-                        StringBuilder::appendCodePoint,
-                        StringBuilder::append
-                    ).toString();
+                StringBuilder sb = new StringBuilder( firstAlphaString.length() );
+                for ( int i = 0; i < firstAlphaString.length(); i++ ) {
+                    int codePoint = firstAlphaString.codePointAt( i );
+                    if ( Character.isJavaIdentifierPart( codePoint ) || codePoint == '.') {
+                        sb.appendCodePoint( codePoint );
+                    }
+                    else {
+                        sb.append( '_' );
+                    }
+                }
+                return sb.toString();
             }
 
             return identifier.replace( "[]", "Array" );

--- a/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
@@ -113,6 +113,11 @@ public class StringsTest {
     }
 
     @Test
+    public void sanitizeIdentifierNameHandlesInvalidJavaIdentifierStrings() {
+        assertThat( Strings.sanitizeIdentifierName( "bad/test" ) ).isEqualTo("bad_test");
+    }
+    
+    @Test
     public void findMostSimilarWord() {
         String mostSimilarWord = Strings.getMostSimilarWord(
             "fulName",

--- a/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/util/StringsTest.java
@@ -72,6 +72,7 @@ public class StringsTest {
         assertThat( Strings.getSafeVariableName( "__Test" ) ).isEqualTo( "test" );
         assertThat( Strings.getSafeVariableName( "_0Test" ) ).isEqualTo( "test" );
         assertThat( Strings.getSafeVariableName( "_0123Test" ) ).isEqualTo( "test" );
+        assertThat( Strings.getSafeVariableName( "bad/test" ) ).isEqualTo( "bad_test" );
     }
 
     @Test
@@ -94,6 +95,7 @@ public class StringsTest {
         assertThat( Strings.getSafeVariableName( "__0Test", Arrays.asList( "test" ) ) ).isEqualTo( "test1" );
         assertThat( Strings.getSafeVariableName( "___0", new ArrayList<>() ) ).isEqualTo( "___0" );
         assertThat( Strings.getSafeVariableName( "__0123456789Test", Arrays.asList( "test" ) ) ).isEqualTo( "test1" );
+        assertThat( Strings.getSafeVariableName( "bad/test", Arrays.asList( "bad_test" ) ) ).isEqualTo( "bad_test1" );
     }
 
     @Test
@@ -110,13 +112,9 @@ public class StringsTest {
         assertThat( Strings.sanitizeIdentifierName( "_0int[]" ) ).isEqualTo( "intArray" );
         assertThat( Strings.sanitizeIdentifierName( "__0int[]" ) ).isEqualTo( "intArray" );
         assertThat( Strings.sanitizeIdentifierName( "___0" ) ).isEqualTo( "___0" );
+        assertThat( Strings.sanitizeIdentifierName( "bad/test" ) ).isEqualTo( "bad_test" );
     }
 
-    @Test
-    public void sanitizeIdentifierNameHandlesInvalidJavaIdentifierStrings() {
-        assertThat( Strings.sanitizeIdentifierName( "bad/test" ) ).isEqualTo("bad_test");
-    }
-    
     @Test
     public void findMostSimilarWord() {
         String mostSimilarWord = Strings.getMostSimilarWord(

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2748/Issue2748Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2748/Issue2748Mapper.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2748;
+
+import java.util.Map;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue2748Mapper {
+
+    Issue2748Mapper INSTANCE = Mappers.getMapper( Issue2748Mapper.class );
+
+    @Mapping(target = "specificValue", source = "annotations.specific/value")
+    Target map(Source source);
+
+    class Target {
+        private final String specificValue;
+
+        public Target(String specificValue) {
+            this.specificValue = specificValue;
+        }
+
+        public String getSpecificValue() {
+            return specificValue;
+        }
+    }
+
+    class Source {
+        private final Map<String, String> annotations;
+
+        public Source(Map<String, String> annotations) {
+            this.annotations = annotations;
+        }
+
+        public Map<String, String> getAnnotations() {
+            return annotations;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2748/Issue2748Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2748/Issue2748Test.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2748;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2748")
+@WithClasses( {
+    Issue2748Mapper.class
+} )
+class Issue2748Test {
+
+    @ProcessorTest
+    void shouldMapNonJavaIdentifier() {
+        Map<String, String> annotations = Collections.singletonMap( "specific/value", "value" );
+        Issue2748Mapper.Source source = new Issue2748Mapper.Source( annotations );
+
+        Issue2748Mapper.Target target = Issue2748Mapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getSpecificValue() ).isEqualTo( "value" );
+    }
+}


### PR DESCRIPTION
This is an attempt to try and allow mapping of maps that have keys that contain invalid characters for Java method names.  Fixes #2748