### PR TITLE
Fix Typo Mappper in SubclassMapping Doc

### DIFF
--- a/copyright.txt
+++ b/copyright.txt
@@ -68,4 +68,5 @@ Timo Eckhardt - https://github.com/timoe
 Tomek Gubala - https://github.com/vgtworld
 Valentin Kulesh - https://github.com/unshare
 Vincent Alexander Beelte - https://github.com/grandmasterpixel
+Winter Andreas - https://github.dev/wandi34
 Xiu Hong Kooi - https://github.com/kooixh

--- a/core/src/main/java/org/mapstruct/SubclassMapping.java
+++ b/core/src/main/java/org/mapstruct/SubclassMapping.java
@@ -49,7 +49,7 @@ import org.mapstruct.util.Experimental;
  * }
  * </code></pre>
  * <strong>Example 2:</strong> For parents that can be created. (e.g. normal classes or interfaces with
- * &#64;Mappper( uses = ObjectFactory.class ) )
+ * &#64;Mapper( uses = ObjectFactory.class ) )
  * <pre><code class='java'>
  * // generates
  * &#64;Override


### PR DESCRIPTION
Just a small fix for a typo in the JavaDoc I recognized during use of the lib.

