### PR TITLE
use primitive types in NativeTypes

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/util/NativeTypes.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/NativeTypes.java
@@ -270,11 +270,11 @@ public class NativeTypes {
 
                 @Override
                 void parse(String val, int radix) {
-                    Double d = Double.parseDouble( radix == 16 ? "0x" + val : val );
+                    double d = Double.parseDouble( radix == 16 ? "0x" + val : val );
                     if ( doubleHasBecomeZero( d  ) ) {
                         throw new NumberFormatException( "floating point number too small" );
                     }
-                    if ( d.isInfinite() ) {
+                    if ( Double.isInfinite( d ) ) {
                         throw new NumberFormatException( "infinitive is not allowed" );
                     }
                 }
@@ -297,11 +297,11 @@ public class NativeTypes {
             NumberRepresentation br = new NumberRepresentation( s, false, false, true ) {
                 @Override
                 void parse(String val, int radix) {
-                    Float f = Float.parseFloat( radix == 16 ? "0x" + val : val );
+                    float f = Float.parseFloat( radix == 16 ? "0x" + val : val );
                     if ( doubleHasBecomeZero( f  ) ) {
                         throw new NumberFormatException( "floating point number too small" );
                     }
-                    if ( f.isInfinite() ) {
+                    if ( Float.isInfinite( f ) ) {
                         throw new NumberFormatException( "infinitive is not allowed" );
                     }
                 }


### PR DESCRIPTION
`Double.parseDouble` returns a primitive `double` and `Float.parseFloat` returns a primitive`float`. By using the primitive types directly instead of the wrapper types unnecessary boxing can be avoided.