### PR TITLE
Fix typos and improve readability in multiple classes

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractBaseBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AbstractBaseBuilder.java
@@ -41,7 +41,7 @@ class AbstractBaseBuilder<B extends AbstractBaseBuilder<B>> {
     }
 
     /**
-     * Checks if MapStruct is allowed to generate an automatic sub-mapping between {@code sourceType} and @{code
+     * Checks if MapStruct is allowed to generate an automatic sub-mapping between {@code sourceType} and {@code
      * targetType}.
      * This will evaluate to {@code true}, when:
      * <li>
@@ -66,7 +66,7 @@ class AbstractBaseBuilder<B extends AbstractBaseBuilder<B>> {
 
     /**
      * Creates a forged assignment from the provided {@code sourceRHS} and {@code forgedMethod}. If a mapping method
-     * for the {@code forgedMethod} already exists, then this method used for the assignment.
+     * for the {@code forgedMethod} already exists, this method will be used for the assignment.
      *
      * @param sourceRHS that needs to be used for the assignment
      * @param forgedMethod the forged method for which we want to create an {@link Assignment}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/AnnotatedConstructor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/AnnotatedConstructor.java
@@ -36,14 +36,14 @@ public class AnnotatedConstructor extends ModelElement implements Constructor {
         if ( constructor instanceof NoArgumentConstructor ) {
             noArgumentConstructor = (NoArgumentConstructor) constructor;
         }
-        NoArgumentConstructor noArgConstructorToInBecluded = null;
+        NoArgumentConstructor noArgConstructorToBeIncluded = null;
         Set<SupportingConstructorFragment> fragmentsToBeIncluded = Collections.emptySet();
         if ( includeNoArgConstructor ) {
             if ( noArgumentConstructor != null ) {
-                noArgConstructorToInBecluded = noArgumentConstructor;
+                noArgConstructorToBeIncluded = noArgumentConstructor;
             }
             else {
-                noArgConstructorToInBecluded = new NoArgumentConstructor( name, fragmentsToBeIncluded );
+                noArgConstructorToBeIncluded = new NoArgumentConstructor( name, fragmentsToBeIncluded );
             }
         }
         else if ( noArgumentConstructor != null ) {
@@ -53,7 +53,7 @@ public class AnnotatedConstructor extends ModelElement implements Constructor {
             name,
             mapperReferences,
             annotations,
-            noArgConstructorToInBecluded,
+            noArgConstructorToBeIncluded,
             fragmentsToBeIncluded
         );
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/InheritanceSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/InheritanceSelector.java
@@ -33,7 +33,7 @@ public class InheritanceSelector implements MethodSelector {
         List<SelectedMethod<T>> candidatesWithBestMatchingSourceType = new ArrayList<>();
         int bestMatchingSourceTypeDistance = Integer.MAX_VALUE;
 
-        // find the methods with the minimum distance regarding getParameter getParameter type
+        // Find methods with the minimum inheritance distance from the source parameter type
         for ( SelectedMethod<T> method : methods ) {
             Parameter singleSourceParam = first( method.getMethod().getSourceParameters() );
 
@@ -49,17 +49,17 @@ public class InheritanceSelector implements MethodSelector {
         return candidatesWithBestMatchingSourceType;
     }
 
-    private <T extends Method> int addToCandidateListIfMinimal(List<SelectedMethod<T>> candidatesWithBestMathingType,
+    private <T extends Method> int addToCandidateListIfMinimal(List<SelectedMethod<T>> candidatesWithBestMatchingType,
                                                                int bestMatchingTypeDistance, SelectedMethod<T> method,
                                                                int currentTypeDistance) {
         if ( currentTypeDistance == bestMatchingTypeDistance ) {
-            candidatesWithBestMathingType.add( method );
+            candidatesWithBestMatchingType.add( method );
         }
         else if ( currentTypeDistance < bestMatchingTypeDistance ) {
             bestMatchingTypeDistance = currentTypeDistance;
 
-            candidatesWithBestMathingType.clear();
-            candidatesWithBestMathingType.add( method );
+            candidatesWithBestMatchingType.clear();
+            candidatesWithBestMatchingType.add( method );
         }
         return bestMatchingTypeDistance;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/SourceRhsSelector.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/SourceRhsSelector.java
@@ -12,7 +12,7 @@ import org.mapstruct.ap.internal.model.common.ParameterBinding;
 import org.mapstruct.ap.internal.model.source.Method;
 
 /**
- * Selector that tries to resolve an ambiquity between methods that contain source parameters and
+ * Selector that tries to resolve an ambiguity between methods that contain source parameters and
  * {@link org.mapstruct.ap.internal.model.common.SourceRHS SourceRHS} type parameters.
  * @author Filip Hrisafov
  */


### PR DESCRIPTION
This PR addresses typo corrections and readability improvements across several classes.

- AnnotatedConstructor: Fixed a variable name typo (noArgConstructorToInBecluded → noArgConstructorToBeIncluded) to enhance code clarity.
- AbstractBaseBuilder: Improved Javadoc by fixing typos and clarifying wording for better documentation quality.
- SourceRhsSelector: Corrected a typo in the class-level Javadoc.
- InheritanceSelector: Enhanced readability by fixing typos in variable names and refining comments.

This PR aims to improve code and documentation readability and clarity without altering functionality.