### PR TITLE
#3652 Inverse Inheritance possible for ignore-mappings without source

### DIFF
--- a/NEXT_RELEASE_CHANGELOG.md
+++ b/NEXT_RELEASE_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bugs
 
+* Inverse Inheritance Strategy not working for ignored mappings only with target (#3652)
+
 ### Documentation
 
 ### Build

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
@@ -479,7 +479,7 @@ public class MappingOptions extends DelegatingOptions {
     }
 
     /**
-     *  mapping can only be inversed if the source was not a constant nor an expression nor a nested property
+     *  Mapping can only be inversed if the source was not a constant nor an expression
      *
      * @return true when the above applies
      */

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MappingOptions.java
@@ -480,12 +480,11 @@ public class MappingOptions extends DelegatingOptions {
 
     /**
      *  mapping can only be inversed if the source was not a constant nor an expression nor a nested property
-     *  and the mapping is not a 'target-source-ignore' mapping
      *
      * @return true when the above applies
      */
     public boolean canInverse() {
-        return constant == null && javaExpression == null && !( isIgnored && sourceName == null );
+        return constant == null && javaExpression == null;
     }
 
     public MappingOptions copyForInverseInheritance(SourceMethod templateMethod,

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/Bar.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/Bar.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.mapstruct.ap.test.bugs._3652;
+
+public class Bar {
+
+    private int secret;
+    private int doesNotExistInFoo;
+
+    public int getSecret() {
+        return secret;
+    }
+
+    public void setSecret(int secret) {
+        this.secret = secret;
+    }
+
+    public int getDoesNotExistInFoo() {
+        return doesNotExistInFoo;
+    }
+
+    public void setDoesNotExistInFoo(int doesNotExistInFoo) {
+        this.doesNotExistInFoo = doesNotExistInFoo;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/Foo.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/Foo.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.mapstruct.ap.test.bugs._3652;
+
+public class Foo {
+
+    private int secret;
+
+    public int getSecret() {
+        return secret;
+    }
+
+    public void setSecret(int secret) {
+        this.secret = secret;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/FooBarConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/FooBarConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.mapstruct.ap.test.bugs._3652;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingInheritanceStrategy;
+
+@MapperConfig(mappingInheritanceStrategy = MappingInheritanceStrategy.AUTO_INHERIT_ALL_FROM_CONFIG)
+public interface FooBarConfig {
+
+    @Mapping(target = "doesNotExistInFoo", ignore = true)
+    @Mapping(target = "secret", ignore = true)
+    Bar toBar(Foo foo);
+
+    @InheritInverseConfiguration(name = "toBar")
+    Foo toFoo(Bar bar);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/FooBarMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/FooBarMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.mapstruct.ap.test.bugs._3652;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(config = FooBarConfig.class)
+public interface FooBarMapper {
+
+    FooBarMapper INSTANCE = Mappers.getMapper( FooBarMapper.class );
+
+    Bar toBar(Foo foo);
+
+    Foo toFoo(Bar bar);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/Issue3652Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/Issue3652Test.java
@@ -6,9 +6,6 @@
 
 package org.mapstruct.ap.test.bugs._3652;
 
-import java.text.ParseException;
-
-import org.junitpioneer.jupiter.DefaultLocale;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
@@ -16,7 +13,6 @@ import org.mapstruct.ap.testutil.WithClasses;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @IssueKey("3652")
-@DefaultLocale("en")
 public class Issue3652Test {
 
     @WithClasses({
@@ -26,7 +22,7 @@ public class Issue3652Test {
         FooBarMapper.class,
     })
     @ProcessorTest
-    void ignoreMappingsWithoutSourceShouldBeInvertible() throws ParseException {
+    void ignoreMappingsWithoutSourceShouldBeInvertible() {
         Bar bar = new Bar();
         bar.setSecret( 123 );
         bar.setDoesNotExistInFoo( 6 );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/Issue3652Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3652/Issue3652Test.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.mapstruct.ap.test.bugs._3652;
+
+import java.text.ParseException;
+
+import org.junitpioneer.jupiter.DefaultLocale;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("3652")
+@DefaultLocale("en")
+public class Issue3652Test {
+
+    @WithClasses({
+        Bar.class,
+        Foo.class,
+        FooBarConfig.class,
+        FooBarMapper.class,
+    })
+    @ProcessorTest
+    void ignoreMappingsWithoutSourceShouldBeInvertible() throws ParseException {
+        Bar bar = new Bar();
+        bar.setSecret( 123 );
+        bar.setDoesNotExistInFoo( 6 );
+
+        Foo foo = FooBarMapper.INSTANCE.toFoo( bar );
+
+        assertThat( foo.getSecret() ).isEqualTo( 0 );
+    }
+
+}


### PR DESCRIPTION
Fixes #3652

I have added a test case where the target has a property that does not exist on the source type.
The inverse inheritation still works, because this property is then simply ignored in `BeanMappingMethod#handleDefinedMapping` (line 1240):

```java
else if ( inheritContext.isReversed() ) {
    // When a configuration is reverse inherited and there are no read or write accessor
    // then we should ignore this mapping.
    // This most likely means that we were mapping the source parameter to the target.
    // If the error is due to something else it will be reported on the original mapping
    return false;
}
```

I have another question:
The javadoc of `MappingOptions#canInverse` says:
>mapping can only be inversed if the source was not a constant nor an expression **nor a nested property**

But there is no check for a nested property in this method and it seems to work: Some tests uses `@InheritInverseConfiguration` with nested properties:
e.g.: `ReversingNestedSourcePropertiesConstructorTest#shouldGenerateNestedWithConfigReverse`

Should I remove this statement from the javadoc comment?