### PR TITLE
#3495 when updating targets with collections without a setter, clear them only when null-check or condition is satisfied

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.ftl
@@ -10,10 +10,10 @@
 <@lib.sourceLocalVarAssignment/>
 if ( ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing /> != null ) {
     <@lib.handleExceptions>
-      <#if ext.existingInstanceMapping>
-        ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing />.clear();
-      </#if>
       <@lib.handleLocalVarNullCheck needs_explicit_local_var=false>
+        <#if ext.existingInstanceMapping>
+          ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing />.clear();
+        </#if>
         ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing />.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( <@lib.handleWithAssignmentOrNullCheckVar/> );
       </@lib.handleLocalVarNullCheck>
     </@lib.handleExceptions>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_289/Issue289Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_289/Issue289Test.java
@@ -44,11 +44,12 @@ public class Issue289Test {
         Source source = new Source();
         source.setCollection( null );
         TargetWithoutSetter target = new TargetWithoutSetter();
-        target.getCollection().add( new TargetElement() );
+        TargetElement existingElement = new TargetElement();
+        target.getCollection().add( existingElement );
 
         Issue289Mapper.INSTANCE.sourceToTargetWithoutSetter( source, target );
 
-        assertThat( target.getCollection() ).isEmpty();
+        assertThat( target.getCollection() ).containsExactly( existingElement );
     }
 
     @ProcessorTest

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3495/Issue3495Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3495/Issue3495Mapper.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3495;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mapstruct.Condition;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue3495Mapper {
+
+    Issue3495Mapper INSTANCE = Mappers.getMapper( Issue3495Mapper.class );
+
+    @Mapping(target = "names", source = "names", conditionQualifiedByName = "alwaysFalse")
+    void update(Source source, @MappingTarget TargetWithoutSetter target);
+
+    @Condition
+    @Named("alwaysFalse")
+    default boolean alwaysFalse(@MappingTarget TargetWithoutSetter target) {
+        return false;
+    }
+
+    class Source {
+
+        private List<String> names;
+
+        public List<String> getNames() {
+            return names;
+        }
+
+        public void setNames(List<String> names) {
+            this.names = names;
+        }
+    }
+
+    class TargetWithoutSetter {
+
+        private final List<String> names = new ArrayList<>();
+
+        public List<String> getNames() {
+            return names;
+        }
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3495/Issue3495Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3495/Issue3495Test.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3495;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Oliver Erhart
+ */
+@IssueKey("3495")
+@WithClasses(Issue3495Mapper.class)
+class Issue3495Test {
+
+    @ProcessorTest
+    void shouldNotClearCollectionBecauseConditionWasNotMet() {
+
+        Issue3495Mapper.Source source = new Issue3495Mapper.Source();
+
+        Issue3495Mapper.TargetWithoutSetter target = new Issue3495Mapper.TargetWithoutSetter();
+        target.getNames().add( "name" );
+
+        Issue3495Mapper.INSTANCE.update( source, target );
+        assertThat( target ).isNotNull();
+        assertThat( target.getNames() ).containsExactly( "name" );
+    }
+}


### PR DESCRIPTION
With this change, updating targets without a setter now works exactly like updating a target with a collection setter. So hopefully no more confusion with this.

This breaks a very old test, see `Issue289Test`. However, I feel that this was always a bug. @filiphr Let me know what you think.

Closes #3495