### PR TITLE
Improve line location report for invalid qualifier for SubclassMapping

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -420,7 +420,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                                        FormattingParameters.EMPTY,
                                        criteria,
                                        rightHandSide,
-                                       null,
+                                       subclassMappingOptions.getMirror(),
                                            () -> forgeSubclassMapping(
                                                rightHandSide,
                                                sourceType,

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/ErroneousSubclassQualifiedByMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/ErroneousSubclassQualifiedByMapper.java
@@ -11,6 +11,5 @@ import org.mapstruct.SubclassMapping;
 @Mapper(uses = { RossiniMapper.class, VivaldiMapper.class })
 public interface ErroneousSubclassQualifiedByMapper {
     @SubclassMapping(source = Rossini.class, target = RossiniDto.class, qualifiedBy = NonExistent.class)
-    @SubclassMapping(source = Vivaldi.class, target = VivaldiDto.class)
     ComposerDto toDto(Composer composer);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/SubclassQualifierMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/subclassmapping/qualifier/SubclassQualifierMapperTest.java
@@ -230,7 +230,7 @@ public class SubclassQualifierMapperTest {
         diagnostics = @Diagnostic(
             type = ErroneousSubclassQualifiedByMapper.class,
             kind = javax.tools.Diagnostic.Kind.ERROR,
-            line = 15,
+            line = 13,
             message = "Qualifier error. No method found annotated with: [ @NonExistent ]. " +
                 "See https://mapstruct.org/faq/#qualifier for more info."
         )
@@ -245,7 +245,8 @@ public class SubclassQualifierMapperTest {
         diagnostics = @Diagnostic(
             type = ErroneousSubclassQualifiedByNameMapper.class,
             kind = javax.tools.Diagnostic.Kind.ERROR,
-            line = 15,
+            line = 13,
+            alternativeLine = 15,
             message = "Qualifier error. No method found annotated with @Named#value: [ non-existent ]. " +
                 "See https://mapstruct.org/faq/#qualifier for more info."
         )


### PR DESCRIPTION
Fix #3202 

I had to remove one of the `@SubclassMapping` annotations from the erroneous mappers because otherwise the tests would fail.

It seems that if more than one annotations of the same type as `AnnotationMirror` are present on the mapping method the compiler will fallback to emit the error on the method itself. Eclipse compiler seems to work fine regardless of the number of annotations. Is this an already known issue?