### PR TITLE
Configure maven retry behavior for Windows CI pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 env:
   SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
   SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
-  MAVEN_ARGS: -V -B --no-transfer-progress -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+  MAVEN_ARGS: -V -B --no-transfer-progress -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.http.retryHandler.count=3 -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
 
 jobs:
   test_jdk:


### PR DESCRIPTION
I have included the following configuration property in the MAVEN_ARGS variable defined in main.yml to enable retry in Windows:

-Dmaven.wagon.http.retryHandler.count=3

The CI defined pipeline for that operating system constantly  timeouts when fetching maven dependencies: perhaps the change could solve the issue.