### PR TITLE
Mapper, Mapping, Mappings - Change RetentionPolicy to RUNTIME

### DIFF
--- a/core/src/main/java/org/mapstruct/Mapper.java
+++ b/core/src/main/java/org/mapstruct/Mapper.java
@@ -77,7 +77,7 @@ import static org.mapstruct.SubclassExhaustiveStrategy.COMPILE_ERROR;
  * @see Javadoc
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 public @interface Mapper {
 
     /**

--- a/core/src/main/java/org/mapstruct/Mapping.java
+++ b/core/src/main/java/org/mapstruct/Mapping.java
@@ -143,7 +143,7 @@ import static org.mapstruct.NullValueCheckStrategy.ON_IMPLICIT_CONVERSION;
  */
 
 @Repeatable(Mappings.class)
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 public @interface Mapping {
 

--- a/core/src/main/java/org/mapstruct/Mappings.java
+++ b/core/src/main/java/org/mapstruct/Mappings.java
@@ -41,7 +41,7 @@ import java.lang.annotation.Target;
  *
  * @author Gunnar Morling
  */
-@Retention(RetentionPolicy.CLASS)
+@Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 public @interface Mappings {
 


### PR DESCRIPTION
Changing for Mapper, Mapping, Mappings the RetentionPolicy from CLASS to RUNTIME. This is to get at runtime the defintion of the mapping. Can be used for example to convert a sorting definition of a database object that is used in a query in the corresponding sorting defintion of the dto that can be used in the frontend.