### PR TITLE
ignoreUnmappedSourceProperties does not propagatevia  @InheritConfiguration

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3248b/Issue3248aMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3248b/Issue3248aMapper.java
@@ -16,78 +16,70 @@ import org.mapstruct.ReportingPolicy;
  *
  * Adding inheritance to issue 3248
  *
- * Unmapped source properties of the parent do not propagate to the subclass:
+ * ignoreUnmappedSourceProperties of the parent does not propagate to the subclass via  @InheritConfiguration
  *
- * Diagnostics: [DiagnosticDescriptor: ERROR Issue3248aMapper.java:30 Unmapped source property: "otherValue".,
- * DiagnosticDescriptor: ERROR Issue3248aMapper.java:33 Unmapped source property: "otherValue".]]
+ * Diagnostics: [DiagnosticDescriptor: ERROR Issue3248aMapper.java:34
+ * Unmapped source property: "value1Ignore".]]  expected: SUCCEEDED but was: FAILED]
  */
 @Mapper(unmappedSourcePolicy = ReportingPolicy.ERROR)
 public interface Issue3248aMapper {
 
-    @BeanMapping(ignoreUnmappedSourceProperties = "otherValue")
-    Target map1(Source source);
+    @Mapping( target = "value1", source = "value1")
+    @BeanMapping(ignoreUnmappedSourceProperties = "value1Ignore")
+    Target1 map1(Source1 source);
 
-    @InheritConfiguration(name = "map1")
-    Target secondMap(Source source);
-
+    @InheritConfiguration
     @Mapping( target = "value2", source = "value2")
-    @BeanMapping(ignoreUnmappedSourceProperties = "otherValue2")
-    Target2 map2(Source2 source2); // fails to ignore "otherValue"
+    @BeanMapping(ignoreUnmappedSourceProperties = "value2Ignore")
+    Target2 map2(Source2 source2); // fails to ignore "value1Ignore"
 
-    @InheritConfiguration(name = "map2")
-    Target2 secondMap2(Source2 source2);
+    class Target1 {
+      private String value1;
 
-    class Target {
-        protected final String value;
-
-        public Target(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
-    }
-
-    class Source {
-      protected final String value;
-
-        public Source(String value) {
-            this.value = value;
-        }
-
-        public String getValue() {
-            return value;
-        }
-
-        public String getOtherValue() {
-            return value;
-        }
-    }
-
-    class Target2 extends Target {
-
-      public Target2(String value, String value2) {
-          super( value );
+      public String getValue1() {
+         return value1;
       }
+
+      public void setValue1(String value1) {
+         this.value1 = value1;
+      }
+    }
+
+    class Source1 {
+      private String value1;
+      private String value1Ignore;
+
+      public String getValue1() {
+         return value1;
+      }
+
+      public String getValue1Ignore() {
+         return value1Ignore;
+      }
+    }
+
+    class Target2 extends Target1 {
+      private String value2;
 
       public String getValue2() {
-          return value;
+         return value2;
       }
-  }
 
-    class Source2 extends Source {
+      public void setValue2(String value2) {
+         this.value2 = value2;
+      }
+    }
 
-        public Source2(String value) {
-          super( value );
-        }
+    class Source2 extends Source1 {
+      private String value2;
+      private String value2Ignore;
 
-        public String getValue2() {
-            return value;
-        }
+      public String getValue2() {
+         return value2;
+      }
 
-        public String getOtherValue2() {
-            return value;
-        }
+      public String getValue2Ignore() {
+         return value2Ignore;
+      }
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3248b/Issue3248aMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3248b/Issue3248aMapper.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3248b;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.InheritConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+
+/**
+ * @author RichMacDonald
+ *
+ * Adding inheritance to issue 3248
+ *
+ * Unmapped source properties of the parent do not propagate to the subclass:
+ *
+ * Diagnostics: [DiagnosticDescriptor: ERROR Issue3248aMapper.java:30 Unmapped source property: "otherValue".,
+ * DiagnosticDescriptor: ERROR Issue3248aMapper.java:33 Unmapped source property: "otherValue".]]
+ */
+@Mapper(unmappedSourcePolicy = ReportingPolicy.ERROR)
+public interface Issue3248aMapper {
+
+    @BeanMapping(ignoreUnmappedSourceProperties = "otherValue")
+    Target map1(Source source);
+
+    @InheritConfiguration(name = "map1")
+    Target secondMap(Source source);
+
+    @Mapping( target = "value2", source = "value2")
+    @BeanMapping(ignoreUnmappedSourceProperties = "otherValue2")
+    Target2 map2(Source2 source2); // fails to ignore "otherValue"
+
+    @InheritConfiguration(name = "map2")
+    Target2 secondMap2(Source2 source2);
+
+    class Target {
+        protected final String value;
+
+        public Target(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    class Source {
+      protected final String value;
+
+        public Source(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+
+        public String getOtherValue() {
+            return value;
+        }
+    }
+
+    class Target2 extends Target {
+
+      public Target2(String value, String value2) {
+          super( value );
+      }
+
+      public String getValue2() {
+          return value;
+      }
+  }
+
+    class Source2 extends Source {
+
+        public Source2(String value) {
+          super( value );
+        }
+
+        public String getValue2() {
+            return value;
+        }
+
+        public String getOtherValue2() {
+            return value;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3248b/Issue3248bTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3248b/Issue3248bTest.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3248b;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+/**
+ * @author Filip Hrisafov
+ */
+@IssueKey("3248")
+@WithClasses({
+    Issue3248aMapper.class
+})
+class Issue3248bTest {
+
+    @ProcessorTest
+    void shouldCompileCode() {
+
+    }
+}


### PR DESCRIPTION
Refer to https://github.com/mapstruct/mapstruct/discussions/3212#discussioncomment-8584497.

@BeanMapping(ignoreUnmappedSourceProperties = ...) does not propagate via @InheritConfiguration. So if a domain superclass object is mapped using ignoreUnmappedSourceProperties, any subclass mappings that use @InheritConfiguration have to redeclare the ignoreUnmappedSourceProperties.

Is this something that should always be true, or should it be an optional value, e.g.,  @InheritConfiguration(inheritIgnoreUnmappedSourceProperties=true)?

I am afraid I lack the understanding of the mapstruct implementation code to make the necessary code. However, I do have a failing test case that illustrates the concern.