### PR TITLE
#3174 Also allow multiple SubclassMapping annotations on an annotation `@interface`.

### DIFF
--- a/core/src/main/java/org/mapstruct/SubclassMappings.java
+++ b/core/src/main/java/org/mapstruct/SubclassMappings.java
@@ -45,7 +45,7 @@ import org.mapstruct.util.Experimental;
  * @author Ben Zegveld
  * @since 1.5
  */
-@Target(ElementType.METHOD)
+@Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Retention(RetentionPolicy.CLASS)
 @Experimental
 public @interface SubclassMappings {

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/CompositeSubclassMappingAnnotation.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/CompositeSubclassMappingAnnotation.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping;
+
+import org.mapstruct.Mapping;
+import org.mapstruct.SubclassMapping;
+import org.mapstruct.ap.test.subclassmapping.mappables.Bike;
+import org.mapstruct.ap.test.subclassmapping.mappables.BikeDto;
+import org.mapstruct.ap.test.subclassmapping.mappables.Car;
+import org.mapstruct.ap.test.subclassmapping.mappables.CarDto;
+
+@SubclassMapping( source = Car.class, target = CarDto.class )
+@SubclassMapping( source = Bike.class, target = BikeDto.class )
+@Mapping( source = "vehicleManufacturingCompany", target = "maker")
+public @interface CompositeSubclassMappingAnnotation {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassCompositeMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassCompositeMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.subclassmapping;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.subclassmapping.mappables.Vehicle;
+import org.mapstruct.ap.test.subclassmapping.mappables.VehicleCollection;
+import org.mapstruct.ap.test.subclassmapping.mappables.VehicleCollectionDto;
+import org.mapstruct.ap.test.subclassmapping.mappables.VehicleDto;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface SubclassCompositeMapper {
+    SubclassCompositeMapper INSTANCE = Mappers.getMapper( SubclassCompositeMapper.class );
+
+    VehicleCollectionDto map(VehicleCollection vehicles);
+
+    @CompositeSubclassMappingAnnotation
+    VehicleDto map(Vehicle vehicle);
+
+    VehicleCollection mapInverse(VehicleCollectionDto vehicles);
+
+    @InheritInverseConfiguration
+    Vehicle mapInverse(VehicleDto dto);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/SubclassMappingTest.java
@@ -144,6 +144,51 @@ public class SubclassMappingTest {
     }
 
     @ProcessorTest
+    @WithClasses( { SubclassCompositeMapper.class, CompositeSubclassMappingAnnotation.class })
+    void mappingIsDoneUsingSubclassMappingWithCompositeMapping() {
+        VehicleCollection vehicles = new VehicleCollection();
+        vehicles.getVehicles().add( new Car() );
+        vehicles.getVehicles().add( new Bike() );
+
+        VehicleCollectionDto result = SubclassCompositeMapper.INSTANCE.map( vehicles );
+
+        assertThat( result.getVehicles() ).doesNotContainNull();
+        assertThat( result.getVehicles() ) // remove generic so that test works.
+            .extracting( vehicle -> (Class) vehicle.getClass() )
+            .containsExactly( CarDto.class, BikeDto.class );
+    }
+
+    @ProcessorTest
+    @WithClasses( { SubclassCompositeMapper.class, CompositeSubclassMappingAnnotation.class })
+    void inverseMappingIsDoneUsingSubclassMappingWithCompositeMapping() {
+        VehicleCollectionDto vehicles = new VehicleCollectionDto();
+        vehicles.getVehicles().add( new CarDto() );
+        vehicles.getVehicles().add( new BikeDto() );
+
+        VehicleCollection result = SubclassCompositeMapper.INSTANCE.mapInverse( vehicles );
+
+        assertThat( result.getVehicles() ).doesNotContainNull();
+        assertThat( result.getVehicles() ) // remove generic so that test works.
+            .extracting( vehicle -> (Class) vehicle.getClass() )
+            .containsExactly( Car.class, Bike.class );
+    }
+
+    @ProcessorTest
+    @WithClasses( { SubclassCompositeMapper.class, CompositeSubclassMappingAnnotation.class })
+    void subclassMappingInheritsInverseMappingWithCompositeMapping() {
+        VehicleCollectionDto vehiclesDto = new VehicleCollectionDto();
+        CarDto carDto = new CarDto();
+        carDto.setMaker( "BenZ" );
+        vehiclesDto.getVehicles().add( carDto );
+
+        VehicleCollection result = SubclassCompositeMapper.INSTANCE.mapInverse( vehiclesDto );
+
+        assertThat( result.getVehicles() )
+            .extracting( Vehicle::getVehicleManufacturingCompany )
+            .containsExactly( "BenZ" );
+    }
+
+    @ProcessorTest
     @WithClasses({
         HatchBack.class,
         HatchBackDto.class,


### PR DESCRIPTION
Fixes #3174 