### PR TITLE
#3703 Use include model instead of manually writing the type name for  return type for afterMappingReferencesWithFinalizedReturnType

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -136,7 +136,7 @@
 
     <#if finalizerMethod??>
         <#if (afterMappingReferencesWithFinalizedReturnType?size > 0)>
-            ${returnType.name} ${finalizedResultName} = ${resultName}.<@includeModel object=finalizerMethod />;
+            <@includeModel object=returnType /> ${finalizedResultName} = ${resultName}.<@includeModel object=finalizerMethod />;
 
             <#list afterMappingReferencesWithFinalizedReturnType as callback>
                 <#if callback_index = 0>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3703/Issue3703Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3703/Issue3703Mapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3703;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.ap.test.bugs._3703.dto.Contact;
+
+@Mapper
+public interface Issue3703Mapper {
+
+    Contact map(org.mapstruct.ap.test.bugs._3703.entity.Contact contact);
+
+    org.mapstruct.ap.test.bugs._3703.entity.Contact map(Contact contact);
+
+    @AfterMapping
+    default void afterMapping(@MappingTarget Contact target, org.mapstruct.ap.test.bugs._3703.entity.Contact contact) {
+    }
+
+    @AfterMapping
+    default void afterMapping(@MappingTarget Contact.Builder targetBuilder,
+                              org.mapstruct.ap.test.bugs._3703.entity.Contact contact) {
+    }
+
+    @AfterMapping
+    default void afterMapping(@MappingTarget org.mapstruct.ap.test.bugs._3703.entity.Contact target, Contact contact) {
+    }
+
+    @AfterMapping
+    default void afterMapping(@MappingTarget org.mapstruct.ap.test.bugs._3703.entity.Contact.Builder targetBuilder,
+                              Contact contact) {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3703/Issue3703Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3703/Issue3703Test.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3703;
+
+import org.mapstruct.ap.test.bugs._3703.dto.Contact;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+@IssueKey("3703")
+@WithClasses({
+    Contact.class,
+    org.mapstruct.ap.test.bugs._3703.entity.Contact.class,
+    Issue3703Mapper.class
+})
+public class Issue3703Test {
+
+    @ProcessorTest
+    void shouldCompile() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3703/dto/Contact.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3703/dto/Contact.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3703.dto;
+
+public class Contact {
+
+    private final String name;
+
+    private Contact(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Contact build() {
+            return new Contact( name );
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3703/entity/Contact.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3703/entity/Contact.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3703.entity;
+
+public class Contact {
+
+    private final String name;
+
+    private Contact(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String name;
+
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Contact build() {
+            return new Contact( name );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3703 