### PR TITLE
feat: Add @AnnotateWith support to mapping methods

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractMappingMethodBuilder.java
@@ -13,6 +13,9 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.util.Strings;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * An abstract builder that can be reused for building {@link MappingMethod}(s).
  *
@@ -115,6 +118,17 @@ public abstract class AbstractMappingMethodBuilder<B extends AbstractMappingMeth
 
     public ForgedMethodHistory getDescription() {
         return description;
+    }
+
+    public List<Annotation> getMethodAnnotation() {
+        AdditionalAnnotationsBuilder additionalAnnotationsBuilder =
+                new AdditionalAnnotationsBuilder(
+                        ctx.getElementUtils(),
+                        ctx.getTypeFactory(),
+                        ctx.getMessager() );
+        List<Annotation> annotations = new ArrayList<>();
+        annotations.addAll( additionalAnnotationsBuilder.getProcessedAnnotations( method.getExecutable() ) );
+        return annotations;
     }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -85,7 +85,6 @@ import static org.mapstruct.ap.internal.util.Message.PROPERTYMAPPING_CANNOT_DETE
  */
 public class BeanMappingMethod extends NormalTypeMappingMethod {
 
-    private final List<Annotation> annotations;
     private final List<PropertyMapping> propertyMappings;
     private final Map<String, List<PropertyMapping>> mappingsByParameter;
     private final Map<String, List<PropertyMapping>> constructorMappingsByParameter;
@@ -113,7 +112,6 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         private final Set<Parameter> unprocessedSourceParameters = new HashSet<>();
         private final Set<String> existingVariableNames = new HashSet<>();
         private final Map<String, Set<MappingReference>> unprocessedDefinedTargets = new LinkedHashMap<>();
-        private final List<Annotation> annotations = new ArrayList<>();
 
         private MappingReferences mappingReferences;
         private MethodReference factoryMethod;
@@ -216,12 +214,6 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 // If the return type cannot be constructed then no need to try to create mappings
                 return null;
             }
-            AdditionalAnnotationsBuilder additionalAnnotationsBuilder =
-                new AdditionalAnnotationsBuilder(
-                    ctx.getElementUtils(),
-                    ctx.getTypeFactory(),
-                    ctx.getMessager() );
-            annotations.addAll( additionalAnnotationsBuilder.getProcessedAnnotations( method.getExecutable() ) );
 
             /* the type that needs to be used in the mapping process as target */
             Type resultTypeToMap = returnTypeToConstruct == null ? method.getResultType() : returnTypeToConstruct;
@@ -370,7 +362,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
 
             return new BeanMappingMethod(
                 method,
-                annotations,
+                getMethodAnnotation(),
                 existingVariableNames,
                 propertyMappings,
                 factoryMethod,
@@ -1724,6 +1716,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                               List<SubclassMapping> subclassMappings) {
         super(
             method,
+            annotations,
             existingVariableNames,
             factoryMethod,
             mapNullToDefault,
@@ -1732,7 +1725,6 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         );
         //CHECKSTYLE:ON
 
-        this.annotations = annotations;
         this.propertyMappings = propertyMappings;
         this.returnTypeBuilder = returnTypeBuilder;
         this.finalizerMethod = finalizerMethod;
@@ -1769,10 +1761,6 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         }
         this.returnTypeToConstruct = returnTypeToConstruct;
         this.subclassMappings = subclassMappings;
-    }
-
-    public List<Annotation> getAnnotations() {
-        return annotations;
     }
 
     public List<PropertyMapping> getConstantMappings() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
