### PR TITLE
#3574 Respect only explicit mappings but fail on unmapped source fields

### DIFF
--- a/NEXT_RELEASE_CHANGELOG.md
+++ b/NEXT_RELEASE_CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Enhancements
 
+* Breaking change: Respect only explicit mappings but fail on unmapped source fields (#3574) - 
+This reverts #2560, because we've decided that `@BeanMapping(ignoreByDefault = true)` should only be applied to target properties and not to source properties. 
+Source properties are anyway ignored, the `BeanMapping#unmappedSourcePolicy` should be used to control what should happen with unmapped source policy
+
 ### Bugs
 
 ### Documentation

--- a/NEXT_RELEASE_CHANGELOG.md
+++ b/NEXT_RELEASE_CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ### Enhancements
 
-* Breaking change: Respect only explicit mappings but fail on unmapped source fields (#3574) - 
+* Breaking change:g (#3574) - 
 This reverts #2560, because we've decided that `@BeanMapping(ignoreByDefault = true)` should only be applied to target properties and not to source properties. 
-Source properties are anyway ignored, the `BeanMapping#unmappedSourcePolicy` should be used to control what should happen with unmapped source policy
+Source properties are ignored anyway, the `BeanMapping#unmappedSourcePolicy` should be used to control what should happen with unmapped source policy
 
 ### Bugs
 

--- a/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
@@ -60,7 +60,7 @@ public interface SourceTargetMapper {
 ----
 ====
 
-The example demonstrates how the source properties `time` and `format` are composed into one target property `TimeAndFormat`. Please note that the fully qualified package name is specified because MapStruct does not take care of the import of the `TimeAndFormat` class (unless it's used otherwise explicitly in the `ErroneousSourceTargetMapperWithIgnoreByDefault`). This can be resolved by defining `imports` on the `@Mapper` annotation.
+The example demonstrates how the source properties `time` and `format` are composed into one target property `TimeAndFormat`. Please note that the fully qualified package name is specified because MapStruct does not take care of the import of the `TimeAndFormat` class (unless it's used otherwise explicitly in the `SourceTargetMapper`). This can be resolved by defining `imports` on the `@Mapper` annotation.
 
 .Declaring an import
 ====
@@ -108,7 +108,7 @@ public interface SourceTargetMapper {
 ----
 ====
 
-The example demonstrates how to use defaultExpression to set an `ID` field if the source field is null, this could be used to take the existing `sourceId` from the source object if it is set, or create a new `Id` if it isn't. Please note that the fully qualified package name is specified because MapStruct does not take care of the import of the `UUID` class (unless it’s used otherwise explicitly in the `ErroneousSourceTargetMapperWithIgnoreByDefault`). This can be resolved by defining imports on the @Mapper annotation (see <<expressions>>).
+The example demonstrates how to use defaultExpression to set an `ID` field if the source field is null, this could be used to take the existing `sourceId` from the source object if it is set, or create a new `Id` if it isn't. Please note that the fully qualified package name is specified because MapStruct does not take care of the import of the `UUID` class (unless it’s used otherwise explicitly in the `SourceTargetMapper`). This can be resolved by defining imports on the @Mapper annotation (see <<expressions>>).
 
 [[sub-class-mappings]]
 === Subclass Mapping

--- a/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
@@ -60,7 +60,7 @@ public interface SourceTargetMapper {
 ----
 ====
 
-The example demonstrates how the source properties `time` and `format` are composed into one target property `TimeAndFormat`. Please note that the fully qualified package name is specified because MapStruct does not take care of the import of the `TimeAndFormat` class (unless it's used otherwise explicitly in the `SourceTargetMapper`). This can be resolved by defining `imports` on the `@Mapper` annotation.
+The example demonstrates how the source properties `time` and `format` are composed into one target property `TimeAndFormat`. Please note that the fully qualified package name is specified because MapStruct does not take care of the import of the `TimeAndFormat` class (unless it's used otherwise explicitly in the `ErroneousSourceTargetMapperWithIgnoreByDefault`). This can be resolved by defining `imports` on the `@Mapper` annotation.
 
 .Declaring an import
 ====
@@ -108,7 +108,7 @@ public interface SourceTargetMapper {
 ----
 ====
 
-The example demonstrates how to use defaultExpression to set an `ID` field if the source field is null, this could be used to take the existing `sourceId` from the source object if it is set, or create a new `Id` if it isn't. Please note that the fully qualified package name is specified because MapStruct does not take care of the import of the `UUID` class (unless it’s used otherwise explicitly in the `SourceTargetMapper`). This can be resolved by defining imports on the @Mapper annotation (see <<expressions>>).
+The example demonstrates how to use defaultExpression to set an `ID` field if the source field is null, this could be used to take the existing `sourceId` from the source object if it is set, or create a new `Id` if it isn't. Please note that the fully qualified package name is specified because MapStruct does not take care of the import of the `UUID` class (unless it’s used otherwise explicitly in the `ErroneousSourceTargetMapperWithIgnoreByDefault`). This can be resolved by defining imports on the @Mapper annotation (see <<expressions>>).
 
 [[sub-class-mappings]]
 === Subclass Mapping

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -1764,10 +1764,6 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             if ( mappingReferences.isForForgedMethods() ) {
                 return ReportingPolicyGem.IGNORE;
             }
-            // If we have ignoreByDefault = true, unprocessed source properties are not an issue.
-            if ( method.getOptions().getBeanMapping().isignoreByDefault() ) {
-                return ReportingPolicyGem.IGNORE;
-            }
             return method.getOptions().getBeanMapping().unmappedSourcePolicy();
         }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/ErroneousSourceTargetMapperWithIgnoreByDefault.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/ErroneousSourceTargetMapperWithIgnoreByDefault.java
@@ -15,7 +15,8 @@ import org.mapstruct.factory.Mappers;
     unmappedTargetPolicy = ReportingPolicy.IGNORE,
     unmappedSourcePolicy = ReportingPolicy.ERROR)
 public interface ErroneousSourceTargetMapperWithIgnoreByDefault {
-    ErroneousSourceTargetMapperWithIgnoreByDefault INSTANCE = Mappers.getMapper( ErroneousSourceTargetMapperWithIgnoreByDefault.class );
+    ErroneousSourceTargetMapperWithIgnoreByDefault INSTANCE = Mappers.getMapper(
+        ErroneousSourceTargetMapperWithIgnoreByDefault.class );
 
     @Mapping(source = "one", target = "one")
     @BeanMapping(ignoreByDefault = true)

--- a/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/ErroneousSourceTargetMapperWithIgnoreByDefault.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/ErroneousSourceTargetMapperWithIgnoreByDefault.java
@@ -14,8 +14,8 @@ import org.mapstruct.factory.Mappers;
 @Mapper(
     unmappedTargetPolicy = ReportingPolicy.IGNORE,
     unmappedSourcePolicy = ReportingPolicy.ERROR)
-public interface SourceTargetMapper {
-    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+public interface ErroneousSourceTargetMapperWithIgnoreByDefault {
+    ErroneousSourceTargetMapperWithIgnoreByDefault INSTANCE = Mappers.getMapper( ErroneousSourceTargetMapperWithIgnoreByDefault.class );
 
     @Mapping(source = "one", target = "one")
     @BeanMapping(ignoreByDefault = true)

--- a/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/IgnoreByDefaultSourcesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/IgnoreByDefaultSourcesTest.java
@@ -24,7 +24,7 @@ public class IgnoreByDefaultSourcesTest {
         diagnostics = {
             @Diagnostic(type = ErroneousSourceTargetMapperWithIgnoreByDefault.class,
                 kind = Kind.ERROR,
-                line = 22,
+                line = 23,
                 message = "Unmapped source property: \"other\".")
         }
     )

--- a/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/IgnoreByDefaultSourcesTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/ignorebydefaultsource/IgnoreByDefaultSourcesTest.java
@@ -18,8 +18,17 @@ import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutco
 public class IgnoreByDefaultSourcesTest {
 
     @ProcessorTest
-    @WithClasses({ SourceTargetMapper.class, Source.class, Target.class })
-    public void shouldSucceed() {
+    @WithClasses({ ErroneousSourceTargetMapperWithIgnoreByDefault.class, Source.class, Target.class })
+    @ExpectedCompilationOutcome(
+        value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousSourceTargetMapperWithIgnoreByDefault.class,
+                kind = Kind.ERROR,
+                line = 22,
+                message = "Unmapped source property: \"other\".")
+        }
+    )
+    public void shouldRaiseErrorDueToNonIgnoredSourcePropertyWithBeanMappingIgnoreByDefault() {
     }
 
     @ProcessorTest


### PR DESCRIPTION
This reverts #2560, because we've decided that `@BeanMapping(ignoreByDefault = true)` should only be applied to target properties and not to source properties. Source properties are anyway ignored, the `BeanMapping#unmappedSourcePolicy` should be used to control what should happen with unmapped source policy

Fixes #3574 