### PR TITLE
#2925 Fix IllegalArgumentException when resolving generic parameters

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MethodMatcher.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MethodMatcher.java
@@ -374,6 +374,8 @@ public class MethodMatcher {
                             // something went wrong
                             return null;
                         }
+                        // Use the boxed equivalent for the type arguments,
+                        // because a primitive type cannot be a type argument
                         typeArgs[i] = matchingType.getBoxedEquivalent().getTypeMirror();
                     }
                     else {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MethodMatcher.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MethodMatcher.java
@@ -374,7 +374,7 @@ public class MethodMatcher {
                             // something went wrong
                             return null;
                         }
-                        typeArgs[i] = matchingType.getTypeMirror();
+                        typeArgs[i] = matchingType.getBoxedEquivalent().getTypeMirror();
                     }
                     else {
                         // it is not a type var (e.g. Map<String, T> ), String is not a type var

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2925/Issue2925Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2925/Issue2925Mapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2925;
+
+import java.util.Optional;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue2925Mapper {
+
+    Issue2925Mapper INSTANCE = Mappers.getMapper( Issue2925Mapper.class );
+
+    Target map(Source source);
+
+    static <T> Optional<T> toOptional(T value) {
+        return Optional.ofNullable( value );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2925/Issue2925Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2925/Issue2925Test.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2925;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("2925")
+@WithClasses({
+    Issue2925Mapper.class,
+    Source.class,
+    Target.class,
+})
+class Issue2925Test {
+
+    @ProcessorTest
+    void shouldUseOptionalWrappingMethod() {
+        Target target = Issue2925Mapper.INSTANCE.map( new Source( 10L ) );
+
+        assertThat( target.getValue() )
+            .hasValue( 10L );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2925/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2925/Source.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2925;
+
+public class Source {
+
+    private final long value;
+
+    public Source(long value) {
+        this.value = value;
+    }
+
+    public long getValue() {
+        return value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2925/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2925/Target.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2925;
+
+import java.util.Optional;
+
+public class Target {
+
+    private Long value;
+
+    public Optional<Long> getValue() {
+        return Optional.ofNullable( value );
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    public void setValue(Optional<Long> value) {
+        this.value = value.orElse( null );
+    }
+}


### PR DESCRIPTION
When resolving the parameter for a method like:
```
<T> Optional<T> from(T value)
```

There was an exception in javac because getting a DeclaredType from an Optional
with a primitive type argument throws an exception.
Therefore, when assigning the type arguments we get the boxed equivalent.
This problem does not happen in the Eclipse compiler

Fixes #2925