### PR TITLE
Fixes NullPointerException on void mapping methods

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperAnnotatedFormattingMessenger.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperAnnotatedFormattingMessenger.java
@@ -97,7 +97,8 @@ public class MapperAnnotatedFormattingMessenger implements FormattingMessager {
         if ( e instanceof ExecutableElement ) {
             ExecutableElement ee = (ExecutableElement) e;
             StringBuilder method = new StringBuilder();
-            method.append( typeUtils.asElement( ee.getReturnType() ).getSimpleName() );
+            final Element typeAsElement = typeUtils.asElement( ee.getReturnType() );
+            method.append(typeAsElement != null ? typeAsElement.getSimpleName() : ee.getReturnType());
             method.append( " " );
             method.append( ee.getSimpleName() );
             method.append( "(" );


### PR DESCRIPTION
When `ee.getReturnType()` returns `void`, `typeUtils.asElement( ee.getReturnType() )` returns `null`. So, `typeUtils.asElement( ee.getReturnType() ).getSimpleName()` crashes with `NullPointerException`. 

This PR fixes this situation.