### PR TITLE
Instantiate Kotlin data classes using the _primary_ constructor

### DIFF
--- a/integrationtest/src/test/resources/kotlinDataTest/src/main/java/org/mapstruct/itest/kotlin/data/CustomerEntity.java
+++ b/integrationtest/src/test/resources/kotlinDataTest/src/main/java/org/mapstruct/itest/kotlin/data/CustomerEntity.java
@@ -11,7 +11,9 @@ package org.mapstruct.itest.kotlin.data;
 public class CustomerEntity {
 
     private String name;
+    private int age;
     private String mail;
+    private String job;
 
     public String getName() {
         return name;
@@ -21,11 +23,27 @@ public class CustomerEntity {
         this.name = name;
     }
 
+    public int getAge() {
+        return age;
+    }
+
+    public void setAge(int age) {
+        this.age = age;
+    }
+
     public String getMail() {
         return mail;
     }
 
     public void setMail(String mail) {
         this.mail = mail;
+    }
+
+    public String getJob() {
+        return job;
+    }
+
+    public void setJob(String job) {
+        this.job = job;
     }
 }

--- a/integrationtest/src/test/resources/kotlinDataTest/src/main/java/org/mapstruct/itest/kotlin/data/CustomerMapper.java
+++ b/integrationtest/src/test/resources/kotlinDataTest/src/main/java/org/mapstruct/itest/kotlin/data/CustomerMapper.java
@@ -24,4 +24,9 @@ public interface CustomerMapper {
     @InheritInverseConfiguration
     CustomerDto toRecord(CustomerEntity entity);
 
+    @Mapping(target = "email", source = "mail")
+    CustomerWithOptionalParametersDto mapWithOptionalParameters(CustomerEntity entity);
+
+    @Mapping(target = "email", source = "mail")
+    CustomerWithMixedParametersDto mapWithMixedParameters(CustomerEntity entity);
 }

--- a/integrationtest/src/test/resources/kotlinDataTest/src/main/kotlin/org/mapstruct/itest/kotlin/data/CustomerWithMixedParametersDto.kt
+++ b/integrationtest/src/test/resources/kotlinDataTest/src/main/kotlin/org/mapstruct/itest/kotlin/data/CustomerWithMixedParametersDto.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.kotlin.data
+
+data class CustomerWithMixedParametersDto @Default constructor(
+    val name: String,
+    var age: Int,
+    val email: String? = null
+) {
+    var job: String? = null
+
+    constructor(name: String, email: String, job: String) : this(name, 0, email) {
+        this.job = job
+    }
+
+    annotation class Default
+}

--- a/integrationtest/src/test/resources/kotlinDataTest/src/main/kotlin/org/mapstruct/itest/kotlin/data/CustomerWithOptionalParametersDto.kt
+++ b/integrationtest/src/test/resources/kotlinDataTest/src/main/kotlin/org/mapstruct/itest/kotlin/data/CustomerWithOptionalParametersDto.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.itest.kotlin.data
+
+data class CustomerWithOptionalParametersDto(
+    val name: String? = null,
+    val email: String? = null
+) {
+    constructor(name: String) : this(name, null)
+}

--- a/integrationtest/src/test/resources/kotlinDataTest/src/test/java/org/mapstruct/itest/kotlin/data/KotlinDataTest.java
+++ b/integrationtest/src/test/resources/kotlinDataTest/src/test/java/org/mapstruct/itest/kotlin/data/KotlinDataTest.java
@@ -35,4 +35,34 @@ public class KotlinDataTest {
         assertThat( customer.getName() ).isEqualTo( "Kermit" );
         assertThat( customer.getEmail() ).isEqualTo( "kermit@test.com" );
     }
+
+    @Test
+    public void shouldMapIntoDataWithOptionalParameters() {
+        CustomerEntity entity = new CustomerEntity();
+        entity.setName( "Kermit" );
+        entity.setMail( "kermit@test.com" );
+
+        CustomerWithOptionalParametersDto customer = CustomerMapper.INSTANCE.mapWithOptionalParameters( entity );
+
+        assertThat( customer ).isNotNull();
+        assertThat( customer.getName() ).isEqualTo( "Kermit" );
+        assertThat( customer.getEmail() ).isEqualTo( "kermit@test.com" );
+    }
+
+    @Test
+    public void shouldMapIntoDataWithMixedParameters() {
+        CustomerEntity entity = new CustomerEntity();
+        entity.setName( "Kermit" );
+        entity.setAge( 42 );
+        entity.setMail( "kermit@test.com" );
+        entity.setJob( "Actor" );
+
+        CustomerWithMixedParametersDto customer = CustomerMapper.INSTANCE.mapWithMixedParameters( entity );
+
+        assertThat( customer ).isNotNull();
+        assertThat( customer.getName() ).isEqualTo( "Kermit" );
+        assertThat( customer.getAge() ).isEqualTo( 42 );
+        assertThat( customer.getEmail() ).isEqualTo( "kermit@test.com" );
+        assertThat( customer.getJob() ).isEqualTo( "Actor" );
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -44,6 +44,7 @@ import org.mapstruct.ap.internal.model.beanmapping.TargetReference;
 import org.mapstruct.ap.internal.model.common.Assignment;
 import org.mapstruct.ap.internal.model.common.BuilderType;
 import org.mapstruct.ap.internal.model.common.FormattingParameters;
+import org.mapstruct.ap.internal.model.common.KotlinType;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.ParameterBinding;
 import org.mapstruct.ap.internal.model.common.SourceRHS;
@@ -740,8 +741,15 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 return new ConstructorAccessor( parameterBindings, constructorAccessors );
             }
 
-            List<ExecutableElement> constructors = ElementFilter.constructorsIn( type.getTypeElement()
-                .getEnclosedElements() );
+            List<ExecutableElement> constructors;
+
+            final KotlinType kotlinType = KotlinType.of( type );
+            if ( kotlinType != null && kotlinType.isDataClass() ) {
+                constructors = kotlinType.getDataClassConstructors();
+            }
+            else {
+                constructors = ElementFilter.constructorsIn( type.getTypeElement().getEnclosedElements() );
+            }
 
             // The rules for picking a constructor are the following:
             // 1. Constructor annotated with @Default (from any package) has highest precedence

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/KotlinType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/KotlinType.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model.common;
+
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.util.ElementFilter;
+import java.util.List;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+/**
+ * @author Jakub Wójcik
+ */
+public class KotlinType {
+    private static final String KOTLIN_ANNOTATION = "kotlin.Metadata";
+    private static final Pattern COMPONENT_METHOD_PATTERN = Pattern.compile( "component\\d+" );
+
+    private final Type type;
+    private final long componentMethodCount;
+
+    private KotlinType(Type type) {
+        this.type = type;
+        componentMethodCount = countComponentMethods();
+    }
+
+    /**
+     * Recognizes Kotlin classes by the annotation {@value KOTLIN_ANNOTATION},
+     * that is present on any class file produced by the Kotlin compiler.
+     *
+     * @return A kotlin type or <code>null</code>.
+     * @see <a href="https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-metadata/">@Metadata documentation</a>
+     */
+    public static KotlinType of(Type type) {
+        if ( isKotlinClass( type ) ) {
+            return new KotlinType( type );
+        }
+        return null;
+    }
+
+    private static boolean isKotlinClass(Type type) {
+        return type.getTypeElement().getAnnotationMirrors().stream()
+            .anyMatch(
+                annotationMirror -> KOTLIN_ANNOTATION.equals( annotationMirror.getAnnotationType().toString() )
+            );
+    }
+
+    /**
+     * Data classes are recognized by the presence of <code>componentN()</code> methods as described in
+     * <a href="https://kotlinlang.org/docs/data-classes.html">the documentation about data classes</a>.
+     *
+     * @return Whether the class is <i>likely</i> a data class.
+     */
+    public boolean isDataClass() {
+        return componentMethodCount > 0;
+    }
+
+    /**
+     * @return The constructors suitable to create a Kotlin data class.
+     * <br>
+     * <br>
+     * Only constructors with the same number of parameters
+     * as the number of <code>componentN()</code> methods are returned.
+     */
+    public List<ExecutableElement> getDataClassConstructors() {
+        return ElementFilter.constructorsIn( type.getTypeElement().getEnclosedElements() )
+            .stream()
+            .filter(
+                constructor -> constructor.getParameters().size() == componentMethodCount
+            )
+            .collect( Collectors.toList() );
+    }
+
+    private long countComponentMethods() {
+        return ElementFilter.methodsIn( type.getTypeElement().getEnclosedElements() )
+            .stream()
+            .filter(
+                method -> COMPONENT_METHOD_PATTERN.matcher( method.getSimpleName() ).matches()
+            )
+            .count();
+    }
+}

--- a/processor/src/test/java/kotlin/Metadata.java
+++ b/processor/src/test/java/kotlin/Metadata.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+//CHECKSTYLE:OFF
+package kotlin;
+
+/**
+ * Used to deliberately create fake Kotlin classes.
+ */
+public @interface Metadata {
+}
+//CHECKSTYLE:ON

--- a/processor/src/test/java/org/mapstruct/ap/test/constructor/kotlin/KotlinDataClassConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/constructor/kotlin/KotlinDataClassConstructorMapper.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.constructor.kotlin;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.constructor.PersonDto;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface KotlinDataClassConstructorMapper {
+
+    KotlinDataClassConstructorMapper INSTANCE = Mappers.getMapper( KotlinDataClassConstructorMapper.class );
+
+    PersonDataClass map(PersonDto dto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/constructor/kotlin/KotlinDataClassConstructorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/constructor/kotlin/KotlinDataClassConstructorTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.constructor.kotlin;
+
+import kotlin.Metadata;
+import org.mapstruct.ap.test.constructor.PersonDto;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses({
+    Metadata.class,
+    PersonDto.class,
+    PersonDataClass.class,
+    KotlinDataClassConstructorMapper.class
+})
+public class KotlinDataClassConstructorTest {
+
+    @ProcessorTest
+    public void shouldMap() {
+        PersonDto source = new PersonDto();
+        source.setName( "Bob" );
+        source.setAge( 30 );
+        source.setJob( "Software Engineer" );
+
+        PersonDataClass target = KotlinDataClassConstructorMapper.INSTANCE.map( source );
+
+        assertThat( target.getName() ).isEqualTo( "Bob" );
+        assertThat( target.getAge() ).isEqualTo( 30 );
+        assertThat( target.getJob() ).isEqualTo( "Software Engineer" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/constructor/kotlin/PersonDataClass.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/constructor/kotlin/PersonDataClass.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.constructor.kotlin;
+
+import kotlin.Metadata;
+
+/**
+ * A deliberately constructed, fake Kotlin data class.
+ */
+@SuppressWarnings("unused")
+@Metadata
+public class PersonDataClass {
+
+    private final String name;
+    private final int age;
+    private final String job;
+
+    public String getName() {
+        return name;
+    }
+
+    public int getAge() {
+        return age;
+    }
+
+    public String getJob() {
+        return job;
+    }
+
+    public PersonDataClass(String name, int age, String job) {
+        this.name = name;
+        this.age = age;
+        this.job = job;
+    }
+
+    public PersonDataClass(String name, int age, String job, String email) {
+        this( name, age, job );
+    }
+
+    public PersonDataClass() {
+        this( null, 0, null );
+    }
+
+    public PersonDataClass(String name, int age) {
+        this( name, age, null );
+    }
+
+    public String component1() {
+        return name;
+    }
+
+    public int component2() {
+        return age;
+    }
+
+    public String component3() {
+        return job;
+    }
+}


### PR DESCRIPTION
A lot of Kotlin projects define DTOs using data classes with optional parameters like
```kotlin
data class Person(
    val name: String? = null,
    val email: String? = null
)
```

Unfortunately these data classes do not work with MapStruct because the Kotlin compiler generates multiple constructors under the hood.
Issues #2281, #2378 describe this problem.

This PR is an attempt to make MapStruct use the primary constructor of the data class to instantiate it, and ignore all other generated constructors.

### How it works?
Recognizes data classes and the primary constructor by
- the [annotation `kotlin.Metadata`](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-metadata/), that is present on any class file produced by the Kotlin compiler
- and by the presence of  `componentN()` methods, as described in the [documentation about data classes](https://kotlinlang.org/docs/data-classes.html).

Note: _There might be false positives._

### How to review?
- Start with the changes to [`BeanMappingMethod`](https://github.com/mapstruct/mapstruct/pull/2933/files#diff-a631248fddd6c9d017e345f4e71bbac0fa3eb1ff5e26801c45dba616867af23a).
- Then take a look at [`KotlinType`](https://github.com/mapstruct/mapstruct/pull/2933/files#diff-9681dbb19064dcbb27a6bbb4f8f45893a1f3e1ff81e9726fd21285492e521fcd).
- The rest are tests.

### TODO 
- [ ] Update the reference documentation

### Improvement ideas
- Instead of using the number of `componentN()` methods, use their exact return types to more accurately determine the primary constructor.
