### PR TITLE
resolve a mapper's constructor dependencies when creating via `Mappers.getMapper`

### DIFF
--- a/core/src/test/java/org/mapstruct/factory/MapperWhichIsUsed.java
+++ b/core/src/test/java/org/mapstruct/factory/MapperWhichIsUsed.java
@@ -1,0 +1,17 @@
+package org.mapstruct.factory;
+
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface MapperWhichIsUsed {
+
+    Foo toModel(FooDto dto);
+
+    class Foo {
+        public String name;
+    }
+
+    class FooDto {
+        public String name;
+    }
+}

--- a/core/src/test/java/org/mapstruct/factory/MapperWhichIsUsedImpl.java
+++ b/core/src/test/java/org/mapstruct/factory/MapperWhichIsUsedImpl.java
@@ -1,0 +1,15 @@
+package org.mapstruct.factory;
+
+class MapperWhichIsUsedImpl implements MapperWhichIsUsed {
+
+    @Override
+    public Foo toModel(MapperWhichIsUsed.FooDto dto) {
+        if ( dto == null ) {
+            return null;
+        }
+
+        Foo foo = new Foo();
+
+        return foo;
+    }
+}

--- a/core/src/test/java/org/mapstruct/factory/MapperWithUses.java
+++ b/core/src/test/java/org/mapstruct/factory/MapperWithUses.java
@@ -1,0 +1,40 @@
+package org.mapstruct.factory;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+
+@Mapper(
+    uses = MapperWhichIsUsed.class,
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR
+)
+public interface MapperWithUses {
+    Bar toModel(BarDto dto);
+
+    class Bar {
+        private final String name;
+        private final MapperWhichIsUsed.Foo foo;
+
+        public Bar(String name, MapperWhichIsUsed.Foo foo) {
+            this.name = name;
+            this.foo = foo;
+        }
+    }
+
+    class BarDto {
+        private final String name;
+        private final MapperWhichIsUsed.FooDto foo;
+
+        BarDto(String name, MapperWhichIsUsed.FooDto foo) {
+            this.name = name;
+            this.foo = foo;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        public MapperWhichIsUsed.FooDto getFoo() {
+            return this.foo;
+        }
+    }
+}

--- a/core/src/test/java/org/mapstruct/factory/MapperWithUsesImpl.java
+++ b/core/src/test/java/org/mapstruct/factory/MapperWithUsesImpl.java
@@ -1,0 +1,27 @@
+package org.mapstruct.factory;
+
+public class MapperWithUsesImpl implements MapperWithUses {
+
+    private final MapperWhichIsUsed mapperWhichIsUsed;
+
+    public MapperWithUsesImpl(MapperWhichIsUsed mapperWhichIsUsed) {
+        this.mapperWhichIsUsed = mapperWhichIsUsed;
+    }
+
+    @Override
+    public Bar toModel(BarDto dto) {
+        if (dto == null) {
+            return null;
+        }
+
+        String name = null;
+        MapperWhichIsUsed.Foo foo = null;
+
+        name = dto.getName();
+        foo = mapperWhichIsUsed.toModel(dto.getFoo());
+
+        Bar bar = new Bar(name, foo);
+
+        return bar;
+    }
+}

--- a/core/src/test/java/org/mapstruct/factory/MappersTest.java
+++ b/core/src/test/java/org/mapstruct/factory/MappersTest.java
@@ -58,4 +58,9 @@ public class MappersTest {
     public void shouldReturnPackagePrivateImplementationClass() {
         assertThat( Mappers.getMapperClass( PackagePrivateMapper.class ) ).isNotNull();
     }
+
+    @Test
+    public void shouldReturnImplementationClassOfMapperWhichDependsOnAnotherOnes() {
+        assertThat( Mappers.getMapper( MapperWithUses.class ) ).isNotNull();
+    }
 }


### PR DESCRIPTION
At the moment when a mapper depends on another mappers which are passed via constructor, the call `Mappers.getMapper(...)` fails with an exception "java.lang.NoSuchMethodException: MapperName.<init>()"

This pull request fixes the issue by resolving such dependencies