### PR TITLE
#3485 Exception for Mapping to target = "." without source

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
@@ -260,6 +260,9 @@ public class MappingOptions extends DelegatingOptions {
         else if ( ".".equals( gem.target().get() ) && gem.ignore().hasValue() && gem.ignore().getValue() ) {
             message = Message.PROPERTYMAPPING_TARGET_THIS_AND_IGNORE;
         }
+        else if ( ".".equals( gem.target().get() ) && !gem.source().hasValue() ) {
+            message = Message.PROPERTYMAPPING_TARGET_THIS_NO_SOURCE;
+        }
 
         if ( message == null ) {
             return true;

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -71,6 +71,7 @@ public enum Message {
     PROPERTYMAPPING_DEFAULT_EXPERSSION_AND_NVPMS( "DefaultExpression and nullValuePropertyMappingStrategy are both defined in @Mapping, either define a defaultExpression or an nullValuePropertyMappingStrategy." ),
     PROPERTYMAPPING_IGNORE_AND_NVPMS( "Ignore and nullValuePropertyMappingStrategy are both defined in @Mapping, either define ignore or an nullValuePropertyMappingStrategy." ),
     PROPERTYMAPPING_TARGET_THIS_AND_IGNORE( "Using @Mapping( target = \".\", ignore = true ) is not allowed. You need to use @BeanMapping( ignoreByDefault = true ) if you would like to ignore all non explicitly mapped target properties." ),
+    PROPERTYMAPPING_TARGET_THIS_NO_SOURCE( "Using @Mapping( target = \".\") requires a source property. Expression or constant could not be used as a source."),
     PROPERTYMAPPING_EXPRESSION_AND_QUALIFIER_BOTH_DEFINED("Expression and a qualifier both defined in @Mapping, either define an expression or a qualifier."),
     PROPERTYMAPPING_INVALID_EXPRESSION( "Value for expression must be given in the form \"java(<EXPRESSION>)\"." ),
     PROPERTYMAPPING_INVALID_DEFAULT_EXPRESSION( "Value for default expression must be given in the form \"java(<EXPRESSION>)\"." ),

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -71,7 +71,7 @@ public enum Message {
     PROPERTYMAPPING_DEFAULT_EXPERSSION_AND_NVPMS( "DefaultExpression and nullValuePropertyMappingStrategy are both defined in @Mapping, either define a defaultExpression or an nullValuePropertyMappingStrategy." ),
     PROPERTYMAPPING_IGNORE_AND_NVPMS( "Ignore and nullValuePropertyMappingStrategy are both defined in @Mapping, either define ignore or an nullValuePropertyMappingStrategy." ),
     PROPERTYMAPPING_TARGET_THIS_AND_IGNORE( "Using @Mapping( target = \".\", ignore = true ) is not allowed. You need to use @BeanMapping( ignoreByDefault = true ) if you would like to ignore all non explicitly mapped target properties." ),
-    PROPERTYMAPPING_TARGET_THIS_NO_SOURCE( "Using @Mapping( target = \".\") requires a source property. Expression or constant could not be used as a source."),
+    PROPERTYMAPPING_TARGET_THIS_NO_SOURCE( "Using @Mapping( target = \".\") requires a source property. Expression or constant cannot be used as a source."),
     PROPERTYMAPPING_EXPRESSION_AND_QUALIFIER_BOTH_DEFINED("Expression and a qualifier both defined in @Mapping, either define an expression or a qualifier."),
     PROPERTYMAPPING_INVALID_EXPRESSION( "Value for expression must be given in the form \"java(<EXPRESSION>)\"." ),
     PROPERTYMAPPING_INVALID_DEFAULT_EXPRESSION( "Value for default expression must be given in the form \"java(<EXPRESSION>)\"." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/ErroneousIssue3485Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/ErroneousIssue3485Mapper.java
@@ -14,9 +14,9 @@ import org.mapstruct.factory.Mappers;
  * @author hduelme
  */
 @Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
-public interface Issue3485Mapper {
+public interface ErroneousIssue3485Mapper {
 
-    Issue3485Mapper INSTANCE = Mappers.getMapper( Issue3485Mapper.class );
+    ErroneousIssue3485Mapper INSTANCE = Mappers.getMapper( ErroneousIssue3485Mapper.class );
     class Target {
         private final String value;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Mapper.java
@@ -1,0 +1,27 @@
+package org.mapstruct.ap.test.bugs._3485;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface Issue3485Mapper {
+
+    Issue3485Mapper INSTANCE = Mappers.getMapper( Issue3485Mapper.class );
+    class Target {
+        private final String value;
+
+        public Target( String value ) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+    }
+
+    @Mapping(target = ".")
+    Target targetFromExpression(String s);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Mapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.ap.test.bugs._3485;
 
 import org.mapstruct.Mapper;
@@ -5,6 +10,9 @@ import org.mapstruct.Mapping;
 import org.mapstruct.ReportingPolicy;
 import org.mapstruct.factory.Mappers;
 
+/**
+ * @author hduelme
+ */
 @Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface Issue3485Mapper {
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.ap.test.bugs._3485;
 
 import org.mapstruct.ap.testutil.IssueKey;
@@ -7,6 +12,9 @@ import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 
+/**
+ * @author hduelme
+ */
 @IssueKey("3463")
 @WithClasses({
         Issue3485Mapper.class

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
@@ -16,14 +16,13 @@ import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutco
  * @author hduelme
  */
 @IssueKey("3463")
-@WithClasses({
-        Issue3485Mapper.class
-})
 public class Issue3485Test {
+
     @ProcessorTest
+    @WithClasses(ErroneousIssue3485Mapper.class)
     @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
             diagnostics = {
-                    @Diagnostic(type = Issue3485Mapper.class,
+                    @Diagnostic(type = ErroneousIssue3485Mapper.class,
                             kind = javax.tools.Diagnostic.Kind.ERROR,
                             line = 33,
                             message = "Using @Mapping( target = \".\") requires a source property. Expression or " +

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
@@ -26,7 +26,7 @@ public class Issue3485Test {
                             kind = javax.tools.Diagnostic.Kind.ERROR,
                             line = 33,
                             message = "Using @Mapping( target = \".\") requires a source property. Expression or " +
-                                    "constant could not be used as a source.")
+                                    "constant cannot be used as a source.")
             })
     void thisMappingWithoutSource() {
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
@@ -1,0 +1,25 @@
+package org.mapstruct.ap.test.bugs._3485;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+
+@IssueKey("3463")
+@WithClasses({
+        Issue3485Mapper.class
+})
+public class Issue3485Test {
+    @ProcessorTest
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+            diagnostics = {
+                    @Diagnostic(type = Issue3485Mapper.class,
+                            kind = javax.tools.Diagnostic.Kind.ERROR,
+                            line = 25,
+                            message = "Using @Mapping( target = \".\") requires a source property. Expression or constant could not be used as a source.")
+            })
+    void thisMappingWithoutSource() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
@@ -25,7 +25,7 @@ public class Issue3485Test {
             diagnostics = {
                     @Diagnostic(type = Issue3485Mapper.class,
                             kind = javax.tools.Diagnostic.Kind.ERROR,
-                            line = 25,
+                            line = 33,
                             message = "Using @Mapping( target = \".\") requires a source property. Expression or " +
                                     "constant could not be used as a source.")
             })

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3485/Issue3485Test.java
@@ -26,7 +26,8 @@ public class Issue3485Test {
                     @Diagnostic(type = Issue3485Mapper.class,
                             kind = javax.tools.Diagnostic.Kind.ERROR,
                             line = 25,
-                            message = "Using @Mapping( target = \".\") requires a source property. Expression or constant could not be used as a source.")
+                            message = "Using @Mapping( target = \".\") requires a source property. Expression or " +
+                                    "constant could not be used as a source.")
             })
     void thisMappingWithoutSource() {
     }


### PR DESCRIPTION
Currently using this `.` as a target results in a NPE see #3485.
I added a MappingOptions validation to check if source is present when this target is used. If not a error is reported to use user instead of an crash with NPE.