### PR TITLE
add missing generic type to Javadoc Builder

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Javadoc.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Javadoc.java
@@ -31,7 +31,7 @@ public class Javadoc extends ModelElement {
             return this;
         }
 
-        public Builder authors(List authors) {
+        public Builder authors(List<String> authors) {
             this.authors = authors;
             return this;
         }


### PR DESCRIPTION
Currently there the type of `authors` is missing. I added it as `List<String>`