### PR TITLE
Remove redundant null checks in nested properties

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.ftl
@@ -7,15 +7,16 @@
 -->
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.NestedPropertyMappingMethod" -->
 <#lt>private <@includeModel object=returnType.typeBound/> ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>)<@throws/> {
-    if ( ${sourceParameter.name} == null ) {
-        return ${returnType.null};
-    }
 <#list propertyEntries as entry>
     <#if entry.presenceChecker?? >
     if ( <#if entry_index != 0>${entry.previousPropertyName} == null || </#if>!<@includeModel object=entry.presenceChecker /> ) {
         return ${returnType.null};
     }
     </#if>
+    <#if !entry_has_next>
+    return ${entry.previousPropertyName}.${entry.accessorName};
+    </#if>
+    <#if entry_has_next>
     <@includeModel object=entry.type.typeBound/> ${entry.name} = ${entry.previousPropertyName}.${entry.accessorName};
     <#if !entry.presenceChecker?? >
     <#if !entry.type.primitive>
@@ -24,8 +25,6 @@
     }
     </#if>
     </#if>
-    <#if !entry_has_next>
-    return ${entry.name};
     </#if>
 </#list>
 }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1561/Issue1561MapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1561/Issue1561MapperImpl.java
@@ -61,17 +61,10 @@ public class Issue1561MapperImpl implements Issue1561Mapper {
     }
 
     private Stream<String> targetNestedTargetProperties(Target target) {
-        if ( target == null ) {
-            return null;
-        }
         NestedTarget nestedTarget = target.getNestedTarget();
         if ( nestedTarget == null ) {
             return null;
         }
-        Stream<String> properties = nestedTarget.getProperties();
-        if ( properties == null ) {
-            return null;
-        }
-        return properties;
+        return nestedTarget.getProperties();
     }
 }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1685/UserMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1685/UserMapperImpl.java
@@ -168,77 +168,42 @@ public class UserMapperImpl implements UserMapper {
     }
 
     private String userDTOContactDataDTOEmail(UserDTO userDTO) {
-        if ( userDTO == null ) {
-            return null;
-        }
         ContactDataDTO contactDataDTO = userDTO.getContactDataDTO();
         if ( contactDataDTO == null ) {
             return null;
         }
-        String email = contactDataDTO.getEmail();
-        if ( email == null ) {
-            return null;
-        }
-        return email;
+        return contactDataDTO.getEmail();
     }
 
     private String userDTOContactDataDTOPhone(UserDTO userDTO) {
-        if ( userDTO == null ) {
-            return null;
-        }
         ContactDataDTO contactDataDTO = userDTO.getContactDataDTO();
         if ( contactDataDTO == null ) {
             return null;
         }
-        String phone = contactDataDTO.getPhone();
-        if ( phone == null ) {
-            return null;
-        }
-        return phone;
+        return contactDataDTO.getPhone();
     }
 
     private String userDTOContactDataDTOAddress(UserDTO userDTO) {
-        if ( userDTO == null ) {
-            return null;
-        }
         ContactDataDTO contactDataDTO = userDTO.getContactDataDTO();
         if ( contactDataDTO == null ) {
             return null;
         }
-        String address = contactDataDTO.getAddress();
-        if ( address == null ) {
-            return null;
-        }
-        return address;
+        return contactDataDTO.getAddress();
     }
 
     private List<String> userDTOContactDataDTOPreferences(UserDTO userDTO) {
-        if ( userDTO == null ) {
-            return null;
-        }
         ContactDataDTO contactDataDTO = userDTO.getContactDataDTO();
         if ( contactDataDTO == null ) {
             return null;
         }
-        List<String> preferences = contactDataDTO.getPreferences();
-        if ( preferences == null ) {
-            return null;
-        }
-        return preferences;
+        return contactDataDTO.getPreferences();
     }
 
     private String[] userDTOContactDataDTOSettings(UserDTO userDTO) {
-        if ( userDTO == null ) {
-            return null;
-        }
         ContactDataDTO contactDataDTO = userDTO.getContactDataDTO();
         if ( contactDataDTO == null ) {
             return null;
         }
-        String[] settings = contactDataDTO.getSettings();
-        if ( settings == null ) {
-            return null;
-        }
-        return settings;
+        return contactDataDTO.getSettings();
     }
 }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_2245/TestMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_2245/TestMapperImpl.java
@@ -34,17 +34,10 @@ public class TestMapperImpl implements TestMapper {
     }
 
     private String tenantInnerId(TenantDTO tenantDTO) {
-        if ( tenantDTO == null ) {
-            return null;
-        }
         Inner inner = tenantDTO.getInner();
         if ( inner == null ) {
             return null;
         }
-        String id = inner.getId();
-        if ( id == null ) {
-            return null;
-        }
-        return id;
+        return inner.getId();
     }
 }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/constructor/nestedsource/ArtistToChartEntryImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/constructor/nestedsource/ArtistToChartEntryImpl.java
