### PR TITLE
#674 Support Java 8 java.util.Optional type

### DIFF
--- a/documentation/src/main/asciidoc/chapter-5-data-type-conversions.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-5-data-type-conversions.asciidoc
@@ -125,6 +125,8 @@ public interface CarMapper {
 * Between `java.net.URL` and `String`.
 ** When converting from a `String`, the value needs to be a valid https://en.wikipedia.org/wiki/URL[URL] otherwise a `MalformedURLException` is thrown.
 
+* Between `java.util.Optional<T>` and `T`.
+
 [[mapping-object-references]]
 === Mapping object references
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/OptionalToObjectConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/OptionalToObjectConversion.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.conversion;
+
+import java.util.Optional;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.ConversionContext;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.util.Collections;
+
+/**
+ * Conversion between {@link Optional} and {@link Object}.
+ *
+ * @author Iaroslav Bogdanchikov
+ */
+public class OptionalToObjectConversion extends SimpleConversion {
+
+    @Override
+    protected String getToExpression(ConversionContext conversionContext) {
+        return "<SOURCE>.get()";
+    }
+
+    @Override
+    protected String getFromExpression(ConversionContext conversionContext) {
+        return "Optional.ofNullable( <SOURCE> )";
+    }
+
+    @Override
+    protected Set<Type> getFromConversionImportTypes(final ConversionContext conversionContext) {
+        return Collections.asSet( conversionContext.getTypeFactory().getType( Optional.class ) );
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -500,6 +500,14 @@ public class PropertyMapping extends ModelElement {
                 return true;
             }
 
+            if ( rhs.getSourceType().isOptionalType() && !targetType.isOptionalType() ) {
+                return true;
+            }
+
+            if ( !rhs.getSourceType().isOptionalType() && targetType.isOptionalType() ) {
+                return false;
+            }
+
             if ( rhs.getType().isConverted() ) {
                 // A type conversion is applied, so a null check is required
                 return true;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -15,6 +15,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -93,6 +94,7 @@ public class Type extends ModelElement implements Comparable<Type> {
     private final boolean isVoid;
     private final boolean isStream;
     private final boolean isLiteral;
+    private final boolean isOptional;
 
     private final boolean loggingVerbose;
 
@@ -132,7 +134,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                 Map<String, String> toBeImportedTypes,
                 Map<String, String> notToBeImportedTypes,
                 Boolean isToBeImported,
-                boolean isLiteral, boolean loggingVerbose) {
+                boolean isLiteral, boolean isOptional, boolean loggingVerbose) {
 
         this.typeUtils = typeUtils;
         this.elementUtils = elementUtils;
@@ -157,6 +159,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         this.isStream = isStreamType;
         this.isVoid = typeMirror.getKind() == TypeKind.VOID;
         this.isLiteral = isLiteral;
+        this.isOptional = isOptional;
 
         if ( isEnumType ) {
             enumConstants = new ArrayList<>();
@@ -372,6 +375,15 @@ public class Type extends ModelElement implements Comparable<Type> {
     }
 
     /**
+     * Whether this type is an {@link Optional}.
+     *
+     * @return true if this type is an {@link Optional}, false otherwise
+     */
+    public boolean isOptionalType() {
+        return isOptional;
+    }
+
+    /**
      * A wild card type can have two types of bounds (mutual exclusive): extends and super.
      *
      * @return true if the bound has a wild card super bound (e.g. ? super Number)
@@ -537,6 +549,7 @@ public class Type extends ModelElement implements Comparable<Type> {
             notToBeImportedTypes,
             isToBeImported,
             isLiteral,
+            isOptional,
             loggingVerbose
         );
     }
@@ -580,6 +593,7 @@ public class Type extends ModelElement implements Comparable<Type> {
             notToBeImportedTypes,
             isToBeImported,
             isLiteral,
+            isOptional,
             loggingVerbose
         );
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
+import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
@@ -38,12 +39,11 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.type.TypeVariable;
 import javax.lang.model.type.WildcardType;
-import org.mapstruct.ap.internal.util.ElementUtils;
-import org.mapstruct.ap.internal.util.TypeUtils;
 
 import org.mapstruct.ap.internal.gem.BuilderGem;
 import org.mapstruct.ap.internal.util.AnnotationProcessingException;
 import org.mapstruct.ap.internal.util.Collections;
+import org.mapstruct.ap.internal.util.ElementUtils;
 import org.mapstruct.ap.internal.util.Extractor;
 import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.JavaStreamConstants;
@@ -51,6 +51,7 @@ import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.RoundContext;
 import org.mapstruct.ap.internal.util.Strings;
+import org.mapstruct.ap.internal.util.TypeUtils;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.spi.AstModifyingAnnotationProcessor;
 import org.mapstruct.ap.spi.BuilderInfo;
@@ -92,6 +93,7 @@ public class TypeFactory {
     private final TypeMirror collectionType;
     private final TypeMirror mapType;
     private final TypeMirror streamType;
+    private final TypeMirror optionalType;
 
     private final Map<String, ImplementationType> implementationTypes = new HashMap<>();
     private final Map<String, String> toBeImportedTypes = new HashMap<>();
@@ -113,6 +115,7 @@ public class TypeFactory {
         mapType = typeUtils.erasure( elementUtils.getTypeElement( Map.class.getCanonicalName() ).asType() );
         TypeElement streamTypeElement = elementUtils.getTypeElement( JavaStreamConstants.STREAM_FQN );
         streamType = streamTypeElement == null ? null : typeUtils.erasure( streamTypeElement.asType() );
+        optionalType = typeUtils.erasure( elementUtils.getTypeElement( Optional.class.getCanonicalName() ).asType() );
 
         implementationTypes.put( Iterable.class.getName(), withInitialCapacity( getType( ArrayList.class ) ) );
         implementationTypes.put( Collection.class.getName(), withInitialCapacity( getType( ArrayList.class ) ) );
@@ -221,6 +224,7 @@ public class TypeFactory {
         boolean isCollectionType = typeUtils.isSubtypeErased( mirror, collectionType );
         boolean isMapType = typeUtils.isSubtypeErased( mirror, mapType );
         boolean isStreamType = streamType != null && typeUtils.isSubtypeErased( mirror, streamType );
+        boolean isOptionalType = typeUtils.isSubtypeErased( mirror, optionalType );
 
         boolean isEnumType;
         boolean isInterface;
@@ -334,6 +338,7 @@ public class TypeFactory {
             notToBeImportedTypes,
             toBeImported,
             isLiteral,
+            isOptionalType,
             loggingVerbose
         );
     }
@@ -560,6 +565,7 @@ public class TypeFactory {
                 notToBeImportedTypes,
                 null,
                 implementationType.isLiteral(),
+                implementationType.isOptionalType(),
                 loggingVerbose
             );
             return implementation.createNew( replacement );

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
@@ -22,7 +22,7 @@
         }
         <@elseDefaultAssignment/>
     <#elseif includeSourceNullCheck || ext.defaultValueAssignment??>
-        if ( <#if sourceLocalVarName??>${sourceLocalVarName}<#else>${sourceReference}</#if> != null ) {
+        if ( <#if sourceLocalVarName??>${sourceLocalVarName}<#else>${sourceReference}</#if><#if getSourceType().isOptionalType()>.isPresent()<#else> != null</#if> ) {
             <#nested>
         }
         <@elseDefaultAssignment/>

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/DateFormatValidatorFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/DateFormatValidatorFactoryTest.java
@@ -5,8 +5,6 @@
  */
 package org.mapstruct.ap.internal.model.common;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.lang.annotation.Annotation;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -14,7 +12,6 @@ import java.time.LocalTime;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
-
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
@@ -23,6 +20,8 @@ import javax.lang.model.type.TypeVisitor;
 import org.junit.jupiter.api.Test;
 import org.mapstruct.ap.internal.util.JodaTimeConstants;
 import org.mapstruct.ap.testutil.IssueKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests for {@link org.mapstruct.ap.internal.model.common.DateFormatValidatorFactory}.
@@ -177,7 +176,9 @@ public class DateFormatValidatorFactoryTest {
             new HashMap<>(  ),
             new HashMap<>(  ),
                         false,
-                        false, false
+                        false,
+                        false,
+                        false
         );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
@@ -5,13 +5,10 @@
  */
 package org.mapstruct.ap.internal.model.common;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.lang.annotation.Annotation;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
 import java.util.List;
-
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.AnnotationValue;
 import javax.lang.model.element.Element;
@@ -24,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.testutil.IssueKey;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Testing DefaultConversionContext for dateFormat
@@ -125,7 +124,9 @@ public class DefaultConversionContextTest {
             new HashMap<>(  ),
             new HashMap<>(  ),
                         false,
-                        false, false
+                        false,
+                        false,
+                        false
         );
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/optional/OptionalConversionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/optional/OptionalConversionTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.conversion.optional;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests conversions between {@link Optional} and {@link Object}.
+ *
+ * @author Iaroslav Bogdanchikov
+ */
+@WithClasses({
+    SourceTargetMapper.class,
+    Source.class,
+    Target.class
+})
+public class OptionalConversionTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource().addComparisonToFixtureFor( SourceTargetMapper.class );
+
+    @ProcessorTest
+    public void shouldApplyOptionalConversions() {
+        Source source = new Source();
+        source.setOptional( Optional.of( "TEST" ) );
+        source.setFromOptionalProp( Optional.of( "FROM OPTIONAL TEST" ) );
+        source.setToOptionalProp( "TO OPTIONAL TEST" );
+        source.fromOptionalPubProp = Optional.of( "FROM OPTIONAL PUBLIC TEST" );
+        source.toOptionalPubProp = "TO OPTIONAL PUBLIC TEST";
+
+        Target target = SourceTargetMapper.INSTANCE.map( source );
+        assertThat( target ).isNotNull();
+        assertThat( target.getOptional() ).isPresent();
+        assertThat( target.getOptional() ).get().isEqualTo( "TEST" );
+        assertThat( target.getFromOptionalProp() ).isEqualTo( "FROM OPTIONAL TEST" );
+        assertThat( target.getToOptionalProp() ).isPresent();
+        assertThat( target.getToOptionalProp() ).get().isEqualTo( "TO OPTIONAL TEST" );
+        assertThat( target.fromOptionalPubProp ).isEqualTo( "FROM OPTIONAL PUBLIC TEST" );
+        assertThat( target.toOptionalPubProp ).isPresent();
+        assertThat( target.toOptionalPubProp ).get().isEqualTo( "TO OPTIONAL PUBLIC TEST" );
+    }
+
+    @ProcessorTest
+    public void shouldApplyOptionalConversionsWhenNullOrEmpty() {
+        Source source = new Source();
+        source.setOptional( Optional.empty() );
+        source.setFromOptionalProp( Optional.empty() );
+        source.setToOptionalProp( null );
+        source.fromOptionalPubProp = Optional.empty();
+        source.toOptionalPubProp = null;
+
+        Target target = SourceTargetMapper.INSTANCE.map( source );
+        assertThat( target ).isNotNull();
+        assertThat( target.getOptional() ).isEmpty();
+        assertThat( target.getFromOptionalProp() ).isNull();
+        assertThat( target.getToOptionalProp() ).isEmpty();
+        assertThat( target.fromOptionalPubProp ).isNull();
+        assertThat( target.toOptionalPubProp ).isEmpty();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/optional/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/optional/Source.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.conversion.optional;
+
+import java.util.Optional;
+
+public class Source {
+
+    // CHECKSTYLE:OFF
+    public Optional<String> fromOptionalPubProp;
+    // CHECKSTYLE:ON
+
+    // CHECKSTYLE:OFF
+    public String toOptionalPubProp;
+    // CHECKSTYLE:ON
+
+    private Optional<String> fromOptionalProp;
+
+    private String toOptionalProp;
+
+    private Optional<String> optional;
+
+    public Optional<String> getFromOptionalProp() {
+        return fromOptionalProp;
+    }
+
+    public void setFromOptionalProp(Optional<String> fromOptionalProp) {
+        this.fromOptionalProp = fromOptionalProp;
+    }
+
+    public String getToOptionalProp() {
+        return toOptionalProp;
+    }
+
+    public void setToOptionalProp(String toOptionalProp) {
+        this.toOptionalProp = toOptionalProp;
+    }
+
+    public Optional<String> getOptional() {
+        return optional;
+    }
+
+    public void setOptional(Optional<String> optional) {
+        this.optional = optional;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/optional/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/optional/SourceTargetMapper.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.conversion.optional;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface SourceTargetMapper {
+
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    Target map(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/conversion/optional/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conversion/optional/Target.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.conversion.optional;
+
+import java.util.Optional;
+
+public class Target {
+
+    // CHECKSTYLE:OFF
+    public Optional<String> toOptionalPubProp;
+    // CHECKSTYLE:ON
+
+    // CHECKSTYLE:OFF
+    public String fromOptionalPubProp;
+    // CHECKSTYLE:ON
+
+    private Optional<String> toOptionalProp;
+
+    private String fromOptionalProp;
+
+    private Optional<String> optional;
+
+    public Optional<String> getToOptionalProp() {
+        return toOptionalProp;
+    }
+
+    public void setToOptionalProp(Optional<String> toOptionalProp) {
+        this.toOptionalProp = toOptionalProp;
+    }
+
+    public String getFromOptionalProp() {
+        return fromOptionalProp;
+    }
+
+    public void setFromOptionalProp(String fromOptionalProp) {
+        this.fromOptionalProp = fromOptionalProp;
+    }
+
+    public Optional<String> getOptional() {
+        return optional;
+    }
+
+    public void setOptional(Optional<String> optional) {
+        this.optional = optional;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/optional/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/optional/SourceTargetMapperImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.conversion.optional;
+
+import java.util.Optional;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2022-06-07T10:33:01+0200",
+    comments = "version: , compiler: Eclipse JDT (Batch) 3.20.0.v20191203-2131, environment: Java 17.0.3 (Eclipse Adoptium)"
+)
+public class SourceTargetMapperImpl implements SourceTargetMapper {
+
+    @Override
+    public Target map(Source source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        Target target = new Target();
+
+        target.setToOptionalProp( Optional.ofNullable( source.getToOptionalProp() ) );
+        if ( source.getFromOptionalProp().isPresent() ) {
+            target.setFromOptionalProp( source.getFromOptionalProp().get() );
+        }
+        target.setOptional( source.getOptional() );
+        target.toOptionalPubProp = Optional.ofNullable( source.toOptionalPubProp );
+        if ( source.fromOptionalPubProp.isPresent() ) {
+            target.fromOptionalPubProp = source.fromOptionalPubProp.get();
+        }
+
+        return target;
+    }
+}


### PR DESCRIPTION
Adds support for mapping between `java.util.Optional<T>` and `T`. See #674 for details.

Asking the maintainers for a code review. Thank you for your time.

This is my first time ever trying to contribute to an open source project, so I apologize in advance for anything I might have done wrong.