### PR TITLE
add kora framework support

### DIFF
--- a/core/src/main/java/org/mapstruct/MappingConstants.java
+++ b/core/src/main/java/org/mapstruct/MappingConstants.java
@@ -149,6 +149,12 @@ public final class MappingConstants {
          */
         public static final String JAKARTA_CDI = "jakarta-cdi";
 
+        /**
+         * The generated mapper is a Kora component
+         *
+         */
+        public static final String KORA = "kora";
+
     }
 
 }

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -102,6 +102,14 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Kora -->
+        <dependency>
+            <groupId>ru.tinkoff.kora</groupId>
+            <artifactId>common</artifactId>
+            <version>0.11.6</version>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Spring -->
         <dependency>
             <groupId>org.springframework</groupId>
@@ -286,6 +294,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
+                    <testSource>17</testSource>
+                    <testTarget>17</testTarget>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.mapstruct.tools.gem</groupId>

--- a/processor/src/main/java/org/mapstruct/ap/internal/gem/MappingConstantsGem.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/gem/MappingConstantsGem.java
@@ -53,6 +53,8 @@ public final class MappingConstantsGem {
         public static final String JAKARTA = "jakarta";
 
         public static final String JAKARTA_CDI = "jakarta-cdi";
+
+        public static final String KORA = "kora";
      }
 
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/KoraComponentProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/KoraComponentProcessor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.processor;
+
+import org.mapstruct.ap.internal.gem.MappingConstantsGem;
+import org.mapstruct.ap.internal.model.Annotation;
+import org.mapstruct.ap.internal.model.Mapper;
+
+import java.util.Collections;
+import java.util.List;
+
+public class KoraComponentProcessor extends AnnotationBasedComponentModelProcessor {
+
+    @Override
+    protected String getComponentModelIdentifier() {
+        return MappingConstantsGem.ComponentModelGem.KORA;
+    }
+
+    @Override
+    protected List<Annotation> getTypeAnnotations(Mapper mapper) {
+        return Collections.singletonList(
+                new Annotation( getTypeFactory().getType( "ru.tinkoff.kora.common.Component" )
+                ) );
+    }
+
+    @Override
+    protected List<Annotation> getMapperReferenceAnnotations() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    protected boolean requiresGenerationOfDecoratorClass() {
+        return true;
+    }
+
+}

--- a/processor/src/main/resources/META-INF/services/org.mapstruct.ap.internal.processor.ModelElementProcessor
+++ b/processor/src/main/resources/META-INF/services/org.mapstruct.ap.internal.processor.ModelElementProcessor
@@ -11,3 +11,4 @@ org.mapstruct.ap.internal.processor.MapperRenderingProcessor
 org.mapstruct.ap.internal.processor.MethodRetrievalProcessor
 org.mapstruct.ap.internal.processor.SpringComponentProcessor
 org.mapstruct.ap.internal.processor.MapperServiceProcessor
+org.mapstruct.ap.internal.processor.KoraComponentProcessor

--- a/processor/src/test/java/org/mapstruct/ap/test/gem/ConstantTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/gem/ConstantTest.java
@@ -44,5 +44,6 @@ public class ConstantTest {
             .isEqualTo( MappingConstantsGem.ComponentModelGem.JAKARTA );
         assertThat( MappingConstants.ComponentModel.JAKARTA_CDI )
             .isEqualTo( MappingConstantsGem.ComponentModelGem.JAKARTA_CDI );
+        assertThat( MappingConstants.ComponentModel.KORA ).isEqualTo( MappingConstantsGem.ComponentModelGem.KORA );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/kora/CustomerKoraConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/kora/CustomerKoraConstructorMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.kora;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
+import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.KORA,
+        uses = GenderKoraConstructorMapper.class,
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR )
+public interface CustomerKoraConstructorMapper {
+
+    @Mapping(target = "gender", source = "gender")
+    CustomerDto asTarget(CustomerEntity customerEntity);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/kora/GenderKoraConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/kora/GenderKoraConstructorMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.kora;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ValueMappings;
+import org.mapstruct.ap.test.injectionstrategy.kora.constructor.ConstructorKoraConfig;
+import org.mapstruct.ap.test.injectionstrategy.shared.Gender;
+import org.mapstruct.ap.test.injectionstrategy.shared.GenderDto;
+
+@Mapper(config = ConstructorKoraConfig.class)
+public interface GenderKoraConstructorMapper {
+
+    @ValueMappings({
+        @ValueMapping(source = "MALE", target = "M"),
+        @ValueMapping(source = "FEMALE", target = "F")
+    })
+    GenderDto mapToDto(Gender gender);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/kora/KoraMapperConstructorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/kora/KoraMapperConstructorTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.kora;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.injectionstrategy.kora.constructor.ConstructorKoraConfig;
+import org.mapstruct.ap.test.injectionstrategy.shared.*;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithTestDependency;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static java.lang.System.lineSeparator;
+
+@WithClasses( {
+        CustomerRecordDto.class,
+        CustomerRecordEntity.class,
+        CustomerDto.class,
+        CustomerEntity.class,
+        Gender.class,
+        GenderDto.class,
+        CustomerKoraConstructorMapper.class,
+        GenderKoraConstructorMapper.class,
+        ConstructorKoraConfig.class
+} )
+@WithTestDependency("common")
+public class KoraMapperConstructorTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldHaveConstructorInjection() {
+        generatedSource.forMapper( CustomerKoraConstructorMapper.class )
+            .content()
+            .contains( "@Component" + lineSeparator() +
+                "public class CustomerKoraConstructorMapperImpl" )
+            .contains( "private final GenderKoraConstructorMapper" )
+            .contains( "public CustomerKoraConstructorMapperImpl(GenderKoraConstructorMapper" );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/kora/constructor/ConstructorKoraConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/kora/constructor/ConstructorKoraConfig.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.injectionstrategy.kora.constructor;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.MappingConstants;
+
+@MapperConfig(componentModel = MappingConstants.ComponentModel.KORA,
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR)
+public interface ConstructorKoraConfig {
+}


### PR DESCRIPTION
Recently, a lightweight and fast compile–time framework has appeared - [kora](https://github.com/Tinkoff/kora). Unfortunately, it can't recognize @Singleton and other annotations from Jakarta. So this pull request adds a new type of component model - **kora**.