### PR TITLE
#3360 Do not report unmapped source and target properties when result type is  abstract due to runtime exception subclass exhaustive strategy

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -319,8 +319,10 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             handleUnmappedConstructorProperties();
 
             // report errors on unmapped properties
-            reportErrorForUnmappedTargetPropertiesIfRequired();
-            reportErrorForUnmappedSourcePropertiesIfRequired();
+            if ( shouldHandledDefinedMappings ) {
+                reportErrorForUnmappedTargetPropertiesIfRequired();
+                reportErrorForUnmappedSourcePropertiesIfRequired();
+            }
             reportErrorForMissingIgnoredSourceProperties();
             reportErrorForUnusedSourceParameters();
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3360/Issue3360Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3360/Issue3360Mapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3360;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.SubclassExhaustiveStrategy;
+import org.mapstruct.SubclassMapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper(
+    subclassExhaustiveStrategy = SubclassExhaustiveStrategy.RUNTIME_EXCEPTION,
+    unmappedTargetPolicy = ReportingPolicy.ERROR,
+    unmappedSourcePolicy = ReportingPolicy.ERROR
+)
+public interface Issue3360Mapper {
+
+    Issue3360Mapper INSTANCE = Mappers.getMapper( Issue3360Mapper.class );
+
+    @SubclassMapping(target = VehicleDto.Car.class, source = Vehicle.Car.class)
+    VehicleDto map(Vehicle vehicle);
+
+    @Mapping(target = "model", source = "modelName")
+    @BeanMapping(ignoreUnmappedSourceProperties = "computedName")
+    VehicleDto.Car map(Vehicle.Car car);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3360/Issue3360Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3360/Issue3360Test.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3360;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("3360")
+@WithClasses({
+    Issue3360Mapper.class,
+    Vehicle.class,
+    VehicleDto.class,
+})
+class Issue3360Test {
+
+    @ProcessorTest
+    void shouldCompileWithoutErrorsAndWarnings() {
+
+        Vehicle vehicle = new Vehicle.Car( "Test", "car", 4 );
+
+        VehicleDto target = Issue3360Mapper.INSTANCE.map( vehicle );
+
+        assertThat( target.getName() ).isEqualTo( "Test" );
+        assertThat( target.getModel() ).isEqualTo( "car" );
+        assertThat( target ).isInstanceOfSatisfying( VehicleDto.Car.class, car -> {
+            assertThat( car.getNumOfDoors() ).isEqualTo( 4 );
+        } );
+
+        assertThatThrownBy( () -> Issue3360Mapper.INSTANCE.map( new Vehicle.Motorbike( "Test", "bike" ) ) )
+            .isInstanceOf( IllegalArgumentException.class )
+            .hasMessage( "Not all subclasses are supported for this mapping. Missing for " + Vehicle.Motorbike.class );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3360/Vehicle.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3360/Vehicle.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3360;
+
+/**
+ * @author Filip Hrisafov
+ */
+public abstract class Vehicle {
+
+    private final String name;
+    private final String modelName;
+
+    protected Vehicle(String name, String modelName) {
+        this.name = name;
+        this.modelName = modelName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getModelName() {
+        return modelName;
+    }
+
+    public String getComputedName() {
+        return null;
+    }
+
+    public static class Car extends Vehicle {
+
+        private final int numOfDoors;
+
+        public Car(String name, String modelName, int numOfDoors) {
+            super( name, modelName );
+            this.numOfDoors = numOfDoors;
+        }
+
+        public int getNumOfDoors() {
+            return numOfDoors;
+        }
+    }
+
+    public static class Motorbike extends Vehicle {
+
+        public Motorbike(String name, String modelName) {
+            super( name, modelName );
+        }
+
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3360/VehicleDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3360/VehicleDto.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3360;
+
+/**
+ * @author Filip Hrisafov
+ */
+public abstract class VehicleDto {
+
+    private String name;
+    private String model;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getModel() {
+        return model;
+    }
+
+    public void setModel(String model) {
+        this.model = model;
+    }
+
+    public static class Car extends VehicleDto {
+
+        private int numOfDoors;
+
+        public int getNumOfDoors() {
+            return numOfDoors;
+        }
+
+        public void setNumOfDoors(int numOfDoors) {
+            this.numOfDoors = numOfDoors;
+        }
+    }
+
+}


### PR DESCRIPTION
Fixes #3360 