### PR TITLE
#2947: fix for wildcard bounded values. 

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/SourceReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/SourceReference.java
@@ -311,7 +311,7 @@ public class SourceReference extends AbstractReference {
             Type newType = type;
             for ( int i = 0; i < entryNames.length; i++ ) {
                 boolean matchFound = false;
-                Type noBoundsType = newType.withoutBounds();
+                Type noBoundsType = newType.hasTypeBound() ? newType.getTypeBound() : newType;
                 ReadAccessor readAccessor = noBoundsType.getReadAccessor( entryNames[i] );
                 if ( readAccessor != null ) {
                     PresenceCheckAccessor presenceChecker = noBoundsType.getPresenceChecker( entryNames[i] );
@@ -432,6 +432,7 @@ public class SourceReference extends AbstractReference {
         PropertyEntry deepestProperty = getDeepestProperty();
         if ( deepestProperty != null ) {
             Type type = deepestProperty.getType();
+            type = type.hasTypeBound() ? type.getTypeBound() : type;
             Map<String, ReadAccessor> newDeepestReadAccessors = type.getPropertyReadAccessors();
             String parameterName = getParameter().getName();
             String deepestPropertyFullName = deepestProperty.getFullName();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -1264,6 +1264,10 @@ public class Type extends ModelElement implements Comparable<Type> {
         return boundingBase;
     }
 
+    public boolean hasTypeBound() {
+        return getTypeBound() != null;
+    }
+
     public boolean hasAccessibleConstructor() {
         if ( hasAccessibleConstructor == null ) {
             hasAccessibleConstructor = false;

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/Source.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.generics.wildcardextends;
+
+/**
+ * @author Ben Zegveld
+ */
+public class Source<T extends WildcardedInterface> {
+    private T object;
+
+    public T getObject() {
+        return object;
+    }
+
+    public void setObject(T object) {
+        this.object = object;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/Target.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.generics.wildcardextends;
+
+/**
+ * @author Ben Zegveld
+ */
+public class Target {
+    String object;
+
+    public String getObject() {
+        return object;
+    }
+
+    public void setObject(String object) {
+        this.object = object;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/WildcardExtendsMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/WildcardExtendsMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.generics.wildcardextends;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Ben Zegveld
+ */
+@Mapper
+public abstract class WildcardExtendsMapper {
+    public static final WildcardExtendsMapper INSTANCE = Mappers.getMapper( WildcardExtendsMapper.class );
+
+    @Mapping( target = "object", source = "object" )
+    public abstract Target map(Source<?> action);
+
+    String mapToString(WildcardedInterface rawData) {
+        return rawData.getContents();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/WildcardGenericsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/WildcardGenericsTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.generics.wildcardextends;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+/**
+ * @author Ben Zegveld
+ */
+@IssueKey( "2947" )
+@WithClasses( { Source.class, Target.class, WildcardedInterface.class } )
+class WildcardGenericsTest {
+
+    @ProcessorTest
+    @WithClasses( { WildcardExtendsMapper.class } )
+    void mapsWithWildcardSuccesfully() {
+        Source<WildcardedInterfaceImpl> source = new Source<>();
+        source.setObject( new WildcardedInterfaceImpl() );
+        source.getObject().setContents( "Test contents" );
+
+        Target target = WildcardExtendsMapper.INSTANCE.map( source );
+
+        assertThat( target.getObject() ).isEqualTo( "Test contents" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/WildcardedInterface.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/WildcardedInterface.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.generics.wildcardextends;
+
+/**
+ * @author Ben Zegveld
+ */
+public interface WildcardedInterface {
+
+    String getContents();
+
+    void setContents(String contents);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/WildcardedInterfaceImpl.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/wildcardextends/WildcardedInterfaceImpl.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.generics.wildcardextends;
+
+/**
+ * @author Ben Zegveld
+ */
+class WildcardedInterfaceImpl implements WildcardedInterface {
+
+    private String contents;
+
+    @Override
+    public String getContents() {
+        return contents;
+    }
+
+    @Override
+    public void setContents(String contents) {
+        this.contents = contents;
+    }
+
+}


### PR DESCRIPTION
Got the given example situation working and all other tests still pass.
- [ ] Add testcase with super wildcard.
- [ ] rename test package to be more generic for extends/super wildcard usage. maybe `typebound` instead of `wildcardextends`.

Already created the PR so that the fix is already reviewable. (Only planning on adding more tests not changing more code)