@@ -32,12 +32,13 @@ public abstract class ContainerMappingMethod extends NormalTypeMappingMethod {
     private final String index2Name;
     private IterableCreation iterableCreation;
 
-    ContainerMappingMethod(Method method, Collection<String> existingVariables, Assignment parameterAssignment,
+    ContainerMappingMethod(Method method, List<Annotation> annotations,
+                           Collection<String> existingVariables, Assignment parameterAssignment,
         MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
         List<LifecycleCallbackMethodReference> beforeMappingReferences,
         List<LifecycleCallbackMethodReference> afterMappingReferences,
         SelectionParameters selectionParameters) {
-        super( method, existingVariables, factoryMethod, mapNullToDefault, beforeMappingReferences,
+        super( method, annotations, existingVariables, factoryMethod, mapNullToDefault, beforeMappingReferences,
             afterMappingReferences );
         this.elementAssignment = parameterAssignment;
         this.loopVariableName = loopVariableName;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -57,6 +57,7 @@ public class IterableMappingMethod extends ContainerMappingMethod {
             List<LifecycleCallbackMethodReference> afterMappingMethods, SelectionParameters selectionParameters) {
             return new IterableMappingMethod(
                 method,
+                getMethodAnnotation(),
                 existingVariables,
                 assignment,
                 factoryMethod,
@@ -69,13 +70,15 @@ public class IterableMappingMethod extends ContainerMappingMethod {
         }
     }
 
-    private IterableMappingMethod(Method method, Collection<String> existingVariables, Assignment parameterAssignment,
+    private IterableMappingMethod(Method method, List<Annotation> annotations,
+                                  Collection<String> existingVariables, Assignment parameterAssignment,
                                   MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
                                   List<LifecycleCallbackMethodReference> beforeMappingReferences,
                                   List<LifecycleCallbackMethodReference> afterMappingReferences,
         SelectionParameters selectionParameters) {
         super(
             method,
+            annotations,
             existingVariables,
             parameterAssignment,
             factoryMethod,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -199,6 +199,7 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
 
             return new MapMappingMethod(
                 method,
+                getMethodAnnotation(),
                 existingVariables,
                 keyAssignment,
                 valueAssignment,
@@ -224,11 +225,12 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
 
     }
 
-    private MapMappingMethod(Method method, Collection<String> existingVariableNames, Assignment keyAssignment,
+    private MapMappingMethod(Method method, List<Annotation> annotations,
+                             Collection<String> existingVariableNames, Assignment keyAssignment,
                              Assignment valueAssignment, MethodReference factoryMethod, boolean mapNullToDefault,
                              List<LifecycleCallbackMethodReference> beforeMappingReferences,
                              List<LifecycleCallbackMethodReference> afterMappingReferences) {
-        super( method, existingVariableNames, factoryMethod, mapNullToDefault, beforeMappingReferences,
+        super( method, annotations, existingVariableNames, factoryMethod, mapNullToDefault, beforeMappingReferences,
             afterMappingReferences );
 
         this.keyAssignment = keyAssignment;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NormalTypeMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NormalTypeMappingMethod.java
@@ -24,7 +24,10 @@ public abstract class NormalTypeMappingMethod extends MappingMethod {
     private final boolean overridden;
     private final boolean mapNullToDefault;
 
-    NormalTypeMappingMethod(Method method, Collection<String> existingVariableNames, MethodReference factoryMethod,
+    private final List<Annotation> annotations;
+
+    NormalTypeMappingMethod(Method method, List<Annotation> annotations,
+        Collection<String> existingVariableNames, MethodReference factoryMethod,
         boolean mapNullToDefault,
         List<LifecycleCallbackMethodReference> beforeMappingReferences,
         List<LifecycleCallbackMethodReference> afterMappingReferences) {
@@ -32,6 +35,7 @@ public abstract class NormalTypeMappingMethod extends MappingMethod {
         this.factoryMethod = factoryMethod;
         this.overridden = method.overridesMethod();
         this.mapNullToDefault = mapNullToDefault;
+        this.annotations = annotations;
     }
 
     @Override
@@ -58,6 +62,10 @@ public abstract class NormalTypeMappingMethod extends MappingMethod {
 
     public MethodReference getFactoryMethod() {
         return this.factoryMethod;
+    }
+
+    public List<Annotation> getAnnotations() {
+        return annotations;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
@@ -6,8 +6,10 @@
 package org.mapstruct.ap.internal.model;
 
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -63,36 +65,39 @@ public class StreamMappingMethod extends ContainerMappingMethod {
                 sourceParameterType.isIterableType() ) {
                 helperImports.add( ctx.getTypeFactory().getType( StreamSupport.class ) );
             }
-
+            Map<String, List<LifecycleCallbackMethodReference>> mappingReferencesMap = new HashMap<>(2);
+            mappingReferencesMap.put( "before", beforeMappingMethods );
+            mappingReferencesMap.put( "after", afterMappingMethods );
             return new StreamMappingMethod(
                 method,
+                getMethodAnnotation(),
                 existingVariables,
                 assignment,
                 factoryMethod,
                 mapNullToDefault,
                 loopVariableName,
-                beforeMappingMethods,
-                afterMappingMethods,
+                mappingReferencesMap,
                 selectionParameters,
                 helperImports
             );
         }
     }
 
-    private StreamMappingMethod(Method method, Collection<String> existingVariables, Assignment parameterAssignment,
+    private StreamMappingMethod(Method method, List<Annotation> annotations,
+                                Collection<String> existingVariables, Assignment parameterAssignment,
                                 MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
-                                List<LifecycleCallbackMethodReference> beforeMappingReferences,
-                                List<LifecycleCallbackMethodReference> afterMappingReferences,
+                                Map<String, List<LifecycleCallbackMethodReference>> mappingReferencesMap,
         SelectionParameters selectionParameters, Set<Type> helperImports) {
         super(
             method,
+            annotations,
             existingVariables,
             parameterAssignment,
             factoryMethod,
             mapNullToDefault,
             loopVariableName,
-            beforeMappingReferences,
-            afterMappingReferences,
+            mappingReferencesMap.get( "before" ),
+            mappingReferencesMap.get( "after" ),
             selectionParameters
         );
         this.helperImports = helperImports;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
@@ -41,6 +41,7 @@ import static org.mapstruct.ap.internal.util.Collections.first;
  */
 public class ValueMappingMethod extends MappingMethod {
 
+    private final List<Annotation> annotations;
     private final List<MappingEntry> valueMappings;
     private final MappingEntry defaultTarget;
     private final MappingEntry nullTarget;
@@ -116,9 +117,16 @@ public class ValueMappingMethod extends MappingMethod {
                 LifecycleMethodResolver.beforeMappingMethods( method, selectionParameters, ctx, existingVariables );
             List<LifecycleCallbackMethodReference> afterMappingMethods =
                 LifecycleMethodResolver.afterMappingMethods( method, selectionParameters, ctx, existingVariables );
-
+            AdditionalAnnotationsBuilder additionalAnnotationsBuilder =
+                    new AdditionalAnnotationsBuilder(
+                            ctx.getElementUtils(),
+                            ctx.getTypeFactory(),
+                            ctx.getMessager() );
+            List<Annotation> annotations = new ArrayList<>();
+            annotations.addAll( additionalAnnotationsBuilder.getProcessedAnnotations( method.getExecutable() ) );
             // finally return a mapping
             return new ValueMappingMethod( method,
+                annotations,
                 mappingEntries,
                 valueMappings.nullValueTarget,
                 valueMappings.defaultTargetValue,
@@ -532,6 +540,7 @@ public class ValueMappingMethod extends MappingMethod {
     }
 
     private ValueMappingMethod(Method method,
+                               List<Annotation> annotations,
                                List<MappingEntry> enumMappings,
                                String nullTarget,
                                String defaultTarget,
@@ -544,6 +553,7 @@ public class ValueMappingMethod extends MappingMethod {
         this.defaultTarget = new MappingEntry( null, defaultTarget != null ? defaultTarget : THROW_EXCEPTION);
         this.unexpectedValueMappingException = unexpectedValueMappingException;
         this.overridden = method.overridesMethod();
+        this.annotations = annotations;
     }
 
     @Override
@@ -588,6 +598,10 @@ public class ValueMappingMethod extends MappingMethod {
 
     public boolean isOverridden() {
         return overridden;
+    }
+
+    public List<Annotation> getAnnotations() {
+        return annotations;
     }
 
     public static class MappingEntry {

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
@@ -6,6 +6,9 @@
 
 -->
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.IterableMappingMethod" -->
+<#list annotations as annotation>
+    <#nt><@includeModel object=annotation/>
+</#list>
 <#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     <#list beforeMappingReferencesWithoutMappingTarget as callback>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
@@ -6,6 +6,9 @@
 
 -->
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.MapMappingMethod" -->
+<#list annotations as annotation>
+    <#nt><@includeModel object=annotation/>
+</#list>
 <#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType /> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     <#list beforeMappingReferencesWithoutMappingTarget as callback>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
@@ -6,6 +6,9 @@
 
 -->
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.StreamMappingMethod" -->
+<#list annotations as annotation>
+    <#nt><@includeModel object=annotation/>
+</#list>
 <#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
     <#--TODO does it even make sense to do a callback if the result is a Stream, as they are immutable-->

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
@@ -6,6 +6,9 @@
 
 -->
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.ValueMappingMethod" -->
+<#list annotations as annotation>
+    <#nt><@includeModel object=annotation/>
+</#list>
 <#if overridden>@Override</#if>
 <#lt>${accessibility.keyword} <@includeModel object=returnType/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>) {
     <#list beforeMappingReferencesWithoutMappingTarget as callback>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2983/Issue2983Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2983/Issue2983Mapper.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2983;
+
+import org.mapstruct.AnnotateWith;
+import org.mapstruct.MapMapping;
+import org.mapstruct.Mapper;
+
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.value.ExternalOrderType;
+import org.mapstruct.ap.test.value.OrderType;
+import org.mapstruct.factory.Mappers;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * @author orange add
+ */
+@Mapper
+public interface Issue2983Mapper {
+
+    Issue2983Mapper INSTANCE = Mappers.getMapper( Issue2983Mapper.class );
+
+    @AnnotateWith(Deprecated.class)
+    Target map(Source source);
+
+    @AnnotateWith(Deprecated.class)
+    List<String> toStringList(List<Integer> integers);
+
+    @AnnotateWith(Deprecated.class)
+    Stream<String> toStringStream(Stream<Integer> integerStream);
+
+    @MapMapping(valueDateFormat = "dd.MM.yyyy")
+    @AnnotateWith(Deprecated.class)
+    Map<String, String> longDateMapToStringStringMap(Map<Long, Date> source);
+
+    @ValueMappings({
+            @ValueMapping(target = "SPECIAL", source = "EXTRA"),
+            @ValueMapping(target = "DEFAULT", source = "STANDARD"),
+            @ValueMapping(target = "DEFAULT", source = "NORMAL")
+    })
+    @AnnotateWith(Deprecated.class)
+    ExternalOrderType orderTypeToExternalOrderType(OrderType orderType);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2983/Issue2983Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2983/Issue2983Test.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2983;
+
+import org.mapstruct.ap.test.value.ExternalOrderType;
+import org.mapstruct.ap.test.value.OrderType;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author orange add
+ */
+
+@WithClasses({Issue2983Mapper.class, Source.class, Target.class, OrderType.class, ExternalOrderType.class})
+public class Issue2983Test {
+
+    @ProcessorTest
+    void shouldContainAnnotationWithNormalTypeMappingMethod() throws NoSuchMethodException {
+        Class<? extends Issue2983Mapper> instanceClass = Issue2983Mapper.INSTANCE.getClass();
+        Method map = instanceClass.getMethod( "map", Source.class );
+        Method toStringList = instanceClass.getMethod( "toStringList", List.class );
+        Method toStringStream = instanceClass.getMethod( "toStringStream", Stream.class );
+        Method longDateMapToStringStringMap = instanceClass.getMethod( "longDateMapToStringStringMap", Map.class );
+        assertThat( map.getAnnotation( Deprecated.class ) ).isNotNull();
+        assertThat( toStringList.getAnnotation( Deprecated.class ) ).isNotNull();
+        assertThat( toStringStream.getAnnotation( Deprecated.class ) ).isNotNull();
+        assertThat( longDateMapToStringStringMap.getAnnotation( Deprecated.class ) ).isNotNull();
+    }
+
+    @ProcessorTest
+    void shouldContainAnnotationWithValueMappingMethod() throws NoSuchMethodException {
+        Class<? extends Issue2983Mapper> instanceClass = Issue2983Mapper.INSTANCE.getClass();
+        Method orderTypeToExternalOrderType = instanceClass
+                .getMethod( "orderTypeToExternalOrderType", OrderType.class );
+        assertThat( orderTypeToExternalOrderType.getAnnotation( Deprecated.class ) ).isNotNull();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2983/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2983/Source.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2983;
+
+/**
+ * @author orange add
+ */
+public class Source {
+
+    private  String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2983/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2983/Target.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2983;
+
+/**
+ * @author orange add
+ */
+public class Target {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}


### PR DESCRIPTION
Try to achieve #2983 
Enables `@AnnotateWith` to support `NormalTypeMappingMethod` and `ValueMappingMethod`