### PR TITLE
Use retainAll() for Set and Map instead of clear()

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -106,6 +106,7 @@ public class Type extends ModelElement implements Comparable<Type> {
     private final boolean isIterableType;
     private final boolean isCollectionType;
     private final boolean isMapType;
+    private final boolean isSetType;
     private final boolean isVoid;
     private final boolean isStream;
     private final boolean isLiteral;
@@ -145,7 +146,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                 List<Type> typeParameters, ImplementationType implementationType, Type componentType,
                 String packageName, String name, String qualifiedName,
                 boolean isInterface, boolean isEnumType, boolean isIterableType,
-                boolean isCollectionType, boolean isMapType, boolean isStreamType,
+                boolean isCollectionType, boolean isMapType, boolean isSetType, boolean isStreamType,
                 Map<String, String> toBeImportedTypes,
                 Map<String, String> notToBeImportedTypes,
                 Boolean isToBeImported,
@@ -171,6 +172,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         this.isIterableType = isIterableType;
         this.isCollectionType = isCollectionType;
         this.isMapType = isMapType;
+        this.isSetType = isSetType;
         this.isStream = isStreamType;
         this.isVoid = typeMirror.getKind() == TypeKind.VOID;
         this.isLiteral = isLiteral;
@@ -346,6 +348,10 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     public boolean isMapType() {
         return isMapType;
+    }
+
+    public boolean isSetType() {
+        return isSetType;
     }
 
     private boolean hasStringMapSignature() {
@@ -553,6 +559,7 @@ public class Type extends ModelElement implements Comparable<Type> {
             isIterableType,
             isCollectionType,
             isMapType,
+            isSetType,
             isStream,
             toBeImportedTypes,
             notToBeImportedTypes,
@@ -596,6 +603,7 @@ public class Type extends ModelElement implements Comparable<Type> {
             isIterableType,
             isCollectionType,
             isMapType,
+            isSetType,
             isStream,
             toBeImportedTypes,
             notToBeImportedTypes,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -95,6 +95,7 @@ public class TypeFactory {
     private final TypeMirror iterableType;
     private final TypeMirror collectionType;
     private final TypeMirror mapType;
+    private final TypeMirror setType;
     private final TypeMirror streamType;
 
     private final Map<String, ImplementationType> implementationTypes = new HashMap<>();
@@ -116,6 +117,7 @@ public class TypeFactory {
         collectionType =
             typeUtils.erasure( elementUtils.getTypeElement( Collection.class.getCanonicalName() ).asType() );
         mapType = typeUtils.erasure( elementUtils.getTypeElement( Map.class.getCanonicalName() ).asType() );
+        setType = typeUtils.erasure( elementUtils.getTypeElement( Set.class.getCanonicalName() ).asType() );
         TypeElement streamTypeElement = elementUtils.getTypeElement( JavaStreamConstants.STREAM_FQN );
         streamType = streamTypeElement == null ? null : typeUtils.erasure( streamTypeElement.asType() );
 
@@ -236,6 +238,7 @@ public class TypeFactory {
         boolean isIterableType = typeUtils.isSubtypeErased( mirror, iterableType );
         boolean isCollectionType = typeUtils.isSubtypeErased( mirror, collectionType );
         boolean isMapType = typeUtils.isSubtypeErased( mirror, mapType );
+        boolean isSetType = typeUtils.isSubtypeErased( mirror, setType );
         boolean isStreamType = streamType != null && typeUtils.isSubtypeErased( mirror, streamType );
 
         boolean isEnumType;
@@ -345,6 +348,7 @@ public class TypeFactory {
             isIterableType,
             isCollectionType,
             isMapType,
+            isSetType,
             isStreamType,
             toBeImportedTypes,
             notToBeImportedTypes,
@@ -571,6 +575,7 @@ public class TypeFactory {
                 implementationType.isIterableType(),
                 implementationType.isCollectionType(),
                 implementationType.isMapType(),
+                implementationType.isSetType(),
                 implementationType.isStreamType(),
                 toBeImportedTypes,
                 notToBeImportedTypes,

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
@@ -49,7 +49,11 @@
         </#if>
     <#else>
         <#if existingInstanceMapping>
-            ${resultName}.clear();
+            <#if resultType.setType>
+                ${resultName}.retainAll( java.util.stream.StreamSupport.stream( ${sourceParameter.name}.spliterator(), false ).collect( java.util.stream.Collectors.toSet() ) );
+            <#else>
+                ${resultName}.clear();
+            </#if>
         <#else>
             <#-- Use the interface type on the left side, except it is java.lang.Iterable; use the implementation type - if present - on the right side -->
             <@iterableLocalVarDef/> ${resultName} = <@includeModel object=iterableCreation useSizeIfPossible=true/>;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
@@ -31,7 +31,7 @@
     }
 
     <#if existingInstanceMapping>
-        ${resultName}.clear();
+        ${resultName}.entrySet().retainAll( ${sourceParameter.name}.entrySet() );
     <#else>
         <@includeModel object=resultType /> ${resultName} = <@includeModel object=iterableCreation useSizeIfPossible=true/>;
     </#if>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.ftl
@@ -10,14 +10,19 @@
 <@lib.sourceLocalVarAssignment/>
 <@lib.handleExceptions>
   if ( ${ext.targetBeanName}.${ext.targetReadAccessorName} != null ) {
-      <@lib.handleLocalVarNullCheck needs_explicit_local_var=false>
-      ${ext.targetBeanName}.${ext.targetReadAccessorName}.clear();
-      ${ext.targetBeanName}.${ext.targetReadAccessorName}.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( <@lib.handleWithAssignmentOrNullCheckVar/> );
-      </@lib.handleLocalVarNullCheck>
-      <#if !ext.defaultValueAssignment?? && !sourcePresenceCheckerReference?? && includeElseBranch>else {<#-- the opposite (defaultValueAssignment) case is handeld inside lib.handleLocalVarNullCheck -->
-      ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite><#if mapNullToDefault><@lib.initTargetObject/><#else>null</#if></@lib.handleWrite>;
-      }
+    <@lib.handleLocalVarNullCheck needs_explicit_local_var=false cleanBefore=true ; sourcePresent>
+      <#if !sourcePresent??>
+        ${ext.targetBeanName}.${ext.targetReadAccessorName}.<#if ext.targetType.mapType>putAll<#else>addAll</#if>( <@lib.handleWithAssignmentOrNullCheckVar/> );
+      <#elseif !sourcePresent>
+        <#if !ext.defaultValueAssignment?? && !sourcePresenceCheckerReference?? && includeElseBranch><#-- the opposite (defaultValueAssignment) case is handeld inside lib.handleLocalVarNullCheck -->
+          ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite><#if mapNullToDefault><@lib.initTargetObject/><#else>null</#if></@lib.handleWrite>;
+        </#if>
+      <#elseif ext.targetType.setType || ext.targetType.mapType>
+        ${ext.targetBeanName}.${ext.targetReadAccessorName}.<#if ext.targetType.mapType>entrySet().</#if>retainAll( <@lib.handleWithAssignmentOrNullCheckVar/><#if sourceType.mapType>.entrySet()</#if> );
+      <#else>
+        ${ext.targetBeanName}.${ext.targetReadAccessorName}.clear();
       </#if>
+    </@lib.handleLocalVarNullCheck>
   }
   else {
       <@callTargetWriteAccessor/>
@@ -27,7 +32,7 @@
   assigns the target via the regular target write accessor (usually the setter)
 -->
 <#macro callTargetWriteAccessor>
-  <@lib.handleLocalVarNullCheck needs_explicit_local_var=directAssignment>
+  <@lib.handleLocalVarNullCheck needs_explicit_local_var=directAssignment cleanBefore=false>
     ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWrite><#if directAssignment><@wrapLocalVarInCollectionInitializer/><#else><@lib.handleWithAssignmentOrNullCheckVar/></#if></@lib.handleWrite>;
   </@lib.handleLocalVarNullCheck>
 </#macro>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/GetterWrapperForCollectionsAndMaps.ftl
@@ -10,11 +10,18 @@
 <@lib.sourceLocalVarAssignment/>
 if ( ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing /> != null ) {
     <@lib.handleExceptions>
-      <#if ext.existingInstanceMapping>
-        ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing />.clear();
-      </#if>
-      <@lib.handleLocalVarNullCheck needs_explicit_local_var=false>
-        ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing />.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( <@lib.handleWithAssignmentOrNullCheckVar/> );
+      <@lib.handleLocalVarNullCheck needs_explicit_local_var=false cleanBefore=true ; sourcePresent>
+        <#if sourcePresent??>
+          <#if ext.existingInstanceMapping>
+            <#if sourcePresent && (ext.targetType.setType || ext.targetType.mapType)>
+              ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing />.<#if ext.targetType.mapType>entrySet().</#if>retainAll( <@lib.handleWithAssignmentOrNullCheckVar/><#if sourceType.mapType>.entrySet()</#if> );
+            <#else>
+              ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing />.clear();
+            </#if>
+          </#if>
+        <#else>
+          ${ext.targetBeanName}.${ext.targetWriteAccessorName}<@lib.handleWriteAccesing />.<#if ext.targetType.mapType>putAll<#else>addAll</#if>( <@lib.handleWithAssignmentOrNullCheckVar/> );
+        </#if>
       </@lib.handleLocalVarNullCheck>
     </@lib.handleExceptions>
 }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/NewInstanceSetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/NewInstanceSetterWrapperForCollectionsAndMaps.ftl
@@ -15,7 +15,7 @@
   assigns the target via the regular target write accessor (usually the setter)
 -->
 <#macro callTargetWriteAccessor>
-  <@lib.handleLocalVarNullCheck needs_explicit_local_var=directAssignment>
+  <@lib.handleLocalVarNullCheck needs_explicit_local_var=directAssignment cleanBefore=false>
       <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if> ${instanceVar} = new <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if>();
       ${instanceVar}.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( ${nullCheckLocalVarName} );
       <#if ext.targetBeanName?has_content>${ext.targetBeanName}.</#if>${ext.targetWriteAccessorName}<@lib.handleWrite>${instanceVar}</@lib.handleWrite>;

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.ftl
@@ -15,7 +15,7 @@
   assigns the target via the regular target write accessor (usually the setter)
 -->
 <#macro callTargetWriteAccessor>
-  <@lib.handleLocalVarNullCheck needs_explicit_local_var=directAssignment>
+  <@lib.handleLocalVarNullCheck needs_explicit_local_var=directAssignment cleanBefore=false>
       <#if ext.targetBeanName?has_content>${ext.targetBeanName}.</#if>${ext.targetWriteAccessorName}<@lib.handleWrite><#if directAssignment><@wrapLocalVarInCollectionInitializer/><#else><@lib.handleWithAssignmentOrNullCheckVar/></#if></@lib.handleWrite>;
   </@lib.handleLocalVarNullCheck>
 </#macro>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
@@ -58,28 +58,34 @@
            requires: caller to implement String:getNullCheckLocalVarName()
                      caller to implement Type:getNullCheckLocalVarType()
 -->
-<#macro handleLocalVarNullCheck needs_explicit_local_var>
+<#macro handleLocalVarNullCheck needs_explicit_local_var cleanBefore>
   <#if sourcePresenceCheckerReference??>
     if ( <@includeModel object=sourcePresenceCheckerReference
            targetType=ext.targetType
            sourcePropertyName=ext.sourcePropertyName
            targetPropertyName=ext.targetPropertyName /> ) {
       <#if needs_explicit_local_var>
-        <@includeModel object=nullCheckLocalVarType/> ${nullCheckLocalVarName} = <@lib.handleAssignment/>;
-        <#nested>
-      <#else>
-        <#nested>
+          <@includeModel object=nullCheckLocalVarType/> ${nullCheckLocalVarName} = <@lib.handleAssignment/>;
       </#if>
+      <#if cleanBefore><#nested true></#if>
+      <#nested>
     }
   <#else>
-    <@includeModel object=nullCheckLocalVarType/> ${nullCheckLocalVarName} = <@lib.handleAssignment/>;
+      <@includeModel object=nullCheckLocalVarType/> ${nullCheckLocalVarName} = <@lib.handleAssignment/>;
     if ( ${nullCheckLocalVarName} != null ) {
+      <#if cleanBefore><#nested true></#if>
       <#nested>
     }
   </#if>
+  <#local nestedContent><#nested false></#local>
   <#if ext.defaultValueAssignment?? >
   else {
+    <#if cleanBefore><#nested false></#if>
     <@handeDefaultAssigment/>
+  }
+  <#elseif cleanBefore && nestedContent?trim?has_content>
+  else {
+    <#nested false>
   }
   </#if>
 </#macro>

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/DateFormatValidatorFactoryTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/DateFormatValidatorFactoryTest.java
@@ -174,6 +174,7 @@ public class DateFormatValidatorFactoryTest {
                         false,
                         false,
                         false,
+            false,
             new HashMap<>(  ),
             new HashMap<>(  ),
                         false,

--- a/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/internal/model/common/DefaultConversionContextTest.java
@@ -122,6 +122,7 @@ public class DefaultConversionContextTest {
                         false,
                         false,
                         false,
+                        false,
             new HashMap<>(  ),
             new HashMap<>(  ),
                         false,

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_3591/ContainerBeanMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_3591/ContainerBeanMapperImpl.java
@@ -26,7 +26,7 @@ public class ContainerBeanMapperImpl implements ContainerBeanMapper {
         if ( containerBeanDto.getBeanMap() != null ) {
             Map<String, ContainerBeanDto> map = stringContainerBeanMapToStringContainerBeanDtoMap( containerBean.getBeanMap() );
             if ( map != null ) {
-                containerBeanDto.getBeanMap().clear();
+                containerBeanDto.getBeanMap().entrySet().retainAll( map.entrySet() );
                 containerBeanDto.getBeanMap().putAll( map );
             }
             else {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
@@ -61,7 +61,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
 
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
-                target.getStrings().clear();
+                target.getStrings().retainAll( source.getStrings() );
                 target.getStrings().addAll( source.getStrings() );
             }
         }
@@ -73,7 +73,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
-                target.getLongs().clear();
+                target.getLongs().retainAll( stringListToLongSet( source.getStrings() ) );
                 target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
             }
         }
@@ -84,7 +84,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                target.getStringsInitialized().clear();
+                target.getStringsInitialized().retainAll( source.getStringsInitialized() );
                 target.getStringsInitialized().addAll( source.getStringsInitialized() );
             }
         }
@@ -96,7 +96,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                target.getLongsInitialized().clear();
+                target.getLongsInitialized().retainAll( stringListToLongSet( source.getStringsInitialized() ) );
                 target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }
@@ -133,7 +133,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
 
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
-                target.getStrings().clear();
+                target.getStrings().retainAll( source.getStrings() );
                 target.getStrings().addAll( source.getStrings() );
             }
         }
@@ -145,7 +145,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
-                target.getLongs().clear();
+                target.getLongs().retainAll( stringListToLongSet( source.getStrings() ) );
                 target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
             }
         }
@@ -156,7 +156,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                target.getStringsInitialized().clear();
+                target.getStringsInitialized().retainAll( source.getStringsInitialized() );
                 target.getStringsInitialized().addAll( source.getStringsInitialized() );
             }
         }
