### PR TITLE
#3361 Inheriting mappings should only be applied if the target has been redefined

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
@@ -278,6 +278,7 @@ public class MappingMethodOptions {
     }
 
     private void addAllNonRedefined(Set<MappingOptions> inheritedMappings) {
+        // We are only adding the targets here since this mappings have already been reversed
         Set<String> redefinedTargets = new HashSet<>();
         for ( MappingOptions redefinedMappings : mappings ) {
             if ( redefinedMappings.getTargetName() != null ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
@@ -278,20 +278,15 @@ public class MappingMethodOptions {
     }
 
     private void addAllNonRedefined(Set<MappingOptions> inheritedMappings) {
-        Set<String> redefinedSources = new HashSet<>();
         Set<String> redefinedTargets = new HashSet<>();
         for ( MappingOptions redefinedMappings : mappings ) {
-            if ( redefinedMappings.getSourceName() != null ) {
-                redefinedSources.add( redefinedMappings.getSourceName() );
-            }
             if ( redefinedMappings.getTargetName() != null ) {
                 redefinedTargets.add( redefinedMappings.getTargetName() );
             }
         }
         for ( MappingOptions inheritedMapping : inheritedMappings ) {
             if ( inheritedMapping.isIgnored()
-                || ( !isRedefined( redefinedSources, inheritedMapping.getSourceName() )
-                && !isRedefined( redefinedTargets, inheritedMapping.getTargetName() ) )
+                || !isRedefined( redefinedTargets, inheritedMapping.getTargetName() )
             ) {
                 mappings.add( inheritedMapping );
             }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3361/Issue3361Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3361/Issue3361Mapper.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3361;
+
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class Issue3361Mapper {
+
+    public static final Issue3361Mapper INSTANCE = Mappers.getMapper( Issue3361Mapper.class );
+
+    @Mapping(target = "someAttribute", source = "source.attribute")
+    @Mapping(target = "otherAttribute", source = "otherSource.anotherAttribute")
+    public abstract Target mapFromSource(Source source, OtherSource otherSource);
+
+    @InheritConfiguration(name = "mapFromSource")
+    @Mapping(target = "otherAttribute", source = "source", qualifiedByName = "otherMapping")
+    public abstract Target mapInherited(Source source, OtherSource otherSource);
+
+    @Named("otherMapping")
+    protected Long otherMapping(Source source) {
+        return source.getAttribute() != null ? 1L : 0L;
+    }
+
+    public static class Target {
+        private String someAttribute;
+        private Long otherAttribute;
+
+        public String getSomeAttribute() {
+            return someAttribute;
+        }
+
+        public Target setSomeAttribute(String someAttribute) {
+            this.someAttribute = someAttribute;
+            return this;
+        }
+
+        public Long getOtherAttribute() {
+            return otherAttribute;
+        }
+
+        public Target setOtherAttribute(Long otherAttribute) {
+            this.otherAttribute = otherAttribute;
+            return this;
+        }
+    }
+
+    public static class Source {
+        private final String attribute;
+
+        public Source(String attribute) {
+            this.attribute = attribute;
+        }
+
+        public String getAttribute() {
+            return attribute;
+        }
+    }
+
+    public static class OtherSource {
+
+        private final Long anotherAttribute;
+
+        public OtherSource(Long anotherAttribute) {
+            this.anotherAttribute = anotherAttribute;
+        }
+
+        public Long getAnotherAttribute() {
+            return anotherAttribute;
+        }
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3361/Issue3361Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3361/Issue3361Test.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3361;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("3361")
+@WithClasses(Issue3361Mapper.class)
+class Issue3361Test {
+
+    @ProcessorTest
+    void multiSourceShouldInherit() {
+        Issue3361Mapper.Source source = new Issue3361Mapper.Source( "Test" );
+        Issue3361Mapper.OtherSource otherSource = new Issue3361Mapper.OtherSource( 10L );
+
+        Issue3361Mapper.Target target = Issue3361Mapper.INSTANCE.mapFromSource( source, otherSource );
+        assertThat( target.getSomeAttribute() ).isEqualTo( "Test" );
+        assertThat( target.getOtherAttribute() ).isEqualTo( 10L );
+
+        target = Issue3361Mapper.INSTANCE.mapInherited( source, otherSource );
+        assertThat( target.getSomeAttribute() ).isEqualTo( "Test" );
+        assertThat( target.getOtherAttribute() ).isEqualTo( 1L );
+    }
+}


### PR DESCRIPTION
Fixes #3361.

The issue was caused by the fixes done for ##2101 in PR ##2103.

@sjaakd can you please have a look at this PR?