### PR TITLE
#3317 Do not generate source parameter if check for only primitives

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -27,7 +27,7 @@
 
     	</#if>
     </#list>
-    <#if !mapNullToDefault>
+    <#if !mapNullToDefault && !sourceParametersExcludingPrimitives.empty>
     if ( <#list sourceParametersExcludingPrimitives as sourceParam>${sourceParam.name} == null<#if sourceParam_has_next> && </#if></#list> ) {
         return<#if returnType.name != "void"> <#if existingInstanceMapping>${resultName}<#if finalizerMethod??>.<@includeModel object=finalizerMethod /></#if><#else>null</#if></#if>;
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3317/Issue3317Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3317/Issue3317Mapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3317;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue3317Mapper {
+
+    Issue3317Mapper INSTANCE = Mappers.getMapper( Issue3317Mapper.class );
+
+    Target map(int id, long value);
+
+    class Target {
+
+        private final int id;
+        private final long value;
+
+        public Target(int id, long value) {
+            this.id = id;
+            this.value = value;
+        }
+
+        public int getId() {
+            return id;
+        }
+
+        public long getValue() {
+            return value;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3317/Issue3317Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3317/Issue3317Test.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3317;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("3317")
+@WithClasses(Issue3317Mapper.class)
+class Issue3317Test {
+
+    @ProcessorTest
+    void shouldGenerateValidCode() {
+        Issue3317Mapper.Target target = Issue3317Mapper.INSTANCE.map( 10, 42L );
+        assertThat( target ).isNotNull();
+        assertThat( target.getId() ).isEqualTo( 10 );
+        assertThat( target.getValue() ).isEqualTo( 42L );
+    }
+}


### PR DESCRIPTION
Fixes #3317 