### PR TITLE
#3670 Fix regression when using `InheritInverseConfiguration` with nested target properties and reversing `target = "."`

### DIFF
--- a/NEXT_RELEASE_CHANGELOG.md
+++ b/NEXT_RELEASE_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bugs
 
+* Fix regression when using `InheritInverseConfiguration` with nested target properties and reversing `target = "."` (#3670)
+
 ### Documentation
 
 ### Build

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
@@ -362,7 +362,13 @@ public class NestedTargetPropertyMappingHolder {
             Map<String, Set<MappingReference>> singleTargetReferences = new LinkedHashMap<>();
             for ( MappingReference mapping : mappingReferences.getMappingReferences() )  {
                 TargetReference targetReference = mapping.getTargetReference();
-                String property = first( targetReference.getPropertyEntries() );
+                List<String> propertyEntries = targetReference.getPropertyEntries();
+                if ( propertyEntries.isEmpty() ) {
+                    // This can happen if the target property is target = ".",
+                    // this usually happens when doing a reverse mapping
+                    continue;
+                }
+                String property = first( propertyEntries );
                 MappingReference newMapping = mapping.popTargetReference();
                 if ( newMapping != null ) {
                     // group properties on current name.

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3670/Issue3670Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3670/Issue3670Mapper.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3670;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface Issue3670Mapper {
+
+    @Mapping(target = "name", source = ".", qualifiedByName = "nestedName")
+    Target map(Source source);
+
+    @InheritInverseConfiguration
+    @Mapping(target = "nested.nestedName", source = "name")
+    Source map(Target target);
+
+    @Named("nestedName")
+    default String mapNestedName(Source source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        Nested nested = source.getNested();
+
+        return nested != null ? nested.getNestedName() : null;
+    }
+
+
+    class Target {
+
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    class Nested {
+        private String nestedName;
+
+        public String getNestedName() {
+            return nestedName;
+        }
+
+        public void setNestedName(String nestedName) {
+            this.nestedName = nestedName;
+        }
+    }
+
+    class Source {
+
+        private Nested nested;
+
+        public Nested getNested() {
+            return nested;
+        }
+
+        public void setNested(Nested nested) {
+            this.nested = nested;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3670/Issue3670Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3670/Issue3670Mapper.java
@@ -34,7 +34,6 @@ public interface Issue3670Mapper {
         return nested != null ? nested.getNestedName() : null;
     }
 
-
     class Target {
 
         private String name;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3670/Issue3670Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3670/Issue3670Test.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3670;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("3670")
+@WithClasses(Issue3670Mapper.class)
+class Issue3670Test {
+
+    @ProcessorTest
+    void shouldCompile() {
+    }
+}


### PR DESCRIPTION
Fixes #3670