### PR TITLE
fix(sec): upgrade freemarker to 2.3.30

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -109,7 +109,7 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.21</version>
+                <version>2.3.30</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>


### PR DESCRIPTION
Upgrade freemarker from 2.3.21 to 2.3.30 for vulnerability fix:
- [MPS-2022-12438](https://www.oscs1024.com/hd/MPS-2022-12438)