### PR TITLE
Bump some versions for quick win

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -22,17 +22,17 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <org.mapstruct.gem.version>1.0.0.Alpha3</org.mapstruct.gem.version>
-        <org.apache.maven.plugins.enforcer.version>3.0.0-M3</org.apache.maven.plugins.enforcer.version>
-        <org.apache.maven.plugins.surefire.version>3.0.0-M5</org.apache.maven.plugins.surefire.version>
+        <org.apache.maven.plugins.enforcer.version>3.4.1</org.apache.maven.plugins.enforcer.version>
+        <org.apache.maven.plugins.surefire.version>3.2.2</org.apache.maven.plugins.surefire.version>
         <org.apache.maven.plugins.javadoc.version>3.1.0</org.apache.maven.plugins.javadoc.version>
         <org.springframework.version>5.3.18</org.springframework.version>
         <org.eclipse.tycho.compiler-jdt.version>1.6.0</org.eclipse.tycho.compiler-jdt.version>
         <com.puppycrawl.tools.checkstyle.version>8.36.1</com.puppycrawl.tools.checkstyle.version>
-        <org.junit.jupiter.version>5.8.0-M1</org.junit.jupiter.version>
-        <junit-pioneer.version>1.4.2</junit-pioneer.version>
+        <org.junit.jupiter.version>5.10.1</org.junit.jupiter.version>
+        <junit-pioneer.version>2.2.0</junit-pioneer.version>
         <add.release.arguments />
         <forkCount>1</forkCount>
-        <assertj.version>3.17.2</assertj.version>
+        <assertj.version>3.24.2</assertj.version>
         <!-- automatically run annotation processors within the incremental compilation -->
         <!-- Needed for the gem tools processor-->
         <m2e.apt.activation>jdt_apt</m2e.apt.activation>
@@ -226,7 +226,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.22</version>
+                <version>1.18.30</version>
             </dependency>
             <dependency>
                 <groupId>org.immutables</groupId>
@@ -253,7 +253,7 @@
             <dependency>
                 <groupId>joda-time</groupId>
                 <artifactId>joda-time</artifactId>
-                <version>2.9</version>
+                <version>2.12.5</version>
             </dependency>
 
             <!-- XML Binding -->
@@ -309,7 +309,7 @@
             <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
-                <version>2.7</version>
+                <version>2.15.0</version>
             </dependency>
 
             <!-- Project modules -->

--- a/processor/src/test/java/org/mapstruct/ap/testutil/assertions/JavaFileAssert.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/assertions/JavaFileAssert.java
@@ -5,7 +5,11 @@
  */
 package org.mapstruct.ap.testutil.assertions;
 
-import static java.lang.String.format;
+import org.assertj.core.api.FileAssert;
+import org.assertj.core.error.ShouldHaveSameContent;
+import org.assertj.core.internal.Diff;
+import org.assertj.core.internal.Failures;
+import org.assertj.core.util.diff.Delta;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,14 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.io.FileUtils;
-import org.assertj.core.api.AbstractCharSequenceAssert;
-import org.assertj.core.api.Assertions;
-import org.assertj.core.api.FileAssert;
-import org.assertj.core.error.ShouldHaveSameContent;
-import org.assertj.core.internal.Diff;
-import org.assertj.core.internal.Failures;
-import org.assertj.core.util.diff.Delta;
+import static java.lang.String.format;
 
 /**
  * Allows to perform assertions on .java source files.
@@ -39,29 +36,13 @@ public class JavaFileAssert extends FileAssert {
     private static final String IMPORT_GENERATED_ANNOTATION_REGEX = "import javax\\.annotation\\.(processing\\.)?" +
         "Generated;";
 
-    private Diff diff = new Diff();
+    private final Diff diff = new Diff();
 
     /**
      * @param actual the actual file
      */
     public JavaFileAssert(File actual) {
         super( actual );
-    }
-
-    /**
-     * @return assertion on the file content
-     */
-    public AbstractCharSequenceAssert<?, String> content() {
-        exists();
-        isFile();
-
-        try {
-            return Assertions.assertThat( FileUtils.readFileToString( actual, StandardCharsets.UTF_8 ) );
-        }
-        catch ( IOException e ) {
-            failWithMessage( "Unable to read" + actual + ". Exception: " + e.getMessage() );
-        }
-        return null;
     }
 
     /**
@@ -118,7 +99,6 @@ public class JavaFileAssert extends FileAssert {
      * or if it is a change delta for the date/comments part of a {@code @Generated} annotation.
      *
      * @param delta that needs to be checked
-     *
      * @return {@code true} if this delta should be ignored, {@code false} otherwise
      */
     private boolean ignoreDelta(Delta<String> delta) {


### PR DESCRIPTION
I looked into the code to learn how it works and saw some old versions of libs which should be save to bump version in a minor version jump 1.5 ->1.6. I decided to provide this quick win.

Everything works fine.