### PR TITLE
Fixed the misleading default of defaultValue in Mapping

### DIFF
--- a/core/src/main/java/org/mapstruct/Mapping.java
+++ b/core/src/main/java/org/mapstruct/Mapping.java
@@ -442,7 +442,7 @@ public @interface Mapping {
      *
      * @return Default value to set in case the source property is {@code null}.
      */
-    String defaultValue() default "";
+    String defaultValue();
 
     /**
      * Determines when to include a null check on the source property value of a bean mapping.


### PR DESCRIPTION
In the org.mapstruct.Mapping.java the defaultValue() is provided with a default ""; Actually during the source generation the default empty value is not applied if defaultValue is not provided in the annotation. It is working perfectly when you provide the defaultValue="" in the annotation. The problem is that the definition of the default is misleading and even the IDE (e.g. the IDEA) propose to remove the redundant parameter. But removing the parameter result is null value in target. 