### PR TITLE
#1454 Support for lifecycle methods on type being built with builders

### DIFF
--- a/build-config/src/main/resources/build-config/checkstyle.xml
+++ b/build-config/src/main/resources/build-config/checkstyle.xml
@@ -29,7 +29,9 @@
     <!-- See http://checkstyle.sf.net/config_misc.html#Translation -->
     <module name="Translation"/>
 
-    <module name="FileLength"/>
+    <module name="FileLength">
+        <property name="max" value="2500"/>
+    </module>
 
     <module name="LineLength">
         <property name="max" value="120"/>

--- a/documentation/src/main/asciidoc/chapter-12-customizing-mapping.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-12-customizing-mapping.asciidoc
@@ -248,9 +248,8 @@ All before/after-mapping methods that *can* be applied to a mapping method *will
 
 The order of the method invocation is determined primarily by their variant:
 
-1. `@BeforeMapping` methods without an `@MappingTarget` parameter are called before any null-checks on source
-parameters and constructing a new target bean.
-2. `@BeforeMapping` methods with an `@MappingTarget` parameter are called after constructing a new target bean.
+1. `@BeforeMapping` methods without parameters, a `@MappingTarget` parameter or a `@TargetType` parameter are called before any null-checks on source parameters and constructing a new target bean.
+2. `@BeforeMapping` methods with a `@MappingTarget` parameter are called after constructing a new target bean.
 3. `@AfterMapping` methods are called at the end of the mapping method before the last `return` statement.
 
 Within those groups, the method invocations are ordered by their location of definition:
@@ -262,4 +261,11 @@ Within those groups, the method invocations are ordered by their location of def
 
 *Important:* the order of methods declared within one type can not be guaranteed, as it depends on the compiler and the processing environment implementation.
 
-*Important:* when using a builder, the `@AfterMapping` annotated method must have the builder as `@MappingTarget` annotated parameter so that the method is able to modify the object going to be build. The `build` method is called when the `@AfterMapping` annotated method scope finishes. MapStruct will not call the `@AfterMapping` annotated method if the real target is used as `@MappingTarget` annotated parameter.
+[NOTE]
+====
+Before/After-mapping methods can also be used with builders:
+
+* `@BeforeMapping` methods with a `@MappingTarget` parameter of the real target will not be invoked because it is only available after the mapping was already performed.
+* To be able to modify the object that is going to be built, the `@AfterMapping` annotated method must have the builder as `@MappingTarget` annotated parameter. The `build` method is called when the `@AfterMapping` annotated method scope finishes.
+* The `@AfterMapping` annotated method can also have the real target as `@TargetType` or `@MappingTarget`. It will be invoked after the real target was built (first the methods annotated with `@TargetType`, then the methods annotated with `@MappingTarget`)
+====

--- a/documentation/src/main/asciidoc/chapter-13-using-mapstruct-spi.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-13-using-mapstruct-spi.asciidoc
@@ -71,7 +71,7 @@ public class GolfPlayerDto {
 
     public GolfPlayerDto withName(String name) {
         this.name = name;
-        return this
+        return this;
     }
 }
 ----

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
@@ -186,8 +186,8 @@ public abstract class MappingMethod extends ModelElement {
         return returnType + " " + getName() + "(" + join( parameters, ", " ) + ")";
     }
 
