### PR TITLE
#2797: When adding imports for types also check if the types own imports are needed.

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -10,14 +10,15 @@ import java.util.Collection;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
+
 import javax.lang.model.type.TypeKind;
+import org.mapstruct.ap.internal.util.ElementUtils;
 
 import org.mapstruct.ap.internal.model.common.Accessibility;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.option.Options;
-import org.mapstruct.ap.internal.util.ElementUtils;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.version.VersionInformation;
 
@@ -256,10 +257,8 @@ public abstract class GeneratedType extends ModelElement {
             return;
         }
 
-        for ( Type importType : typeToAdd.getImportTypes() ) {
-            if ( needsImportDeclaration( importType ) ) {
-                collection.add( importType );
-            }
+        if ( needsImportDeclaration( typeToAdd ) ) {
+            collection.add( typeToAdd );
         }
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -10,15 +10,14 @@ import java.util.Collection;
 import java.util.List;
 import java.util.SortedSet;
 import java.util.TreeSet;
-
 import javax.lang.model.type.TypeKind;
-import org.mapstruct.ap.internal.util.ElementUtils;
 
 import org.mapstruct.ap.internal.model.common.Accessibility;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.option.Options;
+import org.mapstruct.ap.internal.util.ElementUtils;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.version.VersionInformation;
 
@@ -257,8 +256,10 @@ public abstract class GeneratedType extends ModelElement {
             return;
         }
 
-        if ( needsImportDeclaration( typeToAdd ) ) {
-            collection.add( typeToAdd );
+        for ( Type importType : typeToAdd.getImportTypes() ) {
+            if ( needsImportDeclaration( importType ) ) {
+                collection.add( importType );
+            }
         }
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
@@ -103,7 +103,7 @@ public class NestedPropertyMappingMethod extends MappingMethod {
     public Set<Type> getImportTypes() {
         Set<Type> types = super.getImportTypes();
         for ( SafePropertyEntry propertyEntry : safePropertyEntries) {
-            types.add( propertyEntry.getType() );
+            types.addAll( propertyEntry.getType().getImportTypes() );
             if ( propertyEntry.getPresenceChecker() != null ) {
                 types.addAll( propertyEntry.getPresenceChecker().getImportTypes() );
             }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2797/ExampleDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2797/ExampleDto.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2797;
+
+/**
+ * @author Ben Zegveld
+ */
+public class ExampleDto {
+
+    private String personFirstName;
+    private String personLastName;
+
+    public String getPersonFirstName() {
+        return personFirstName;
+    }
+
+    public String getPersonLastName() {
+        return personLastName;
+    }
+
+    public void setPersonFirstName(String personFirstName) {
+        this.personFirstName = personFirstName;
+    }
+
+    public void setPersonLastName(String personLastName) {
+        this.personLastName = personLastName;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2797/ExampleMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2797/ExampleMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2797;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ap.test.bugs._2797.model.Example.Person;
+
+import static org.mapstruct.ReportingPolicy.ERROR;
+
+/**
+ * @author Ben Zegveld
+ */
+@Mapper(unmappedTargetPolicy = ERROR)
+public interface ExampleMapper {
+
+  @Mapping(target = "personFirstName", source = "names.first")
+  @Mapping(target = "personLastName", source = "names.last")
+  ExampleDto map(Person person);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2797/Issue2797Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2797/Issue2797Test.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2797;
+
+import org.mapstruct.ap.test.bugs._2797.model.BasePerson;
+import org.mapstruct.ap.test.bugs._2797.model.Example;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+/**
+ * @author Ben Zegveld
+ */
+@IssueKey( "2797" )
+@WithClasses( { ExampleDto.class, ExampleMapper.class, Example.class, BasePerson.class } )
+public class Issue2797Test {
+
+    @ProcessorTest
+    void shouldCompile() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2797/model/BasePerson.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2797/model/BasePerson.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2797.model;
+
+/**
+ * @author Ben Zegveld
+ */
+public class BasePerson {
+
+    private Names names;
+
+    public Names getNames() {
+        return names;
+    }
+
+    public void setNames(Names names) {
+        this.names = names;
+    }
+
+  public static class Names {
+
+        private String first;
+        private String last;
+
+        public String getFirst() {
+            return first;
+        }
+
+        public String getLast() {
+            return last;
+        }
+
+        public void setFirst(String first) {
+            this.first = first;
+        }
+
+        public void setLast(String last) {
+            this.last = last;
+        }
+  }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2797/model/Example.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2797/model/Example.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2797.model;
+
+/**
+ * @author Ben Zegveld
+ */
+public class Example {
+
+  public static class Person extends BasePerson {
+
+  }
+}


### PR DESCRIPTION
Type's own imports consist of itself and top levels. Sometimes top level imports are used instead of the Type itself. In this case the top level type needs to be added to the import listing.

fixes #2797