### PR TITLE
Java EA GitHub Actions improvements

### DIFF
--- a/.github/workflows/java-ea.yml
+++ b/.github/workflows/java-ea.yml
@@ -7,11 +7,7 @@ env:
 
 jobs:
   test_jdk_ea:
-    strategy:
-      fail-fast: false
-      matrix:
-        java: [19-ea]
-    name: 'Linux JDK ${{ matrix.java }}'
+    name: 'Linux JDK EA'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,45 +24,38 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - name: 'Test'
-        run: ./mvnw ${MAVEN_ARGS} -Djacoco.skip=true install -DskipDistribution=true
-  linux:
-    name: 'Linux JDK 11'
-    runs-on: ubuntu-latest
-    steps:
-      - name: 'Checkout'
-        uses: actions/checkout@v3
-      - name: 'Set up JDK 11'
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'zulu'
-          java-version: 11
-      - name: 'Test'
-        run: ./mvnw ${MAVEN_ARGS} install
+        run: ./mvnw ${MAVEN_ARGS} -Djacoco.skip=${{ matrix.java != 17 }} install -DskipDistribution=${{ matrix.java != 17 }}
       - name: 'Generate coverage report'
+        if: matrix.java == 17
         run: ./mvnw jacoco:report
       - name: 'Upload coverage to Codecov'
+        if: matrix.java == 17
         uses: codecov/codecov-action@v2
       - name: 'Publish Snapshots'
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'mapstruct/mapstruct'
+        if: matrix.java == 17 && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'mapstruct/mapstruct'
         run: ./mvnw -s etc/ci-settings.xml -DskipTests=true -DskipDistribution=true deploy
-  linux-jdk-8:
-    name: 'Linux JDK 8'
+  integration_test_jdk:
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ 8, 11 ]
+    name: 'Linux JDK ${{ matrix.java }}'
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
         uses: actions/checkout@v3
-      - name: 'Set up JDK 11 for building everything'
+      - name: 'Set up JDK 17 for building everything'
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - name: 'Install Processor'
         run: ./mvnw ${MAVEN_ARGS} -DskipTests install -pl processor -am
-      - name: 'Set up JDK 8 for running integration tests'
+      - name: 'Set up JDK ${{ matrix.java }} for running integration tests'
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 8
+          java-version: ${{ matrix.java }}
       - name: 'Run integration tests'
         run: ./mvnw ${MAVEN_ARGS} verify -pl integrationtest
   windows:
@@ -70,11 +63,11 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 17'
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - name: 'Test'
         run: ./mvnw %MAVEN_ARGS% install
   mac:
@@ -82,10 +75,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-      - name: 'Set up JDK 11'
+      - name: 'Set up JDK 17'
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 17
       - name: 'Test'
         run: ./mvnw ${MAVEN_ARGS} install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
           cache: maven
 

--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationExclusionCliEnhancer.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationExclusionCliEnhancer.java
@@ -30,6 +30,10 @@ public final class FullFeatureCompilationExclusionCliEnhancer implements Process
 
         switch ( currentJreVersion ) {
             case JAVA_8:
+                additionalExcludes.add( "org/mapstruct/ap/test/*/spring/**/*.java" );
+                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_880/**/*.java" );
+                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_1395/**/*.java" );
+                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_2807/**/*.java" );
                 additionalExcludes.add( "org/mapstruct/ap/test/injectionstrategy/cdi/**/*.java" );
                 additionalExcludes.add( "org/mapstruct/ap/test/injectionstrategy/jakarta_cdi/**/*.java" );
                 additionalExcludes.add( "org/mapstruct/ap/test/annotatewith/deprecated/jdk11/*.java" );
@@ -42,6 +46,11 @@ public final class FullFeatureCompilationExclusionCliEnhancer implements Process
                 // TODO find out why this fails:
                 additionalExcludes.add( "org/mapstruct/ap/test/collection/wildcard/BeanMapper.java" );
                 break;
+            case JAVA_11:
+                additionalExcludes.add( "org/mapstruct/ap/test/*/spring/**/*.java" );
+                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_880/**/*.java" );
+                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_1395/**/*.java" );
+                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_2807/**/*.java" );
             default:
         }
 

