### PR TITLE
#3153 Do not use compress directive to strip whitespaces for value mapping switch method

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
@@ -48,26 +48,22 @@
     </#if>
 }
 <#macro writeSource source="">
-    <@compress single_line=true>
-        <#if sourceParameter.type.enumType>
-             ${source}
-        <#elseif sourceParameter.type.string>
-            "${source}"
-        </#if>
-    </@compress>
+    <#if sourceParameter.type.enumType>
+        ${source}<#t>
+    <#elseif sourceParameter.type.string>
+        "${source}"<#t>
+    </#if>
 </#macro>
 <#macro writeTarget target="">
-    <@compress single_line=true>
-        <#if target?has_content>
-            <#if returnType.enumType>
-                <@includeModel object=returnType/>.${target}
-            <#elseif returnType.string>
-                "${target}"
-            </#if>
-        <#else>
-            null
+    <#if target?has_content>
+        <#if returnType.enumType>
+            <@includeModel object=returnType/>.${target}<#t>
+        <#elseif returnType.string>
+            "${target}"<#t>
         </#if>
-    </@compress>
+    <#else>
+        null<#t>
+    </#if>
 </#macro>
 <#macro throws>
     <#if (thrownTypes?size > 0)><#lt> throws </#if><@compress single_line=true>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3153/Issue3153Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3153/Issue3153Mapper.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3153;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+interface Issue3153Mapper {
+
+    Issue3153Mapper INSTANCE = Mappers.getMapper( Issue3153Mapper.class );
+
+    @ValueMapping(source = " PR", target = "PR")
+    @ValueMapping(source = "  PR", target = "PR")
+    @ValueMapping(source = "   PR", target = "PR")
+    @ValueMapping(source = MappingConstants.ANY_REMAINING, target = MappingConstants.NULL)
+    Target mapToEnum(String value);
+
+    @ValueMapping(source = "PR", target = "   PR")
+    String mapFromEnum(Target value);
+
+    enum Target {
+        PR,
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3153/Issue3153Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3153/Issue3153Test.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3153;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@WithClasses(Issue3153Mapper.class)
+@IssueKey("3153")
+class Issue3153Test {
+
+    @ProcessorTest
+    void shouldNotTrimStringValueSource() {
+        assertThat( Issue3153Mapper.INSTANCE.mapToEnum( "PR" ) ).isEqualTo( Issue3153Mapper.Target.PR );
+        assertThat( Issue3153Mapper.INSTANCE.mapToEnum( " PR" ) ).isEqualTo( Issue3153Mapper.Target.PR );
+        assertThat( Issue3153Mapper.INSTANCE.mapToEnum( "  PR" ) ).isEqualTo( Issue3153Mapper.Target.PR );
+        assertThat( Issue3153Mapper.INSTANCE.mapToEnum( "   PR" ) ).isEqualTo( Issue3153Mapper.Target.PR );
+
+        assertThat( Issue3153Mapper.INSTANCE.mapFromEnum( Issue3153Mapper.Target.PR ) ).isEqualTo( "   PR" );
+    }
+}


### PR DESCRIPTION
When using the compress directive it is going to strip whitespaces from the templates as well (i.e. what the user defined in `ValueMapping#source` and / or `ValueMapping#target`

fixes #3153