### PR TITLE
#3126: do not change source parameter name for subclassmappings

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ForgedMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ForgedMethod.java
@@ -141,6 +141,7 @@ public class ForgedMethod implements Method {
         return new ForgedMethod(
             name,
             sourceType,
+            new Parameter(basedOn.getSourceParameters().get( 0 ).getName(), sourceType),
             returnType,
             basedOn.getContextParameters(),
             basedOn,
@@ -153,7 +154,12 @@ public class ForgedMethod implements Method {
     private ForgedMethod(String name, Type sourceType, Type returnType, List<Parameter> additionalParameters,
                          Method basedOn, ForgedMethodHistory history, MappingReferences mappingReferences,
                          boolean forgedNameBased) {
+        this( name, sourceType, determineSourceParameterName( sourceType, additionalParameters ), returnType,
+            additionalParameters, basedOn, history, mappingReferences, forgedNameBased );
 
+    }
+
+    private static Parameter determineSourceParameterName(Type sourceType, List<Parameter> additionalParameters) {
         // establish name
         String sourceParamSafeName;
         if ( additionalParameters.isEmpty() ) {
@@ -165,10 +171,15 @@ public class ForgedMethod implements Method {
                 additionalParameters.stream().map( Parameter::getName ).collect( Collectors.toList() )
             );
         }
+        return new Parameter( sourceParamSafeName, sourceType );
+    }
+
+    private ForgedMethod(String name, Type sourceType, Parameter sourceParameter, Type returnType,
+                         List<Parameter> additionalParameters, Method basedOn, ForgedMethodHistory history,
+                         MappingReferences mappingReferences, boolean forgedNameBased) {
 
         // establish parameters
         this.parameters = new ArrayList<>( 1 + additionalParameters.size() );
-        Parameter sourceParameter = new Parameter( sourceParamSafeName, sourceType );
         this.parameters.add( sourceParameter );
         this.parameters.addAll( additionalParameters );
         this.sourceParameters = Parameter.getSourceParameters( parameters );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3126/AddressMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3126/AddressMapper.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3126;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.SubclassExhaustiveStrategy;
+import org.mapstruct.SubclassMapping;
+
+/**
+ * @author Ben Zegveld
+ */
+abstract class AddressDO {
+    private String id;
+    private Auditable auditable;
+
+    public Auditable getAuditable() {
+        return auditable;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setAuditable(Auditable auditable) {
+        this.auditable = auditable;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}
+
+class Auditable {
+    private String createdBy;
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+}
+
+class HomeAddressDO extends AddressDO {
+    private String unit;
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+}
+
+class OfficeAddressDO extends AddressDO {
+    private String building;
+
+    public String getBuilding() {
+        return building;
+    }
+
+    public void setBuilding(String building) {
+        this.building = building;
+    }
+}
+
+interface AddressResponseDto {
+}
+
+class HomeAddressResponseDto implements AddressResponseDto {
+    private String id;
+    private String unit;
+    private String createdBy;
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getUnit() {
+        return unit;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public void setUnit(String unit) {
+        this.unit = unit;
+    }
+}
+
+class OfficeAddressResponseDto implements AddressResponseDto {
+    private String id;
+    private String building;
+    private String createdBy;
+
+    public String getBuilding() {
+        return building;
+    }
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setBuilding(String building) {
+        this.building = building;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}
+
+@Mapper( subclassExhaustiveStrategy = SubclassExhaustiveStrategy.RUNTIME_EXCEPTION )
+public interface AddressMapper {
+    @SubclassMapping( source = HomeAddressDO.class, target = HomeAddressResponseDto.class )
+    @SubclassMapping( source = OfficeAddressDO.class, target = OfficeAddressResponseDto.class )
+    @Mapping( source = "auditable", target = "." )
+    AddressResponseDto toDto(AddressDO addressDo);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3126/AddressMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3126/AddressMapperTest.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3126;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+/**
+ * @author Ben Zegveld
+ */
+@IssueKey( "3126" )
+public class AddressMapperTest {
+
+    @ProcessorTest
+    @WithClasses(AddressMapper.class)
+    void shouldCompile() { }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_2891/Issue2891MapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_2891/Issue2891MapperImpl.java
@@ -31,28 +31,28 @@ public class Issue2891MapperImpl implements Issue2891Mapper {
         }
     }
 
-    protected Target1 source1ToTarget1(Source1 source1) {
-        if ( source1 == null ) {
+    protected Target1 source1ToTarget1(Source1 source) {
+        if ( source == null ) {
             return null;
         }
 
         String name = null;
 
-        name = source1.getName();
+        name = source.getName();
 
         Target1 target1 = new Target1( name );
 
         return target1;
     }
 
-    protected Target2 source2ToTarget2(Source2 source2) {
-        if ( source2 == null ) {
+    protected Target2 source2ToTarget2(Source2 source) {
+        if ( source == null ) {
             return null;
         }
 
         String name = null;
 
-        name = source2.getName();
+        name = source.getName();
 
         Target2 target2 = new Target2( name );
 

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/subclassmapping/fixture/SubclassAbstractMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/subclassmapping/fixture/SubclassAbstractMapperImpl.java
@@ -51,68 +51,68 @@ public class SubclassAbstractMapperImpl implements SubclassAbstractMapper {
         }
     }
 
-    protected SubTarget subSourceToSubTarget(SubSource subSource) {
-        if ( subSource == null ) {
+    protected SubTarget subSourceToSubTarget(SubSource item) {
+        if ( item == null ) {
             return null;
         }
 
         SubTarget subTarget = new SubTarget();
 
-        subTarget.setValue( subSource.getValue() );
+        subTarget.setValue( item.getValue() );
 
         return subTarget;
     }
 
-    protected SubTargetOther subSourceOtherToSubTargetOther(SubSourceOther subSourceOther) {
-        if ( subSourceOther == null ) {
+    protected SubTargetOther subSourceOtherToSubTargetOther(SubSourceOther item) {
+        if ( item == null ) {
             return null;
         }
 
         String finalValue = null;
 
-        finalValue = subSourceOther.getFinalValue();
+        finalValue = item.getFinalValue();
 
         SubTargetOther subTargetOther = new SubTargetOther( finalValue );
 
         return subTargetOther;
     }
 
-    protected SubSourceSeparate subTargetSeparateToSubSourceSeparate(SubTargetSeparate subTargetSeparate) {
-        if ( subTargetSeparate == null ) {
+    protected SubSourceSeparate subTargetSeparateToSubSourceSeparate(SubTargetSeparate item) {
+        if ( item == null ) {
             return null;
         }
 
         String separateValue = null;
 
-        separateValue = subTargetSeparate.getSeparateValue();
+        separateValue = item.getSeparateValue();
 
         SubSourceSeparate subSourceSeparate = new SubSourceSeparate( separateValue );
 
         return subSourceSeparate;
     }
 
-    protected SubSourceOverride subTargetOtherToSubSourceOverride(SubTargetOther subTargetOther) {
-        if ( subTargetOther == null ) {
+    protected SubSourceOverride subTargetOtherToSubSourceOverride(SubTargetOther item) {
+        if ( item == null ) {
             return null;
         }
 
         String finalValue = null;
 
-        finalValue = subTargetOther.getFinalValue();
+        finalValue = item.getFinalValue();
 
         SubSourceOverride subSourceOverride = new SubSourceOverride( finalValue );
 
         return subSourceOverride;
     }
 
-    protected SubSource subTargetToSubSource(SubTarget subTarget) {
-        if ( subTarget == null ) {
+    protected SubSource subTargetToSubSource(SubTarget item) {
+        if ( item == null ) {
             return null;
         }
 
         SubSource subSource = new SubSource();
 
-        subSource.setValue( subTarget.getValue() );
+        subSource.setValue( item.getValue() );
 
         return subSource;
     }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/subclassmapping/fixture/SubclassImplementedMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/subclassmapping/fixture/SubclassImplementedMapperImpl.java
@@ -33,26 +33,26 @@ public class SubclassImplementedMapperImpl implements SubclassImplementedMapper 
         }
     }
 
-    protected SubTarget subSourceToSubTarget(SubSource subSource) {
-        if ( subSource == null ) {
+    protected SubTarget subSourceToSubTarget(SubSource item) {
+        if ( item == null ) {
             return null;
         }
 
         SubTarget subTarget = new SubTarget();
 
-        subTarget.setValue( subSource.getValue() );
+        subTarget.setValue( item.getValue() );
 
         return subTarget;
     }
 
-    protected SubTargetOther subSourceOtherToSubTargetOther(SubSourceOther subSourceOther) {
-        if ( subSourceOther == null ) {
+    protected SubTargetOther subSourceOtherToSubTargetOther(SubSourceOther item) {
+        if ( item == null ) {
             return null;
         }
 
         String finalValue = null;
 
-        finalValue = subSourceOther.getFinalValue();
+        finalValue = item.getFinalValue();
 
         SubTargetOther subTargetOther = new SubTargetOther( finalValue );
 

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/subclassmapping/fixture/SubclassInterfaceMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/subclassmapping/fixture/SubclassInterfaceMapperImpl.java
@@ -31,26 +31,26 @@ public class SubclassInterfaceMapperImpl implements SubclassInterfaceMapper {
         }
     }
 
-    protected SubTarget subSourceToSubTarget(SubSource subSource) {
-        if ( subSource == null ) {
+    protected SubTarget subSourceToSubTarget(SubSource item) {
+        if ( item == null ) {
             return null;
         }
 
         SubTarget subTarget = new SubTarget();
 
-        subTarget.setValue( subSource.getValue() );
+        subTarget.setValue( item.getValue() );
 
         return subTarget;
     }
 
-    protected SubTargetOther subSourceOtherToSubTargetOther(SubSourceOther subSourceOther) {
-        if ( subSourceOther == null ) {
+    protected SubTargetOther subSourceOtherToSubTargetOther(SubSourceOther item) {
+        if ( item == null ) {
             return null;
         }
 
         String finalValue = null;
 
-        finalValue = subSourceOther.getFinalValue();
+        finalValue = item.getFinalValue();
 
         SubTargetOther subTargetOther = new SubTargetOther( finalValue );
 


### PR DESCRIPTION
keep parameter name intact for subclassmappings to ensure inherited mappings keep working.

closes #3126 