### PR TITLE
[#1830] NullValuePropertyMappingStrategy.CLEAR

### DIFF
--- a/core/src/main/java/org/mapstruct/NullValuePropertyMappingStrategy.java
+++ b/core/src/main/java/org/mapstruct/NullValuePropertyMappingStrategy.java
@@ -5,6 +5,8 @@
  */
 package org.mapstruct;
 
+import java.util.Collection;
+
 /**
  * Strategy for dealing with {@code null} or not present properties in the source bean. The
  * {@link NullValuePropertyMappingStrategy} can be defined on {@link MapperConfig}, {@link Mapper}, {@link BeanMapping}
@@ -53,5 +55,12 @@ public enum NullValuePropertyMappingStrategy {
      * If a source bean property equals {@code null} the target bean property will be ignored and retain its
      * existing value.
      */
-    IGNORE;
+    IGNORE,
+
+    /**
+     * This strategy is applicable only to update methods that annotate with {@code @}{@link MappingTarget}.
+     * If a source bean property, of type {@link Collection} equals {@code null},
+     * the target bean property will be cleared {@link Collection#clear()}.
+     */
+    CLEAR;
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/gem/NullValuePropertyMappingStrategyGem.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/gem/NullValuePropertyMappingStrategyGem.java
@@ -15,5 +15,6 @@ public enum NullValuePropertyMappingStrategyGem {
 
     SET_TO_NULL,
     SET_TO_DEFAULT,
-    IGNORE;
+    IGNORE,
+    CLEAR;
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -52,6 +52,7 @@ import org.mapstruct.ap.internal.util.accessor.AccessorType;
 import org.mapstruct.ap.internal.util.accessor.ReadAccessor;
 
 import static org.mapstruct.ap.internal.gem.NullValueCheckStrategyGem.ALWAYS;
+import static org.mapstruct.ap.internal.gem.NullValuePropertyMappingStrategyGem.CLEAR;
 import static org.mapstruct.ap.internal.gem.NullValuePropertyMappingStrategyGem.IGNORE;
 import static org.mapstruct.ap.internal.gem.NullValuePropertyMappingStrategyGem.SET_TO_DEFAULT;
 import static org.mapstruct.ap.internal.gem.NullValuePropertyMappingStrategyGem.SET_TO_NULL;
@@ -272,15 +273,11 @@ public class PropertyMapping extends ModelElement {
             Type sourceType = rightHandSide.getSourceType();
             if ( assignment != null ) {
                 ctx.getMessager().note( 2,  Message.PROPERTYMAPPING_SELECT_NOTE,  assignment );
-                if ( targetType.isCollectionOrMapType() ) {
-                    assignment = assignToCollection( targetType, targetWriteAccessorType, assignment );
+                if ( !targetType.isCollectionOrMapType() &&
+                    nvpms == CLEAR ) { // TODO: It works, but should the check be done here?
+                    reportNullValueClearStrategyError();
                 }
-                else if ( targetType.isArrayType() && sourceType.isArrayType() && assignment.getType() == DIRECT ) {
-                    assignment = assignToArray( targetType, assignment );
-                }
-                else {
-                    assignment = assignToPlain( targetType, targetWriteAccessorType, assignment );
-                }
+                assignment = assignToTargetType( assignment, sourceType );
             }
             else {
                 reportCannotCreateMapping();
@@ -297,6 +294,27 @@ public class PropertyMapping extends ModelElement {
                 dependsOn,
                 getDefaultValueAssignment( assignment ),
                 targetWriteAccessorType == AccessorType.PARAMETER
+            );
+        }
+
+        private Assignment assignToTargetType(Assignment assignment, Type sourceType) {
+            if ( targetType.isCollectionOrMapType() ) {
+                assignment = assignToCollection( targetType, targetWriteAccessorType, assignment );
+            }
+            else if ( targetType.isArrayType() && sourceType.isArrayType() && assignment.getType() == DIRECT ) {
+                assignment = assignToArray( targetType, assignment );
+            }
+            else {
+                assignment = assignToPlain( targetType, targetWriteAccessorType, assignment );
+            }
+            return assignment;
+        }
+
+        private void reportNullValueClearStrategyError() {
+            ctx.getMessager().printMessage( //TODO: Is this the correct way to print the error?
+                method.getExecutable(),
+                Message.PROPERTYMAPPING_NULL_VALUE_CLEAR_STRATEGY_CANT_BE_USED_WITH_NON_MAP_OR_COLLECTION_TYPE,
+                targetPropertyName
             );
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -92,6 +92,9 @@ public enum Message {
     PROPERTYMAPPING_CANNOT_DETERMINE_SOURCE_PARAMETER_FROM_TARGET("No property named \"%s\" exists in source parameter(s). Please define the source explicitly."),
     PROPERTYMAPPING_NO_SUITABLE_COLLECTION_OR_MAP_CONSTRUCTOR( "%s does not have an accessible copy or no-args constructor." ),
     PROPERTYMAPPING_EXPRESSION_AND_CONDITION_QUALIFIED_BY_NAME_BOTH_DEFINED( "Expression and condition qualified by name are both defined in @Mapping, either define an expression or a condition qualified by name." ),
+    PROPERTYMAPPING_NULL_VALUE_CLEAR_STRATEGY_CANT_BE_USED_WITH_NON_MAP_OR_COLLECTION_TYPE(
+        "Target property: \"%s\" is not a Collection or Map and can't be used with NullValuePropertyMappingStrategy: 'CLEAR'",
+        Diagnostic.Kind.ERROR ),
 
     CONVERSION_LOSSY_WARNING( "%s has a possibly lossy conversion from %s to %s.", Diagnostic.Kind.WARNING ),
     CONVERSION_LOSSY_ERROR( "Can't map %s. It has a possibly lossy conversion from %s to %s." ),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.ftl
@@ -15,8 +15,12 @@
       ${ext.targetBeanName}.${ext.targetReadAccessorName}.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( <@lib.handleWithAssignmentOrNullCheckVar/> );
       </@lib.handleLocalVarNullCheck>
       <#if !ext.defaultValueAssignment?? && !sourcePresenceCheckerReference?? && includeElseBranch>else {<#-- the opposite (defaultValueAssignment) case is handeld inside lib.handleLocalVarNullCheck -->
-      ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite><#if mapNullToDefault><@lib.initTargetObject/><#else>null</#if></@lib.handleWrite>;
-      }
+          <#if mapNullToClear>
+              ${ext.targetBeanName}.${ext.targetReadAccessorName}.clear();
+          <#else >
+              ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite><#if mapNullToDefault><@lib.initTargetObject/><#else>null</#if></@lib.handleWrite>;
+          </#if>
+          }
       </#if>
   }
   else {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/Bean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/Bean.java
@@ -1,0 +1,16 @@
+package org.mapstruct.ap.test.bugs._1830;
+
+import java.util.Collection;
+
+public class Bean {
+    private Collection<String> list;
+
+    public Collection<String> getList() {
+        return list;
+    }
+
+    public void setList(Collection<String> list) {
+        this.list = list;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanDTO.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanDTO.java
@@ -1,0 +1,18 @@
+package org.mapstruct.ap.test.bugs._1830;
+
+import java.util.Collection;
+
+public class BeanDTO {
+    private String id;
+
+    private Collection<String> list;
+
+    public Collection<String> getList() {
+        return list;
+    }
+
+    public void setList(Collection<String> list) {
+        this.list = list;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanDTOWithId.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanDTOWithId.java
@@ -1,0 +1,13 @@
+package org.mapstruct.ap.test.bugs._1830;
+
+public class BeanDTOWithId extends BeanDTO {
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanMapper.java
@@ -1,0 +1,20 @@
+package org.mapstruct.ap.test.bugs._1830;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper()
+public interface BeanMapper {
+
+    BeanMapper INSTANCE = Mappers.getMapper( BeanMapper.class );
+
+    @Mapping(source = "list", target = "list", nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.CLEAR)
+    BeanDTO map(Bean source, @MappingTarget BeanDTO target);
+
+    @Mapping(source = "bean.list", target = "list", nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.CLEAR)
+    BeanDTO map(NestedBean source, @MappingTarget BeanDTO target);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanMapperTest.java
@@ -1,0 +1,66 @@
+package org.mapstruct.ap.test.bugs._1830;
+
+import java.util.ArrayList;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses({
+    Bean.class,
+    BeanDTO.class,
+    BeanMapper.class,
+    NestedBean.class
+})
+class BeanMapperTest {
+
+    private static final String EXPECTED_MAPPER_IMPL = "src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1830/BeanMapperImplClear.java";
+    @RegisterExtension
+    GeneratedSource generatedSource = new GeneratedSource();
+    private final Bean bean = new Bean();
+    private BeanDTO beanDTO = new BeanDTO();
+
+    @ProcessorTest
+    void mapNull() {
+        beanDTO = BeanMapper.INSTANCE.map( bean, beanDTO );
+        assertThat( beanDTO.getList() ).isNull();
+    }
+
+    @ProcessorTest
+    void mapEmptyList() {
+        beanDTO.setList( new ArrayList<>() );
+        beanDTO = BeanMapper.INSTANCE.map( bean, beanDTO );
+        assertThat( beanDTO.getList() ).isEmpty();
+    }
+
+    @ProcessorTest
+    void generatedMapperMethodsShouldCallClear() {
+        generatedSource.forMapper( BeanMapper.class )
+            .hasSameMapperContent( FileUtils.getFile( EXPECTED_MAPPER_IMPL ) );
+    }
+
+    @ProcessorTest
+    @WithClasses({
+        MapperWithErrorInTargetMapping.class,
+        BeanWithId.class,
+        BeanDTOWithId.class
+    })
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = MapperWithErrorInTargetMapping.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 15,
+                message = "Target property: \"id\" is not a Collection or Map and can't be used with NullValuePropertyMappingStrategy: 'CLEAR'")
+        })
+    void mapNullWithCustomClearStrategy() {
+    }
+
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanMapperWithValidConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanMapperWithValidConfig.java
@@ -1,0 +1,19 @@
+package org.mapstruct.ap.test.bugs._1830;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(
+//    nullValueMapMappingStrategy = NullValueMappingStrategy.CLEAR, // TODO: IS this feature wanted?
+//    nullValueIterableMappingStrategy = NullValueMappingStrategy.CLEAR // TODO: IS this feature wanted?
+)
+public interface BeanMapperWithValidConfig {
+
+    BeanMapperWithValidConfig INSTANCE = Mappers.getMapper( BeanMapperWithValidConfig.class );
+
+    BeanDTO map(Bean source, @MappingTarget BeanDTO target);
+
+    BeanDTO map(NestedBean source, @MappingTarget BeanDTO target);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanWithId.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/BeanWithId.java
@@ -1,0 +1,13 @@
+package org.mapstruct.ap.test.bugs._1830;
+
+public class BeanWithId extends Bean {
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/MapperWithErrorInConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/MapperWithErrorInConfig.java
@@ -1,0 +1,9 @@
+package org.mapstruct.ap.test.bugs._1830;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+@Mapper(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.CLEAR)
+// TODO: This should lead to an compile error
+public interface MapperWithErrorInConfig {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/MapperWithErrorInTargetMapping.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/MapperWithErrorInTargetMapping.java
@@ -1,0 +1,16 @@
+package org.mapstruct.ap.test.bugs._1830;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper()
+public interface MapperWithErrorInTargetMapping {
+
+    MapperWithErrorInTargetMapping INSTANCE = Mappers.getMapper( MapperWithErrorInTargetMapping.class );
+
+    @Mapping(target = "id", source = "id", nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.CLEAR)
+    BeanDTOWithId map(BeanWithId source, @MappingTarget BeanDTOWithId target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/NestedBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1830/NestedBean.java
@@ -1,0 +1,13 @@
+package org.mapstruct.ap.test.bugs._1830;
+
+public class NestedBean {
+    private Bean bean;
+
+    public Bean getBean() {
+        return bean;
+    }
+
+    public void setBean(Bean bean) {
+        this.bean = bean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1830/BeanMapperImplClear.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1830/BeanMapperImplClear.java
@@ -1,0 +1,74 @@
+package org.mapstruct.ap.test.bugs._1830;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2024-05-03T08:15:14+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.2 (Azul Systems, Inc.)"
+)
+public class BeanMapperImpl implements BeanMapper {
+
+    @Override
+    public BeanDTO map(Bean source, BeanDTO target) {
+        if ( source == null ) {
+            return target;
+        }
+
+        if ( target.getList() != null ) {
+            Collection<String> collection = source.getList();
+            if ( collection != null ) {
+                target.getList().clear();
+                target.getList().addAll( collection );
+            }
+            else {
+                target.getList().clear();
+            }
+        }
+        else {
+            Collection<String> collection = source.getList();
+            if ( collection != null ) {
+                target.setList( new ArrayList<String>( collection ) );
+            }
+        }
+
+        return target;
+    }
+
+    @Override
+    public BeanDTO map(NestedBean source, BeanDTO target) {
+        if ( source == null ) {
+            return target;
+        }
+
+        Collection<String> list = sourceBeanList( source );
+        if ( target.getList() != null ) {
+            Collection<String> collection = list;
+            if ( collection != null ) {
+                target.getList().clear();
+                target.getList().addAll( collection );
+            }
+            else {
+                target.getList().clear();
+            }
+        }
+        else {
+            Collection<String> collection = list;
+            if ( collection != null ) {
+                target.setList( new ArrayList<String>( collection ) );
+            }
+        }
+
+        return target;
+    }
+
+    private Collection<String> sourceBeanList(NestedBean nestedBean) {
+        Bean bean = nestedBean.getBean();
+        if ( bean == null ) {
+            return null;
+        }
+        return bean.getList();
+    }
+}


### PR DESCRIPTION
- adds CLEAR as a new strategy under NullValuePropertyMappingStrategy for handling null values
- clears collections or maps when the source property is null
- includes tests for functionality and error handling