### PR TITLE
#2863 Add validation of String type to @TargetPropertyName

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -173,6 +173,7 @@ public enum Message {
     RETRIEVAL_MAPPER_USES_CYCLE( "The mapper %s is referenced itself in Mapper#uses.", Diagnostic.Kind.WARNING ),
     RETRIEVAL_AFTER_METHOD_NOT_IMPLEMENTED( "@AfterMapping can only be applied to an implemented method." ),
     RETRIEVAL_BEFORE_METHOD_NOT_IMPLEMENTED( "@BeforeMapping can only be applied to an implemented method." ),
+    RETRIEVAL_TARGET_PROPERTY_NAME_WRONG_TYPE( "@TargetPropertyName can only by applied to a String parameter." ),
 
     INHERITINVERSECONFIGURATION_DUPLICATES( "Several matching inverse methods exist: %s(). Specify a name explicitly." ),
     INHERITINVERSECONFIGURATION_INVALID_NAME( "None of the candidates %s() matches given name: \"%s\"." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/conditional/targetpropertyname/ErroneousNonStringTargetPropertyNameParameter.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conditional/targetpropertyname/ErroneousNonStringTargetPropertyNameParameter.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.conditional.targetpropertyname;
+
+import org.mapstruct.Condition;
+import org.mapstruct.Mapper;
+import org.mapstruct.TargetPropertyName;
+
+@Mapper
+public interface ErroneousNonStringTargetPropertyNameParameter {
+
+    Employee map(EmployeeDto employee);
+
+    @Condition
+    default boolean isNotBlank(String value, @TargetPropertyName int propName) {
+        return value != null && !value.trim().isEmpty();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/conditional/targetpropertyname/TargetPropertyNameTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/conditional/targetpropertyname/TargetPropertyNameTest.java
@@ -9,6 +9,9 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
 import java.util.Collections;
@@ -277,5 +280,25 @@ public class TargetPropertyNameTest {
                 "addresses",
                 "addresses.street"
             );
+    }
+
+    @IssueKey("2863")
+    @ProcessorTest
+    @WithClasses({
+        ErroneousNonStringTargetPropertyNameParameter.class
+    })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                type = ErroneousNonStringTargetPropertyNameParameter.class,
+                line = 18,
+                message = "@TargetPropertyName can only by applied to a String parameter."
+            )
+        }
+    )
+    public void nonStringTargetPropertyNameParameter() {
+
     }
 }


### PR DESCRIPTION
Check that a parameter annotated with @TargetPropertyName is String and report an error.

With the following mapper:

```java
@Mapper
public interface ErroneousNonStringTargetPropertyNameParameter {

    Employee map(EmployeeDto employee);

    @Condition
    default boolean isNotBlank(String value, @TargetPropertyName int propName) { // propName is int
        return value != null && !value.trim().isEmpty();
    }
}
```

Compilation will fail with this error message:

> error: @TargetPropertyName can only by applied to a String parameter.

Fixes #2863