-    private List<LifecycleCallbackMethodReference> filterMappingTarget(List<LifecycleCallbackMethodReference> methods,
-                                                                       boolean mustHaveMappingTargetParameter) {
+    protected static List<LifecycleCallbackMethodReference> filterMappingTarget(
+        List<LifecycleCallbackMethodReference> methods, boolean mustHaveMappingTargetParameter) {
         if ( methods == null ) {
             return Collections.emptyList();
         }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -21,6 +21,12 @@
 
     	</#if>
     </#list>
+    <#list beforeMappingReferencesWithFinalizedReturnType as callback>
+    	<@includeModel object=callback targetBeanName=finalizedResultName targetType=returnType/>
+    	<#if !callback_has_next>
+
+    	</#if>
+    </#list>
     <#if !mapNullToDefault>
     if ( <#list sourceParametersExcludingPrimitives as sourceParam>${sourceParam.name} == null<#if sourceParam_has_next> && </#if></#list> ) {
         return<#if returnType.name != "void"> <#if existingInstanceMapping>${resultName}<#if finalizerMethod??>.<@includeModel object=finalizerMethod /></#if><#else>null</#if></#if>;
@@ -129,7 +135,20 @@
     <#if returnType.name != "void">
 
     <#if finalizerMethod??>
-        return ${resultName}.<@includeModel object=finalizerMethod />;
+        <#if (afterMappingReferencesWithFinalizedReturnType?size > 0)>
+            ${returnType.name} ${finalizedResultName} = ${resultName}.<@includeModel object=finalizerMethod />;
+
+            <#list afterMappingReferencesWithFinalizedReturnType as callback>
+                <#if callback_index = 0>
+
+                </#if>
+                <@includeModel object=callback targetBeanName=finalizedResultName targetType=returnType/>
+            </#list>
+
+            return ${finalizedResultName};
+        <#else>
+            return ${resultName}.<@includeModel object=finalizerMethod />;
+        </#if>
     <#else>
         return ${resultName};
     </#if>

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/lifecycle/BuilderLifecycleCallbacksTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/lifecycle/BuilderLifecycleCallbacksTest.java
@@ -43,12 +43,16 @@ public class BuilderLifecycleCallbacksTest {
         assertThat( context.getInvokedMethods() )
             .contains(
                 "beforeWithoutParameters",
+                "beforeWithTargetType",
                 "beforeWithBuilderTargetType",
                 "beforeWithBuilderTarget",
                 "afterWithoutParameters",
                 "afterWithBuilderTargetType",
                 "afterWithBuilderTarget",
-                "afterWithBuilderTargetReturningTarget"
+                "afterWithBuilderTargetReturningTarget",
+                "afterWithTargetType",
+                "afterWithTarget",
+                "afterWithTargetReturningTarget"
             );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/builder/lifecycle/MappingContext.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/builder/lifecycle/MappingContext.java
@@ -74,7 +74,15 @@ public class MappingContext {
     public Order afterWithBuilderTargetReturningTarget(@MappingTarget Order.Builder orderBuilder) {
         invokedMethods.add( "afterWithBuilderTargetReturningTarget" );
 
-        return orderBuilder.create();
+        // return null, so that @AfterMapping methods on the finalized object will be called in the tests
+        return null;
+    }
+
+    @AfterMapping
+    public Order afterWithTargetReturningTarget(@MappingTarget Order order) {
+        invokedMethods.add( "afterWithTargetReturningTarget" );
+
+        return order;
     }
 
     public List<String> getInvokedMethods() {


### PR DESCRIPTION
Hi,

this is my first PR for mapstruct. Disclaimer: Because of the IntelliJ Community Edition I do not have any highlighting or formatting for `.ftl` files, so bear with me. 😅 

I tried to be as consistent as possible with the naming of the lifecycle method reference collections (`beforeMappingReferencesWithFinalizedReturnType` & `afterMappingReferencesWithFinalizedReturnType`) but if you have better suggestions, please tell me.

There is one edge-case i stumbled accross. With supporting `@AfterMapping` on the targets builder and finalized object, the following combination can be done by using methods **both returning** the result:

```java
    // snippet of processor/src/test/java/org/mapstruct/ap/test/builder/lifecycle/MappingContext.java
    @AfterMapping
    public Order afterWithBuilderTargetReturningTarget(@MappingTarget Order.Builder orderBuilder) {
        invokedMethods.add( "afterWithBuilderTargetReturningTarget" );

        return orderBuilder.create();
    }

    @AfterMapping
    public Order afterWithTargetReturningTarget(@MappingTarget Order order) {
        invokedMethods.add( "afterWithTargetReturningTarget" );

        return order;
    }

```

Which results in the following mapper:

```java

public class OrderMapperImpl implements OrderMapper {

    @Override
    public Order map(OrderDto source, MappingContext context) {

        // ... removed for brevity ...

        context.afterWithBuilderTarget( source, order );
        Order target = context.afterWithBuilderTargetReturningTarget( order );
        if ( target != null ) {
            return target; // in this case it will return here
        }

        // this code will not be reached
        Order orderResult = order.create();

        context.afterWithTargetType( source, Order.class );
        context.afterWithTarget( source, orderResult );
        Order target1 = context.afterWithTargetReturningTarget( orderResult );
        if ( target1 != null ) {
            return target1;
        }

        return orderResult;
    }
```

This makes sense but might be confusing. I was wondering if MapStruct should throw an error in that case?
For me, I had to adapt the test, that `context#afterWithBuilderTargetReturningTarget` returns null so that he other `@AfterMappings` get called.

Fixes #1454
---

- [x] documentation still has to be adapted [here](https://github.com/thunderhook/mapstruct/blob/693e1ab12410ae8fbbbdb371a505ed547e74a9fc/documentation/src/main/asciidoc/chapter-12-customizing-mapping.asciidoc#L265-L265)