--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationExclusionCliEnhancer.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationExclusionCliEnhancer.java
@@ -30,10 +30,7 @@ public final class FullFeatureCompilationExclusionCliEnhancer implements Process
 
         switch ( currentJreVersion ) {
             case JAVA_8:
-                additionalExcludes.add( "org/mapstruct/ap/test/*/spring/**/*.java" );
-                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_880/**/*.java" );
-                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_1395/**/*.java" );
-                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_2807/**/*.java" );
+                additionalExcludes.add( "org/mapstruct/ap/test/**/spring/**/*.java" );
                 additionalExcludes.add( "org/mapstruct/ap/test/injectionstrategy/cdi/**/*.java" );
                 additionalExcludes.add( "org/mapstruct/ap/test/injectionstrategy/jakarta_cdi/**/*.java" );
                 additionalExcludes.add( "org/mapstruct/ap/test/annotatewith/deprecated/jdk11/*.java" );
@@ -47,10 +44,7 @@ public final class FullFeatureCompilationExclusionCliEnhancer implements Process
                 additionalExcludes.add( "org/mapstruct/ap/test/collection/wildcard/BeanMapper.java" );
                 break;
             case JAVA_11:
-                additionalExcludes.add( "org/mapstruct/ap/test/*/spring/**/*.java" );
-                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_880/**/*.java" );
-                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_1395/**/*.java" );
-                additionalExcludes.add( "org/mapstruct/ap/test/bugs/_2807/**/*.java" );
+                additionalExcludes.add( "org/mapstruct/ap/test/**/spring/**/*.java" );
             default:
         }
 

--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct.itest.tests;
 
+import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.condition.EnabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.parallel.Execution;
@@ -81,12 +82,14 @@ public class MavenIntegrationTest {
 
     @ProcessorTest(baseDir = "jsr330Test")
     @EnabledForJreRange(min = JRE.JAVA_17)
+    @DisabledOnJre(JRE.OTHER)
     void jsr330Test() {
     }
 
     @ProcessorTest(baseDir = "lombokBuilderTest", processorTypes = {
         ProcessorTest.ProcessorType.JAVAC
     })
+    @DisabledOnJre(JRE.OTHER)
     void lombokBuilderTest() {
     }
 
@@ -95,6 +98,7 @@ public class MavenIntegrationTest {
         ProcessorTest.ProcessorType.JAVAC_WITH_PATHS
     })
     @EnabledForJreRange(min = JRE.JAVA_11)
+    @DisabledOnJre(JRE.OTHER)
     void lombokModuleTest() {
     }
 
@@ -151,6 +155,7 @@ public class MavenIntegrationTest {
     }, forkJvm = true)
     // We have to fork the jvm because there is an NPE in com.intellij.openapi.util.SystemInfo.getRtVersion
     // and the kotlin-maven-plugin uses that. See also https://youtrack.jetbrains.com/issue/IDEA-238907
+    @DisabledOnJre(JRE.OTHER)
     void kotlinDataTest() {
     }
 
