### PR TITLE
#3129: detect collection adders using Iterable setter/getter

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -898,7 +898,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
         List<Accessor> candidates;
 
-        if ( collectionProperty.isCollectionType() ) {
+        if ( collectionProperty.isIterableType() ) {
             candidates = getAccessorCandidates( collectionProperty, Iterable.class );
         }
         else if ( collectionProperty.isStreamType() ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/LombokBuilderAccessorNamingStrategy.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/LombokBuilderAccessorNamingStrategy.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builder.lombok;
+
+import org.mapstruct.ap.spi.DefaultAccessorNamingStrategy;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.ExecutableElement;
+import java.util.List;
+
+/**
+ * LombokBuilderAccessorNamingStrategy is an extension of a default naming strategy
+ * that recognizes lombok mapstruct adders defined by a default @lombok.Singular annotation.
+ * Lombok adders don't have the 'add' prefix OOTB, an adder is herein recognized by
+ * the presence of another builder method with an 's' suffix.
+ *
+ * @see <a href="https://projectlombok.org/features/BuilderSingular">Lombok @Singular</a>
+ */
+public class LombokBuilderAccessorNamingStrategy extends DefaultAccessorNamingStrategy {
+
+    private boolean isLombokBuilderAdder(ExecutableElement method) {
+        // check that the method is defined in a lombok Builder class
+        Element enclosingElement = method.getEnclosingElement();
+        if (enclosingElement == null || !enclosingElement.getSimpleName().toString().endsWith( "Builder" )) {
+            return false;
+        }
+        Element parentElement = enclosingElement.getEnclosingElement();
+        if (parentElement == null || (enclosingElement.getKind() != ElementKind.CLASS
+                && !enclosingElement.getKind().name().equals( "RECORD" ))) {
+            return false;
+        }
+        // check if there is a plural setter for this adder in the builder
+        List<? extends Element> enclosedElements = enclosingElement.getEnclosedElements();
+        String plural1 = method.getSimpleName().toString() + "s";
+        for (Element enclosedElement : enclosedElements) {
+            if (!(enclosedElement instanceof ExecutableElement)) {
+                continue;
+            }
+            ExecutableElement setterMethod = (ExecutableElement) enclosedElement;
+            String name = enclosedElement.getSimpleName().toString();
+            if (plural1.equals( name )) {
+                if (setterMethod.getParameters().size() != 1) {
+                    continue;
+                }
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected boolean isFluentSetter(ExecutableElement method) {
+        return super.isFluentSetter( method ) &&
+                !isLombokBuilderAdder( method );
+    }
+
+    public boolean isAdderMethod(ExecutableElement method) {
+        return super.isAdderMethod( method ) || isLombokBuilderAdder( method );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/LombokBuilderAdderTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/LombokBuilderAdderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builder.lombok;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.spi.AccessorNamingStrategy;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithServiceImplementation;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+import org.mapstruct.factory.Mappers;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses({
+    LombokImmutablePath.class,
+    MutablePath.class
+})
+public class LombokBuilderAdderTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({ PathMapper.class })
+    @WithServiceImplementation(
+        provides = AccessorNamingStrategy.class,
+        value = LombokBuilderAccessorNamingStrategy.class
+    )
+    public void testSimpleImmutableBuilderWithLombokNamingStrategy() {
+        PathMapper mapper = Mappers.getMapper( PathMapper.class );
+        MutablePath source = new MutablePath();
+        source.setEdges( Arrays.asList( "e1", "e2" ) );
+
+        LombokImmutablePath targetObject = mapper.map( source );
+
+        // assert that target properties were added by builder's adder (edge method), which upper-cases arguments
+        assertThat( targetObject.getEdges() ).contains( "E1", "E2" );
+    }
+
+    @ProcessorTest
+    @WithClasses({ PathMapper2.class, LombokImmutablePath2.class })
+    public void testSimpleImmutableBuilderWithDefaultNamingStrategy() {
+        PathMapper mapper = Mappers.getMapper( PathMapper.class );
+        MutablePath source = new MutablePath();
+        source.setEdges( Arrays.asList( "e1", "e2" ) );
+
+        LombokImmutablePath targetObject = mapper.map( source );
+
+        // assert that target properties were added by builder's adder (addEdge method), which upper-cases arguments
+        assertThat( targetObject.getEdges() ).contains( "E1", "E2" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/LombokImmutablePath.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/LombokImmutablePath.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builder.lombok;
+
+import com.google.common.collect.ImmutableList;
+import java.beans.ConstructorProperties;
+import java.util.List;
+
+@SuppressWarnings("RedundantIfStatement")
+public final class LombokImmutablePath {
+    private final List<String> edges;
+
+    @ConstructorProperties({"edges"})
+    LombokImmutablePath(List<String> edges) {
+        this.edges = edges;
+    }
+
+    public static LombokImmutablePathBuilder builder() {
+        return new LombokImmutablePathBuilder();
+    }
+
+    public List<String> getEdges() {
+        return this.edges;
+    }
+
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        else if (!(o instanceof LombokImmutablePath)) {
+            return false;
+        }
+        else {
+            LombokImmutablePath other = (LombokImmutablePath) o;
+            Object thisEdges = this.getEdges();
+            Object otherEdges = other.getEdges();
+            if (thisEdges == null) {
+                if (otherEdges != null) {
+                    return false;
+                }
+            }
+            else if (!thisEdges.equals( otherEdges )) {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    public int hashCode() {
+        int result = 1;
+        Object edges = this.getEdges();
+        result = result * 59 + (edges == null ? 43 : edges.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "Path(edges=" + this.getEdges() + ")";
+    }
+
+    @SuppressWarnings("unused")
+    public static class LombokImmutablePathBuilder {
+        private ImmutableList.Builder<String> edges;
+
+        LombokImmutablePathBuilder() {
+        }
+
+        public LombokImmutablePathBuilder edge(String edge) {
+            if (this.edges == null) {
+                this.edges = ImmutableList.builder();
+            }
+
+            this.edges.add( edge.toUpperCase() ); // modified manually to add UPPERCASE characters
+            return this;
+        }
+
+        public LombokImmutablePathBuilder edges(Iterable<? extends String> edges) {
+            if (edges == null) {
+                throw new NullPointerException("edges cannot be null");
+            }
+            else {
+                if (this.edges == null) {
+                    this.edges = ImmutableList.builder();
+                }
+
+                this.edges.addAll( edges );
+                return this;
+            }
+        }
+
+        public LombokImmutablePathBuilder clearEdges() {
+            this.edges = null;
+            return this;
+        }
+
+        public LombokImmutablePath build() {
+            List<String> edges = this.edges == null ? ImmutableList.of() : this.edges.build();
+            return new LombokImmutablePath(edges);
+        }
+
+        public String toString() {
+            return "Path.PathBuilder(edges=" + this.edges + ")";
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/LombokImmutablePath2.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/LombokImmutablePath2.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builder.lombok;
+
+import com.google.common.collect.ImmutableList;
+
+import java.beans.ConstructorProperties;
+import java.util.List;
+
+@SuppressWarnings("RedundantIfStatement")
+public final class LombokImmutablePath2 {
+    private final List<String> edges;
+
+    @ConstructorProperties({"edges"})
+    LombokImmutablePath2(List<String> edges) {
+        this.edges = edges;
+    }
+
+    public static LombokImmutablePathBuilder builder() {
+        return new LombokImmutablePathBuilder();
+    }
+
+    public List<String> getEdges() {
+        return this.edges;
+    }
+
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+        else if (!(o instanceof LombokImmutablePath2)) {
+            return false;
+        }
+        else {
+            LombokImmutablePath2 other = (LombokImmutablePath2) o;
+            Object thisEdges = this.getEdges();
+            Object otherEdges = other.getEdges();
+            if (thisEdges == null) {
+                if (otherEdges != null) {
+                    return false;
+                }
+            }
+            else if (!thisEdges.equals( otherEdges )) {
+                return false;
+            }
+
+            return true;
+        }
+    }
+
+    public int hashCode() {
+        int result = 1;
+        Object edges = this.getEdges();
+        result = result * 59 + (edges == null ? 43 : edges.hashCode());
+        return result;
+    }
+
+    public String toString() {
+        return "Path(edges=" + this.getEdges() + ")";
+    }
+
+    @SuppressWarnings("unused")
+    public static class LombokImmutablePathBuilder {
+        private ImmutableList.Builder<String> edges;
+
+        LombokImmutablePathBuilder() {
+        }
+
+        public LombokImmutablePathBuilder addEdge(String edge) { // follows mapstruct convention of an adder method
+            if (this.edges == null) {
+                this.edges = ImmutableList.builder();
+            }
+
+            this.edges.add( edge.toUpperCase() ); // modified manually to add UPPERCASE characters
+            return this;
+        }
+
+        public LombokImmutablePathBuilder edges(Iterable<? extends String> edges) {
+            if (edges == null) {
+                throw new NullPointerException("edges cannot be null");
+            }
+            else {
+                if (this.edges == null) {
+                    this.edges = ImmutableList.builder();
+                }
+
+                this.edges.addAll( edges );
+                return this;
+            }
+        }
+
+        public LombokImmutablePathBuilder clearEdges() {
+            this.edges = null;
+            return this;
+        }
+
+        public LombokImmutablePath2 build() {
+            List<String> edges = this.edges == null ? ImmutableList.of() : this.edges.build();
+            return new LombokImmutablePath2(edges);
+        }
+
+        public String toString() {
+            return "Path.PathBuilder(edges=" + this.edges + ")";
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/MutablePath.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/MutablePath.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builder.lombok;
+
+import java.util.List;
+
+public class MutablePath {
+    private List<String> edges;
+
+    public List<String> getEdges() {
+        return edges;
+    }
+
+    public void setEdges(List<String> edges) {
+        this.edges = edges;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/PathMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/PathMapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builder.lombok;
+
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+@Mapper(collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED)
+public interface PathMapper {
+
+    @Mappings({
+        @Mapping(target = "edges", source = "edges"),
+    })
+    LombokImmutablePath map(MutablePath source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/PathMapper2.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/lombok/PathMapper2.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.builder.lombok;
+
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Mappings;
+
+@Mapper(collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED)
+public interface PathMapper2 {
+
+    @Mappings({
+            @Mapping(target = "edges", source = "edges"),
+    })
+    LombokImmutablePath2 map2(MutablePath source);
+}


### PR DESCRIPTION
Closes #3129

The code herein fixes the detection of collection adders to use a more generic `Iterable` as a setter argument (or a getter return value). As consequence, a lombok generated builder setter (fluent) method:
```
public LombokImmutablePathBuilder edges(Iterable<? extends String> edges) {
  // ...
  return this;
}
```
is now also considered as a candidate for searching of an associated adder:
```
public LombokImmutablePathBuilder addEdge(String edge) {
  // ...
  return this;
}
```

Using the adders directly has a performance benefit when using lombok builders. The mapper implementation then does not need to create intermediary ArrayList values to map collection properties. For example, in place of this code (before this PR):

```java
...
ActionRule.ActionRuleBuilder actionRule = ActionRule.builder();
if (actionRules.getCostList() != null) {
    actionRule.costs(this.costListToCostIterable(actionRules.getCostList()));
}
...
protected Iterable<Cost> costListToCostIterable(List<b.Cost> list) {
    if (list == null) {
        return null;
    } else {
        ArrayList<Cost> iterable = new ArrayList(list.size());
        Iterator var3 = list.iterator();

        while(var3.hasNext()) {
            com.goeuro.search2.model.proto.Cost cost = (com.goeuro.search2.model.proto.Cost)var3.next();
            iterable.add(this.costMapper.map(cost));
        }

        return iterable;
    }
}
```

, the new mapper implementation is then optimal (this PR):

```java
ActionRule.ActionRuleBuilder actionRule = ActionRule.builder();
if (actionRules.getCostList() != null) {
    Iterator var3 = actionRules.getCostList().iterator();

    while(var3.hasNext()) {
        Cost costList = (Cost)var3.next();
        actionRule.addCost(this.costMapper.map(costList));
    }
}
```