### PR TITLE
#3539 Support BeanMapping#ignoredTargets instead of repeating @Mapping(target = "foo", ignore = true)

### DIFF
--- a/core/src/main/java/org/mapstruct/BeanMapping.java
+++ b/core/src/main/java/org/mapstruct/BeanMapping.java
@@ -153,6 +153,28 @@ public @interface BeanMapping {
     String[] ignoreUnmappedSourceProperties() default {};
 
     /**
+     * Used to support multiple target properties ignoring.
+     * Repeated declarations of the ignore property of multiple {@link Mapping} annotations can be replaced
+     *
+     *
+     * <p> For example, see the following Mapping list </p>
+     * <p>&#64;Mapping(target = "foo", ignore = true)</p>
+     * <p>&#64;Mapping(target = "bar", ignore = true)</p>
+     * <p>&#64;Mapping(target = "baz", ignore = true)</p>
+     * <p>&#64;Mapping(target = "qux", ignore = true)</p>
+     *
+     *
+     * <p> Can be simplified as
+     * &#64;BeanMapping(ignoreTargets = ["foo", "bar", "baz", "qux"]) </p>
+     *
+     * @return The target properties should be ignored
+     *
+     * @since 1.7
+     */
+    String[] ignoreTargets() default {};
+
+
+    /**
      * How unmapped properties of the source type of a mapping should be reported.
      * If no policy is configured, the policy given via {@link MapperConfig#unmappedSourcePolicy()} or
      * {@link Mapper#unmappedSourcePolicy()} will be applied, using {@link ReportingPolicy#IGNORE} by default.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -7,7 +7,6 @@ package org.mapstruct.ap.internal.model;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -284,20 +283,6 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             }
 
             initializeMappingReferencesIfNeeded( resultTypeToMap );
-
-            if ( beanMapping != null ) {
-                for (String ignoreUnmapped : beanMapping.getIgnoreUnmappedTargetProperties()) {
-                    MappingOptions forIgnore = MappingOptions.
-                            forBeanMappingIgnoreTargets( ignoreUnmapped, method.getExecutable() );
-
-                    mappingReferences.getMappingReferences().add( new MappingReference(
-                            forIgnore,
-                            new TargetReference(null, Arrays.asList( ignoreUnmapped.split(  "\\."  ) )),
-                            null
-
-                    ) );
-                }
-            }
 
             boolean shouldHandledDefinedMappings = shouldHandledDefinedMappings( resultTypeToMap );
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -7,6 +7,7 @@ package org.mapstruct.ap.internal.model;
 
 import java.text.MessageFormat;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -283,6 +284,18 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             }
 
             initializeMappingReferencesIfNeeded( resultTypeToMap );
+
+            if ( beanMapping != null ) {
+                for (String ignoreUnmapped : beanMapping.getIgnoreUnmappedTargetProperties()) {
+                    MappingOptions forIgnore = MappingOptions.forIgnore( ignoreUnmapped );
+                    mappingReferences.getMappingReferences().add( new MappingReference(
+                            forIgnore,
+                            new TargetReference(null, Arrays.asList( ignoreUnmapped.split(  "\\."  ) )),
+                            null
+
+                    ) );
+                }
+            }
 
             boolean shouldHandledDefinedMappings = shouldHandledDefinedMappings( resultTypeToMap );
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -287,7 +287,9 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
 
             if ( beanMapping != null ) {
                 for (String ignoreUnmapped : beanMapping.getIgnoreUnmappedTargetProperties()) {
-                    MappingOptions forIgnore = MappingOptions.forIgnore( ignoreUnmapped );
+                    MappingOptions forIgnore = MappingOptions.
+                            forBeanMappingIgnoreTargets( ignoreUnmapped, method.getExecutable() );
+
                     mappingReferences.getMappingReferences().add( new MappingReference(
                             forIgnore,
                             new TargetReference(null, Arrays.asList( ignoreUnmapped.split(  "\\."  ) )),

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/BeanMappingOptions.java
@@ -35,6 +35,7 @@ public class BeanMappingOptions extends DelegatingOptions {
 
     private final SelectionParameters selectionParameters;
     private final List<String> ignoreUnmappedSourceProperties;
+    private final List<String> ignoreUnmappedTargetProperties;
     private final BeanMappingGem beanMapping;
 
     /**
@@ -49,6 +50,7 @@ public class BeanMappingOptions extends DelegatingOptions {
         BeanMappingOptions options =  new BeanMappingOptions(
             SelectionParameters.forInheritance( beanMapping.selectionParameters ),
             isInverse ? Collections.emptyList() : beanMapping.ignoreUnmappedSourceProperties,
+            isInverse ? Collections.emptyList() : beanMapping.ignoreUnmappedTargetProperties,
             beanMapping.beanMapping,
             beanMapping
         );
@@ -60,6 +62,7 @@ public class BeanMappingOptions extends DelegatingOptions {
             beanMapping.selectionParameters != null ?
                 SelectionParameters.withoutResultType( beanMapping.selectionParameters ) : null,
             Collections.emptyList(),
+            Collections.emptyList(),
             beanMapping.beanMapping,
             beanMapping
         );
@@ -67,7 +70,8 @@ public class BeanMappingOptions extends DelegatingOptions {
     }
 
     public static BeanMappingOptions empty(DelegatingOptions delegatingOptions) {
-        return new BeanMappingOptions( null, Collections.emptyList(), null, delegatingOptions );
+        return new BeanMappingOptions( null, Collections.emptyList(),
+                Collections.emptyList(), null, delegatingOptions );
     }
 
     public static BeanMappingOptions getInstanceOn(BeanMappingGem beanMapping, MapperOptions mapperOptions,
@@ -95,6 +99,7 @@ public class BeanMappingOptions extends DelegatingOptions {
         BeanMappingOptions options = new BeanMappingOptions(
             selectionParameters,
             beanMapping.ignoreUnmappedSourceProperties().get(),
+            beanMapping.ignoreTargets().get(),
             beanMapping,
             mapperOptions
         );
@@ -108,6 +113,7 @@ public class BeanMappingOptions extends DelegatingOptions {
             && !gem.qualifiedBy().hasValue()
             && !gem.qualifiedByName().hasValue()
             && !gem.ignoreUnmappedSourceProperties().hasValue()
+            && !gem.ignoreTargets().hasValue()
             && !gem.nullValueCheckStrategy().hasValue()
             && !gem.nullValuePropertyMappingStrategy().hasValue()
             && !gem.nullValueMappingStrategy().hasValue()
@@ -125,11 +131,13 @@ public class BeanMappingOptions extends DelegatingOptions {
 
     private BeanMappingOptions(SelectionParameters selectionParameters,
                                List<String> ignoreUnmappedSourceProperties,
+                               List<String> ignoreUnmappedTargetProperties,
                                BeanMappingGem beanMapping,
                                DelegatingOptions next) {
         super( next );
         this.selectionParameters = selectionParameters;
         this.ignoreUnmappedSourceProperties = ignoreUnmappedSourceProperties;
+        this.ignoreUnmappedTargetProperties = ignoreUnmappedTargetProperties;
         this.beanMapping = beanMapping;
     }
 
@@ -220,6 +228,10 @@ public class BeanMappingOptions extends DelegatingOptions {
 
     public List<String> getIgnoreUnmappedSourceProperties() {
         return ignoreUnmappedSourceProperties;
+    }
+
+    public List<String> getIgnoreUnmappedTargetProperties() {
+        return ignoreUnmappedTargetProperties;
     }
 
     public AnnotationMirror getMirror() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
@@ -357,13 +357,20 @@ public class MappingMethodOptions {
 
     public void applyIgnoreTargets(SourceMethod method, FormattingMessager messager,
                                     List<String> ignoreTargets ) {
+        if ( ignoreTargets.contains( "." ) ) {
+            messager.printMessage(
+                    method.getExecutable(),
+                    getBeanMapping().getMirror(),
+                    Message.BEANMAPPING_IGNORE_TARGETS_WITH_MAPPING_TARGET_THIS
+            );
+            return;
+        }
         for ( MappingOptions mapping : mappings ) {
-            if ( !mapping.isIgnored() && ignoreTargets.contains( mapping.getTargetName() ) ) {
+            if ( ignoreTargets.contains( mapping.getTargetName() ) ) {
                 messager.printMessage(
                         method.getExecutable(),
                         getBeanMapping().getMirror(),
                         Message.BEANMAPPING_IGNORE_TARGETS_WITH_MAPPING_TARGET_ERROR,
-                        ignoreTargets,
                         mapping.getTargetName()
                 );
             }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingMethodOptions.java
@@ -355,6 +355,27 @@ public class MappingMethodOptions {
         }
     }
 
+    public void applyIgnoreTargets(SourceMethod method, FormattingMessager messager,
+                                    List<String> ignoreTargets ) {
+        for ( MappingOptions mapping : mappings ) {
+            if ( !mapping.isIgnored() && ignoreTargets.contains( mapping.getTargetName() ) ) {
+                messager.printMessage(
+                        method.getExecutable(),
+                        getBeanMapping().getMirror(),
+                        Message.BEANMAPPING_IGNORE_TARGETS_WITH_MAPPING_TARGET_ERROR,
+                        ignoreTargets,
+                        mapping.getTargetName()
+                );
+            }
+        }
+
+        for (String ignoreTarget : ignoreTargets) {
+            MappingOptions mapping =
+                    MappingOptions.forBeanMappingIgnoreTargets( ignoreTarget, method.getExecutable() );
+            mappings.add( mapping );
+        }
+    }
+
     private void filterNestedTargetIgnores( Set<MappingOptions> mappings) {
 
         // collect all properties to ignore, and safe their target name ( == same name as first ref target property)

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
@@ -190,6 +190,28 @@ public class MappingOptions extends DelegatingOptions {
         );
     }
 
+    public static MappingOptions forBeanMappingIgnoreTargets(String targetName, Element element) {
+        return new MappingOptions(
+                targetName,
+                element,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                true,
+                null,
+                null,
+                Collections.emptySet(),
+                null,
+                null,
+                null
+        );
+    }
+
     private static boolean isConsistent(MappingGem gem, ExecutableElement method,
                                         FormattingMessager messager) {
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -569,6 +569,14 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
             mappingOptions.applyIgnoreAll( method, typeFactory, mappingContext.getMessager() );
         }
 
+        // @BeanMapping ( ignoreTargets = {...} )
+        if ( mappingOptions.getBeanMapping() != null &&
+                mappingOptions.getBeanMapping().getIgnoreUnmappedTargetProperties() != null ) {
+            mappingOptions.applyIgnoreTargets( method,
+                    mappingContext.getMessager(),
+                    mappingOptions.getBeanMapping().getIgnoreUnmappedTargetProperties() );
+        }
+
         mappingOptions.markAsFullyInitialized();
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -45,6 +45,7 @@ public enum Message {
     BEANMAPPING_CYCLE_BETWEEN_PROPERTIES( "Cycle(s) between properties given via dependsOn(): %s." ),
     BEANMAPPING_UNKNOWN_PROPERTY_IN_DEPENDS_ON( "\"%s\" is no property of the method return type." ),
     BEANMAPPING_IGNORE_BY_DEFAULT_WITH_MAPPING_TARGET_THIS( "Using @BeanMapping( ignoreByDefault = true ) with @Mapping( target = \".\", ... ) is not allowed. You'll need to explicitly ignore the target properties that should be ignored instead." ),
+    BEANMAPPING_IGNORE_TARGETS_WITH_MAPPING_TARGET_ERROR("Use @BeanMapping(ignoreTargets = \"%s\") and @Mapping(target = \"%s\",...) There's a conflict."),
 
     PROPERTYMAPPING_MAPPING_NOTE( "mapping property: %s to: %s.", Diagnostic.Kind.NOTE ),
     PROPERTYMAPPING_CREATE_NOTE( "creating property mapping: %s.", Diagnostic.Kind.NOTE ),

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -45,7 +45,9 @@ public enum Message {
     BEANMAPPING_CYCLE_BETWEEN_PROPERTIES( "Cycle(s) between properties given via dependsOn(): %s." ),
     BEANMAPPING_UNKNOWN_PROPERTY_IN_DEPENDS_ON( "\"%s\" is no property of the method return type." ),
     BEANMAPPING_IGNORE_BY_DEFAULT_WITH_MAPPING_TARGET_THIS( "Using @BeanMapping( ignoreByDefault = true ) with @Mapping( target = \".\", ... ) is not allowed. You'll need to explicitly ignore the target properties that should be ignored instead." ),
-    BEANMAPPING_IGNORE_TARGETS_WITH_MAPPING_TARGET_ERROR("Use @BeanMapping(ignoreTargets = \"%s\") and @Mapping(target = \"%s\",...) There's a conflict."),
+    BEANMAPPING_IGNORE_TARGETS_WITH_MAPPING_TARGET_ERROR("The target property %s cannot be mapped more than once in @BeanMapping and @Mapping."),
+    BEANMAPPING_IGNORE_TARGETS_WITH_MAPPING_TARGET_THIS( "Using @BeanMapping( ignoreTargets = {\".\"} ) with @Mapping( target = \".\", ... ) is not allowed. You'll need to explicitly ignore the target properties that should be ignored instead." ),
+
 
     PROPERTYMAPPING_MAPPING_NOTE( "mapping property: %s to: %s.", Diagnostic.Kind.NOTE ),
     PROPERTYMAPPING_CREATE_NOTE( "creating property mapping: %s.", Diagnostic.Kind.NOTE ),

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetMapper.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.ap.test.unmappedtarget.beanmapping;
 
 import org.mapstruct.BeanMapping;

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetMapper.java
@@ -1,0 +1,15 @@
+package org.mapstruct.ap.test.unmappedtarget.beanmapping;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface BeanMappingIgnoreTargetMapper {
+
+    BeanMappingIgnoreTargetMapper INSTANCE =
+            Mappers.getMapper( BeanMappingIgnoreTargetMapper.class );
+
+    @BeanMapping( ignoreTargets = {"nested.flag", "address"} )
+    Target convert( Source source );
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetTest.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.ap.test.unmappedtarget.beanmapping;
 
 import org.mapstruct.BeanMapping;

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetTest.java
@@ -50,7 +50,8 @@ public class BeanMappingIgnoreTargetTest {
                     @Diagnostic(type = ErroneousBeanMappingIgnoreTargetConflictMapper.class,
                             kind = javax.tools.Diagnostic.Kind.ERROR,
                             line = 19,
-                            message = "The target property name cannot be mapped more than once in @BeanMapping and @Mapping.")
+                            message = "The target property name cannot be mapped more than once " +
+                                    "in @BeanMapping and @Mapping.")
             }
     )
     public void shouldRaiseErrorDueToConflictProperty() {

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetTest.java
@@ -50,11 +50,29 @@ public class BeanMappingIgnoreTargetTest {
                     @Diagnostic(type = ErroneousBeanMappingIgnoreTargetConflictMapper.class,
                             kind = javax.tools.Diagnostic.Kind.ERROR,
                             line = 19,
-                            message = "Use @BeanMapping(ignoreTargets = \"[name, address]\") " +
-                                    "and @Mapping(target = \"name\",...) There's a conflict.")
+                            message = "The target property name cannot be mapped more than once in @BeanMapping and @Mapping.")
             }
     )
     public void shouldRaiseErrorDueToConflictProperty() {
 
     }
+
+    @ProcessorTest
+    @WithClasses({Source.class, Target.class, ErroneousBeanMappingIgnoreTargetThisMapper.class})
+    @ExpectedCompilationOutcome(
+            value = CompilationResult.FAILED,
+            diagnostics = {
+                    @Diagnostic(type = ErroneousBeanMappingIgnoreTargetThisMapper.class,
+                            kind = javax.tools.Diagnostic.Kind.ERROR,
+                            line = 19,
+                            message = "Using @BeanMapping( ignoreTargets = {\".\"} ) " +
+                                    "with @Mapping( target = \".\", ... ) is not allowed. " +
+                                    "You'll need to explicitly ignore the target properties " +
+                                    "that should be ignored instead.")
+            }
+    )
+    public void shouldRaiseErrorDueToThisProperty() {
+
+    }
+
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetTest.java
@@ -1,0 +1,17 @@
+package org.mapstruct.ap.test.unmappedtarget.beanmapping;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+@IssueKey("3539")
+public class BeanMappingIgnoreTargetTest {
+
+    @ProcessorTest
+    @WithClasses( {Source.class, Target.class, BeanMappingIgnoreTargetMapper.class} )
+    @BeanMapping
+    public void shouldIgnoreTargetProperty() {
+        BeanMappingIgnoreTargetMapper.INSTANCE.convert( new Source() );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/BeanMappingIgnoreTargetTest.java
@@ -5,18 +5,34 @@
  */
 package org.mapstruct.ap.test.unmappedtarget.beanmapping;
 
-import org.mapstruct.BeanMapping;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 
 @IssueKey("3539")
 public class BeanMappingIgnoreTargetTest {
 
     @ProcessorTest
-    @WithClasses( {Source.class, Target.class, BeanMappingIgnoreTargetMapper.class} )
-    @BeanMapping
+    @WithClasses({Source.class, Target.class, BeanMappingIgnoreTargetMapper.class})
     public void shouldIgnoreTargetProperty() {
         BeanMappingIgnoreTargetMapper.INSTANCE.convert( new Source() );
+    }
+
+    @ProcessorTest
+    @WithClasses({Source.class, Target.class, ErroneousBeanMappingIgnoreTargetMapper.class})
+    @ExpectedCompilationOutcome(
+            value = CompilationResult.FAILED,
+            diagnostics = {
+                    @Diagnostic(type = ErroneousBeanMappingIgnoreTargetMapper.class,
+                            kind = javax.tools.Diagnostic.Kind.ERROR,
+                            line = 19,
+                            message = "Unknown property \"unknownProperty\" in result type Target. " +
+                                    "Did you mean \"name\"?")
+            }
+    )
+    public void shouldRaiseErrorDueToUnknownProperty() {
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/ErroneousBeanMappingIgnoreTargetConflictMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/ErroneousBeanMappingIgnoreTargetConflictMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.unmappedtarget.beanmapping;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ErroneousBeanMappingIgnoreTargetConflictMapper {
+
+    ErroneousBeanMappingIgnoreTargetConflictMapper INSTANCE =
+            Mappers.getMapper( ErroneousBeanMappingIgnoreTargetConflictMapper.class );
+
+    @BeanMapping( ignoreTargets = { "name", "address" } )
+    @Mapping( target = "name", defaultValue = "TOM" )
+    Target convert(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/ErroneousBeanMappingIgnoreTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/ErroneousBeanMappingIgnoreTargetMapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.unmappedtarget.beanmapping;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ErroneousBeanMappingIgnoreTargetMapper {
+
+    ErroneousBeanMappingIgnoreTargetMapper INSTANCE =
+            Mappers.getMapper( ErroneousBeanMappingIgnoreTargetMapper.class );
+
+    @BeanMapping( ignoreTargets = { "unknownProperty" } )
+    Target convert(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/ErroneousBeanMappingIgnoreTargetThisMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/ErroneousBeanMappingIgnoreTargetThisMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.unmappedtarget.beanmapping;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ErroneousBeanMappingIgnoreTargetThisMapper {
+
+    ErroneousBeanMappingIgnoreTargetThisMapper INSTANCE =
+            Mappers.getMapper( ErroneousBeanMappingIgnoreTargetThisMapper.class );
+
+    @BeanMapping( ignoreTargets = { "." } )
+    @Mapping( ignore = true, target = "address" )
+    Target convert(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/Source.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.ap.test.unmappedtarget.beanmapping;
 
 public class Source {

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/Source.java
@@ -1,0 +1,47 @@
+package org.mapstruct.ap.test.unmappedtarget.beanmapping;
+
+public class Source {
+
+    private String name;
+
+    private Integer age;
+
+    private NestedSource nested;
+
+    public NestedSource getNested() {
+        return nested;
+    }
+
+    public void setNested(NestedSource nested) {
+        this.nested = nested;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    public static class NestedSource {
+        private Double score;
+
+        public Double getScore() {
+            return score;
+        }
+
+        public void setScore(Double score) {
+            this.score = score;
+        }
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/Target.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.ap.test.unmappedtarget.beanmapping;
 
 public class Target {

--- a/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/unmappedtarget/beanmapping/Target.java
@@ -1,0 +1,68 @@
+package org.mapstruct.ap.test.unmappedtarget.beanmapping;
+
+public class Target {
+
+    private String name;
+
+    private String address;
+
+    private Integer age;
+
+    private NestedTarget nested;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public Integer getAge() {
+        return age;
+    }
+
+    public void setAge(Integer age) {
+        this.age = age;
+    }
+
+    public NestedTarget getNested() {
+        return nested;
+    }
+
+    public void setNested(NestedTarget nested) {
+        this.nested = nested;
+    }
+
+    public static class NestedTarget {
+
+        private Double score;
+
+        private Boolean flag;
+
+        public Double getScore() {
+            return score;
+        }
+
+        public void setScore(Double score) {
+            this.score = score;
+        }
+
+        public Boolean getFlag() {
+            return flag;
+        }
+
+        public void setFlag(Boolean flag) {
+            this.flag = flag;
+        }
+    }
+
+}


### PR DESCRIPTION
This commit attempts to implement [#2599](https://github.com/mapstruct/mapstruct/issues/3539), mapping `BeanMapping#ignoredTargets` to multiple `Mapping#ignore` annotations. 

If there are any necessary changes, I'll do my best to address them.