### PR TITLE
Alternative for the ReferencedAccessibilityTest

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/AbstractSourceTargetMapperPrivate.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/AbstractSourceTargetMapperPrivate.java
@@ -7,13 +7,14 @@ package org.mapstruct.ap.test.accessibility.referenced;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 /**
  *
  * @author Sjaak Derksen
  */
-@Mapper
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public abstract class AbstractSourceTargetMapperPrivate extends SourceTargetmapperPrivateBase {
 
     public static final AbstractSourceTargetMapperPrivate INSTANCE =

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/AbstractSourceTargetMapperProtected.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/AbstractSourceTargetMapperProtected.java
@@ -7,13 +7,14 @@ package org.mapstruct.ap.test.accessibility.referenced;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 /**
  *
  * @author Sjaak Derksen
  */
-@Mapper
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public abstract class AbstractSourceTargetMapperProtected extends SourceTargetmapperProtectedBase {
 
     public static final AbstractSourceTargetMapperProtected INSTANCE =

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/ReferencedAccessibilityTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/ReferencedAccessibilityTest.java
@@ -5,14 +5,13 @@
  */
 package org.mapstruct.ap.test.accessibility.referenced;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.test.accessibility.referenced.a.ReferencedMapperDefaultOther;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
-import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
-import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
-import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
 /**
@@ -27,68 +26,85 @@ public class ReferencedAccessibilityTest {
     final GeneratedSource generatedSource = new GeneratedSource();
 
     @ProcessorTest
-    @IssueKey("206")
-    @WithClasses({ SourceTargetMapperPrivate.class, ReferencedMapperPrivate.class })
-    @ExpectedCompilationOutcome(
-        value = CompilationResult.SUCCEEDED,
-        diagnostics = {
-            @Diagnostic(type = SourceTargetMapperPrivate.class,
-                kind = javax.tools.Diagnostic.Kind.WARNING,
-                line = 22,
-                message = "Unmapped target property: \"bar\". Mapping from property " +
-                    "\"ReferencedSource referencedSource\" to \"ReferencedTarget referencedTarget\".")
-        }
-    )
+    @IssueKey( "206" )
+    @WithClasses( { SourceTargetMapperPrivate.class, ReferencedMapperPrivate.class } )
     public void shouldNotBeAbleToAccessPrivateMethodInReferenced() {
         generatedSource.addComparisonToFixtureFor( SourceTargetMapperPrivate.class );
+        Source source = createSourceWithReferencedSourceAndField( "Foo" );
+
+        Target target = SourceTargetMapperPrivate.INSTANCE.toTarget( source );
+
+        assertThat( target.getReferencedTarget() ).isNotNull();
+        assertThat( target.getReferencedTarget().getBar() ).isNull();
+    }
+
+    @ProcessorTest
+    @IssueKey( "206" )
+    @WithClasses( { SourceTargetMapperDefaultOther.class, ReferencedMapperDefaultOther.class } )
+    public void shouldNotBeAbleToAccessDefaultMethodInReferencedInOtherPackage() {
+        generatedSource.addComparisonToFixtureFor( SourceTargetMapperDefaultOther.class );
+        Source source = createSourceWithReferencedSourceAndField( "Foo" );
+
+        Target target = SourceTargetMapperDefaultOther.INSTANCE.toTarget( source );
+
+        assertThat( target.getReferencedTarget() ).isNotNull();
+        assertThat( target.getReferencedTarget().getBar() ).isNull();
+    }
+
+    @ProcessorTest
+    @IssueKey( "206" )
+    @WithClasses( { AbstractSourceTargetMapperPrivate.class, SourceTargetmapperPrivateBase.class } )
+    public void shouldNotBeAbleToAccessPrivateMethodInBase() {
+        generatedSource.addComparisonToFixtureFor( AbstractSourceTargetMapperPrivate.class );
+        Source source = createSourceWithReferencedSourceAndField( "Foo" );
+
+        Target target = AbstractSourceTargetMapperPrivate.INSTANCE.toTarget( source );
+
+        assertThat( target.getReferencedTarget() ).isNotNull();
+        assertThat( target.getReferencedTarget().getBar() ).isNull();
     }
 
     @ProcessorTest
     @IssueKey( "206" )
     @WithClasses( { SourceTargetMapperDefaultSame.class, ReferencedMapperDefaultSame.class } )
-    public void shouldBeAbleToAccessDefaultMethodInReferencedInSamePackage() { }
+    public void shouldBeAbleToAccessDefaultMethodInReferencedInSamePackage() {
+        Source source = createSourceWithReferencedSourceAndField( "Foo" );
+
+        Target target = SourceTargetMapperDefaultSame.INSTANCE.toTarget( source );
+
+        assertThat( target.getReferencedTarget() ).isNotNull();
+        assertThat( target.getReferencedTarget().getBar() ).isEqualTo( "Foo" );
+    }
 
     @ProcessorTest
     @IssueKey( "206" )
     @WithClasses( { SourceTargetMapperProtected.class, ReferencedMapperProtected.class } )
-    public void shouldBeAbleToAccessProtectedMethodInReferencedInSamePackage() { }
+    public void shouldBeAbleToAccessProtectedMethodInReferencedInSamePackage() {
+        Source source = createSourceWithReferencedSourceAndField( "Foo" );
 
-    @ProcessorTest
-    @IssueKey("206")
-    @WithClasses({ SourceTargetMapperDefaultOther.class, ReferencedMapperDefaultOther.class })
-    @ExpectedCompilationOutcome(
-        value = CompilationResult.SUCCEEDED,
-        diagnostics = {
-            @Diagnostic(type = SourceTargetMapperDefaultOther.class,
-                kind = javax.tools.Diagnostic.Kind.WARNING,
-                line = 24,
-                message = "Unmapped target property: \"bar\". Mapping " +
-                    "from property \"ReferencedSource referencedSource\" to \"ReferencedTarget referencedTarget\".")
-        }
-    )
-    public void shouldNotBeAbleToAccessDefaultMethodInReferencedInOtherPackage() {
-        generatedSource.addComparisonToFixtureFor( SourceTargetMapperDefaultOther.class );
+        Target target = SourceTargetMapperProtected.INSTANCE.toTarget( source );
+
+        assertThat( target.getReferencedTarget() ).isNotNull();
+        assertThat( target.getReferencedTarget().getBar() ).isEqualTo( "Foo" );
     }
 
     @ProcessorTest
     @IssueKey( "206" )
     @WithClasses( { AbstractSourceTargetMapperProtected.class, SourceTargetmapperProtectedBase.class } )
-    public void shouldBeAbleToAccessProtectedMethodInBase() { }
+    public void shouldBeAbleToAccessProtectedMethodInBase() {
+        Source source = createSourceWithReferencedSourceAndField( "Foo" );
 
-    @ProcessorTest
-    @IssueKey("206")
-    @WithClasses({ AbstractSourceTargetMapperPrivate.class, SourceTargetmapperPrivateBase.class })
-    @ExpectedCompilationOutcome(
-        value = CompilationResult.SUCCEEDED,
-        diagnostics = {
-            @Diagnostic(type = AbstractSourceTargetMapperPrivate.class,
-                kind = javax.tools.Diagnostic.Kind.WARNING,
-                line = 23,
-                message = "Unmapped target property: \"bar\". Mapping from property " +
-                    "\"ReferencedSource referencedSource\" to \"ReferencedTarget referencedTarget\".")
-        }
-    )
-    public void shouldNotBeAbleToAccessPrivateMethodInBase() {
-        generatedSource.addComparisonToFixtureFor( AbstractSourceTargetMapperPrivate.class );
+        Target target = AbstractSourceTargetMapperProtected.INSTANCE.toTarget( source );
+
+        assertThat( target.getReferencedTarget() ).isNotNull();
+        assertThat( target.getReferencedTarget().getBar() ).isEqualTo( "Foo" );
+    }
+
+    private Source createSourceWithReferencedSourceAndField(String fieldValue) {
+        Source source = new Source();
+        ReferencedSource referencedSource = new ReferencedSource();
+        referencedSource.setFoo( fieldValue );
+        source.setReferencedSource( referencedSource );
+        return source;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/SourceTargetMapperDefaultOther.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/SourceTargetMapperDefaultOther.java
@@ -7,6 +7,7 @@ package org.mapstruct.ap.test.accessibility.referenced;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.ap.test.accessibility.referenced.a.ReferencedMapperDefaultOther;
 import org.mapstruct.factory.Mappers;
 
@@ -14,7 +15,7 @@ import org.mapstruct.factory.Mappers;
  *
  * @author Sjaak Derksen
  */
-@Mapper(uses = ReferencedMapperDefaultOther.class)
+@Mapper(uses = ReferencedMapperDefaultOther.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface SourceTargetMapperDefaultOther {
 
     SourceTargetMapperDefaultOther INSTANCE =

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/SourceTargetMapperDefaultSame.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/SourceTargetMapperDefaultSame.java
@@ -7,13 +7,14 @@ package org.mapstruct.ap.test.accessibility.referenced;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 /**
  *
  * @author Sjaak Derksen
  */
-@Mapper(uses = ReferencedMapperDefaultSame.class)
+@Mapper(uses = ReferencedMapperDefaultSame.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface SourceTargetMapperDefaultSame {
 
     SourceTargetMapperDefaultSame INSTANCE = Mappers.getMapper( SourceTargetMapperDefaultSame.class );

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/SourceTargetMapperPrivate.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/SourceTargetMapperPrivate.java
@@ -7,13 +7,14 @@ package org.mapstruct.ap.test.accessibility.referenced;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 /**
  *
  * @author Sjaak Derksen
  */
-@Mapper(uses = ReferencedMapperPrivate.class)
+@Mapper(uses = ReferencedMapperPrivate.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface SourceTargetMapperPrivate {
 
     SourceTargetMapperPrivate INSTANCE = Mappers.getMapper( SourceTargetMapperPrivate.class );

--- a/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/SourceTargetMapperProtected.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/accessibility/referenced/SourceTargetMapperProtected.java
@@ -7,13 +7,14 @@ package org.mapstruct.ap.test.accessibility.referenced;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
 /**
  *
  * @author Sjaak Derksen
  */
-@Mapper(uses = ReferencedMapperProtected.class)
+@Mapper(uses = ReferencedMapperProtected.class, unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface SourceTargetMapperProtected {
 
     SourceTargetMapperProtected INSTANCE = Mappers.getMapper( SourceTargetMapperProtected.class );


### PR DESCRIPTION
This way the test does not use the target property warning mechanism to check if a mapping did not take place, but instead checks if the resulting field is filled or not.

2 reasons why I want to change this:

The first reason is that a change in the property message should not result in this test failing.

The second reason would be traceability for when a bug appears.

If a bug would be introduced with the following symptoms:
1. it would remove the field from unmapped properties
2. it would not store the mapping for generation.

These tests would then still pass, while this sounds to me like a failure situation for this test class.

Created this PR to continue the discussion started at #3522