### PR TITLE
#2882: target type is now correctly passed on

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MethodReferencePresenceCheck.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MethodReferencePresenceCheck.ftl
@@ -6,4 +6,5 @@
 
 -->
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.MethodReferencePresenceCheck" -->
-<@includeModel object=methodReference/>
+<@includeModel object=methodReference
+               targetType=ext.targetType/>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
@@ -15,7 +15,8 @@
 -->
 <#macro handleSourceReferenceNullCheck>
     <#if sourcePresenceCheckerReference??>
-        if ( <@includeModel object=sourcePresenceCheckerReference /> ) {
+        if ( <@includeModel object=sourcePresenceCheckerReference
+               targetType=ext.targetType/> ) {
             <#nested>
         }
         <@elseDefaultAssignment/>

--- a/processor/src/test/java/org/mapstruct/ap/test/conditional/basic/ConditionalMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conditional/basic/ConditionalMappingTest.java
@@ -50,6 +50,12 @@ public class ConditionalMappingTest {
         assertThat( employee.getName() ).isNull();
     }
 
+    @IssueKey( "2882" )
+    @ProcessorTest
+    @WithClasses( { ConditionalMethodWithTargetType.class } )
+    public void conditionalMethodWithTargetTypeShouldCompile() {
+    }
+
     @ProcessorTest
     @WithClasses({
         ConditionalMethodAndBeanPresenceCheckMapper.class

--- a/processor/src/test/java/org/mapstruct/ap/test/conditional/basic/ConditionalMethodWithTargetType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conditional/basic/ConditionalMethodWithTargetType.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.conditional.basic;
+
+import org.mapstruct.Condition;
+import org.mapstruct.Mapper;
+import org.mapstruct.TargetType;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Ben Zegveld
+ */
+@Mapper
+public interface ConditionalMethodWithTargetType {
+
+    ConditionalMethodWithTargetType INSTANCE = Mappers.getMapper( ConditionalMethodWithTargetType.class );
+
+    BasicEmployee map(BasicEmployeeDto employee);
+
+    @Condition
+    default boolean isNotBlank(String value, @TargetType Class<?> targetType) {
+        return value != null && !value.trim().isEmpty();
+    }
+}


### PR DESCRIPTION
`targetType` is now correctly passed on through the `MethodReferencePresenceCheck.ftl` to the `MethodReference.ftl`

closes #2882 