### PR TITLE
#3119 Add qualifiedBy and qualifiedByName to SubclassMapping annotation

### DIFF
--- a/core/src/main/java/org/mapstruct/Qualifier.java
+++ b/core/src/main/java/org/mapstruct/Qualifier.java
@@ -21,6 +21,7 @@ import java.lang.annotation.Target;
  * <li>{@link IterableMapping#qualifiedBy() }</li>
  * <li>{@link MapMapping#keyQualifiedBy() }</li>
  * <li>{@link MapMapping#valueQualifiedBy() }</li>
+ * <li>{@link SubclassMapping#qualifiedBy() }</li>
  * </ul>
  * <p><strong>Example:</strong></p>
  * <pre><code class='java'>

--- a/core/src/main/java/org/mapstruct/SubclassMapping.java
+++ b/core/src/main/java/org/mapstruct/SubclassMapping.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
@@ -81,4 +82,29 @@ public @interface SubclassMapping {
      * @return the target subclass to map the source to.
      */
     Class<?> target();
+
+    /**
+     * A qualifier can be specified to aid the selection process of a suitable mapper. This is useful in case multiple
+     * mapping methods (hand written or generated) qualify and thus would result in an 'Ambiguous mapping methods found'
+     * error. A qualifier is a custom annotation and can be placed on a hand written mapper class or a method.
+     *
+     * @return the qualifiers
+     * @see Qualifier
+     */
+    Class<? extends Annotation>[] qualifiedBy() default {};
+
+    /**
+     * String-based form of qualifiers; When looking for a suitable mapping method for a given property, MapStruct will
+     * only consider those methods carrying directly or indirectly (i.e. on the class-level) a {@link Named} annotation
+     * for each of the specified qualifier names.
+     * <p>
+     * Note that annotation-based qualifiers are generally preferable as they allow more easily to find references and
+     * are safe for refactorings, but name-based qualifiers can be a less verbose alternative when requiring a large
+     * number of qualifiers as no custom annotation types are needed.
+     *
+     * @return One or more qualifier name(s)
+     * @see #qualifiedBy()
+     * @see Named
+     */
+    String[] qualifiedByName() default {};
 }

--- a/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
@@ -141,6 +141,8 @@ In the case that the `Fruit` is an abstract class or an interface, you would get
 To allow mappings for abstract classes or interfaces you need to set the `subclassExhaustiveStrategy` to `RUNTIME_EXCEPTION`, you can do this at the `@MapperConfig`, `@Mapper` or `@BeanMapping` annotations. If you then pass a `GrapeDto` an `IllegalArgumentException` will be thrown because it is unknown how to map a `GrapeDto`.
 Adding the missing (`@SubclassMapping`) for it will fix that.
 
+<<selection-based-on-qualifiers>> can be used to further control which methods may be chosen to map a specific subclass. For that, you will need to use one of `SubclassMapping#qualifiedByName` or `SubclassMapping#qualifiedBy`.
+
 [TIP]
 ====
 If the mapping method for the subclasses does not exist it will be created and any other annotations on the fruit mapping method will be inherited by the newly generated mappings.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -399,13 +399,10 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 "SubclassMapping for " + sourceType.getFullyQualifiedName() );
             SelectionCriteria criteria =
                 SelectionCriteria
-                                 .forSubclassMappingMethods(
-                                     new SelectionParameters(
-                                         Collections.emptyList(),
-                                         Collections.emptyList(),
-                                         subclassMappingOptions.getTarget(),
-                                         ctx.getTypeUtils() ).withSourceRHS( rightHandSide ),
-                                     subclassMappingOptions.getMappingControl( ctx.getElementUtils() ) );
+                    .forSubclassMappingMethods(
+                        subclassMappingOptions.getSelectionParameters().withSourceRHS( rightHandSide ),
+                        subclassMappingOptions.getMappingControl( ctx.getElementUtils() )
+                    );
             Assignment assignment = ctx
                                    .getMappingResolver()
                                    .getTargetAssignment(
@@ -424,10 +421,13 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             String sourceArgument = null;
             for ( Parameter parameter : method.getSourceParameters() ) {
                 if ( ctx
-                        .getTypeUtils()
-                        .isAssignable( sourceType.getTypeMirror(), parameter.getType().getTypeMirror() ) ) {
+                    .getTypeUtils()
+                    .isAssignable( sourceType.getTypeMirror(), parameter.getType().getTypeMirror() ) ) {
                     sourceArgument = parameter.getName();
-                    assignment.setSourceLocalVarName( "(" + sourceType.createReferenceName() + ") " + sourceArgument );
+                    if ( assignment != null ) {
+                        assignment.setSourceLocalVarName(
+                            "(" + sourceType.createReferenceName() + ") " + sourceArgument );
+                    }
                 }
             }
             return new SubclassMapping( sourceType, sourceArgument, targetType, assignment );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
@@ -33,12 +33,15 @@ public class SubclassMappingOptions extends DelegatingOptions {
     private final TypeMirror source;
     private final TypeMirror target;
     private final TypeUtils typeUtils;
+    private final SelectionParameters selectionParameters;
 
-    public SubclassMappingOptions(TypeMirror source, TypeMirror target, TypeUtils typeUtils, DelegatingOptions next) {
+    public SubclassMappingOptions(TypeMirror source, TypeMirror target, TypeUtils typeUtils, DelegatingOptions next,
+                                  SelectionParameters selectionParameters) {
         super( next );
         this.source = source;
         this.target = target;
         this.typeUtils = typeUtils;
+        this.selectionParameters = selectionParameters;
     }
 
     @Override
@@ -117,6 +120,10 @@ public class SubclassMappingOptions extends DelegatingOptions {
         return target;
     }
 
+    public SelectionParameters getSelectionParameters() {
+        return selectionParameters;
+    }
+
     public static void addInstances(SubclassMappingsGem gem, ExecutableElement method,
                                     BeanMappingOptions beanMappingOptions, FormattingMessager messager,
                                     TypeUtils typeUtils, Set<SubclassMappingOptions> mappings,
@@ -154,6 +161,12 @@ public class SubclassMappingOptions extends DelegatingOptions {
 
         TypeMirror sourceSubclass = subclassMapping.source().getValue();
         TypeMirror targetSubclass = subclassMapping.target().getValue();
+        SelectionParameters selectionParameters = new SelectionParameters(
+            subclassMapping.qualifiedBy().get(),
+            subclassMapping.qualifiedByName().get(),
+            targetSubclass,
+            typeUtils
+        );
 
         mappings
                 .add(
@@ -161,20 +174,24 @@ public class SubclassMappingOptions extends DelegatingOptions {
                         sourceSubclass,
                         targetSubclass,
                         typeUtils,
-                        beanMappingOptions ) );
+                        beanMappingOptions,
+                        selectionParameters
+                    ) );
     }
 
     public static List<SubclassMappingOptions> copyForInverseInheritance(Set<SubclassMappingOptions> subclassMappings,
-                                                                        BeanMappingOptions beanMappingOptions) {
+                                                                         BeanMappingOptions beanMappingOptions) {
         // we are not interested in keeping it unique at this point.
         List<SubclassMappingOptions> mappings = new ArrayList<>();
         for ( SubclassMappingOptions subclassMapping : subclassMappings ) {
             mappings.add(
-                        new SubclassMappingOptions(
-                                   subclassMapping.target,
-                                   subclassMapping.source,
-                                   subclassMapping.typeUtils,
-                                   beanMappingOptions ) );
+                new SubclassMappingOptions(
+                    subclassMapping.target,
+                    subclassMapping.source,
+                    subclassMapping.typeUtils,
+                    beanMappingOptions,
+                    subclassMapping.selectionParameters
+                ) );
         }
         return mappings;
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/Composer.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/Composer.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+public class Composer {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/ComposerDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/ComposerDto.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+public class ComposerDto {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/ErroneousSubclassQualifiedByMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/ErroneousSubclassQualifiedByMapper.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.SubclassMapping;
+
+@Mapper(uses = { RossiniMapper.class, VivaldiMapper.class })
+public interface ErroneousSubclassQualifiedByMapper {
+    @SubclassMapping(source = Rossini.class, target = RossiniDto.class, qualifiedBy = NonExistent.class)
+    @SubclassMapping(source = Vivaldi.class, target = VivaldiDto.class)
+    ComposerDto toDto(Composer composer);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/ErroneousSubclassQualifiedByNameMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/ErroneousSubclassQualifiedByNameMapper.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.SubclassMapping;
+
+@Mapper(uses = { RossiniMapper.class, VivaldiMapper.class })
+public interface ErroneousSubclassQualifiedByNameMapper {
+    @SubclassMapping(source = Rossini.class, target = RossiniDto.class, qualifiedByName = "non-existent")
+    @SubclassMapping(source = Vivaldi.class, target = VivaldiDto.class)
+    ComposerDto toDto(Composer composer);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/Light.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/Light.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.mapstruct.Qualifier;
+
+@Qualifier
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface Light {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/NonExistent.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/NonExistent.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.mapstruct.Qualifier;
+
+@Qualifier
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface NonExistent {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/Rossini.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/Rossini.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import java.util.List;
+
+public class Rossini extends Composer {
+    private List<String> crescendo;
+
+    public List<String> getCrescendo() {
+        return crescendo;
+    }
+
+    public void setCrescendo(List<String> crescendo) {
+        this.crescendo = crescendo;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/RossiniDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/RossiniDto.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import java.util.List;
+
+public class RossiniDto extends ComposerDto {
+    private List<String> crescendo;
+
+    public List<String> getCrescendo() {
+        return crescendo;
+    }
+
+    public void setCrescendo(List<String> crescendo) {
+        this.crescendo = crescendo;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/RossiniMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/RossiniMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+@Mapper
+public interface RossiniMapper {
+    RossiniDto toDto(Rossini rossini);
+
+    @Light
+    @Mapping(target = "crescendo", ignore = true)
+    RossiniDto toDtoLight(Rossini source);
+
+    @Named("light")
+    @Mapping(target = "crescendo", ignore = true)
+    RossiniDto toDtoLightNamed(Rossini source);
+
+    @Unused
+    @BeanMapping(ignoreByDefault = true)
+    RossiniDto toDtoUnused(Rossini source);
+
+    @Named("unused")
+    @BeanMapping(ignoreByDefault = true)
+    RossiniDto toDtoUnusedNamed(Rossini source);
+
+    Rossini fromDto(RossiniDto rossini);
+
+    @Light
+    @Mapping(target = "crescendo", ignore = true)
+    Rossini fromDtoLight(RossiniDto source);
+
+    @Named("light")
+    @Mapping(target = "crescendo", ignore = true)
+    Rossini fromDtoLightNamed(RossiniDto source);
+
+    @Unused
+    @BeanMapping(ignoreByDefault = true)
+    Rossini fromDtoUnused(RossiniDto source);
+
+    @Named("unused")
+    @BeanMapping(ignoreByDefault = true)
+    Rossini fromDtoUnusedNamed(RossiniDto source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/SubclassQualifiedByMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/SubclassQualifiedByMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.SubclassMapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = { RossiniMapper.class, VivaldiMapper.class })
+public interface SubclassQualifiedByMapper {
+    SubclassQualifiedByMapper INSTANCE = Mappers.getMapper( SubclassQualifiedByMapper.class );
+
+    @SubclassMapping(source = Rossini.class, target = RossiniDto.class)
+    @SubclassMapping(source = Vivaldi.class, target = VivaldiDto.class)
+    ComposerDto toDto(Composer composer);
+
+    @SubclassMapping(source = Rossini.class, target = RossiniDto.class, qualifiedBy = Light.class)
+    @SubclassMapping(source = Vivaldi.class, target = VivaldiDto.class, qualifiedBy = Light.class)
+    ComposerDto toDtoLight(Composer composer);
+
+    @SubclassMapping(source = Rossini.class, target = RossiniDto.class)
+    @SubclassMapping(source = Vivaldi.class, target = VivaldiDto.class, qualifiedBy = Light.class)
+    ComposerDto toDtoLightJustVivaldi(Composer composer);
+
+    @InheritInverseConfiguration(name = "toDto")
+    Composer fromDto(ComposerDto composer);
+
+    @InheritInverseConfiguration(name = "toDtoLight")
+    Composer fromDtoLight(ComposerDto composer);
+
+    @InheritInverseConfiguration(name = "toDtoLightJustVivaldi")
+    Composer fromDtoLightJustVivaldi(ComposerDto composer);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/SubclassQualifiedByNameMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/SubclassQualifiedByNameMapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.SubclassMapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = { RossiniMapper.class, VivaldiMapper.class })
+public interface SubclassQualifiedByNameMapper {
+    SubclassQualifiedByNameMapper INSTANCE = Mappers.getMapper( SubclassQualifiedByNameMapper.class );
+
+    @SubclassMapping(source = Rossini.class, target = RossiniDto.class)
+    @SubclassMapping(source = Vivaldi.class, target = VivaldiDto.class)
+    ComposerDto toDto(Composer composer);
+
+    @SubclassMapping(source = Rossini.class, target = RossiniDto.class, qualifiedByName = "light")
+    @SubclassMapping(source = Vivaldi.class, target = VivaldiDto.class, qualifiedByName = "light")
+    ComposerDto toDtoLight(Composer composer);
+
+    @SubclassMapping(source = Rossini.class, target = RossiniDto.class)
+    @SubclassMapping(source = Vivaldi.class, target = VivaldiDto.class, qualifiedByName = "light")
+    ComposerDto toDtoLightJustVivaldi(Composer composer);
+
+    @InheritInverseConfiguration(name = "toDto")
+    Composer fromDto(ComposerDto composer);
+
+    @InheritInverseConfiguration(name = "toDtoLight")
+    Composer fromDtoLight(ComposerDto composer);
+
+    @InheritInverseConfiguration(name = "toDtoLightJustVivaldi")
+    Composer fromDtoLightJustVivaldi(ComposerDto composer);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/SubclassQualifierMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/SubclassQualifierMapperTest.java
@@ -1,0 +1,297 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses({
+    Composer.class,
+    ComposerDto.class,
+    Rossini.class,
+    RossiniDto.class,
+    Vivaldi.class,
+    VivaldiDto.class,
+    VivaldiDto.class,
+    VivaldiDto.class,
+    Light.class,
+    Unused.class,
+    NonExistent.class,
+    RossiniMapper.class,
+    VivaldiMapper.class
+})
+@IssueKey("3119")
+public class SubclassQualifierMapperTest {
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses(SubclassQualifiedByMapper.class)
+    void subclassQualifiedBy() {
+        Rossini rossini = buildRossini();
+
+        Vivaldi vivaldi = buildVivaldi();
+
+        RossiniDto rossiniDto = (RossiniDto) SubclassQualifiedByMapper.INSTANCE.toDto( rossini );
+        RossiniDto rossiniDtoLight = (RossiniDto) SubclassQualifiedByMapper.INSTANCE.toDtoLight( rossini );
+
+        VivaldiDto vivaldiDto = (VivaldiDto) SubclassQualifiedByMapper.INSTANCE.toDto( vivaldi );
+        VivaldiDto vivaldiDtoLight = (VivaldiDto) SubclassQualifiedByMapper.INSTANCE.toDtoLight( vivaldi );
+
+        assertThat( rossiniDto.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossiniDto.getCrescendo() ).containsExactly( "andante", "allegro", "vivace" );
+        assertThat( rossiniDtoLight.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossiniDtoLight.getCrescendo() ).isNull();
+
+        assertThat( vivaldiDto.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldiDto.getSeasons() ).containsExactly( "spring", "winter" );
+        assertThat( vivaldiDtoLight.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldiDtoLight.getSeasons() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses(SubclassQualifiedByMapper.class)
+    void subclassQualifiedByOnlyOne() {
+        Rossini rossini = buildRossini();
+
+        Vivaldi vivaldi = buildVivaldi();
+
+        RossiniDto rossiniDto = (RossiniDto) SubclassQualifiedByMapper.INSTANCE.toDtoLightJustVivaldi( rossini );
+
+        VivaldiDto vivaldiDto = (VivaldiDto) SubclassQualifiedByMapper.INSTANCE.toDtoLightJustVivaldi( vivaldi );
+
+        assertThat( rossiniDto.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossiniDto.getCrescendo() ).containsExactly( "andante", "allegro", "vivace" );
+
+        assertThat( vivaldiDto.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldiDto.getSeasons() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses(SubclassQualifiedByNameMapper.class)
+    void subclassQualifiedByName() {
+        Rossini rossini = buildRossini();
+
+        Vivaldi vivaldi = buildVivaldi();
+
+        RossiniDto rossiniDto = (RossiniDto) SubclassQualifiedByNameMapper.INSTANCE.toDto( rossini );
+        RossiniDto rossiniDtoLight = (RossiniDto) SubclassQualifiedByNameMapper.INSTANCE.toDtoLight( rossini );
+
+        VivaldiDto vivaldiDto = (VivaldiDto) SubclassQualifiedByNameMapper.INSTANCE.toDto( vivaldi );
+        VivaldiDto vivaldiDtoLight = (VivaldiDto) SubclassQualifiedByNameMapper.INSTANCE.toDtoLight( vivaldi );
+
+        assertThat( rossiniDto.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossiniDto.getCrescendo() ).containsExactly( "andante", "allegro", "vivace" );
+        assertThat( rossiniDtoLight.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossiniDtoLight.getCrescendo() ).isNull();
+
+        assertThat( vivaldiDto.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldiDto.getSeasons() ).containsExactly( "spring", "winter" );
+        assertThat( vivaldiDtoLight.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldiDtoLight.getSeasons() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses(SubclassQualifiedByNameMapper.class)
+    void subclassQualifiedByNameOnlyOne() {
+        Rossini rossini = buildRossini();
+
+        Vivaldi vivaldi = buildVivaldi();
+
+        RossiniDto rossiniDto = (RossiniDto) SubclassQualifiedByNameMapper.INSTANCE.toDtoLightJustVivaldi( rossini );
+
+        VivaldiDto vivaldiDto = (VivaldiDto) SubclassQualifiedByNameMapper.INSTANCE.toDtoLightJustVivaldi( vivaldi );
+
+        assertThat( rossiniDto.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossiniDto.getCrescendo() ).containsExactly( "andante", "allegro", "vivace" );
+
+        assertThat( vivaldiDto.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldiDto.getSeasons() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses(SubclassQualifiedByMapper.class)
+    void subclassQualifiedByInverse() {
+        RossiniDto rossiniDto = buildRossiniDto();
+
+        VivaldiDto vivaldiDto = buildVivaldiDto();
+
+        Rossini rossini = (Rossini) SubclassQualifiedByMapper.INSTANCE.fromDto( rossiniDto );
+        Rossini rossiniLight = (Rossini) SubclassQualifiedByMapper.INSTANCE.fromDtoLight( rossiniDto );
+
+        Vivaldi vivaldi = (Vivaldi) SubclassQualifiedByMapper.INSTANCE.fromDto( vivaldiDto );
+        Vivaldi vivaldiLight = (Vivaldi) SubclassQualifiedByMapper.INSTANCE.fromDtoLight( vivaldiDto );
+
+        assertThat( rossini.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossini.getCrescendo() ).containsExactly( "andante", "allegro", "vivace" );
+        assertThat( rossiniLight.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossiniLight.getCrescendo() ).isNull();
+
+        assertThat( vivaldi.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldi.getSeasons() ).containsExactly( "spring", "winter" );
+        assertThat( vivaldiLight.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldiLight.getSeasons() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses(SubclassQualifiedByMapper.class)
+    void subclassQualifiedByOnlyOneInverse() {
+        RossiniDto rossiniDto = buildRossiniDto();
+
+        VivaldiDto vivaldiDto = buildVivaldiDto();
+
+        Rossini rossini = (Rossini) SubclassQualifiedByMapper.INSTANCE.fromDtoLightJustVivaldi( rossiniDto );
+
+        Vivaldi vivaldi = (Vivaldi) SubclassQualifiedByMapper.INSTANCE.fromDtoLightJustVivaldi( vivaldiDto );
+
+        assertThat( rossini.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossini.getCrescendo() ).containsExactly( "andante", "allegro", "vivace" );
+
+        assertThat( vivaldi.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldi.getSeasons() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses(SubclassQualifiedByNameMapper.class)
+    void subclassQualifiedByNameInverse() {
+        RossiniDto rossiniDto = buildRossiniDto();
+
+        VivaldiDto vivaldiDto = buildVivaldiDto();
+
+        Rossini rossini = (Rossini) SubclassQualifiedByNameMapper.INSTANCE.fromDto( rossiniDto );
+        Rossini rossiniLight = (Rossini) SubclassQualifiedByNameMapper.INSTANCE.fromDtoLight( rossiniDto );
+
+        Vivaldi vivaldi = (Vivaldi) SubclassQualifiedByNameMapper.INSTANCE.fromDto( vivaldiDto );
+        Vivaldi vivaldiLight = (Vivaldi) SubclassQualifiedByNameMapper.INSTANCE.fromDtoLight( vivaldiDto );
+
+        assertThat( rossini.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossini.getCrescendo() ).containsExactly( "andante", "allegro", "vivace" );
+        assertThat( rossiniLight.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossiniLight.getCrescendo() ).isNull();
+
+        assertThat( vivaldi.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldi.getSeasons() ).containsExactly( "spring", "winter" );
+        assertThat( vivaldiLight.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldiLight.getSeasons() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses(SubclassQualifiedByNameMapper.class)
+    void subclassQualifiedByNameOnlyOneInverse() {
+        RossiniDto rossiniDto = buildRossiniDto();
+
+        VivaldiDto vivaldiDto = buildVivaldiDto();
+
+        Rossini rossini = (Rossini) SubclassQualifiedByNameMapper.INSTANCE.fromDtoLightJustVivaldi( rossiniDto );
+
+        Vivaldi vivaldi = (Vivaldi) SubclassQualifiedByNameMapper.INSTANCE.fromDtoLightJustVivaldi( vivaldiDto );
+
+        assertThat( rossini.getName() ).isEqualTo( "gioacchino" );
+        assertThat( rossini.getCrescendo() ).containsExactly( "andante", "allegro", "vivace" );
+
+        assertThat( vivaldi.getName() ).isEqualTo( "antonio" );
+        assertThat( vivaldi.getSeasons() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses(SubclassQualifiedByMapper.class)
+    void subclassQualifiedByDoesNotContainUnused() {
+        generatedSource.forMapper( SubclassQualifiedByMapper.class )
+            .content()
+            .doesNotContain( "DtoUnused" );
+    }
+
+    @ProcessorTest
+    @WithClasses(SubclassQualifiedByNameMapper.class)
+    void subclassQualifiedByNameDoesNotContainUnused() {
+        generatedSource.forMapper( SubclassQualifiedByNameMapper.class )
+            .content()
+            .doesNotContain( "DtoUnused" );
+    }
+
+    @ProcessorTest
+    @WithClasses(ErroneousSubclassQualifiedByMapper.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = @Diagnostic(
+            type = ErroneousSubclassQualifiedByMapper.class,
+            kind = javax.tools.Diagnostic.Kind.ERROR,
+            line = 15,
+            message = "Qualifier error. No method found annotated with: [ @NonExistent ]. " +
+                "See https://mapstruct.org/faq/#qualifier for more info."
+        )
+    )
+    void subclassQualifiedByErroneous() {
+    }
+
+    @ProcessorTest
+    @WithClasses(ErroneousSubclassQualifiedByNameMapper.class)
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = @Diagnostic(
+            type = ErroneousSubclassQualifiedByNameMapper.class,
+            kind = javax.tools.Diagnostic.Kind.ERROR,
+            line = 15,
+            message = "Qualifier error. No method found annotated with @Named#value: [ non-existent ]. " +
+                "See https://mapstruct.org/faq/#qualifier for more info."
+        )
+    )
+    void subclassQualifiedByNameErroneous() {
+    }
+
+    private Rossini buildRossini() {
+        Rossini rossini = new Rossini();
+        rossini.setName( "gioacchino" );
+        List<String> crescendo = new ArrayList<>();
+        crescendo.add( "andante" );
+        crescendo.add( "allegro" );
+        crescendo.add( "vivace" );
+        rossini.setCrescendo( crescendo );
+        return rossini;
+    }
+
+    private Vivaldi buildVivaldi() {
+        Vivaldi vivaldi = new Vivaldi();
+        vivaldi.setName( "antonio" );
+        List<String> season = new ArrayList<>();
+        season.add( "spring" );
+        season.add( "winter" );
+        vivaldi.setSeasons( season );
+        return vivaldi;
+    }
+
+    private RossiniDto buildRossiniDto() {
+        RossiniDto rossiniDto = new RossiniDto();
+        rossiniDto.setName( "gioacchino" );
+        List<String> crescendo = new ArrayList<>();
+        crescendo.add( "andante" );
+        crescendo.add( "allegro" );
+        crescendo.add( "vivace" );
+        rossiniDto.setCrescendo( crescendo );
+        return rossiniDto;
+    }
+
+    private VivaldiDto buildVivaldiDto() {
+        VivaldiDto vivaldiDto = new VivaldiDto();
+        vivaldiDto.setName( "antonio" );
+        List<String> season = new ArrayList<>();
+        season.add( "spring" );
+        season.add( "winter" );
+        vivaldiDto.setSeasons( season );
+        return vivaldiDto;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/Unused.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/Unused.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.mapstruct.Qualifier;
+
+@Qualifier
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.CLASS)
+public @interface Unused {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/Vivaldi.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/Vivaldi.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import java.util.List;
+
+public class Vivaldi extends Composer {
+    private List<String> seasons;
+
+    public List<String> getSeasons() {
+        return seasons;
+    }
+
+    public void setSeasons(List<String> seasons) {
+        this.seasons = seasons;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/VivaldiDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/VivaldiDto.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import java.util.List;
+
+public class VivaldiDto extends ComposerDto {
+    private List<String> seasons;
+
+    public List<String> getSeasons() {
+        return seasons;
+    }
+
+    public void setSeasons(List<String> seasons) {
+        this.seasons = seasons;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/VivaldiMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/VivaldiMapper.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping.qualifier;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+@Mapper
+public interface VivaldiMapper {
+    VivaldiDto toDto(Vivaldi vivaldi);
+
+    @Light
+    @Mapping(target = "seasons", ignore = true)
+    VivaldiDto toDtoLight(Vivaldi vivaldi);
+
+    @Named("light")
+    @Mapping(target = "seasons", ignore = true)
+    VivaldiDto toDtoLightNamed(Vivaldi vivaldi);
+
+    @Unused
+    @BeanMapping(ignoreByDefault = true)
+    VivaldiDto toDtoUnused(Vivaldi vivaldi);
+
+    @Named("unused")
+    @BeanMapping(ignoreByDefault = true)
+    VivaldiDto toDtoUnusedNamed(Vivaldi vivaldi);
+
+    Vivaldi fromDto(VivaldiDto vivaldi);
+
+    @Light
+    @Mapping(target = "seasons", ignore = true)
+    Vivaldi fromDtoLight(VivaldiDto vivaldi);
+
+    @Named("light")
+    @Mapping(target = "seasons", ignore = true)
+    Vivaldi fromDtoLightNamed(VivaldiDto vivaldi);
+
+    @Unused
+    @BeanMapping(ignoreByDefault = true)
+    Vivaldi fromDtoUnused(VivaldiDto vivaldi);
+
+    @Named("unused")
+    @BeanMapping(ignoreByDefault = true)
+    Vivaldi fromDtoUnusedNamed(VivaldiDto vivaldi);
+}


### PR DESCRIPTION
Close #3119 

It's a simple fix that just passes along the qualifiers present on the BeanMapping annotation to aid the resolution of the subclass specific method.

I don't know if this is the right approach or you would prefer two specific new attributes on the SubclassMapping annotation. For my needs it is enough.