### PR TITLE
#3667, #3673 MappingReference should custom MappingOption equality instead of the default only target name based one

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/MappingReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/MappingReference.java
@@ -71,7 +71,37 @@ public class MappingReference {
             return false;
         }
         MappingReference that = (MappingReference) o;
-        return mapping.equals( that.mapping );
+        if ( ".".equals( that.mapping.getTargetName() ) ) {
+            // target this will never be equal to any other target this or any other.
+            return false;
+        }
+
+        if (!Objects.equals( mapping.getTargetName(), that.mapping.getTargetName() ) ) {
+            return false;
+        }
+
+        if ( !Objects.equals( mapping.getConstant(), that.mapping.getConstant() ) ) {
+            return false;
+        }
+
+        if ( !Objects.equals( mapping.getJavaExpression(), that.mapping.getJavaExpression() ) ) {
+            return false;
+        }
+
+        if ( sourceReference == null ) {
+            return that.sourceReference == null;
+        }
+
+        if ( that.sourceReference == null ) {
+            return false;
+        }
+
+
+        if (!Objects.equals( sourceReference.getPropertyEntries(), that.sourceReference.getPropertyEntries() ) ) {
+            return false;
+        }
+
+        return true;
     }
 
     @Override

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3667/Issue3667Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3667/Issue3667Mapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3667;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue3667Mapper {
+
+    Issue3667Mapper INSTANCE = Mappers.getMapper( Issue3667Mapper.class );
+
+    @Mapping(target = "nested.value", source = "nested.nested1.value")
+    Target mapFirst(Source source);
+
+    @Mapping(target = "nested.value", source = "nested.nested2.value")
+    Target mapSecond(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3667/Issue3667Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3667/Issue3667Test.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3667;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("3667")
+@WithClasses({
+    Issue3667Mapper.class,
+    Source.class,
+    Target.class
+})
+class Issue3667Test {
+
+    @ProcessorTest
+    void shouldCorrectlyMapNestedProperty() {
+        Source source = new Source(
+            new Source.Nested(
+                new Source.NestedNested( "value1" ),
+                new Source.NestedNested( "value2" )
+            )
+        );
+
+        Target target1 = Issue3667Mapper.INSTANCE.mapFirst( source );
+        Target target2 = Issue3667Mapper.INSTANCE.mapSecond( source );
+
+        assertThat( target1 ).isNotNull();
+        assertThat( target1.getNested() ).isNotNull();
+        assertThat( target1.getNested().getValue() ).isEqualTo( "value1" );
+
+        assertThat( target2 ).isNotNull();
+        assertThat( target2.getNested() ).isNotNull();
+        assertThat( target2.getNested().getValue() ).isEqualTo( "value2" );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3667/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3667/Source.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3667;
+
+public class Source {
+
+    private final Nested nested;
+
+    public Source(Nested nested) {
+        this.nested = nested;
+    }
+
+    public Nested getNested() {
+        return nested;
+    }
+
+    public static class Nested {
+
+        private final NestedNested nested1;
+        private final NestedNested nested2;
+
+        public Nested(NestedNested nested1, NestedNested nested2) {
+            this.nested1 = nested1;
+            this.nested2 = nested2;
+        }
+
+        public NestedNested getNested1() {
+            return nested1;
+        }
+
+        public NestedNested getNested2() {
+            return nested2;
+        }
+    }
+
+    public static class NestedNested {
+
+        private final String value;
+
+        public NestedNested(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3667/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3667/Target.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3667;
+
+public class Target {
+
+    private Nested nested;
+
+    public Nested getNested() {
+        return nested;
+    }
+
+    public void setNested(Nested nested) {
+        this.nested = nested;
+    }
+
+    public static class Nested {
+
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Animal.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Animal.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3673;
+
+public class Animal {
+
+    private AnimalDetails details;
+
+    public AnimalDetails getDetails() {
+        return details;
+    }
+
+    public void setDetails(AnimalDetails details) {
+        this.details = details;
+    }
+
+    public enum Type {
+        CAT,
+        DOG
+    }
+
+    public static class AnimalDetails {
+        private Type type;
+        private String name;
+
+        public Type getType() {
+            return type;
+        }
+
+        public void setType(Type type) {
+            this.type = type;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Cat.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Cat.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3673;
+
+public class Cat {
+
+    private final Details details;
+
+    public Cat(Details details) {
+        this.details = details;
+    }
+
+    public Details getDetails() {
+        return details;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Details.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Details.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3673;
+
+public class Details {
+
+    private final String name;
+
+    public Details(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Dog.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Dog.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3673;
+
+public class Dog {
+
+    private final Details details;
+
+    public Dog(Details details) {
+        this.details = details;
+    }
+
+    public Details getDetails() {
+        return details;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Issue3673ConstantMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Issue3673ConstantMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3673;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue3673ConstantMapper {
+
+    Issue3673ConstantMapper INSTANCE = Mappers.getMapper( Issue3673ConstantMapper.class );
+
+    @Mapping(target = "details.name", source = "details.name")
+    @Mapping(target = "details.type", constant = "DOG")
+    Animal map(Dog dog);
+
+    @Mapping(target = "details.name", source = "details.name")
+    @Mapping(target = "details.type", constant = "CAT")
+    Animal map(Cat cat);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Issue3673ExpressionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Issue3673ExpressionMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3673;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue3673ExpressionMapper {
+
+    Issue3673ExpressionMapper INSTANCE = Mappers.getMapper( Issue3673ExpressionMapper.class );
+
+    @Mapping(target = "details.name", source = "details.name")
+    @Mapping(target = "details.type", expression = "java(Animal.Type.DOG)")
+    Animal map(Dog dog);
+
+    @Mapping(target = "details.name", source = "details.name")
+    @Mapping(target = "details.type", expression = "java(Animal.Type.CAT)")
+    Animal map(Cat cat);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Issue3673Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3673/Issue3673Test.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3673;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("3673")
+@WithClasses({
+    Cat.class,
+    Dog.class,
+    Details.class,
+    Animal.class
+})
+class Issue3673Test {
+
+    @ProcessorTest
+    @WithClasses(Issue3673ConstantMapper.class)
+    void shouldCorrectlyMapNestedPropertyConstant() {
+
+        Animal cat = Issue3673ConstantMapper.INSTANCE.map(
+            new Cat( new Details( "cat" ) )
+        );
+
+        Animal dog = Issue3673ConstantMapper.INSTANCE.map(
+            new Dog( new Details( "dog" ) )
+        );
+
+        assertThat( cat ).isNotNull();
+        assertThat( cat.getDetails() ).isNotNull();
+        assertThat( cat.getDetails().getName() ).isEqualTo( "cat" );
+        assertThat( cat.getDetails().getType() ).isEqualTo( Animal.Type.CAT );
+
+        assertThat( dog ).isNotNull();
+        assertThat( dog.getDetails() ).isNotNull();
+        assertThat( dog.getDetails().getName() ).isEqualTo( "dog" );
+        assertThat( dog.getDetails().getType() ).isEqualTo( Animal.Type.DOG );
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue3673ExpressionMapper.class)
+    void shouldCorrectlyMapNestedPropertyExpression() {
+
+        Animal cat = Issue3673ExpressionMapper.INSTANCE.map(
+            new Cat( new Details( "cat" ) )
+        );
+
+        Animal dog = Issue3673ExpressionMapper.INSTANCE.map(
+            new Dog( new Details( "dog" ) )
+        );
+
+        assertThat( cat ).isNotNull();
+        assertThat( cat.getDetails() ).isNotNull();
+        assertThat( cat.getDetails().getName() ).isEqualTo( "cat" );
+        assertThat( cat.getDetails().getType() ).isEqualTo( Animal.Type.CAT );
+
+        assertThat( dog ).isNotNull();
+        assertThat( dog.getDetails() ).isNotNull();
+        assertThat( dog.getDetails().getName() ).isEqualTo( "dog" );
+        assertThat( dog.getDetails().getType() ).isEqualTo( Animal.Type.DOG );
+    }
+}


### PR DESCRIPTION
Fixes #3667
Fixes #3673 

The main culprit for this was due to the fact that the `MappingReference` was using `MappingOption` equality and the `MappingOption` is based only on the `targetName`, but we need to take `sourceName`, `constant` and `expression` into consideration.

All the tests should be green, and I hope that this isn't causing another regression.