### PR TITLE
Replace old issue template with new GitHub issue form templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,45 @@
+name: Bug report
+description: Create a report and help us improve
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please fill in all required fields with as many details as possible.
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: |
+        Describe what you were expecting MapStruct to do
+      placeholder: |
+        Here you can also add the generated code that you would like MapStruct to generate
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: |
+        Describe what you observed MapStruct did instead
+      placeholder: |
+        Here you can also add the generated code that MapStruct generated
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce the problem
+      description: |
+        - Share your mapping configuration
+        - An [MCVE (Minimal Complete Verifiable Example)](https://stackoverflow.com/help/minimal-reproducible-example) can be helpful to provide a complete reproduction case
+      placeholder: |
+        Share your MapStruct configuration
+    validations:
+      required: true
+  - type: input
+    id: mapstruct-version
+    attributes:
+      label: MapStruct Version
+      description: |
+        Which MapStruct version did you use?
+        Note: While you can obviously continue using older versions of MapStruct, it may well be that your bug is already fixed. If you're using an older version, please also try to reproduce the bug in the latest version of MapStruct before reporting it.
+      placeholder: ex. MapStruct 1.5.2
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,16 @@
+contact_links:
+  - name: MapStruct Discussions
+    url: https://github.com/mapstruct/mapstruct/discussions
+    about: Please use the MapStruct GitHub Discussions for open ended discussions and to reach out to the community.
+  - name: Stack Overflow
+    url: https://stackoverflow.com/questions/tagged/mapstruct
+    about: For questions about how to use MapStruct, consider asking your question on Stack Overflow, tagged [mapstruct].
+  - name: Documentation
+    url: https://mapstruct.org/documentation/stable/reference/html/
+    about: The MapStruct reference documentation.
+  - name: Gitter Chat
+    url: https://gitter.im/mapstruct/mapstruct-users
+    about: For realtime communication with the MapStruct community, consider writing in our Gitter chat room.
+  - name: MapStruct Examples
+    url: https://github.com/mapstruct/mapstruct-examples
+    about: Some examples of what can be achieved with MapStruct. (contributions are always welcome)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,43 @@
+name: Feature Request
+description: Suggest an idea
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Please describe the use-case you have. This will better help us understand the context in which you're looking for a new feature.
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: |
+        Please describe the use-case you have. This will better help us understand the context in which you're looking for a new feature.
+      placeholder: Describe the use-case here
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Generated Code
+      description: |
+        Please describe the possible generated code you'd like to see in MapStruct generate.
+        Please note, it's not always easy to describe a good solution. Describing the use-case above is much more important to us.
+      placeholder: Describe the possible solution here.
+    validations:
+      required: false
+  - type: textarea
+    id: workarounds
+    attributes:
+      label: Possible workarounds
+      description: |
+        Please describe the possible workarounds you've implemented to work around the lacking functionality.
+      placeholder: Describe the possible workarounds here.
+    validations:
+      required: false
+  - type: input
+    id: mapstruct-version
+    attributes:
+      label: MapStruct Version
+      description: What MapStruct version and edition did you try?
+      placeholder: ex. MapStruct 1.5.2
+    validations:
+      required: false

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,9 +1,0 @@
-- [ ] Is this an issue (and hence not a question)? 
-
-If this is a question how to use MapStruct there are several resources available.
-- Our reference- and API [documentation](http://mapstruct.org/documentation/reference-guide/).
-- Our [examples](https://github.com/mapstruct/mapstruct-examples) repository (contributions always welcome)
-- Our [FAQ](http://mapstruct.org/faq/)
-- [StackOverflow](https://stackoverflow.com), tag MapStruct 
-- [Gitter](https://gitter.im/mapstruct/mapstruct-users) (you usually get fast feedback)
-- Our [google group](https://groups.google.com/forum/#!forum/mapstruct-users)


### PR DESCRIPTION
Fixes #3008

This adds new issue templates to our repo.

With this templates when a user clicks on "New Issue" they will see:

![image](https://user-images.githubusercontent.com/6012094/188303145-30b1ffc6-b6aa-4b7c-9977-f442ead8c9d3.png)

Creating a bug report looks like:

![image](https://user-images.githubusercontent.com/6012094/188303161-af4c05dd-e829-40c0-8f63-cf60e22451ac.png)

Creating a feature request looks like:

![image](https://user-images.githubusercontent.com/6012094/188303175-7c9acba4-e333-46d4-831c-2e800a48f49c.png)

Note: The work in this PR has been inspired by what jOOQ offers with their own issue templates https://github.com/jOOQ/jOOQ/issues/new/choose