### PR TITLE
Switch order of literals to prevent NullPointerException

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -130,7 +130,7 @@
                     <!--
                         There is a bug in JDK 11 (https://bugs.openjdk.java.net/browse/JDK-8215291) which doesn't work correctly when searching and adds undefined.
                         It has been fixed since JDK 12, but not yet backported to JDK 11 (https://bugs.openjdk.java.net/browse/JDK-8244171).
-                        One workardound is https://stackoverflow.com/a/57284322/1115491.
+                        One workaround is https://stackoverflow.com/a/57284322/1115491.
                          -->
                     <bottom>
                         <![CDATA[

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -1364,7 +1364,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 handledTargets.add( targetPropertyName );
             }
 
-            // its a constant
+            // it's a constant
             // if we have an unprocessed target that means that it most probably is nested and we should
             // not generated any mapping for it now. Eventually it will be done though
             else if ( mapping.getConstant() != null ) {
@@ -1384,7 +1384,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 handledTargets.add( targetPropertyName );
             }
 
-            // its an expression
+            // it's an expression
             // if we have an unprocessed target that means that it most probably is nested and we should
             // not generated any mapping for it now. Eventually it will be done though
             else if ( mapping.getJavaExpression() != null ) {
@@ -1400,7 +1400,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                     .build();
                 handledTargets.add( targetPropertyName );
             }
-            // its a plain-old property mapping
+            // it's a plain-old property mapping
             else  {
 
                 SourceReference sourceRef = mappingRef.getSourceReference();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
@@ -259,7 +259,7 @@ public class MappingBuilderContext {
     }
 
     /**
-     * @param type that MapStruct wants to use to genrate an autoamtic sub-mapping for/from
+     * @param type that MapStruct wants to use to generate an automatic sub-mapping for/from
      *
      * @return {@code true} if the type is not excluded from the {@link MappingExclusionProvider}
      */

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
@@ -226,7 +226,7 @@ public class NestedTargetPropertyMappingHolder {
                         handledTargets.add( entryByTP.getKey() );
                     }
 
-                    // For the nonNested mappings (assymetric) Mappings we also forge mappings
+                    // For the nonNested mappings (asymmetric) Mappings we also forge mappings
                     // However, here we do not forge name based mappings and we only
                     // do update on the defined Mappings.
                     if ( !groupedSourceReferences.nonNested.isEmpty() ) {
@@ -755,7 +755,7 @@ public class NestedTargetPropertyMappingHolder {
     }
 
     /**
-     * This class is used to group Source references in respected to the nestings that they have.
+     * This class is used to group Source references in respected to the nesting that they have.
      *
      * This class contains all groupings by Property Entries if they are nested, or a list of all the other options
      * that could not have been popped.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
@@ -274,7 +274,7 @@ public class ValueMappingMethod extends MappingMethod {
                 return mappings;
             }
 
-            // Start to fill the mappings with the defined valuemappings
+            // Start to fill the mappings with the defined valueMappings
             for ( ValueMappingOptions valueMapping : valueMappings.regularValueMappings ) {
                 mappings.add( new MappingEntry( valueMapping.getSource(), valueMapping.getTarget() ) );
                 unmappedSourceConstants.remove( valueMapping.getSource() );
@@ -305,7 +305,7 @@ public class ValueMappingMethod extends MappingMethod {
             }
             Set<String> mappedSources = new LinkedHashSet<>();
 
-            // Start to fill the mappings with the defined valuemappings
+            // Start to fill the mappings with the defined value mappings
             for ( ValueMappingOptions valueMapping : valueMappings.regularValueMappings ) {
                 mappedSources.add( valueMapping.getSource() );
                 mappings.add( new MappingEntry( valueMapping.getSource(), valueMapping.getTarget() ) );

--- a/processor/src/main/java/org/mapstruct/ap/spi/AccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/AccessorNamingStrategy.java
@@ -68,7 +68,7 @@ public interface AccessorNamingStrategy {
      *
      * @return getter name for collection properties
      *
-     * @deprecated MapStuct will not call this method anymore. Use {@link #getMethodType(ExecutableElement)} to
+     * @deprecated MapStruct will not call this method anymore. Use {@link #getMethodType(ExecutableElement)} to
      * determine the {@link MethodType}. When collections somehow need to be treated special, it should be done in
      * {@link #getMethodType(ExecutableElement) } as well. In the future, this method will be removed.
      */


### PR DESCRIPTION
Hi, my name is Zach and I'm a developer for Pixee. I wanted to bring some light to this change as it was generated from our automated code security bot.

This change defensively switches the order of literals in comparison expressions to ensure that no null pointer exceptions are unexpectedly thrown. Runtime exceptions especially can cause exceptional and unexpected code paths to be taken, and this can result in unexpected behavior. 

Both simple vulnerabilities (like information disclosure) and complex vulnerabilities (like business logic flaws) can take advantage of these unexpected code paths.

Our changes look something like this:

```diff
  String fieldName = header.getFieldName();
  String fieldValue = header.getFieldValue();
- if(fieldName.equals("requestId")) {
+ if("requestId".equals(fieldName)) {
    logRequest(fieldValue);
  }
```

<details>
  <summary>More reading</summary>

  * [https://cwe.mitre.org/data/definitions/476.html](https://cwe.mitre.org/data/definitions/476.html)
  * [https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException](https://en.wikibooks.org/wiki/Java_Programming/Preventing_NullPointerException)
  * [https://rules.sonarsource.com/java/RSPEC-1132/](https://rules.sonarsource.com/java/RSPEC-1132/)
</details>

🧚🤖  Powered by Pixeebot  

[Feedback](https://ask.pixee.ai/feedback) | [Community](https://pixee-community.slack.com/signup#/domain-signup) | [Docs](https://docs.pixee.ai/) | Codemod ID: pixee:java/switch-literal-first ![](https://d1zaessa2hpsmj.cloudfront.net/pixel/v1/track?writeKey=2PI43jNm7atYvAuK7rJUz3Kcd6A&event=DRIP_PR%7CPixeebot-2-0%2Fmapstruct%7C677b96a2509f34b134d6bf4c19c88437a74f457b)


<!--{"type":"DRIP","codemod":"pixee:java/switch-literal-first"}-->