### PR TITLE
#3747 Fix empty if-block when NullValueMappingStrategy is RETURN_DEFAULT and target is immutable

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -2048,6 +2048,10 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         return !constructorMappingsByParameter.isEmpty() || !constructorConstantMappings.isEmpty();
     }
 
+    public boolean hasPropertyMappingsByParameter() {
+        return !mappingsByParameter.isEmpty();
+    }
+
     public MethodReference getFinalizerMethod() {
         return finalizerMethod;
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -99,30 +99,32 @@
 
     	</#if>
     </#list>
-    <#if (sourceParameters?size > 1)>
-        <#list sourceParametersNeedingPresenceCheck as sourceParam>
-            <#if (propertyMappingsByParameter(sourceParam)?size > 0)>
-                if ( <@includeModel object=getPresenceCheckByParameter(sourceParam) /> ) {
-                    <#list propertyMappingsByParameter(sourceParam) as propertyMapping>
-                        <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
-                    </#list>
-                }
-            </#if>
-        </#list>
-        <#list sourceParametersNotNeedingPresenceCheck as sourceParam>
-            <#if (propertyMappingsByParameter(sourceParam)?size > 0)>
-                <#list propertyMappingsByParameter(sourceParam) as propertyMapping>
+        <#if hasPropertyMappingsByParameter()>
+            <#if (sourceParameters?size > 1)>
+                <#list sourceParametersNeedingPresenceCheck as sourceParam>
+                    <#if (propertyMappingsByParameter(sourceParam)?size > 0)>
+                        if ( <@includeModel object=getPresenceCheckByParameter(sourceParam) /> ) {
+                            <#list propertyMappingsByParameter(sourceParam) as propertyMapping>
+                                <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
+                            </#list>
+                        }
+                    </#if>
+                </#list>
+                <#list sourceParametersNotNeedingPresenceCheck as sourceParam>
+                    <#if (propertyMappingsByParameter(sourceParam)?size > 0)>
+                        <#list propertyMappingsByParameter(sourceParam) as propertyMapping>
+                            <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
+                        </#list>
+                    </#if>
+                </#list>
+            <#else>
+                <#if mapNullToDefault>if ( <@includeModel object=getPresenceCheckByParameter(sourceParameters[0]) /> ) {</#if>
+                <#list propertyMappingsByParameter(sourceParameters[0]) as propertyMapping>
                     <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
                 </#list>
+                <#if mapNullToDefault>}</#if>
             </#if>
-        </#list>
-    <#else>
-        <#if mapNullToDefault>if ( <@includeModel object=getPresenceCheckByParameter(sourceParameters[0]) /> ) {</#if>
-        <#list propertyMappingsByParameter(sourceParameters[0]) as propertyMapping>
-            <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
-        </#list>
-        <#if mapNullToDefault>}</#if>
-    </#if>
+        </#if>
     <#list constantMappings as constantMapping>
          <@includeModel object=constantMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping/>
     </#list>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3747/ApiCategoryRecord.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3747/ApiCategoryRecord.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.mapstruct.ap.test.bugs._3747;
+
+public class ApiCategoryRecord {
+    private final Long id;
+    private final String title;
+
+    public ApiCategoryRecord(Long id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3747/Category.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3747/Category.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.mapstruct.ap.test.bugs._3747;
+
+public class Category {
+
+    private final Long id;
+    private final String title;
+
+    public Category(Long id, String title) {
+        this.id = id;
+        this.title = title;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3747/ICategoryMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3747/ICategoryMapper.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.mapstruct.ap.test.bugs._3747;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValueMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+public interface ICategoryMapper {
+
+    ICategoryMapper INSTANCE = Mappers.getMapper( ICategoryMapper.class );
+
+    ApiCategoryRecord mapRecord(Category category);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3747/Issue3747Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3747/Issue3747Test.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+package org.mapstruct.ap.test.bugs._3747;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class Issue3747Test {
+
+    @RegisterExtension
+    GeneratedSource generatedSource = new GeneratedSource().addComparisonToFixtureFor( ICategoryMapper.class );
+
+    @ProcessorTest
+    @WithClasses({
+        ICategoryMapper.class,
+        Category.class,
+        ApiCategoryRecord.class
+    })
+    void shouldNotGenerateEmptyIfConditionWhenPropertyMappingsAreEmpty() {
+        Category category = new Category( 123L, "Category 1" );
+
+        ApiCategoryRecord apiCategoryRecord = ICategoryMapper.INSTANCE.mapRecord( category );
+
+        assertThat( apiCategoryRecord.getId() ).isEqualTo( 123L );
+        assertThat( apiCategoryRecord.getTitle() ).isEqualTo( "Category 1" );
+    }
+
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_3747/ICategoryMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_3747/ICategoryMapperImpl.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3747;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2024-10-19T17:01:16+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.4 (Arch Linux)"
+)
+public class ICategoryMapperImpl implements ICategoryMapper {
+
+    @Override
+    public ApiCategoryRecord mapRecord(Category category) {
+
+        Long id = null;
+        String title = null;
+        if ( category != null ) {
+            id = category.getId();
+            title = category.getTitle();
+        }
+
+        ApiCategoryRecord apiCategoryRecord = new ApiCategoryRecord( id, title );
+
+        return apiCategoryRecord;
+    }
+}


### PR DESCRIPTION
Fixes #3747

**Problem:**
The BeanMappingMethod template always creates the if-block for the property mappings, even if the target only has constructor mappings. 

The unit tests are green but when I run "mvnw install" I get an exception from the maven shade plugin. The exception disappears when I set the version to 3.2.1