### PR TITLE
#3125: Allow subclassmapping inheritance for methods with identical signature.

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
@@ -21,7 +21,6 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.Message;
-import org.mapstruct.ap.internal.util.TypeUtils;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 
 /**
@@ -31,7 +30,6 @@ import org.mapstruct.ap.internal.util.accessor.Accessor;
  */
 public class MappingMethodOptions {
     private static final MappingMethodOptions EMPTY = new MappingMethodOptions(
-        null,
         null,
         Collections.emptySet(),
         null,
@@ -55,15 +53,12 @@ public class MappingMethodOptions {
 
     private SubclassValidator subclassValidator;
 
-    private TypeUtils typeUtils;
-
-    public MappingMethodOptions(TypeUtils typeUtils, MapperOptions mapper, Set<MappingOptions> mappings,
+    public MappingMethodOptions(MapperOptions mapper, Set<MappingOptions> mappings,
                                 IterableMappingOptions iterableMapping,
                                 MapMappingOptions mapMapping, BeanMappingOptions beanMapping,
                                 EnumMappingOptions enumMappingOptions,
                                 List<ValueMappingOptions> valueMappings,
                                 Set<SubclassMappingOptions> subclassMappings, SubclassValidator subclassValidator) {
-        this.typeUtils = typeUtils;
         this.mapper = mapper;
         this.mappings = mappings;
         this.iterableMapping = iterableMapping;
@@ -255,8 +250,8 @@ public class MappingMethodOptions {
             return false;
         }
         for ( int i = 0; i < templateMethod.getParameters().size(); i++ ) {
-            if (!typeUtils.isSameType( templateMethod.getParameters().get( i ).getType().getTypeMirror(),
-                                       sourceMethod.getParameters().get( i ).getType().getTypeMirror() ) ) {
+            if (!templateMethod.getParameters().get( i ).getType().equals(
+                                       sourceMethod.getParameters().get( i ).getType() ) ) {
                 return false;
             }
         }
@@ -264,8 +259,7 @@ public class MappingMethodOptions {
     }
 
     private boolean resultTypeIsTheSame(SourceMethod templateMethod, SourceMethod sourceMethod) {
-        return typeUtils.isSameType( templateMethod.getResultType().getTypeMirror(),
-                                     sourceMethod.getResultType().getTypeMirror() );
+        return templateMethod.getResultType().equals( sourceMethod.getResultType() );
     }
 
     private void addAllNonRedefined(SourceMethod sourceMethod, AnnotationMirror annotationMirror,
@@ -397,7 +391,6 @@ public class MappingMethodOptions {
      */
     public static MappingMethodOptions getForgedMethodInheritedOptions(MappingMethodOptions options) {
         return new MappingMethodOptions(
-            options.typeUtils,
             options.mapper,
             options.mappings,
             options.iterableMapping,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -211,7 +211,6 @@ public class SourceMethod implements Method {
             }
 
             MappingMethodOptions mappingMethodOptions = new MappingMethodOptions(
-                typeUtils,
                 mapper,
                 mappings,
                 iterableMapping,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -211,6 +211,7 @@ public class SourceMethod implements Method {
             }
 
             MappingMethodOptions mappingMethodOptions = new MappingMethodOptions(
+                typeUtils,
                 mapper,
                 mappings,
                 iterableMapping,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
@@ -179,6 +179,21 @@ public class SubclassMappingOptions extends DelegatingOptions {
         return mappings;
     }
 
+    public static List<SubclassMappingOptions> copyForInheritance(Set<SubclassMappingOptions> subclassMappings,
+                                                                  BeanMappingOptions beanMappingOptions) {
+         // we are not interested in keeping it unique at this point.
+         List<SubclassMappingOptions> mappings = new ArrayList<>();
+         for ( SubclassMappingOptions subclassMapping : subclassMappings ) {
+             mappings.add(
+                         new SubclassMappingOptions(
+                                    subclassMapping.source,
+                                    subclassMapping.target,
+                                    subclassMapping.typeUtils,
+                                    beanMappingOptions ) );
+         }
+         return mappings;
+     }
+
     @Override
     public boolean equals(Object obj) {
         if ( obj == null || !( obj instanceof SubclassMappingOptions ) ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SubclassMappingOptions.java
@@ -212,7 +212,9 @@ public class SubclassMappingOptions extends DelegatingOptions {
                                     subclassMapping.source,
                                     subclassMapping.target,
                                     subclassMapping.typeUtils,
-                                    beanMappingOptions ) );
+                                    beanMappingOptions,
+                                    subclassMapping.selectionParameters,
+                                    subclassMapping.subclassMapping ) );
          }
          return mappings;
      }

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/InheritedSubclassMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/InheritedSubclassMapper.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping;
+
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.SubclassMapping;
+import org.mapstruct.ap.test.subclassmapping.mappables.Bike;
+import org.mapstruct.ap.test.subclassmapping.mappables.BikeDto;
+import org.mapstruct.ap.test.subclassmapping.mappables.Car;
+import org.mapstruct.ap.test.subclassmapping.mappables.CarDto;
+import org.mapstruct.ap.test.subclassmapping.mappables.HatchBack;
+import org.mapstruct.ap.test.subclassmapping.mappables.Vehicle;
+import org.mapstruct.ap.test.subclassmapping.mappables.VehicleDto;
+import org.mapstruct.factory.Mappers;
+
+@Mapper( unmappedTargetPolicy = ReportingPolicy.IGNORE )
+public interface InheritedSubclassMapper {
+    InheritedSubclassMapper INSTANCE = Mappers.getMapper( InheritedSubclassMapper.class );
+
+    @SubclassMapping( source = HatchBack.class, target = CarDto.class )
+    @SubclassMapping( source = Car.class, target = CarDto.class )
+    @SubclassMapping( source = Bike.class, target = BikeDto.class )
+    @Mapping( source = "vehicleManufacturingCompany", target = "maker" )
+    VehicleDto map(Vehicle vehicle);
+
+    @InheritConfiguration( name = "map" )
+    VehicleDto mapInherited(Vehicle dto);
+
+    @SubclassMapping( source = Bike.class, target = CarDto.class )
+    @InheritConfiguration( name = "map" )
+    VehicleDto mapInheritedOverride(Vehicle dto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassMappingTest.java
@@ -130,7 +130,7 @@ public class SubclassMappingTest {
         HatchBack.class,
         InverseOrderSubclassMapper.class
     } )
-    void subclassMappingOverridesInverseInheritsMapping() {
+    void subclassMappingOverridesInverseInheritedMapping() {
         VehicleCollectionDto vehicleDtos = new VehicleCollectionDto();
         CarDto carDto = new CarDto();
         carDto.setMaker( "BenZ" );
@@ -141,6 +141,24 @@ public class SubclassMappingTest {
         assertThat( result.getVehicles() ) // remove generic so that test works.
             .extracting( vehicle -> (Class) vehicle.getClass() )
             .containsExactly( Car.class );
+    }
+
+    @IssueKey( "3125" )
+    @ProcessorTest
+    @WithClasses( {
+        HatchBack.class,
+        InheritedSubclassMapper.class
+    } )
+    void subclassMappingOverridesInheritedMapping() {
+        Vehicle bike = new Bike();
+
+        VehicleDto result = InheritedSubclassMapper.INSTANCE.map( bike );
+        VehicleDto resultInherited = InheritedSubclassMapper.INSTANCE.mapInherited( bike );
+        VehicleDto resultOverride = InheritedSubclassMapper.INSTANCE.mapInheritedOverride( bike );
+
+        assertThat( result ).isInstanceOf( BikeDto.class );
+        assertThat( resultInherited ).isInstanceOf( BikeDto.class );
+        assertThat( resultOverride ).isInstanceOf( CarDto.class );
     }
 
     @ProcessorTest


### PR DESCRIPTION
closes #3125
