### PR TITLE
Fix typo in readme Maven plugin config

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -84,7 +84,7 @@ For Maven-based projects, add the following to your POM file in order to use Map
             <version>3.13.0</version>
             <configuration>
                 <source>17</source>
-                <target>1<7/target>
+                <target>17</target>
                 <annotationProcessorPaths>
                     <path>
                         <groupId>org.mapstruct</groupId>


### PR DESCRIPTION
Currently the `target` tag for the `maven-compiler-plugin` is not closed correctly.