### PR TITLE
@AfterMapping to render mapping calls after the build() methods for result type value.

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -327,6 +327,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                             ctx,
                             existingVariableNames
             );
+            // TODO: Use returnTypeToConstruct to add relevant after-mapping lifecycle-method
             List<LifecycleCallbackMethodReference> afterMappingMethods = LifecycleMethodResolver.afterMappingMethods(
                             method,
                             resultTypeToMap,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -327,7 +327,6 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                             ctx,
                             existingVariableNames
             );
-            // TODO: Use returnTypeToConstruct to add relevant after-mapping lifecycle-method
             List<LifecycleCallbackMethodReference> afterMappingMethods = LifecycleMethodResolver.afterMappingMethods(
                             method,
                             resultTypeToMap,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleCallbackMethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleCallbackMethodReference.java
@@ -86,6 +86,10 @@ public class LifecycleCallbackMethodReference extends MethodReference {
     public boolean hasMappingTargetParameter() {
         return getParameterBindings().stream().anyMatch( ParameterBinding::isMappingTarget );
     }
+    
+    public boolean hasResultMappingTargetParameter() {
+    	return getParameterBindings().stream().anyMatch( ParameterBinding::isResultMappingTarget );
+    }
 
     /**
      * @return true if this callback method has a return type that is not void

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleCallbackMethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/LifecycleCallbackMethodReference.java
@@ -88,7 +88,7 @@ public class LifecycleCallbackMethodReference extends MethodReference {
     }
     
     public boolean hasResultMappingTargetParameter() {
-    	return getParameterBindings().stream().anyMatch( ParameterBinding::isResultMappingTarget );
+        return getParameterBindings().stream().anyMatch( ParameterBinding::isResultMappingTarget );
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingMethod.java
@@ -195,44 +195,34 @@ public abstract class MappingMethod extends ModelElement {
             return Collections.emptyList();
         }
 
-        List<LifecycleCallbackMethodReference> result =
-            new ArrayList<>( methods.size() );
-
-        for ( LifecycleCallbackMethodReference method : methods ) {
-            if ( mustHaveMappingTargetParameter == method.hasMappingTargetParameter() ) {
-                result.add( method );
-            }
-        }
-
-        return result;
+        return methods.stream()
+                .filter( method -> mustHaveMappingTargetParameter == method.hasMappingTargetParameter() )
+                .filter( method -> !method.hasResultMappingTargetParameter() )
+                .collect( Collectors.toList() );
     }
     
     /**
      * @param methods after-mapping methods for this {@link MappingMethod}.
      * @param isForResultType boolean indicating whether the after-mapping method is meant for the result
      * 						  type and not the target type.
-     * @return
+     * @return list of method refs that conform to the condition.
      */
     private List<LifecycleCallbackMethodReference> filterAfterMappingTarget(List<LifecycleCallbackMethodReference> methods,
-    																		boolean isForResultType) {
-    	if ( isForResultType ) {
-	    	return methods.stream()
-					.filter( LifecycleCallbackMethodReference::hasResultMappingTargetParameter )
-					.collect(Collectors.toList());
-    	}
-    	else {
-	    	return methods.stream()
-					.filter( callback -> !callback.hasResultMappingTargetParameter() )
-					.collect(Collectors.toList());
-    	}
+                                                                            boolean isForResultType) {
+        if (methods == null) {
+            return Collections.emptyList();
+        }
+        
+        return methods.stream()
+                .filter( callback -> isForResultType == callback.hasResultMappingTargetParameter() ).collect(Collectors.toList());
     }
 
     public List<LifecycleCallbackMethodReference> getAfterMappingReferences() {
         return afterMappingReferences;
     }
 
-	public List<LifecycleCallbackMethodReference> getAfterMappingReferencesForResultType() {
-		return afterMappingReferencesForResultType;
+    public List<LifecycleCallbackMethodReference> getAfterMappingReferencesForResultType() {
+        return afterMappingReferencesForResultType;
 	}
 
     public List<LifecycleCallbackMethodReference> getBeforeMappingReferencesWithMappingTarget() {
@@ -277,5 +267,4 @@ public abstract class MappingMethod extends ModelElement {
 
         return true;
     }
-
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/ParameterBinding.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/ParameterBinding.java
@@ -28,12 +28,12 @@ public class ParameterBinding {
 
     private ParameterBinding(Type parameterType, String variableName, boolean mappingTarget, boolean targetType,
         boolean mappingContext, boolean targetPropertyName, SourceRHS sourceRHS) {
-    	this(parameterType, variableName, mappingTarget, false, targetType, mappingContext, targetPropertyName, sourceRHS);
+        this(parameterType, variableName, mappingTarget, false, targetType, mappingContext, targetPropertyName, sourceRHS);
     }
 
     private ParameterBinding(Type parameterType, String variableName, boolean mappingTarget, boolean afterMappingTarget,
-    	boolean targetType, boolean mappingContext, boolean targetPropertyName, SourceRHS sourceRHS) {
-    	this.type = parameterType;
+        boolean targetType, boolean mappingContext, boolean targetPropertyName, SourceRHS sourceRHS) {
+        this.type = parameterType;
         this.variableName = variableName;
         this.targetType = targetType;
         this.mappingTarget = mappingTarget;
@@ -70,8 +70,8 @@ public class ParameterBinding {
      * after the finalize method is called.
      */
     public boolean isResultMappingTarget() {
-		return resultMappingTarget;
-	}
+        return resultMappingTarget;
+    }
 
 	/**
      * @return {@code true}, if the parameter being bound is a {@code @MappingContext} parameter.
@@ -173,7 +173,7 @@ public class ParameterBinding {
     }
     
     public static ParameterBinding forResultMappingTargetBinding(Type resultType) {
-    	return new ParameterBinding( resultType, null, true, true, false, false, false, null );
+        return new ParameterBinding( resultType, null, true, true, false, false, false, null );
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/ParameterBinding.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/ParameterBinding.java
@@ -21,21 +21,28 @@ public class ParameterBinding {
     private final String variableName;
     private final boolean targetType;
     private final boolean mappingTarget;
+    private final boolean resultMappingTarget;
     private final boolean mappingContext;
     private final boolean targetPropertyName;
     private final SourceRHS sourceRHS;
 
     private ParameterBinding(Type parameterType, String variableName, boolean mappingTarget, boolean targetType,
         boolean mappingContext, boolean targetPropertyName, SourceRHS sourceRHS) {
-        this.type = parameterType;
+    	this(parameterType, variableName, mappingTarget, false, targetType, mappingContext, targetPropertyName, sourceRHS);
+    }
+
+    private ParameterBinding(Type parameterType, String variableName, boolean mappingTarget, boolean afterMappingTarget,
+    	boolean targetType, boolean mappingContext, boolean targetPropertyName, SourceRHS sourceRHS) {
+    	this.type = parameterType;
         this.variableName = variableName;
         this.targetType = targetType;
         this.mappingTarget = mappingTarget;
+        this.resultMappingTarget = afterMappingTarget;
         this.mappingContext = mappingContext;
         this.targetPropertyName = targetPropertyName;
         this.sourceRHS = sourceRHS;
     }
-
+    
     /**
      * @return the name of the variable (or parameter) that is being used as argument for the parameter being bound.
      */
@@ -58,6 +65,15 @@ public class ParameterBinding {
     }
 
     /**
+     * 
+     * @return {@code true}, if the parameter being bound is a {@code @MappingTarget} parameter
+     * after the finalize method is called.
+     */
+    public boolean isResultMappingTarget() {
+		return resultMappingTarget;
+	}
+
+	/**
      * @return {@code true}, if the parameter being bound is a {@code @MappingContext} parameter.
      */
     public boolean isMappingContext() {
@@ -155,6 +171,10 @@ public class ParameterBinding {
     public static ParameterBinding forMappingTargetBinding(Type resultType) {
         return new ParameterBinding( resultType, null, true, false, false, false, null );
     }
+    
+    public static ParameterBinding forResultMappingTargetBinding(Type resultType) {
+    	return new ParameterBinding( resultType, null, true, true, false, false, false, null );
+    }
 
     /**
      * @param sourceType type of the parameter
@@ -163,7 +183,7 @@ public class ParameterBinding {
     public static ParameterBinding forSourceTypeBinding(Type sourceType) {
         return new ParameterBinding( sourceType, null, false, false, false, false, null );
     }
-
+    
     public static ParameterBinding fromSourceRHS(SourceRHS sourceRHS) {
         return new ParameterBinding( sourceRHS.getSourceType(), null, false, false, false, false, sourceRHS );
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/TypeSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/TypeSelector.java
@@ -157,7 +157,7 @@ public class TypeSelector implements MethodSelector {
             availableParams.add( ParameterBinding.forMappingTargetBinding( targetType ) );
         }
         if ( !resultMappingTargetAvailable && !targetType.equals(resultType)) {
-        	availableParams.add( ParameterBinding.forResultMappingTargetBinding( resultType ) );
+            availableParams.add( ParameterBinding.forResultMappingTargetBinding( resultType ) );
         }
         if ( !targetTypeAvailable ) {
             availableParams.add( ParameterBinding.forTargetTypeBinding( typeFactory.classTypeOf( targetType ) ) );

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -128,10 +128,27 @@
     </#list>
     <#if returnType.name != "void">
 
+    <#if afterMappingReferencesForResultType.isEmpty()>
     <#if finalizerMethod??>
         return ${resultName}.<@includeModel object=finalizerMethod />;
     <#else>
         return ${resultName};
+    </#if>
+    <#else>
+    <@compress single_line=true>
+        <@includeModel object=resultType /> _${resultName} =
+        <#if finalizerMethod??>
+          ${resultName}.<@includeModel object=finalizerMethod />;
+        <#else>
+          ${resultName};
+        </#if>
+    </@compress>
+
+    <#list afterMappingReferencesForResultType as callback>
+        <@includeModel object=callback targetBeanName="_${resultName}" targetType=targetType/>
+    </#list>
+
+        return _${resultName};
     </#if>
     </#if>
     </#if>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Issue3176Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Issue3176Mapper.java
@@ -1,0 +1,30 @@
+package org.mapstruct.ap.test.bugs._3176;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class Issue3176Mapper {
+
+    public abstract TargetWithBuilder toTarget(Source source);
+	
+	public static Issue3176Mapper INSTANCE = Mappers.getMapper(Issue3176Mapper.class);
+	
+	@AfterMapping
+	public void handleOriginalAfterMapping(@MappingTarget TargetWithBuilder target) {
+		target.setExample(target.getExample() + " after editing");
+	}
+	
+	@AfterMapping
+	public void handleBuilderAfterMapping(@MappingTarget TargetWithBuilder.Builder builder) {
+		builder.example(builder.getExample() + " after builder editing");
+	}
+	
+	@AfterMapping
+	public void handleBuilderAfterMapping2(@MappingTarget TargetWithBuilder.Builder builder) {
+		builder.example(builder.getExample() + " after builder editing");
+	}
+	
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Issue3176Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Issue3176Mapper.java
@@ -9,22 +9,22 @@ import org.mapstruct.factory.Mappers;
 public abstract class Issue3176Mapper {
 
     public abstract TargetWithBuilder toTarget(Source source);
-	
-	public static Issue3176Mapper INSTANCE = Mappers.getMapper(Issue3176Mapper.class);
-	
-	@AfterMapping
-	public void handleOriginalAfterMapping(@MappingTarget TargetWithBuilder target) {
-		target.setExample(target.getExample() + " after editing");
-	}
-	
-	@AfterMapping
-	public void handleBuilderAfterMapping(@MappingTarget TargetWithBuilder.Builder builder) {
-		builder.example(builder.getExample() + " after builder editing");
-	}
-	
-	@AfterMapping
-	public void handleBuilderAfterMapping2(@MappingTarget TargetWithBuilder.Builder builder) {
-		builder.example(builder.getExample() + " after builder editing");
-	}
-	
+
+    public static Issue3176Mapper INSTANCE = Mappers.getMapper(Issue3176Mapper.class);
+
+    @AfterMapping
+    public void handleOriginalAfterMapping(@MappingTarget TargetWithBuilder target) {
+        target.setExample(target.getExample() + " after editing");
+    }
+
+    @AfterMapping
+    public void handleBuilderAfterMapping(@MappingTarget TargetWithBuilder.Builder builder) {
+        builder.example(builder.getExample() + " after builder editing");
+    }
+
+    @AfterMapping
+    public void handleBuilderAfterMapping2(@MappingTarget TargetWithBuilder.Builder builder) {
+        builder.example(builder.getExample() + " after builder editing");
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Issue3176MapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Issue3176MapperTest.java
@@ -1,0 +1,24 @@
+package org.mapstruct.ap.test.bugs._3176;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+@WithClasses({ Source.class, TargetWithBuilder.class, Issue3176Mapper.class })
+@IssueKey("3176")
+@Disabled
+class Issue3176MapperTest {
+
+	@RegisterExtension
+	GeneratedSource generated = new GeneratedSource();
+
+	@ProcessorTest
+	void AfterMappingForOriginalSourceWithBuilder() {
+		generated.forMapper(Issue3176Mapper.class).content()
+			.contains("handleOriginalAfterMapping");
+	}
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Issue3176MapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Issue3176MapperTest.java
@@ -1,6 +1,5 @@
 package org.mapstruct.ap.test.bugs._3176;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
@@ -9,16 +8,14 @@ import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
 @WithClasses({ Source.class, TargetWithBuilder.class, Issue3176Mapper.class })
 @IssueKey("3176")
-@Disabled
 class Issue3176MapperTest {
 
-	@RegisterExtension
-	GeneratedSource generated = new GeneratedSource();
+    @RegisterExtension
+    GeneratedSource generated = new GeneratedSource();
 
-	@ProcessorTest
-	void AfterMappingForOriginalSourceWithBuilder() {
-		generated.forMapper(Issue3176Mapper.class).content()
-			.contains("handleOriginalAfterMapping");
-	}
+    @ProcessorTest
+    void testAfterMappingForOriginalSourceWithBuilder() {
+        generated.forMapper(Issue3176Mapper.class).content().contains("handleOriginalAfterMapping");
+    }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Source.java
@@ -2,14 +2,14 @@ package org.mapstruct.ap.test.bugs._3176;
 
 public class Source {
 
-	private String example;
+    private String example;
 
-	public String getExample() {
-		return example;
-	}
+    public String getExample() {
+        return example;
+    }
 
-	public void setExample(String example) {
-		this.example = example;
-	}
+    public void setExample(String example) {
+        this.example = example;
+    }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/Source.java
@@ -1,0 +1,15 @@
+package org.mapstruct.ap.test.bugs._3176;
+
+public class Source {
+
+	private String example;
+
+	public String getExample() {
+		return example;
+	}
+
+	public void setExample(String example) {
+		this.example = example;
+	}
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/TargetWithBuilder.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/TargetWithBuilder.java
@@ -1,0 +1,48 @@
+package org.mapstruct.ap.test.bugs._3176;
+
+public class TargetWithBuilder {
+
+	private String example;
+
+	public String getExample() {
+		return example;
+	}
+
+	public void setExample(String example) {
+		this.example = example;
+	}
+
+	private TargetWithBuilder(Builder builder) {
+		this.example = builder.example;
+	}
+	
+
+	public TargetWithBuilder() {
+		
+	}
+	
+	public static Builder builder() {
+		return new Builder();
+	}
+
+
+	public static class Builder {
+
+		private String example;
+
+		public Builder example(String example) {
+			this.example = example;
+			return this;
+		}
+		
+		public String getExample() {
+			return this.example;
+		}
+
+		public TargetWithBuilder build() {
+			return new TargetWithBuilder(this);
+		}
+
+	}
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/TargetWithBuilder.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3176/TargetWithBuilder.java
@@ -2,47 +2,45 @@ package org.mapstruct.ap.test.bugs._3176;
 
 public class TargetWithBuilder {
 
-	private String example;
+    private String example;
 
-	public String getExample() {
-		return example;
-	}
+    public String getExample() {
+        return example;
+    }
 
-	public void setExample(String example) {
-		this.example = example;
-	}
+    public void setExample(String example) {
+        this.example = example;
+    }
 
-	private TargetWithBuilder(Builder builder) {
-		this.example = builder.example;
-	}
-	
+    private TargetWithBuilder(Builder builder) {
+        this.example = builder.example;
+    }
 
-	public TargetWithBuilder() {
-		
-	}
-	
-	public static Builder builder() {
-		return new Builder();
-	}
+    public TargetWithBuilder() {
 
+    }
 
-	public static class Builder {
+    public static Builder builder() {
+        return new Builder();
+    }
 
-		private String example;
+    public static class Builder {
 
-		public Builder example(String example) {
-			this.example = example;
-			return this;
-		}
-		
-		public String getExample() {
-			return this.example;
-		}
+        private String example;
 
-		public TargetWithBuilder build() {
-			return new TargetWithBuilder(this);
-		}
+        public Builder example(String example) {
+            this.example = example;
+            return this;
+        }
 
-	}
+        public String getExample() {
+            return this.example;
+        }
+
+        public TargetWithBuilder build() {
+            return new TargetWithBuilder(this);
+        }
+
+    }
 
 }


### PR DESCRIPTION
Fixes #3176.

Modifed the models for ParameterBinding, MappingMethod, LifecycleCallbackMethod to accomodate for after-mapping callbacks that target return type rather than target type in case Builder.