### PR TITLE
#2950 Disable CDI in the full features tests on Java 8

### DIFF
--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationExclusionCliEnhancer.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationExclusionCliEnhancer.java
@@ -28,6 +28,10 @@ public final class FullFeatureCompilationExclusionCliEnhancer implements Process
         additionalExcludes.add( "org/mapstruct/ap/test/bugs/_1801/*.java" );
 
         switch ( currentJreVersion ) {
+            case JAVA_8:
+                additionalExcludes.add( "org/mapstruct/ap/test/injectionstrategy/cdi/**/*.java" );
+                additionalExcludes.add( "org/mapstruct/ap/test/injectionstrategy/jakarta_cdi/**/*.java" );
+                break;
             case JAVA_9:
                 // TODO find out why this fails:
                 additionalExcludes.add( "org/mapstruct/ap/test/collection/wildcard/BeanMapper.java" );


### PR DESCRIPTION
Fixes problems on Java 8 when running the full feature tests with CDI (the new tests were added for #2950). It depends on #2984 for the processor tests to pass