@@ -165,6 +170,7 @@ public class MavenIntegrationTest {
 
     @ProcessorTest(baseDir = "springTest")
     @EnabledForJreRange(min = JRE.JAVA_17)
+    @DisabledOnJre(JRE.OTHER)
     void springTest() {
     }
 

--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
@@ -80,6 +80,7 @@ public class MavenIntegrationTest {
     }
 
     @ProcessorTest(baseDir = "jsr330Test")
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void jsr330Test() {
     }
 
@@ -163,6 +164,7 @@ public class MavenIntegrationTest {
     }
 
     @ProcessorTest(baseDir = "springTest")
+    @EnabledForJreRange(min = JRE.JAVA_17)
     void springTest() {
     }
 

--- a/integrationtest/src/test/java/org/mapstruct/itest/testutil/extension/ProcessorInvocationInterceptor.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/testutil/extension/ProcessorInvocationInterceptor.java
@@ -134,14 +134,20 @@ public class ProcessorInvocationInterceptor implements InvocationInterceptor {
     }
 
     private void configureProcessor(Verifier verifier) {
-        String compilerId = processorTestContext.getProcessor().getCompilerId();
+        ProcessorTest.ProcessorType processor = processorTestContext.getProcessor();
+        String compilerId = processor.getCompilerId();
         if ( compilerId != null ) {
-            String profile = processorTestContext.getProcessor().getProfile();
+            String profile = processor.getProfile();
             if ( profile == null ) {
                 profile = "generate-via-compiler-plugin";
             }
             verifier.addCliOption( "-P" + profile );
             verifier.addCliOption( "-Dcompiler-id=" + compilerId );
+            if ( processor == ProcessorTest.ProcessorType.JAVAC ) {
+                if ( CURRENT_VERSION.ordinal() >= JRE.JAVA_21.ordinal() ) {
+                    verifier.addCliOption( "-Dmaven.compiler.proc=full" );
+                }
+            }
         }
         else {
             verifier.addCliOption( "-Pgenerate-via-processor-plugin" );

--- a/integrationtest/src/test/resources/fullFeatureTest/pom.xml
+++ b/integrationtest/src/test/resources/fullFeatureTest/pom.xml
@@ -27,6 +27,11 @@
         <additionalExclude4>x</additionalExclude4>
         <additionalExclude5>x</additionalExclude5>
         <additionalExclude6>x</additionalExclude6>
+        <additionalExclude7>x</additionalExclude7>
+        <additionalExclude8>x</additionalExclude8>
+        <additionalExclude9>x</additionalExclude9>
+        <additionalExclude10>x</additionalExclude10>
+        <additionalExclude11>x</additionalExclude11>
     </properties>
 
     <build>
@@ -49,6 +54,11 @@
                         <exclude>${additionalExclude4}</exclude>
                         <exclude>${additionalExclude5}</exclude>
                         <exclude>${additionalExclude6}</exclude>
+                        <exclude>${additionalExclude7}</exclude>
+                        <exclude>${additionalExclude8}</exclude>
+                        <exclude>${additionalExclude9}</exclude>
+                        <exclude>${additionalExclude10}</exclude>
+                        <exclude>${additionalExclude11}</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/integrationtest/src/test/resources/pom.xml
+++ b/integrationtest/src/test/resources/pom.xml
@@ -45,7 +45,6 @@
                             <compilerArgument
                                 combine.self="override"></compilerArgument>
                             <compilerId>\${compiler-id}</compilerId>
-                            <compilerArgument>-proc:full</compilerArgument>
                         </configuration>
                         <dependencies>
                             <dependency>

--- a/integrationtest/src/test/resources/pom.xml
+++ b/integrationtest/src/test/resources/pom.xml
@@ -45,6 +45,7 @@
                             <compilerArgument
                                 combine.self="override"></compilerArgument>
                             <compilerId>\${compiler-id}</compilerId>
+                            <compilerArgument>-proc:full</compilerArgument>
                         </configuration>
                         <dependencies>
                             <dependency>

--- a/integrationtest/src/test/resources/superTypeGenerationTest/generator/pom.xml
+++ b/integrationtest/src/test/resources/superTypeGenerationTest/generator/pom.xml
@@ -32,7 +32,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <compilerArgs>
                         <compilerArg>-proc:none</compilerArg>

--- a/integrationtest/src/test/resources/superTypeGenerationTest/usage/pom.xml
+++ b/integrationtest/src/test/resources/superTypeGenerationTest/usage/pom.xml
@@ -38,7 +38,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <compilerArgs>
                         <compilerArg>-XprintProcessorInfo</compilerArg>

--- a/integrationtest/src/test/resources/targetTypeGenerationTest/generator/pom.xml
+++ b/integrationtest/src/test/resources/targetTypeGenerationTest/generator/pom.xml
@@ -32,7 +32,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <compilerArgs>
                         <compilerArg>-proc:none</compilerArg>

--- a/integrationtest/src/test/resources/targetTypeGenerationTest/usage/pom.xml
+++ b/integrationtest/src/test/resources/targetTypeGenerationTest/usage/pom.xml
@@ -38,7 +38,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
                 <configuration>
                     <compilerArgs>
                         <compilerArg>-XprintProcessorInfo</compilerArg>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -400,7 +400,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.13.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -34,7 +34,7 @@
         <org.apache.maven.plugins.enforcer.version>3.4.1</org.apache.maven.plugins.enforcer.version>
         <org.apache.maven.plugins.surefire.version>3.2.2</org.apache.maven.plugins.surefire.version>
         <org.apache.maven.plugins.javadoc.version>3.1.0</org.apache.maven.plugins.javadoc.version>
-        <org.springframework.version>6.1.12</org.springframework.version>
+        <org.springframework.version>6.2.2</org.springframework.version>
         <org.eclipse.tycho.compiler-jdt.version>1.6.0</org.eclipse.tycho.compiler-jdt.version>
         <com.puppycrawl.tools.checkstyle.version>8.36.1</com.puppycrawl.tools.checkstyle.version>
         <org.junit.jupiter.version>5.10.1</org.junit.jupiter.version>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -34,7 +34,7 @@
         <org.apache.maven.plugins.enforcer.version>3.4.1</org.apache.maven.plugins.enforcer.version>
         <org.apache.maven.plugins.surefire.version>3.2.2</org.apache.maven.plugins.surefire.version>
         <org.apache.maven.plugins.javadoc.version>3.1.0</org.apache.maven.plugins.javadoc.version>
-        <org.springframework.version>5.3.31</org.springframework.version>
+        <org.springframework.version>6.1.12</org.springframework.version>
         <org.eclipse.tycho.compiler-jdt.version>1.6.0</org.eclipse.tycho.compiler-jdt.version>
         <com.puppycrawl.tools.checkstyle.version>8.36.1</com.puppycrawl.tools.checkstyle.version>
         <org.junit.jupiter.version>5.10.1</org.junit.jupiter.version>
@@ -47,7 +47,7 @@
         <m2e.apt.activation>jdt_apt</m2e.apt.activation>
         <!--
             The minimum Java Version that is needed to build a module in MapStruct.
-            The processor module needs at least Java 11.
+            The processor module needs at least Java 17.
          -->
         <minimum.java.version>1.8</minimum.java.version>
         <protobuf.version>3.21.7</protobuf.version>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -24,7 +24,7 @@
         <!-- Netbeans has a problem when we use late binding with @ in the surefire arg line.
             Therefore we set this empty property here-->
         <jacocoArgLine />
-        <minimum.java.version>11</minimum.java.version>
+        <minimum.java.version>17</minimum.java.version>
     </properties>
 
     <dependencies>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/spring/Issue1395Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/spring/Issue1395Mapper.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._1395;
+package org.mapstruct.ap.test.bugs._1395.spring;
 
 import org.mapstruct.InjectionStrategy;
 import org.mapstruct.Mapper;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/spring/Issue1395Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/spring/Issue1395Test.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._1395;
+package org.mapstruct.ap.test.bugs._1395.spring;
 
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/spring/NotUsedService.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/spring/NotUsedService.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._1395;
+package org.mapstruct.ap.test.bugs._1395.spring;
 
 /**
  * @author Filip Hrisafov

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/spring/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/spring/Source.java
@@ -3,12 +3,12 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._1395;
+package org.mapstruct.ap.test.bugs._1395.spring;
 
 /**
  * @author Filip Hrisafov
  */
-public class Target {
+public class Source {
 
     private String value;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/spring/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_1395/spring/Target.java
@@ -3,12 +3,12 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._1395;
+package org.mapstruct.ap.test.bugs._1395.spring;
 
 /**
  * @author Filip Hrisafov
  */
-public class Source {
+public class Target {
 
     private String value;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2807/spring/Issue2807Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2807/spring/Issue2807Test.java
@@ -3,11 +3,11 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._2807;
+package org.mapstruct.ap.test.bugs._2807.spring;
 
-import org.mapstruct.ap.test.bugs._2807.after.AfterMethod;
-import org.mapstruct.ap.test.bugs._2807.before.BeforeMethod;
-import org.mapstruct.ap.test.bugs._2807.beforewithtarget.BeforeWithTarget;
+import org.mapstruct.ap.test.bugs._2807.spring.after.AfterMethod;
+import org.mapstruct.ap.test.bugs._2807.spring.before.BeforeMethod;
+import org.mapstruct.ap.test.bugs._2807.spring.beforewithtarget.BeforeWithTarget;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2807/spring/SpringLifeCycleMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2807/spring/SpringLifeCycleMapper.java
@@ -3,15 +3,15 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._2807;
+package org.mapstruct.ap.test.bugs._2807.spring;
 
 import java.util.List;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
-import org.mapstruct.ap.test.bugs._2807.after.AfterMethod;
-import org.mapstruct.ap.test.bugs._2807.before.BeforeMethod;
-import org.mapstruct.ap.test.bugs._2807.beforewithtarget.BeforeWithTarget;
+import org.mapstruct.ap.test.bugs._2807.spring.after.AfterMethod;
+import org.mapstruct.ap.test.bugs._2807.spring.before.BeforeMethod;
+import org.mapstruct.ap.test.bugs._2807.spring.beforewithtarget.BeforeWithTarget;
 import org.mapstruct.factory.Mappers;
 
 /**

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2807/spring/after/AfterMethod.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2807/spring/after/AfterMethod.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._2807.after;
+package org.mapstruct.ap.test.bugs._2807.spring.after;
 
 import java.util.List;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2807/spring/before/BeforeMethod.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2807/spring/before/BeforeMethod.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._2807.before;
+package org.mapstruct.ap.test.bugs._2807.spring.before;
 
 import org.mapstruct.BeforeMapping;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2807/spring/beforewithtarget/BeforeWithTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2807/spring/beforewithtarget/BeforeWithTarget.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._2807.beforewithtarget;
+package org.mapstruct.ap.test.bugs._2807.spring.beforewithtarget;
 
 import java.util.List;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/spring/Config.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/spring/Config.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._880;
+package org.mapstruct.ap.test.bugs._880.spring;
 
 import org.mapstruct.MapperConfig;
 import org.mapstruct.ReportingPolicy;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/spring/DefaultsToProcessorOptionsMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/spring/DefaultsToProcessorOptionsMapper.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._880;
+package org.mapstruct.ap.test.bugs._880.spring;
 
 import org.mapstruct.Mapper;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/spring/Issue880Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/spring/Issue880Test.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._880;
+package org.mapstruct.ap.test.bugs._880.spring;
 
 import javax.tools.Diagnostic.Kind;
 

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/spring/Poodle.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/spring/Poodle.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._880;
+package org.mapstruct.ap.test.bugs._880.spring;
 
 /**
  * @author Andreas Gudian

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/spring/UsesConfigFromAnnotationMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_880/spring/UsesConfigFromAnnotationMapper.java
@@ -3,7 +3,7 @@
  *
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
-package org.mapstruct.ap.test.bugs._880;
+package org.mapstruct.ap.test.bugs._880.spring;
 
 import org.mapstruct.Mapper;
 import org.mapstruct.MappingConstants;

--- a/processor/src/test/java/org/mapstruct/ap/test/decorator/jsr330/Jsr330DecoratorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/decorator/jsr330/Jsr330DecoratorTest.java
@@ -11,6 +11,8 @@ import javax.inject.Named;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.test.decorator.Address;
 import org.mapstruct.ap.test.decorator.AddressDto;
@@ -46,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ComponentScan(basePackageClasses = Jsr330DecoratorTest.class)
 @Configuration
 @WithJavaxInject
+@DisabledOnJre(JRE.OTHER)
 public class Jsr330DecoratorTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/_default/Jsr330DefaultCompileOptionFieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/_default/Jsr330DefaultCompileOptionFieldMapperTest.java
@@ -10,6 +10,8 @@ import javax.inject.Named;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
@@ -44,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ComponentScan(basePackageClasses = CustomerJsr330DefaultCompileOptionFieldMapper.class)
 @WithJavaxInject
 @Configuration
+@DisabledOnJre(JRE.OTHER)
 public class Jsr330DefaultCompileOptionFieldMapperTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/compileoptionconstructor/Jsr330CompileOptionConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/compileoptionconstructor/Jsr330CompileOptionConstructorMapperTest.java
@@ -7,6 +7,8 @@ package org.mapstruct.ap.test.injectionstrategy.jsr330.compileoptionconstructor;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
@@ -44,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ComponentScan(basePackageClasses = CustomerJsr330CompileOptionConstructorMapper.class)
 @Configuration
 @WithJavaxInject
+@DisabledOnJre(JRE.OTHER)
 public class Jsr330CompileOptionConstructorMapperTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/constructor/Jsr330ConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/constructor/Jsr330ConstructorMapperTest.java
@@ -8,6 +8,7 @@ package org.mapstruct.ap.test.injectionstrategy.jsr330.constructor;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
@@ -45,6 +46,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ComponentScan(basePackageClasses = CustomerJsr330ConstructorMapper.class)
 @Configuration
 @WithJavaxInject
+@DisabledOnJre(JRE.OTHER)
 public class Jsr330ConstructorMapperTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/constructor/Jsr330ConstructorMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/constructor/Jsr330ConstructorMapperTest.java
@@ -7,6 +7,7 @@ package org.mapstruct.ap.test.injectionstrategy.jsr330.constructor;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledOnJre;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/field/Jsr330FieldMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/field/Jsr330FieldMapperTest.java
@@ -10,6 +10,8 @@ import javax.inject.Named;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
@@ -46,6 +48,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ComponentScan(basePackageClasses = CustomerJsr330FieldMapper.class)
 @Configuration
 @WithJavaxInject
+@DisabledOnJre(JRE.OTHER)
 public class Jsr330FieldMapperTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/setter/Jsr330SetterMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/injectionstrategy/jsr330/setter/Jsr330SetterMapperTest.java
@@ -7,6 +7,8 @@ package org.mapstruct.ap.test.injectionstrategy.jsr330.setter;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerDto;
 import org.mapstruct.ap.test.injectionstrategy.shared.CustomerEntity;
@@ -42,6 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ComponentScan(basePackageClasses = CustomerJsr330SetterMapper.class)
 @Configuration
 @WithJavaxInject
+@DisabledOnJre(JRE.OTHER)
 public class Jsr330SetterMapperTest {
 
     @RegisterExtension

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithSpring.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithSpring.java
@@ -10,6 +10,8 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import org.junit.jupiter.api.condition.DisabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 
 /**
  * Meta annotation that adds the needed Spring Dependencies
@@ -23,6 +25,7 @@ import java.lang.annotation.Target;
     "spring-beans",
     "spring-context"
 })
+@DisabledOnJre(JRE.OTHER)
 public @interface WithSpring {
 
 }

--- a/readme.md
+++ b/readme.md
@@ -130,7 +130,7 @@ To learn more about MapStruct, refer to the [project homepage](https://mapstruct
 
 ## Building from Source
 
-MapStruct uses Maven for its build. Java 11 is required for building MapStruct from source. To build the complete project, run
+MapStruct uses Maven for its build. Java 17 is required for building MapStruct from source. To build the complete project, run
 
     ./mvnw clean install
 


### PR DESCRIPTION
With this PR we are upgrading to Spring 6 and thus Java 17 for building MapStruct. However, we are still Java 8 compatible.