### PR TITLE
#3458 generic fix for method override comparison due to eclipse bug.

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/util/AbstractElementUtilsDecorator.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/AbstractElementUtilsDecorator.java
@@ -259,8 +259,8 @@ public abstract class AbstractElementUtilsDecorator implements ElementUtils {
         return true;
     }
 
-    private TypeElement getParentType(ExecutableElement executableInSubtype) {
-        return (TypeElement) executableInSubtype.getEnclosingElement();
+    private TypeElement getParentType(ExecutableElement executableElement) {
+        return (TypeElement) executableElement.getEnclosingElement();
     }
 
     private void addEnclosedFieldsInHierarchy( List<VariableElement> alreadyAdded,

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3458/GenericMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3458/GenericMapper.java
@@ -1,0 +1,11 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3458;
+
+public abstract class GenericMapper<T1, T2> {
+
+    abstract T1 map(T2 source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3458/IdentityMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3458/IdentityMapper.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3458;
+
+public class IdentityMapper<T> extends GenericMapper<T, T> {
+
+    @Override
+    T map(T source) {
+        return source;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3458/Issue3458Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3458/Issue3458Test.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3458;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.factory.Mappers;
+
+@IssueKey( "3458" )
+public class Issue3458Test {
+
+    @ProcessorTest
+    @WithClasses( { Person.class, PersonMapper.class, GenericMapper.class, IdentityMapper.class } )
+    void overridenMethodDoesNotGetOverriddenAgain() {
+        Person lead = new Person();
+
+        Person result = Mappers.getMapper( PersonMapper.class ).map( lead );
+
+        assertThat( result ).isSameAs( lead );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3458/Person.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3458/Person.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3458;
+
+public class Person {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3458/PersonMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3458/PersonMapper.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3458;
+
+import org.mapstruct.Mapper;
+
+@Mapper
+public abstract class PersonMapper extends IdentityMapper<Person> {
+}


### PR DESCRIPTION
instead of passing on the mapper type as parent, use the type of the class where the method is enclosed.

fixes #3458 