@@ -96,24 +96,14 @@ public class ArtistToChartEntryImpl implements ArtistToChartEntry {
     }
 
     private String songArtistName(Song song) {
-        if ( song == null ) {
-            return null;
-        }
         Artist artist = song.getArtist();
         if ( artist == null ) {
             return null;
         }
-        String name = artist.getName();
-        if ( name == null ) {
-            return null;
-        }
-        return name;
+        return artist.getName();
     }
 
     private String songArtistLabelStudioName(Song song) {
-        if ( song == null ) {
-            return null;
-        }
         Artist artist = song.getArtist();
         if ( artist == null ) {
             return null;
@@ -126,17 +116,10 @@ public class ArtistToChartEntryImpl implements ArtistToChartEntry {
         if ( studio == null ) {
             return null;
         }
-        String name = studio.getName();
-        if ( name == null ) {
-            return null;
-        }
-        return name;
+        return studio.getName();
     }
 
     private String songArtistLabelStudioCity(Song song) {
-        if ( song == null ) {
-            return null;
-        }
         Artist artist = song.getArtist();
         if ( artist == null ) {
             return null;
@@ -149,10 +132,6 @@ public class ArtistToChartEntryImpl implements ArtistToChartEntry {
         if ( studio == null ) {
             return null;
         }
-        String city = studio.getCity();
-        if ( city == null ) {
-            return null;
-        }
-        return city;
+        return studio.getCity();
     }
 }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/constructor/nestedtarget/ChartEntryToArtistImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/constructor/nestedtarget/ChartEntryToArtistImpl.java
@@ -132,24 +132,14 @@ public class ChartEntryToArtistImpl extends ChartEntryToArtist {
     }
 
     private String chartSongTitle(Chart chart) {
-        if ( chart == null ) {
-            return null;
-        }
         Song song = chart.getSong();
         if ( song == null ) {
             return null;
         }
-        String title = song.getTitle();
-        if ( title == null ) {
-            return null;
-        }
-        return title;
+        return song.getTitle();
     }
 
     private String chartSongArtistName(Chart chart) {
-        if ( chart == null ) {
-            return null;
-        }
         Song song = chart.getSong();
         if ( song == null ) {
             return null;
@@ -158,17 +148,10 @@ public class ChartEntryToArtistImpl extends ChartEntryToArtist {
         if ( artist == null ) {
             return null;
         }
-        String name = artist.getName();
-        if ( name == null ) {
-            return null;
-        }
-        return name;
+        return artist.getName();
     }
 
     private String chartSongArtistLabelStudioName(Chart chart) {
-        if ( chart == null ) {
-            return null;
-        }
         Song song = chart.getSong();
         if ( song == null ) {
             return null;
@@ -185,17 +168,10 @@ public class ChartEntryToArtistImpl extends ChartEntryToArtist {
         if ( studio == null ) {
             return null;
         }
-        String name = studio.getName();
-        if ( name == null ) {
-            return null;
-        }
-        return name;
+        return studio.getName();
     }
 
     private String chartSongArtistLabelStudioCity(Chart chart) {
-        if ( chart == null ) {
-            return null;
-        }
         Song song = chart.getSong();
         if ( song == null ) {
             return null;
@@ -212,25 +188,14 @@ public class ChartEntryToArtistImpl extends ChartEntryToArtist {
         if ( studio == null ) {
             return null;
         }
-        String city = studio.getCity();
-        if ( city == null ) {
-            return null;
-        }
-        return city;
+        return studio.getCity();
     }
 
     private List<Integer> chartSongPositions(Chart chart) {
-        if ( chart == null ) {
-            return null;
-        }
         Song song = chart.getSong();
         if ( song == null ) {
             return null;
         }
-        List<Integer> positions = song.getPositions();
-        if ( positions == null ) {
-            return null;
-        }
-        return positions;
+        return song.getPositions();
     }
 }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/mixed/FishTankMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/mixed/FishTankMapperImpl.java
@@ -159,18 +159,11 @@ public class FishTankMapperImpl implements FishTankMapper {
     }
 
     private Ornament sourceInteriorOrnament(FishTank fishTank) {
-        if ( fishTank == null ) {
-            return null;
-        }
         Interior interior = fishTank.getInterior();
         if ( interior == null ) {
             return null;
         }
-        Ornament ornament = interior.getOrnament();
-        if ( ornament == null ) {
-            return null;
-        }
-        return ornament;
+        return interior.getOrnament();
     }
 
     protected OrnamentDto ornamentToOrnamentDto(Ornament ornament) {
@@ -295,18 +288,11 @@ public class FishTankMapperImpl implements FishTankMapper {
     }
 
     private String waterQualityReportDtoOrganisationName(WaterQualityReportDto waterQualityReportDto) {
-        if ( waterQualityReportDto == null ) {
-            return null;
-        }
         WaterQualityOrganisationDto organisation = waterQualityReportDto.getOrganisation();
         if ( organisation == null ) {
             return null;
         }
-        String name = organisation.getName();
-        if ( name == null ) {
-            return null;
-        }
-        return name;
+        return organisation.getName();
     }
 
     protected WaterQualityReport waterQualityReportDtoToWaterQualityReport(WaterQualityReportDto waterQualityReportDto) {
@@ -335,18 +321,11 @@ public class FishTankMapperImpl implements FishTankMapper {
     }
 
     private MaterialTypeDto sourceMaterialMaterialType(FishTankDto fishTankDto) {
-        if ( fishTankDto == null ) {
-            return null;
-        }
         MaterialDto material = fishTankDto.getMaterial();
         if ( material == null ) {
             return null;
         }
-        MaterialTypeDto materialType = material.getMaterialType();
-        if ( materialType == null ) {
-            return null;
-        }
-        return materialType;
+        return material.getMaterialType();
     }
 
     protected MaterialType materialTypeDtoToMaterialType(MaterialTypeDto materialTypeDto) {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedsourceproperties/ArtistToChartEntryImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedsourceproperties/ArtistToChartEntryImpl.java
@@ -74,24 +74,14 @@ public class ArtistToChartEntryImpl implements ArtistToChartEntry {
     }
 
     private String songArtistName(Song song) {
-        if ( song == null ) {
-            return null;
-        }
         Artist artist = song.getArtist();
         if ( artist == null ) {
             return null;
         }
-        String name = artist.getName();
-        if ( name == null ) {
-            return null;
-        }
-        return name;
+        return artist.getName();
     }
 
     private String songArtistLabelStudioName(Song song) {
-        if ( song == null ) {
-            return null;
-        }
         Artist artist = song.getArtist();
         if ( artist == null ) {
             return null;
@@ -104,17 +94,10 @@ public class ArtistToChartEntryImpl implements ArtistToChartEntry {
         if ( studio == null ) {
             return null;
         }
-        String name = studio.getName();
-        if ( name == null ) {
-            return null;
-        }
-        return name;
+        return studio.getName();
     }
 
     private String songArtistLabelStudioCity(Song song) {
-        if ( song == null ) {
-            return null;
-        }
         Artist artist = song.getArtist();
         if ( artist == null ) {
             return null;
@@ -127,10 +110,6 @@ public class ArtistToChartEntryImpl implements ArtistToChartEntry {
         if ( studio == null ) {
             return null;
         }
-        String city = studio.getCity();
-        if ( city == null ) {
-            return null;
-        }
-        return city;
+        return studio.getCity();
     }
 }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedtargetproperties/ChartEntryToArtistImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedtargetproperties/ChartEntryToArtistImpl.java
@@ -198,24 +198,14 @@ public class ChartEntryToArtistImpl extends ChartEntryToArtist {
     }
 
     private String chartSongTitle(Chart chart) {
-        if ( chart == null ) {
-            return null;
-        }
         Song song = chart.getSong();
         if ( song == null ) {
             return null;
         }
-        String title = song.getTitle();
-        if ( title == null ) {
-            return null;
-        }
-        return title;
+        return song.getTitle();
     }
 
     private String chartSongArtistName(Chart chart) {
-        if ( chart == null ) {
-            return null;
-        }
         Song song = chart.getSong();
         if ( song == null ) {
             return null;
@@ -224,17 +214,10 @@ public class ChartEntryToArtistImpl extends ChartEntryToArtist {
         if ( artist == null ) {
             return null;
         }
-        String name = artist.getName();
-        if ( name == null ) {
-            return null;
-        }
-        return name;
+        return artist.getName();
     }
 
     private String chartSongArtistLabelStudioName(Chart chart) {
-        if ( chart == null ) {
-            return null;
-        }
         Song song = chart.getSong();
         if ( song == null ) {
             return null;
@@ -251,17 +234,10 @@ public class ChartEntryToArtistImpl extends ChartEntryToArtist {
         if ( studio == null ) {
             return null;
         }
-        String name = studio.getName();
-        if ( name == null ) {
-            return null;
-        }
-        return name;
+        return studio.getName();
     }
 
     private String chartSongArtistLabelStudioCity(Chart chart) {
-        if ( chart == null ) {
-            return null;
-        }
         Song song = chart.getSong();
         if ( song == null ) {
             return null;
@@ -278,25 +254,14 @@ public class ChartEntryToArtistImpl extends ChartEntryToArtist {
         if ( studio == null ) {
             return null;
         }
-        String city = studio.getCity();
-        if ( city == null ) {
-            return null;
-        }
-        return city;
+        return studio.getCity();
     }
 
     private List<Integer> chartSongPositions(Chart chart) {
-        if ( chart == null ) {
-            return null;
-        }
         Song song = chart.getSong();
         if ( song == null ) {
             return null;
         }
-        List<Integer> positions = song.getPositions();
-        if ( positions == null ) {
-            return null;
-        }
-        return positions;
+        return song.getPositions();
     }
 }


### PR DESCRIPTION
The code changes provided try removing redundant null checks for nested properties.

Fixes #3245.