### PR TITLE
Invoke super class constructor on abstract mappers

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractClassConstructor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractClassConstructor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.ModelElement;
+import org.mapstruct.ap.internal.model.common.Type;
+
+/**
+ * Represents a constructor compatible with an abstract superclass
+ *
+ * @author Marvin Froeder
+ */
+public class AbstractClassConstructor extends ModelElement implements Constructor {
+
+    private final String name;
+    private final List<MapperReference> superclassParameters;
+    private final List<MapperReference> extraParameters;
+    private final List<Annotation> annotations;
+
+    public AbstractClassConstructor(String name, List<MapperReference> superclassParameters,
+                                    List<MapperReference> extraParameters, List<Annotation> annotations) {
+        this.name = name;
+        this.superclassParameters = superclassParameters;
+        this.extraParameters = extraParameters;
+        this.annotations = annotations;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        Set<Type> types = new HashSet<>();
+
+        for ( MapperReference mapperReference : superclassParameters ) {
+            types.addAll( mapperReference.getImportTypes() );
+        }
+
+        for ( MapperReference mapperReference : extraParameters ) {
+            types.addAll( mapperReference.getImportTypes() );
+        }
+
+        for ( Annotation annotation : annotations ) {
+            types.addAll( annotation.getImportTypes() );
+        }
+
+        return types;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public List<MapperReference> getSuperclassParameters() {
+        return superclassParameters;
+    }
+
+    public List<MapperReference> getExtraParameters() {
+        return extraParameters;
+    }
+
+    public List<Annotation> getAnnotations() {
+        return annotations;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/AbstractClassConstructorProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/AbstractClassConstructorProcessor.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.processor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.util.ElementFilter;
+import org.mapstruct.ap.internal.model.AbstractClassConstructor;
+import org.mapstruct.ap.internal.model.AnnotatedConstructor;
+import org.mapstruct.ap.internal.model.Annotation;
+import org.mapstruct.ap.internal.model.Constructor;
+import org.mapstruct.ap.internal.model.Mapper;
+import org.mapstruct.ap.internal.model.MapperReference;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.common.TypeFactory;
+
+/**
+ * An {@link ModelElementProcessor} which processes abstract classes and creates a constructor compatible constructor
+ * for the declared {@link TypeElement}
+ *
+ * @author Marvin Froeder
+ */
+public class AbstractClassConstructorProcessor implements ModelElementProcessor<Mapper, Mapper> {
+
+    class SimpleMapperReference extends MapperReference {
+
+        SimpleMapperReference(Type type, String variableName) {
+            super( type, variableName );
+        }
+
+    }
+
+    @Override
+    public int getPriority() {
+        return 2000;
+    }
+
+    @Override
+    public Mapper process(ProcessorContext context, TypeElement mapperTypeElement, Mapper mapper) {
+        if ( !mapperTypeElement.getModifiers().contains( Modifier.ABSTRACT ) ) {
+            return mapper;
+        }
+
+        List<ExecutableElement> constructors = ElementFilter.constructorsIn( mapperTypeElement.getEnclosedElements() );
+        if ( constructors.isEmpty() ) {
+            return mapper;
+        }
+
+        List<MapperReference> superclassParameters = mapperReferences( context, mapperTypeElement );
+
+        List<MapperReference> extraParameters = new ArrayList<>();
+        List<Annotation> annotations = new ArrayList<>();
+
+        Constructor constructor = mapper.getConstructor();
+        if ( constructor instanceof AnnotatedConstructor ) {
+            AnnotatedConstructor annotatedConstructor = (AnnotatedConstructor) constructor;
+            annotations = annotatedConstructor.getAnnotations();
+            extraParameters.addAll( annotatedConstructor.getMapperReferences() );
+        }
+
+        if ( !superclassParameters.isEmpty() ) {
+            mapper.setConstructor( new AbstractClassConstructor( mapper.getName(), superclassParameters,
+                extraParameters, annotations ) );
+        }
+
+        return mapper;
+    }
+
+    private List<MapperReference> mapperReferences(ProcessorContext context, TypeElement mapperTypeElement) {
+        List<ExecutableElement> constructors = ElementFilter.constructorsIn( mapperTypeElement.getEnclosedElements() );
+
+        if ( constructors.size() != 1 ) {
+            throw new RuntimeException();
+        }
+
+        List<MapperReference> mapperReferences = constructors.get( 0 ).getParameters().stream()
+                        .map( element -> toMapperReference( context.getTypeFactory(), element ) )
+                        .collect( Collectors.toList() );
+
+        return mapperReferences;
+    }
+
+    private SimpleMapperReference toMapperReference(TypeFactory typeFactory, VariableElement element) {
+        return new SimpleMapperReference( typeFactory.getType( element.asType() ), element.getSimpleName().toString() );
+    }
+
+}

--- a/processor/src/main/resources/META-INF/services/org.mapstruct.ap.internal.processor.ModelElementProcessor
+++ b/processor/src/main/resources/META-INF/services/org.mapstruct.ap.internal.processor.ModelElementProcessor
@@ -2,6 +2,7 @@
 #
 # Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
 
+org.mapstruct.ap.internal.processor.AbstractClassConstructorProcessor
 org.mapstruct.ap.internal.processor.CdiComponentProcessor
 org.mapstruct.ap.internal.processor.JakartaCdiComponentProcessor
 org.mapstruct.ap.internal.processor.Jsr330ComponentProcessor

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/AbstractClassConstructor.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/AbstractClassConstructor.ftl
@@ -1,0 +1,18 @@
+ <#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+ <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.AbstractClassConstructor" -->
+
+<#list annotations as annotation>
+    <#nt><@includeModel object=annotation/>
+</#list>
+public ${name}( <#list superclassParameters as mapperReference><@includeModel object=mapperReference.type/> ${mapperReference.variableName}<#if mapperReference_has_next>, </#if></#list><#list extraParameters as mapperReference>, <@includeModel object=mapperReference.type/> ${mapperReference.variableName}</#list> ) {
+    super( <#list superclassParameters as mapperReference>${mapperReference.variableName}<#if mapperReference_has_next>, </#if></#list> );
+    <#list extraParameters as mapperReference>
+        this.${mapperReference.variableName} = ${mapperReference.variableName};
+    </#list>
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/AbstractMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/AbstractMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.copyabstractconstructor;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper
+public abstract class AbstractMapper {
+
+    public AbstractMapper(String value) {
+
+    }
+
+    @Mapping( target = "updatedOnTarget", source = "updatedOn" )
+    abstract Target map(Source source);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/CSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/CSource.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.copyabstractconstructor;
+
+public class CSource {
+
+    private Source data;
+
+    public Source getData() {
+        return data;
+    }
+
+    public void setData(Source data) {
+        this.data = data;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/CTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/CTarget.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.copyabstractconstructor;
+
+public class CTarget {
+
+    private Target data;
+
+    public Target getData() {
+        return data;
+    }
+
+    public void setData(Target data) {
+        this.data = data;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/CopyAbstractConstructorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/CopyAbstractConstructorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.copyabstractconstructor;
+
+import static java.lang.System.lineSeparator;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithSpring;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+@WithClasses( { AbstractMapper.class, UsesMapper.class, Source.class, Target.class, CSource.class, CTarget.class } )
+@WithSpring
+public class CopyAbstractConstructorTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveConstructor() {
+        generatedSource.forMapper( AbstractMapper.class )
+            .content()
+            .contains( "    public AbstractMapperImpl( String value ) {" + lineSeparator() +
+                "        super( value );" );
+    }
+
+    @ProcessorTest
+    public void springConstructor() {
+        generatedSource.forMapper( UsesMapper.class )
+            .content()
+            .contains( "private final AbstractMapper abstractMapper" )
+            .contains( "@Autowired" + lineSeparator() +
+                "    public UsesMapperImpl( Integer reference, AbstractMapper abstractMapper ) {"
+                + lineSeparator() +
+                "        super( reference );" + lineSeparator() +
+                "        this.abstractMapper = abstractMapper;" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/Source.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.copyabstractconstructor;
+
+public class Source {
+
+    private Long updatedOn;
+
+    public Source() {
+    }
+
+    public Long getUpdatedOn() {
+        return updatedOn;
+    }
+
+    public void setUpdatedOn(Long updatedOn) {
+        this.updatedOn = updatedOn;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/Target.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.copyabstractconstructor;
+
+public class Target {
+
+    private long updatedOnTarget;
+
+    public long getUpdatedOnTarget() {
+        return updatedOnTarget;
+    }
+
+    public void setUpdatedOnTarget(long updatedOnTarget) {
+        this.updatedOnTarget = updatedOnTarget;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/UsesMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/copyabstractconstructor/UsesMapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.copyabstractconstructor;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+
+@Mapper( componentModel = "spring", injectionStrategy = InjectionStrategy.CONSTRUCTOR, uses = AbstractMapper.class )
+public abstract class UsesMapper {
+
+    public UsesMapper(Integer reference) {
+
+    }
+
+    abstract CTarget targetToSourceReversed(CSource source);
+
+}


### PR DESCRIPTION
This is most useful on CDI environments.

I have a few abstract class mappers that have a few spring inject beans.  But, I can't use constructor injection as is.  This change would allow me to use constructor injection