@@ -168,7 +168,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                target.getLongsInitialized().clear();
+                target.getLongsInitialized().retainAll( stringListToLongSet( source.getStringsInitialized() ) );
                 target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
@@ -55,7 +55,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             if ( target.getStrings() != null ) {
                 List<String> list = source.getStrings();
                 if ( list != null ) {
-                    target.getStrings().clear();
+                    target.getStrings().retainAll( list );
                     target.getStrings().addAll( list );
                 }
                 else {
@@ -71,7 +71,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             if ( target.getLongs() != null ) {
                 Set<Long> set = stringListToLongSet( source.getStrings() );
                 if ( set != null ) {
-                    target.getLongs().clear();
+                    target.getLongs().retainAll( set );
                     target.getLongs().addAll( set );
                 }
                 else {
@@ -87,7 +87,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             if ( target.getStringsInitialized() != null ) {
                 List<String> list1 = source.getStringsInitialized();
                 if ( list1 != null ) {
-                    target.getStringsInitialized().clear();
+                    target.getStringsInitialized().retainAll( list1 );
                     target.getStringsInitialized().addAll( list1 );
                 }
                 else {
@@ -103,7 +103,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             if ( target.getLongsInitialized() != null ) {
                 Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
                 if ( set1 != null ) {
-                    target.getLongsInitialized().clear();
+                    target.getLongsInitialized().retainAll( set1 );
                     target.getLongsInitialized().addAll( set1 );
                 }
                 else {
@@ -145,7 +145,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             if ( target.getStrings() != null ) {
                 List<String> list = source.getStrings();
                 if ( list != null ) {
-                    target.getStrings().clear();
+                    target.getStrings().retainAll( list );
                     target.getStrings().addAll( list );
                 }
                 else {
@@ -161,7 +161,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             if ( target.getLongs() != null ) {
                 Set<Long> set = stringListToLongSet( source.getStrings() );
                 if ( set != null ) {
-                    target.getLongs().clear();
+                    target.getLongs().retainAll( set );
                     target.getLongs().addAll( set );
                 }
                 else {
@@ -177,7 +177,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             if ( target.getStringsInitialized() != null ) {
                 List<String> list1 = source.getStringsInitialized();
                 if ( list1 != null ) {
-                    target.getStringsInitialized().clear();
+                    target.getStringsInitialized().retainAll( list1 );
                     target.getStringsInitialized().addAll( list1 );
                 }
                 else {
@@ -193,7 +193,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             if ( target.getLongsInitialized() != null ) {
                 Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
                 if ( set1 != null ) {
-                    target.getLongsInitialized().clear();
+                    target.getLongsInitialized().retainAll( set1 );
                     target.getLongsInitialized().addAll( set1 );
                 }
                 else {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
@@ -58,7 +58,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         if ( target.getStrings() != null ) {
             List<String> list = source.getStrings();
             if ( list != null ) {
-                target.getStrings().clear();
+                target.getStrings().retainAll( list );
                 target.getStrings().addAll( list );
             }
             else {
@@ -74,7 +74,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         if ( target.getLongs() != null ) {
             Set<Long> set = stringListToLongSet( source.getStrings() );
             if ( set != null ) {
-                target.getLongs().clear();
+                target.getLongs().retainAll( set );
                 target.getLongs().addAll( set );
             }
             else {
@@ -90,7 +90,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         if ( target.getStringsInitialized() != null ) {
             List<String> list1 = source.getStringsInitialized();
             if ( list1 != null ) {
-                target.getStringsInitialized().clear();
+                target.getStringsInitialized().retainAll( list1 );
                 target.getStringsInitialized().addAll( list1 );
             }
             else {
@@ -106,7 +106,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         if ( target.getLongsInitialized() != null ) {
             Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
             if ( set1 != null ) {
-                target.getLongsInitialized().clear();
+                target.getLongsInitialized().retainAll( set1 );
                 target.getLongsInitialized().addAll( set1 );
             }
             else {
@@ -149,7 +149,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         if ( target.getStrings() != null ) {
             List<String> list = source.getStrings();
             if ( list != null ) {
-                target.getStrings().clear();
+                target.getStrings().retainAll( list );
                 target.getStrings().addAll( list );
             }
             else {
@@ -165,7 +165,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         if ( target.getLongs() != null ) {
             Set<Long> set = stringListToLongSet( source.getStrings() );
             if ( set != null ) {
-                target.getLongs().clear();
+                target.getLongs().retainAll( set );
                 target.getLongs().addAll( set );
             }
             else {
@@ -181,7 +181,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         if ( target.getStringsInitialized() != null ) {
             List<String> list1 = source.getStringsInitialized();
             if ( list1 != null ) {
-                target.getStringsInitialized().clear();
+                target.getStringsInitialized().retainAll( list1 );
                 target.getStringsInitialized().addAll( list1 );
             }
             else {
@@ -197,7 +197,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         if ( target.getLongsInitialized() != null ) {
             Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
             if ( set1 != null ) {
-                target.getLongsInitialized().clear();
+                target.getLongsInitialized().retainAll( set1 );
                 target.getLongsInitialized().addAll( set1 );
             }
             else {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
@@ -61,7 +61,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
 
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
-                target.getStrings().clear();
+                target.getStrings().retainAll( source.getStrings() );
                 target.getStrings().addAll( source.getStrings() );
             }
         }
@@ -73,7 +73,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
-                target.getLongs().clear();
+                target.getLongs().retainAll( stringListToLongSet( source.getStrings() ) );
                 target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
             }
         }
@@ -84,7 +84,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                target.getStringsInitialized().clear();
+                target.getStringsInitialized().retainAll( source.getStringsInitialized() );
                 target.getStringsInitialized().addAll( source.getStringsInitialized() );
             }
         }
@@ -96,7 +96,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                target.getLongsInitialized().clear();
+                target.getLongsInitialized().retainAll( stringListToLongSet( source.getStringsInitialized() ) );
                 target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }
@@ -133,7 +133,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
 
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
-                target.getStrings().clear();
+                target.getStrings().retainAll( source.getStrings() );
                 target.getStrings().addAll( source.getStrings() );
             }
         }
@@ -145,7 +145,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
-                target.getLongs().clear();
+                target.getLongs().retainAll( stringListToLongSet( source.getStrings() ) );
                 target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
             }
         }
@@ -156,7 +156,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                target.getStringsInitialized().clear();
+                target.getStringsInitialized().retainAll( source.getStringsInitialized() );
                 target.getStringsInitialized().addAll( source.getStringsInitialized() );
             }
         }
@@ -168,7 +168,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
-                target.getLongsInitialized().clear();
+                target.getLongsInitialized().retainAll( stringListToLongSet( source.getStringsInitialized() ) );
                 target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
             }
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/CompanyMapper1Impl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/CompanyMapper1Impl.java
@@ -103,7 +103,7 @@ public class CompanyMapper1Impl implements CompanyMapper1 {
         if ( mappingTarget.getSecretaryToEmployee() != null ) {
             Map<SecretaryEntity, EmployeeEntity> map = secretaryDtoEmployeeDtoMapToSecretaryEntityEmployeeEntityMap( unmappableDepartmentDto.getSecretaryToEmployee() );
             if ( map != null ) {
-                mappingTarget.getSecretaryToEmployee().clear();
+                mappingTarget.getSecretaryToEmployee().entrySet().retainAll( map.entrySet() );
                 mappingTarget.getSecretaryToEmployee().putAll( map );
             }
             else {


### PR DESCRIPTION
Using retainAll() for Set and Map targets will minimize the amount of add/remove operations required for these types.
This limits side effects of removing preemptively all elements through clear() to non-Set Collections and Arrays.

A good example of why it is important (and the one that made me work on this issue) : when mapping to a Set property of a Hibernate-managed entity, calling clear() then addAll() effectively triggers requests for all deletions then all additions ; though because of the order of execution in Hibernate, only the newer elements are inserted, the others are deleted.