### PR TITLE
#2257 Adding abstract class mappers with defined constructor

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/CanonicalConstructor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/CanonicalConstructor.java
@@ -1,0 +1,39 @@
+package org.mapstruct.ap.internal.model;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.mapstruct.ap.internal.model.common.ModelElement;
+import org.mapstruct.ap.internal.model.common.Parameter;
+import org.mapstruct.ap.internal.model.common.Type;
+
+public class CanonicalConstructor extends ModelElement implements Constructor {
+
+    private final String name;
+    private final List<Parameter> parameters;
+
+    public CanonicalConstructor(String name, List<Parameter> parameters) {
+        this.name = name;
+        this.parameters = parameters;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    public List<Parameter> getParameters() {
+        return parameters;
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        Set<Type> types = new HashSet<>();
+        for ( Parameter parameter : parameters ) {
+            types.addAll( parameter.getType().getImportTypes() );
+        }
+        return types;
+    }
+
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/SpringComponentProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/SpringComponentProcessor.java
@@ -15,15 +15,21 @@ import java.util.Set;
 import org.mapstruct.ap.internal.gem.MappingConstantsGem;
 import org.mapstruct.ap.internal.model.Annotation;
 import org.mapstruct.ap.internal.model.Mapper;
+import org.mapstruct.ap.internal.model.CanonicalConstructor;
 import org.mapstruct.ap.internal.model.annotation.AnnotationElement;
 import org.mapstruct.ap.internal.model.annotation.AnnotationElement.AnnotationElementType;
+import org.mapstruct.ap.internal.model.common.Parameter;
 
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.Modifier;
 import javax.lang.model.element.PackageElement;
 import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
 
 import static javax.lang.model.element.ElementKind.PACKAGE;
+import static javax.lang.model.util.ElementFilter.constructorsIn;
 
 /**
  * A {@link ModelElementProcessor} which converts the given {@link Mapper}
@@ -34,6 +40,40 @@ import static javax.lang.model.element.ElementKind.PACKAGE;
  * @author Andreas Gudian
  */
 public class SpringComponentProcessor extends AnnotationBasedComponentModelProcessor {
+
+    @Override
+    public Mapper process(ProcessorContext context, TypeElement mapperTypeElement, Mapper mapper) {
+        super.process( context, mapperTypeElement, mapper );
+        buildCanonicalConstructor( mapperTypeElement, mapper );
+        return mapper;
+    }
+
+    private void buildCanonicalConstructor(TypeElement mapperTypeElement, Mapper mapper) {
+        if ( mapperTypeElement.getModifiers().contains( Modifier.ABSTRACT ) ) {
+            List<ExecutableElement> constructors = constructorsIn( mapperTypeElement.getEnclosedElements() );
+            if ( constructors.size() == 1 ) {
+                ExecutableElement canonicalConstructor = constructors.get( 0 );
+                if ( !canonicalConstructor.getParameters().isEmpty() ) {
+                    mapper.setConstructor( new CanonicalConstructor(
+                            mapper.getName(),
+                            getParameters( canonicalConstructor )
+                        )
+                    );
+                }
+            }
+        }
+    }
+
+    private List<Parameter> getParameters(ExecutableElement superConstructor) {
+        List<Parameter> parameters = new ArrayList<>();
+        for ( VariableElement parameter : superConstructor.getParameters() ) {
+            parameters.add( new Parameter(
+                parameter.getSimpleName().toString(),
+                getTypeFactory().getType( parameter.asType() )
+            ) );
+        }
+        return parameters;
+    }
 
     @Override
     protected String getComponentModelIdentifier() {

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/CanonicalConstructor.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/CanonicalConstructor.ftl
@@ -1,0 +1,11 @@
+<#--
+
+   Copyright MapStruct Authors.
+
+   Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.CanonicalConstructor" -->
+public ${name}(<#list parameters as param><@includeModel object=param/><#if param_has_next>, </#if></#list>) {
+    super( <#list parameters as param>${param.name}<#if param_has_next>, </#if></#list> );
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/canonicalconstructor/ContactRepository.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/canonicalconstructor/ContactRepository.java
@@ -1,0 +1,12 @@
+package org.mapstruct.ap.test.injectionstrategy.spring.canonicalconstructor;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class ContactRepository {
+
+    public String getUserPhoneNumber(Integer userId) {
+        return "+441134960000";
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/canonicalconstructor/SpringCanonicalConstructorInjectionTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/canonicalconstructor/SpringCanonicalConstructorInjectionTest.java
@@ -1,0 +1,77 @@
+package org.mapstruct.ap.test.injectionstrategy.spring.canonicalconstructor;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithSpring;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+
+import static java.lang.System.lineSeparator;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses({
+    UserEntity.class,
+    UserDto.class,
+    UserSpringCanonicalConstructorMapper.class,
+    ContactRepository.class,
+})
+@IssueKey("2257")
+@ComponentScan(basePackageClasses = SpringCanonicalConstructorInjectionTest.class)
+@Configuration
+@WithSpring
+public class SpringCanonicalConstructorInjectionTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @Autowired
+    private UserSpringCanonicalConstructorMapper customerMapper;
+    private ConfigurableApplicationContext context;
+
+    @BeforeEach
+    public void springUp() {
+        context = new AnnotationConfigApplicationContext( getClass() );
+        context.getAutowireCapableBeanFactory().autowireBean( this );
+    }
+
+    @AfterEach
+    public void springDown() {
+        if ( context != null ) {
+            context.close();
+        }
+    }
+
+    @ProcessorTest
+    public void shouldConvertToTarget() throws Exception {
+        // given
+        UserEntity userEntity = new UserEntity( 23, "Jan Kowalski" );
+
+        // when
+        UserDto userDto = customerMapper.map( userEntity );
+
+        // then
+        assertThat( userDto ).isNotNull();
+        assertThat( userDto.getUserId() ).isEqualTo( 23 );
+        assertThat( userDto.getName() ).isEqualTo( "Jan Kowalski" );
+        assertThat( userDto.getPhoneNumber() ).isEqualTo( "+441134960000" );
+    }
+
+    @ProcessorTest
+    public void shouldHaveCanonicalConstructorInjection() {
+        generatedSource.forMapper( UserSpringCanonicalConstructorMapper.class )
+            .content()
+            .contains(
+                "    public UserSpringCanonicalConstructorMapperImpl(ContactRepository contactRepository) {" + lineSeparator() +
+                "        super( contactRepository );" + lineSeparator() +
+                "    }" );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/canonicalconstructor/UserDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/canonicalconstructor/UserDto.java
@@ -1,0 +1,27 @@
+package org.mapstruct.ap.test.injectionstrategy.spring.canonicalconstructor;
+
+public class UserDto {
+
+    private Integer userId;
+    private String name;
+    private String phoneNumber;
+
+    public UserDto(Integer userId, String name, String phoneNumber) {
+        this.userId = userId;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPhoneNumber() {
+        return phoneNumber;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/canonicalconstructor/UserEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/canonicalconstructor/UserEntity.java
@@ -1,0 +1,21 @@
+package org.mapstruct.ap.test.injectionstrategy.spring.canonicalconstructor;
+
+public class UserEntity {
+
+    private Integer userId;
+    private String name;
+
+    public UserEntity(Integer userId, String name) {
+        this.userId = userId;
+        this.name = name;
+    }
+
+    public Integer getUserId() {
+        return userId;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/canonicalconstructor/UserSpringCanonicalConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/spring/canonicalconstructor/UserSpringCanonicalConstructorMapper.java
@@ -1,0 +1,22 @@
+package org.mapstruct.ap.test.injectionstrategy.spring.canonicalconstructor;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public abstract class UserSpringCanonicalConstructorMapper {
+
+    private final ContactRepository contactRepository;
+
+    public UserSpringCanonicalConstructorMapper(ContactRepository contactRepository) {
+        this.contactRepository = contactRepository;
+    }
+
+    public UserDto map(UserEntity userEntity) {
+        String phoneNumber = contactRepository.getUserPhoneNumber( userEntity.getUserId() );
+        return map( userEntity, phoneNumber );
+    }
+
+    protected abstract UserDto map(UserEntity userEntity, String phoneNumber);
+
+}


### PR DESCRIPTION
For spring mappers you can inject components by constructor when it is defined, mapper implementation will call it's super constructor.

Adding calling super canonical costructor only for Spring mappers as decided in referenced issue by project maintainers