### PR TITLE
fix(sec): upgrade org.freemarker:freemarker to 2.3.30

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -109,7 +109,7 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.21</version>
+                <version>2.3.30</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.freemarker:freemarker 2.3.21
- [MPS-2022-12438](https://www.oscs1024.com/hd/MPS-2022-12438)


### What did I do？
Upgrade org.freemarker:freemarker from 2.3.21 to 2.3.30 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS