### PR TITLE
#2758: fix crash with MappingTarget in Condition

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MethodReference.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MethodReference.ftl
@@ -41,7 +41,7 @@
             <#-- a class is passed on for casting, see @TargetType -->
             <@includeModel object=inferTypeWhenEnum( ext.targetType ) raw=true/>.class<#t>
         <#elseif param.mappingTarget>
-            ${ext.targetBeanName}<#if ext.targetReadAccessorName??>.${ext.targetReadAccessorName}</#if><#t>
+            <#if ext.targetBeanName??>${ext.targetBeanName}<#else>${param.variableName}</#if><#if ext.targetReadAccessorName??>.${ext.targetReadAccessorName}</#if><#t>
         <#elseif param.mappingContext>
             ${param.variableName}<#t>
         <#elseif param.sourceRHS??>

--- a/processor/src/test/java/org/mapstruct/ap/test/conditional/basic/ConditionalMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conditional/basic/ConditionalMappingTest.java
@@ -7,8 +7,8 @@ package org.mapstruct.ap.test.conditional.basic;
 
 import java.util.Arrays;
 import java.util.Collections;
-
 import org.junit.jupiter.api.extension.RegisterExtension;
+
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
@@ -223,4 +223,19 @@ public class ConditionalMappingTest {
 
     }
 
+    @ProcessorTest
+    @WithClasses( {
+        ConditionalMethodWithMappingTargetInUpdateMapper.class
+    } )
+    @IssueKey( "2758" )
+    public void conditionalMethodWithMappingTarget() {
+        ConditionalMethodWithMappingTargetInUpdateMapper mapper =
+            ConditionalMethodWithMappingTargetInUpdateMapper.INSTANCE;
+
+        BasicEmployee targetEmployee = new BasicEmployee();
+        targetEmployee.setName( "CurrentName" );
+        mapper.map( new BasicEmployeeDto( "ReplacementName" ), targetEmployee );
+
+        assertThat( targetEmployee.getName() ).isEqualTo( "CurrentName" );
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/conditional/basic/ConditionalMethodWithMappingTargetInUpdateMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conditional/basic/ConditionalMethodWithMappingTargetInUpdateMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.conditional.basic;
+
+import org.mapstruct.Condition;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Ben Zegveld
+ */
+@Mapper( nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE )
+public interface ConditionalMethodWithMappingTargetInUpdateMapper {
+
+    ConditionalMethodWithMappingTargetInUpdateMapper INSTANCE =
+        Mappers.getMapper( ConditionalMethodWithMappingTargetInUpdateMapper.class );
+
+    void map(BasicEmployeeDto employee, @MappingTarget BasicEmployee targetEmployee);
+
+    @Condition
+    default boolean isNotBlankAndNotPresent(String value, @MappingTarget BasicEmployee targetEmployee) {
+        return value != null && !value.trim().isEmpty() && targetEmployee.getName() == null;
+    }
+}


### PR DESCRIPTION
fallback to param.variableName if ext.targetBeanName is not present in MethodReference handling.

fixes #2758 