### PR TITLE
#1064 Provide a switch to turn off CheckStyle on generated sources

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
@@ -188,10 +188,7 @@ abstract class CompilingExtension implements BeforeEachCallback {
     }
 
     private static boolean skipCheckstyleBySystemProperty() {
-
-        String skipCheckstyleProperty = System.getProperty( "checkstyle.skip" );
-
-        return skipCheckstyleProperty != null && !skipCheckstyleProperty.equals( "false" );
+        return Boolean.parseBoolean( System.getProperty( "checkstyle.skip" ) );
     }
 
     private void assertCheckstyleRules() throws Exception {

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
@@ -182,9 +182,16 @@ abstract class CompilingExtension implements BeforeEachCallback {
         assertDiagnostics( actualResult.getDiagnostics(), expectedResult.getDiagnostics() );
         assertNotes( actualResult.getNotes(), expectedResult.getNotes() );
 
-        if ( !findAnnotation( testClass, DisableCheckstyle.class ).isPresent() ) {
+        if ( !findAnnotation( testClass, DisableCheckstyle.class ).isPresent() && !skipCheckstyleBySystemProperty() ) {
             assertCheckstyleRules();
         }
+    }
+
+    private static boolean skipCheckstyleBySystemProperty() {
+
+        String skipCheckstyleProperty = System.getProperty( "checkstyle.skip" );
+
+        return skipCheckstyleProperty != null && !skipCheckstyleProperty.equals( "false" );
     }
 
     private void assertCheckstyleRules() throws Exception {


### PR DESCRIPTION
Skip checkstyle ifthe system property `checkstyle.skip[=true]` is set (except in the rare case that someone sets it to `checkstyle.skip=false`).

This reducces my build time from 7min 34sec to 6min 49sec. An improvement about 11%. 👍 

Fixes #1064 