### PR TITLE
#3668 Do not apply implicit mappings when using `SubclassExhaustiveStrategy#RUNTIME_EXCEPTION` and return type is abstract

### DIFF
--- a/NEXT_RELEASE_CHANGELOG.md
+++ b/NEXT_RELEASE_CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bugs
 
 * Inverse Inheritance Strategy not working for ignored mappings only with target (#3652)
+* Inconsistent ambiguous mapping method error when using `SubclassMapping`: generic vs raw types (#3668)
 * Fix regression when using `InheritInverseConfiguration` with nested target properties and reversing `target = "."` (#3670)
 
 ### Documentation

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -295,7 +295,9 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 }
             }
 
-            boolean applyImplicitMappings = !mappingReferences.isRestrictToDefinedMappings();
+            // If defined mappings should not be handled then we should not apply implicit mappings
+            boolean applyImplicitMappings =
+                shouldHandledDefinedMappings && !mappingReferences.isRestrictToDefinedMappings();
             if ( applyImplicitMappings ) {
                 applyImplicitMappings = beanMapping == null || !beanMapping.isignoreByDefault();
             }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/Child.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/Child.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3668;
+
+public abstract class Child {
+
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public static class ChildA extends Child { }
+
+    public static class ChildB extends Child { }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/ChildDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/ChildDto.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3668;
+
+public abstract class ChildDto {
+
+    private Long id;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public static class ChildDtoA extends ChildDto { }
+
+    public static class ChildDtoB extends ChildDto { }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/ChildMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/ChildMapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3668;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.SubclassExhaustiveStrategy;
+import org.mapstruct.SubclassMapping;
+
+@Mapper(subclassExhaustiveStrategy = SubclassExhaustiveStrategy.RUNTIME_EXCEPTION)
+public interface ChildMapper {
+
+    @SubclassMapping(target = Child.ChildA.class, source = ChildDto.ChildDtoA.class)
+    @SubclassMapping(target = Child.ChildB.class, source = ChildDto.ChildDtoB.class)
+    Child toEntity(ChildDto childDto);
+
+    @SubclassMapping(target = ChildDto.ChildDtoA.class, source = Child.ChildA.class)
+    @SubclassMapping(target = ChildDto.ChildDtoB.class, source = Child.ChildB.class)
+    ChildDto toDto(Child child);
+
+    Child.ChildA toEntity(ChildDto.ChildDtoA childDto);
+
+    ChildDto.ChildDtoA toDto(Child.ChildA child);
+
+    Child.ChildB toEntity(ChildDto.ChildDtoB childDto);
+
+    ChildDto.ChildDtoB toDto(Child.ChildB child);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/Issue3668Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/Issue3668Test.java
@@ -1,3 +1,8 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
 package org.mapstruct.ap.test.bugs._3668;
 
 import org.mapstruct.ap.testutil.IssueKey;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/Issue3668Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/Issue3668Test.java
@@ -1,0 +1,25 @@
+package org.mapstruct.ap.test.bugs._3668;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("3668")
+@WithClasses({
+    Child.class,
+    ChildDto.class,
+    ChildMapper.class,
+    Parent.class,
+    ParentDto.class,
+    ParentMapper.class,
+})
+class Issue3668Test {
+
+    @ProcessorTest
+    void shouldCompile() {
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/Parent.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/Parent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3668;
+
+public abstract class Parent<T extends Child> {
+
+    private Long id;
+
+    private T child;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public T getChild() {
+        return child;
+    }
+
+    public void setChild(T child) {
+        this.child = child;
+    }
+
+    public static class ParentA extends Parent<Child.ChildA> { }
+
+    public static class ParentB extends Parent<Child.ChildB> { }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/ParentDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/ParentDto.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3668;
+
+public abstract class ParentDto<T extends ChildDto> {
+
+    private Long id;
+
+    private T child;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public T getChild() {
+        return child;
+    }
+
+    public void setChild(T child) {
+        this.child = child;
+    }
+
+    public static class ParentDtoA extends ParentDto<ChildDto.ChildDtoA> { }
+
+    public static class ParentDtoB extends ParentDto<ChildDto.ChildDtoB> { }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/ParentMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3668/ParentMapper.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3668;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.SubclassExhaustiveStrategy;
+import org.mapstruct.SubclassMapping;
+
+@Mapper(uses = { ChildMapper.class }, subclassExhaustiveStrategy = SubclassExhaustiveStrategy.RUNTIME_EXCEPTION)
+public interface ParentMapper {
+
+    @SubclassMapping(target = Parent.ParentA.class, source = ParentDto.ParentDtoA.class)
+    @SubclassMapping(target = Parent.ParentB.class, source = ParentDto.ParentDtoB.class)
+    Parent<?> toEntity(ParentDto<?> parentDto);
+
+    @SubclassMapping(target = ParentDto.ParentDtoA.class, source = Parent.ParentA.class)
+    @SubclassMapping(target = ParentDto.ParentDtoB.class, source = Parent.ParentB.class)
+    ParentDto<?> toDto(Parent<?> parent);
+
+    Parent.ParentA toEntity(ParentDto.ParentDtoA parentDto);
+
+    ParentDto.ParentDtoA toDto(Parent.ParentA parent);
+
+    Parent.ParentB toEntity(ParentDto.ParentDtoB parentDto);
+
+    ParentDto.ParentDtoB toDto(Parent.ParentB parent);
+
+}


### PR DESCRIPTION
Fixes #3668

This fixes the issue. However, the cause is not in the way this was fixed. The main issue why this happens is due to the fact that in 1.6 we treat generics a bit better and we determine that we can use something when mapping the abstract target type.

If the `Parent` and `ParentDto` targets are not abstract we would still have the MapStruct compile error. However, this is not a regression as in 1.5 we would generate code that does not compile. I'll create a separate issue to look into this.