### PR TITLE
#3303 Mapping from Map to Map and specify source and target keys of type String

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AnnotatedConstructor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AnnotatedConstructor.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+import org.mapstruct.ap.internal.model.common.ConstructorFragment;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Type;
 
@@ -20,11 +21,11 @@ import org.mapstruct.ap.internal.model.common.Type;
  */
 public class AnnotatedConstructor extends ModelElement implements Constructor {
 
-    private String name;
+    private final String name;
     private final List<AnnotationMapperReference> mapperReferences;
     private final List<Annotation> annotations;
     private final NoArgumentConstructor noArgumentConstructor;
-    private final Set<SupportingConstructorFragment> fragments;
+    private final Set<ConstructorFragment> fragments;
 
     public static AnnotatedConstructor forComponentModels(String name,
                                                           List<AnnotationMapperReference> mapperReferences,
@@ -37,7 +38,7 @@ public class AnnotatedConstructor extends ModelElement implements Constructor {
             noArgumentConstructor = (NoArgumentConstructor) constructor;
         }
         NoArgumentConstructor noArgConstructorToInBecluded = null;
-        Set<SupportingConstructorFragment> fragmentsToBeIncluded = Collections.emptySet();
+        Set<ConstructorFragment> fragmentsToBeIncluded = Collections.emptySet();
         if ( includeNoArgConstructor ) {
             if ( noArgumentConstructor != null ) {
                 noArgConstructorToInBecluded = noArgumentConstructor;
@@ -60,7 +61,7 @@ public class AnnotatedConstructor extends ModelElement implements Constructor {
 
     private AnnotatedConstructor(String name, List<AnnotationMapperReference> mapperReferences,
                                  List<Annotation> annotations, NoArgumentConstructor noArgumentConstructor,
-                                 Set<SupportingConstructorFragment> fragments) {
+                                 Set<ConstructorFragment> fragments) {
         this.name = name;
         this.mapperReferences = mapperReferences;
         this.annotations = annotations;
@@ -100,7 +101,7 @@ public class AnnotatedConstructor extends ModelElement implements Constructor {
         return noArgumentConstructor;
     }
 
-    public Set<SupportingConstructorFragment> getFragments() {
+    public Set<ConstructorFragment> getFragments() {
         return fragments;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapKeyMappingConstructor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapKeyMappingConstructor.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.Collections;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.ModelElement;
+import org.mapstruct.ap.internal.model.common.Type;
+
+/**
+ * Represents a constructor that is used for mapping keys of a {@link MapMappingMethod}.
+ *
+ * @author Oliver Erhart
+ */
+public class MapKeyMappingConstructor extends ModelElement implements Constructor {
+
+    private final String name;
+    private final String delegateName;
+    private final boolean invokeSuperConstructor;
+
+    public MapKeyMappingConstructor(String name, String delegateName, boolean invokeSuperConstructor) {
+        this.name = name;
+        this.delegateName = delegateName;
+        this.invokeSuperConstructor = invokeSuperConstructor;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return Collections.emptySet();
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public String getDelegateName() {
+        return delegateName;
+    }
+
+    public boolean isInvokeSuperConstructor() {
+        return invokeSuperConstructor;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapKeyMappingConstructorFragment.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapKeyMappingConstructorFragment.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.ConstructorFragment;
+import org.mapstruct.ap.internal.model.common.ModelElement;
+import org.mapstruct.ap.internal.model.common.Type;
+
+/**
+ * Constructor fragment for key mappings for a {@link MapMappingMethod}.
+ *
+ * @author Oliver Erhart
+ */
+public class MapKeyMappingConstructorFragment extends ModelElement implements ConstructorFragment {
+
+    private final MapKeyMappingField field;
+    private final MappingMethod definingMethod;
+    private final List<KeyMappingEntry> keyMappings;
+
+    public MapKeyMappingConstructorFragment(MapKeyMappingField field, MappingMethod definingMethod,
+                                            List<KeyMappingEntry> keyMappings) {
+        this.field = field;
+        this.definingMethod = definingMethod;
+        this.keyMappings = keyMappings;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return Collections.emptySet();
+    }
+
+    public MapKeyMappingField getField() {
+        return field;
+    }
+
+    public MappingMethod getDefiningMethod() {
+        return definingMethod;
+    }
+
+    public List<KeyMappingEntry> getKeyMappings() {
+        return keyMappings;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ( ( field == null ) ? 0 : field.hashCode() );
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if ( this == obj ) {
+            return true;
+        }
+        if ( obj == null ) {
+            return false;
+        }
+        if ( getClass() != obj.getClass() ) {
+            return false;
+        }
+        MapKeyMappingConstructorFragment other = (MapKeyMappingConstructorFragment) obj;
+
+        if ( !Objects.equals( field, other.field ) ) {
+            return false;
+        }
+        return true;
+    }
+
+    public static void addAllMapKeyMappingFragmentsIn(List<MapMappingMethod> mapMappingMethods,
+                                                      Set<ConstructorFragment> targets) {
+        for ( MapMappingMethod mapMappingMethod : mapMappingMethods ) {
+            MapKeyMappingConstructorFragment fragment = mapMappingMethod.getMapMappingConstructorFragment();
+            if ( fragment != null ) {
+                targets.add( mapMappingMethod.getMapMappingConstructorFragment() );
+            }
+        }
+    }
+
+    public static class KeyMappingEntry {
+
+        String source;
+        String target;
+
+        public KeyMappingEntry(String source, String target) {
+            this.source = source;
+            this.target = target;
+        }
+
+        public String getSource() {
+            return source;
+        }
+
+        public String getTarget() {
+            return target;
+        }
+    }
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapKeyMappingField.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapKeyMappingField.java
@@ -8,8 +8,6 @@ package org.mapstruct.ap.internal.model;
 import java.util.List;
 import java.util.Set;
 
-import org.mapstruct.ap.internal.model.common.Type;
-
 /**
  * Field that is used for mapping keys of a {@link MapMappingMethod}.
  *
@@ -17,8 +15,8 @@ import org.mapstruct.ap.internal.model.common.Type;
  */
 public class MapKeyMappingField extends Field {
 
-    public MapKeyMappingField(Type type, String variableName) {
-        super( type, variableName, true );
+    public MapKeyMappingField(String variableName) {
+        super( null, variableName, true );
     }
 
     public static void addAllMapKeyMappingFieldsIn(List<MapMappingMethod> mapMappingMethods, Set<Field> targets) {
@@ -33,8 +31,4 @@ public class MapKeyMappingField extends Field {
         }
     }
 
-    @Override
-    protected String getTemplateName() {
-        return getTemplateNameForClass( Field.class );
-    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapKeyMappingField.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapKeyMappingField.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.List;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.Type;
+
+/**
+ * Field that is used for mapping keys of a {@link MapMappingMethod}.
+ *
+ * @author Oliver Erhart
+ */
+public class MapKeyMappingField extends Field {
+
+    public MapKeyMappingField(Type type, String variableName) {
+        super( type, variableName, true );
+    }
+
+    public static void addAllMapKeyMappingFieldsIn(List<MapMappingMethod> mapMappingMethods, Set<Field> targets) {
+        for ( MapMappingMethod mapMappingMethod : mapMappingMethods ) {
+            MapKeyMappingConstructorFragment fragment = mapMappingMethod.getMapMappingConstructorFragment();
+            if (fragment != null) {
+                Field field = fragment.getField();
+                if ( field != null ) {
+                    targets.add( field );
+                }
+            }
+        }
+    }
+
+    @Override
+    protected String getTemplateName() {
+        return getTemplateNameForClass( Field.class );
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -294,7 +294,7 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
         // safe variable name would probably be better, but chaining all fields during creation is cumbersome...
         this.keyMappingVariableName = method.getName() + "KeyMappings";
 
-        MapKeyMappingField field = new MapKeyMappingField( sourceParameter.getType(), keyMappingVariableName );
+        MapKeyMappingField field = new MapKeyMappingField( this.keyMappingVariableName );
 
         return new MapKeyMappingConstructorFragment( field, this, keyMappings );
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
@@ -12,6 +12,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
 import org.mapstruct.ap.internal.model.common.Accessibility;
+import org.mapstruct.ap.internal.model.common.ConstructorFragment;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.option.Options;
@@ -34,7 +35,7 @@ public class Mapper extends GeneratedType {
 
         private TypeElement element;
         private List<Field> fields;
-        private Set<SupportingConstructorFragment> fragments;
+        private Set<ConstructorFragment> fragments;
 
         private Decorator decorator;
         private String implName;
@@ -59,7 +60,7 @@ public class Mapper extends GeneratedType {
             return this;
         }
 
-        public Builder constructorFragments(Set<SupportingConstructorFragment>  fragments) {
+        public Builder constructorFragments(Set<ConstructorFragment>  fragments) {
             this.fragments = fragments;
             return this;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NoArgumentConstructor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NoArgumentConstructor.java
@@ -8,6 +8,7 @@ package org.mapstruct.ap.internal.model;
 import java.util.Collections;
 import java.util.Set;
 
+import org.mapstruct.ap.internal.model.common.ConstructorFragment;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Type;
 
@@ -19,9 +20,9 @@ import org.mapstruct.ap.internal.model.common.Type;
 public class NoArgumentConstructor extends ModelElement implements Constructor {
 
     private final String name;
-    private final Set<SupportingConstructorFragment> fragments;
+    private final Set<ConstructorFragment> fragments;
 
-    public NoArgumentConstructor(String name, Set<SupportingConstructorFragment> fragments) {
+    public NoArgumentConstructor(String name, Set<ConstructorFragment> fragments) {
         this.name = name;
         this.fragments = fragments;
     }
@@ -36,7 +37,7 @@ public class NoArgumentConstructor extends ModelElement implements Constructor {
         return name;
     }
 
-    public Set<SupportingConstructorFragment> getFragments() {
+    public Set<ConstructorFragment> getFragments() {
         return fragments;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/SupportingConstructorFragment.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/SupportingConstructorFragment.java
@@ -18,7 +18,7 @@ import org.mapstruct.ap.internal.model.common.Type;
  *
  * @author Sjaak Derksen
  */
-public class SupportingConstructorFragment extends ModelElement {
+public class SupportingConstructorFragment extends ModelElement implements ConstructorFragment {
 
     private final String variableName;
     private final String templateName;
@@ -81,7 +81,7 @@ public class SupportingConstructorFragment extends ModelElement {
     }
 
     public static void addAllFragmentsIn(Set<SupportingMappingMethod> supportingMappingMethods,
-                                         Set<SupportingConstructorFragment> targets) {
+                                         Set<ConstructorFragment> targets) {
         for ( SupportingMappingMethod supportingMappingMethod : supportingMappingMethods ) {
             SupportingConstructorFragment fragment = supportingMappingMethod.getSupportingConstructorFragment();
             if ( fragment != null ) {

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MapKeyMappingConstructorFragment.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MapKeyMappingConstructorFragment.ftl
@@ -1,0 +1,12 @@
+<#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.MapKeyMappingConstructorFragment" -->
+this.${field.variableName} = new java.util.HashMap<>();
+<#list keyMappings as entry>
+  this.${field.variableName}.put( "${entry.source}", "${entry.target}" );
+</#list>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MapKeyMappingField.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MapKeyMappingField.ftl
@@ -1,0 +1,9 @@
+<#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.MapKeyMappingField" -->
+private final Map<String, String> ${variableName};

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
@@ -52,7 +52,11 @@
         <@includeModel object=valueAssignment
                    targetWriteAccessorName=valueVariableName
                    targetType=resultElementTypes[1].typeBound/>
-        ${resultName}.put( ${keyVariableName}, ${valueVariableName} );
+        <#if keyMappingVariableName?? >
+          ${resultName}.put( this.${keyMappingVariableName}.getOrDefault( ${keyVariableName}, ${keyVariableName} ), ${valueVariableName} );
+        <#else>
+          ${resultName}.put( ${keyVariableName}, ${valueVariableName} );
+        </#if>
     }
     <#list afterMappingReferences as callback>
     	<#if callback_index = 0>

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/map/AnnotatedMapMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/map/AnnotatedMapMappingTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.collection.map;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.collection.map.other.ImportedType;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static java.lang.System.lineSeparator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+
+/**
+ * Test for implementation of {@code Map} mapping methods with @{@link org.mapstruct.Mapping Mappings}
+ *
+ * @author Oliver Erhart
+ */
+@WithClasses({
+    AnnotatedSourceTargetMapper.class,
+    CustomNumberMapper.class,
+    Source.class,
+    Target.class,
+    ImportedType.class
+})
+@IssueKey("3303")
+public class AnnotatedMapMappingTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldContainTwoKeyMappingMapsInConstructor() {
+        generatedSource.forMapper( AnnotatedSourceTargetMapper.class )
+            .content()
+            .contains(
+                "private final Map<String, String> stringMapToStringMapUsingTargetParameterKeyMappings;" )
+            .contains(
+                "private final Map<String, String> stringMapToStringMapUsingTargetParameterAndReturnKeyMappings;" )
+            .contains( "private final Map<String, String> stringMapWithMappingAnnotationsKeyMappings;" )
+            .contains(
+                "private final Map<String, String> stringMapWithMappingAnnotationsAndDifferentNameKeyMappings;" )
+            .doesNotContain( "private final Map<String, String> stringMapWithInvalidMappingAnnotationsKeyMappings;" )
+            .doesNotContain( "private final Map<String, String> longMapWithMappingAnnotationsKeyMappings;" )
+            .contains( expectedConstructor() );
+    }
+
+    private static String expectedConstructor() {
+        return "public AnnotatedSourceTargetMapperImpl() {" +
+            lineSeparator() +
+            constructorInitOf( "stringMapToStringMapUsingTargetParameterKeyMappings" ) +
+            lineSeparator() +
+            constructorInitOf( "stringMapToStringMapUsingTargetParameterAndReturnKeyMappings" ) +
+            lineSeparator() +
+            constructorInitOf( "stringMapWithMappingAnnotationsKeyMappings" ) +
+            lineSeparator() +
+            constructorInitOf( "stringMapWithMappingAnnotationsAndDifferentNameKeyMappings" ) +
+            "    }";
+    }
+
+    private static String constructorInitOf(String parameterName) {
+        return
+            "        this." + parameterName + " = new java.util.HashMap<>();" +
+                lineSeparator() +
+                "        this." + parameterName + ".put( \"sourceKey\", \"targetKey\" );" +
+                lineSeparator() +
+                "        this." + parameterName + ".put( \"nonExistentSourceKey\", \"otherTargetKey\" );" +
+                lineSeparator();
+    }
+
+    @ProcessorTest
+    public void shouldMapBasedOnKeyMappings() {
+        Map<String, String> values = new HashMap<>();
+        values.put( "sourceKey", "value" );
+        values.put( "unmappedKey", "otherValue" );
+
+        Map<String, String> target = AnnotatedSourceTargetMapper.INSTANCE.stringMapWithMappingAnnotations( values );
+
+        assertThat( target ).isNotNull()
+            .hasSize( 2 )
+            .contains(
+                entry( "targetKey", "value" ),
+                entry( "unmappedKey", "otherValue" )
+            );
+    }
+
+    @ProcessorTest
+    public void shouldNotMapBasedOnKeyMappingsBecauseOfTypeLong() {
+        Map<Long, Long> values = new HashMap<>();
+        values.put( 1L, 2L );
+        values.put( 3L, 4L );
+
+        Map<Long, Long> target = AnnotatedSourceTargetMapper.INSTANCE.longMapWithMappingAnnotations( values );
+
+        assertThat( target ).isNotNull()
+            .hasSize( 2 )
+            .isEqualTo( values );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/map/AnnotatedMapMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/map/AnnotatedMapMappingTest.java
@@ -48,6 +48,8 @@ public class AnnotatedMapMappingTest {
             .contains( "private final Map<String, String> stringMapWithMappingAnnotationsKeyMappings;" )
             .contains(
                 "private final Map<String, String> stringMapWithMappingAnnotationsAndDifferentNameKeyMappings;" )
+            .contains(
+                "private final Map<String, String> stringLongMapToStringIntegerMapWithMappingAnnotationsKeyMappings;" )
             .doesNotContain( "private final Map<String, String> stringMapWithInvalidMappingAnnotationsKeyMappings;" )
             .doesNotContain( "private final Map<String, String> longMapWithMappingAnnotationsKeyMappings;" )
             .contains( expectedConstructor() );
@@ -63,6 +65,8 @@ public class AnnotatedMapMappingTest {
             constructorInitOf( "stringMapWithMappingAnnotationsKeyMappings" ) +
             lineSeparator() +
             constructorInitOf( "stringMapWithMappingAnnotationsAndDifferentNameKeyMappings" ) +
+            lineSeparator() +
+            constructorInitOf( "stringLongMapToStringIntegerMapWithMappingAnnotationsKeyMappings" ) +
             "    }";
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/map/AnnotatedSourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/map/AnnotatedSourceTargetMapper.java
@@ -40,6 +40,10 @@ public interface AnnotatedSourceTargetMapper {
     @Mapping(target = "expressionNotSupported", expression = "java(\"const\")")
     Map<String, String> stringMapWithInvalidMappingAnnotations(Map<String, String> source);
 
+    @Mapping(target = "targetKey", source = "sourceKey")
+    @Mapping(target = "otherTargetKey", source = "nonExistentSourceKey")
+    Map<String, Long> stringLongMapToStringIntegerMapWithMappingAnnotations(Map<String, Integer> source);
+
     @Mapping(target = "2L", source = "1L")
     @Mapping(target = "1L", source = "2L")
     Map<Long, Long> longMapWithMappingAnnotations(Map<Long, Long> source);

--- a/processor/src/test/java/org/mapstruct/ap/test/collection/map/AnnotatedSourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/collection/map/AnnotatedSourceTargetMapper.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.collection.map;
+
+import java.util.Map;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface AnnotatedSourceTargetMapper {
+
+    AnnotatedSourceTargetMapper INSTANCE = Mappers.getMapper( AnnotatedSourceTargetMapper.class );
+
+    @Mapping(target = "targetKey", source = "sourceKey")
+    @Mapping(target = "otherTargetKey", source = "nonExistentSourceKey")
+    void stringMapToStringMapUsingTargetParameter(@MappingTarget Map<String, String> target,
+                                                  Map<String, String> source);
+
+    @Mapping(target = "targetKey", source = "sourceKey")
+    @Mapping(target = "otherTargetKey", source = "nonExistentSourceKey")
+    Map<String, String> stringMapToStringMapUsingTargetParameterAndReturn(Map<String, String> source,
+                                                                          @MappingTarget Map<String, String> target);
+
+    @Mapping(target = "targetKey", source = "sourceKey")
+    @Mapping(target = "otherTargetKey", source = "nonExistentSourceKey")
+    @Mapping(target = "thisWillBeIgnored", ignore = true)
+    Map<String, String> stringMapWithMappingAnnotations(Map<String, String> source);
+
+    @Mapping(target = "targetKey", source = "sourceKey")
+    @Mapping(target = "otherTargetKey", source = "nonExistentSourceKey")
+    Map<String, String> stringMapWithMappingAnnotationsAndDifferentName(Map<String, String> source);
+
+    @Mapping(target = "thisWillBeIgnored", ignore = true)
+    @Mapping(target = "expressionNotSupported", expression = "java(\"const\")")
+    Map<String, String> stringMapWithInvalidMappingAnnotations(Map<String, String> source);
+
+    @Mapping(target = "2L", source = "1L")
+    @Mapping(target = "1L", source = "2L")
+    Map<Long, Long> longMapWithMappingAnnotations(Map<Long, Long> source);
+}


### PR DESCRIPTION
Tackling map mapping with source and target keys.

Things to note:

- The variable containing key mappings is not built safe like in `org.mapstruct.ap.internal.model.SupportingField#getSafeField`. This would need a bigger change in the `MapperCreationProcessor`. However, a collision with a field named like `method.getName() + "KeyMappings"` is very unlikely.
- Only `@Mapping` annotations with set `source` and `target` are considered, the rest is ignored, like `expression` or `ignore` (I felt that it is not worth to throw an error in that case)
- This PR tackles only mapping of  maps with keys of type string (`Map<String, ?>`). Any other type does not feel like a valid use-case (well, `CharSequence` eventually?)
    - Due to this restriction it was easier to implement. Because the type of the keyMappings field are now hard-coded as `Map<String, String>` in the FreeMarker template.
    - I found no easy solution to get a type of `Map<String, String>` with the `TypeFactory`. If you have a solution for this, please let me know. I could then remove the `MapKeyMappingField.ftl` and use a typed `Field.ftl`