### PR TITLE
fix: default value handling for optional

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -231,7 +231,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     /**
      * Returns a String that could be used in generated code to reference to this {@link Type}.<br>
-     *  <p>
+     * <p>
      * The first time a name is referred-to it will be marked as to be imported. For instance
      * {@code LocalDateTime} can be one of {@code java.time.LocalDateTime} and {@code org.joda.LocalDateTime})
      * <p>
@@ -259,7 +259,7 @@ public class Type extends ModelElement implements Comparable<Type> {
             return name;
         }
 
-        if ( isTopLevelTypeToBeImported() && nameWithTopLevelTypeName != null) {
+        if ( isTopLevelTypeToBeImported() && nameWithTopLevelTypeName != null ) {
             return nameWithTopLevelTypeName;
         }
 
@@ -367,8 +367,12 @@ public class Type extends ModelElement implements Comparable<Type> {
         return componentType != null;
     }
 
+    public boolean isOptionalType() {
+        return !isPrimitive() || "java.util.Optional".equals( getFullyQualifiedName() );
+    }
+
     public boolean isTypeVar() {
-        return (typeMirror.getKind() == TypeKind.TYPEVAR);
+        return ( typeMirror.getKind() == TypeKind.TYPEVAR );
     }
 
     public boolean isIntersection() {
@@ -422,7 +426,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     /**
      * A type variable type can have two types of bounds (mutual exclusive): lower and upper.
-     *
+     * <p>
      * Note that its use is only permitted on a definition (not on the place where its used). For instance:
      * {@code<T super Number> T map( T in)}
      *
@@ -439,7 +443,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     /**
      * A type variable type can have two types of bounds (mutual exclusive): lower and upper.
-     *
+     * <p>
      * Note that its use is only permitted on a definition  (not on the place where its used). For instance:
      * {@code><T extends Number> T map( T in)}
      *
@@ -625,7 +629,6 @@ public class Type extends ModelElement implements Comparable<Type> {
      * as well.
      *
      * @param other The other type.
-     *
      * @return {@code true} if and only if this type is assignable to the given other type.
      */
     public boolean isAssignableTo(Type other) {
@@ -644,7 +647,6 @@ public class Type extends ModelElement implements Comparable<Type> {
      * they need to be resolved first.
      *
      * @param other The other type.
-     *
      * @return {@code true} if and only if this type is assignable to the given other type.
      */
     public boolean isRawAssignableTo(Type other) {
@@ -659,6 +661,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     /**
      * removes any bounds from this type.
+     *
      * @return the raw type
      */
     public Type asRawType() {
@@ -704,7 +707,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         if ( readAccessors == null ) {
 
             Map<String, ReadAccessor> recordAccessors = filters.recordAccessorsIn( getRecordComponents() );
-            Map<String, ReadAccessor> modifiableGetters = new LinkedHashMap<>(recordAccessors);
+            Map<String, ReadAccessor> modifiableGetters = new LinkedHashMap<>( recordAccessors );
 
             List<ReadAccessor> getterList = filters.getterMethodsIn( getAllMethods() );
             for ( ReadAccessor getter : getterList ) {
@@ -782,7 +785,7 @@ public class Type extends ModelElement implements Comparable<Type> {
      * @param cmStrategy collection mapping strategy
      * @return an unmodifiable map of all write accessors indexed by property name
      */
-    public Map<String, Accessor> getPropertyWriteAccessors( CollectionMappingStrategyGem cmStrategy ) {
+    public Map<String, Accessor> getPropertyWriteAccessors(CollectionMappingStrategyGem cmStrategy) {
         // collect all candidate target accessors
         List<Accessor> candidates = new ArrayList<>( getSetters() );
         candidates.addAll( getAlternativeTargetAccessors() );
@@ -822,7 +825,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                 }
 
             }
-            else if ( candidate.getAccessorType() == AccessorType.FIELD  && ( Executables.isFinal( candidate ) ||
+            else if ( candidate.getAccessorType() == AccessorType.FIELD && ( Executables.isFinal( candidate ) ||
                 result.containsKey( targetPropertyName ) ) ) {
                 // if the candidate is a field and a mapping already exists, then use that one, skip it.
                 continue;
@@ -869,7 +872,7 @@ public class Type extends ModelElement implements Comparable<Type> {
             return parameter.getType();
         }
         else if ( candidate.getAccessorType() == AccessorType.GETTER
-                        || candidate.getAccessorType().isFieldAssignment() ) {
+            || candidate.getAccessorType().isFieldAssignment() ) {
             return typeFactory.getReturnType( (DeclaredType) typeMirror, candidate );
         }
         return null;
@@ -899,7 +902,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         return Collections.emptyList();
     }
 
-    private String getPropertyName(Accessor accessor ) {
+    private String getPropertyName(Accessor accessor) {
         Element accessorElement = accessor.getElement();
         if ( accessorElement instanceof ExecutableElement ) {
             return getPropertyName( (ExecutableElement) accessorElement );
@@ -915,7 +918,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     /**
      * Tries to find an addMethod in this type for given collection property in this type.
-     *
+     * <p>
      * Matching occurs on:
      * <ol>
      * <li>The generic type parameter type of the collection should match the adder method argument</li>
@@ -927,7 +930,6 @@ public class Type extends ModelElement implements Comparable<Type> {
      *
      * @param collectionProperty property type (assumed collection) to find  the adder method for
      * @param pluralPropertyName the property name (assumed plural)
-     *
      * @return corresponding adder method for getter when present
      */
     private Accessor getAdderForType(Type collectionProperty, String pluralPropertyName) {
@@ -966,9 +968,8 @@ public class Type extends ModelElement implements Comparable<Type> {
      * Returns all accessor candidates that start with "add" and have exactly one argument
      * whose type matches the collection or stream property's type argument.
      *
-     * @param property the collection or stream property
+     * @param property   the collection or stream property
      * @param superclass the superclass to use for type argument lookup
-     *
      * @return accessor candidates
      */
     private List<Accessor> getAccessorCandidates(Type property, Class<?> superclass) {
@@ -1027,7 +1028,7 @@ public class Type extends ModelElement implements Comparable<Type> {
      * Alternative accessors could be a getter for a collection. By means of the
      * {@link java.util.Collection#addAll(java.util.Collection) } this getter can still
      * be used as targetAccessor. JAXB XJC tool generates such constructs.
-     *
+     * <p>
      * This method can be extended when new cases come along.
      *
      * @return an unmodifiable list of alternative target accessors.
@@ -1113,7 +1114,6 @@ public class Type extends ModelElement implements Comparable<Type> {
      * the other type. Returns {@code 1}, if the other type is a direct super type of this type, and so on.
      *
      * @param assignableOther the other type
-     *
      * @return the length of the shortest path in the type hierarchy between this type and the specified other type
      */
     public int distanceTo(Type assignableOther) {
@@ -1142,7 +1142,7 @@ public class Type extends ModelElement implements Comparable<Type> {
     }
 
     /**
-     * @param type the type declaring the method
+     * @param type   the type declaring the method
      * @param method the method to check
      * @return Whether this type can access the given method declared on the given type.
      */
@@ -1163,9 +1163,13 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     /**
      * @return A valid Java expression most suitable for representing null - useful for dealing with primitives from
-     *         FTL.
+     * FTL.
      */
     public String getNull() {
+        if ( !isPrimitive() || isOptionalType() ) {
+            return "Optional.empty()";
+        }
+
         if ( !isPrimitive() || isArrayType() ) {
             return "null";
         }
@@ -1177,7 +1181,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         }
         if ( "char".equals( getName() ) ) {
             //"'\u0000'" would have been better, but depends on platform encoding
-                return "0";
+            return "0";
         }
         if ( "double".equals( getName() ) ) {
             return "0.0d";
@@ -1220,8 +1224,8 @@ public class Type extends ModelElement implements Comparable<Type> {
         // are in another jar than the mapper. So the qualfiedName is a better candidate.
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((name == null) ? 0 : name.hashCode());
-        result = prime * result + ((packageName == null) ? 0 : packageName.hashCode());
+        result = prime * result + ( ( name == null ) ? 0 : name.hashCode() );
+        result = prime * result + ( ( packageName == null ) ? 0 : packageName.hashCode() );
         return result;
     }
 
@@ -1239,7 +1243,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         Type other = (Type) obj;
 
         if ( this.isWildCardBoundByTypeVar() && other.isWildCardBoundByTypeVar() ) {
-            return  ( this.hasExtendsBound() == this.hasExtendsBound()
+            return ( this.hasExtendsBound() == this.hasExtendsBound()
                 || this.hasSuperBound() == this.hasSuperBound() )
                 && typeUtils.isSameType( getTypeBound().getTypeMirror(), other.getTypeBound().getTypeMirror() );
         }
@@ -1280,7 +1284,6 @@ public class Type extends ModelElement implements Comparable<Type> {
     }
 
     /**
-     *
      * @return an identification that can be used as part in a forged method name.
      */
     public String getIdentification() {
@@ -1300,6 +1303,7 @@ public class Type extends ModelElement implements Comparable<Type> {
      * <li>{@code <?>}, returns Object</li>
      * <li>{@code <T extends Number>, returns Number}</li>
      * </ol>
+     *
      * @return the bound for this parameter
      */
     public Type getTypeBound() {
@@ -1387,6 +1391,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     /**
      * All primitive types and their corresponding boxed types are considered native.
+     *
      * @return true when native.
      */
     public boolean isNative() {
@@ -1416,12 +1421,11 @@ public class Type extends ModelElement implements Comparable<Type> {
      * }
      * </pre>
      *
-     * @param declared the type
+     * @param declared      the type
      * @param parameterized the parameterized type
-     *
      * @return - the same type when this is not a type var in the broadest sense (T, T[], or ? extends T)<br>
-     *         - the matching parameter in the parameterized type when this is a type var when found<br>
-     *         - null in all other cases
+     * - the matching parameter in the parameterized type when this is a type var when found<br>
+     * - null in all other cases
      */
     public ResolvedPair resolveParameterToType(Type declared, Type parameterized) {
         if ( isTypeVar() || isArrayTypeVar() || isWildCardBoundByTypeVar() ) {
@@ -1480,7 +1484,7 @@ public class Type extends ModelElement implements Comparable<Type> {
      * result: Map<String, BigDecimal>
      * }
      * </pre>
-     *
+     * <p>
      * Mismatch result examples:
      * <pre>
      * {@code
@@ -1496,12 +1500,11 @@ public class Type extends ModelElement implements Comparable<Type> {
      * }
      * </pre>
      *
-     * @param declared the type
+     * @param declared      the type
      * @param parameterized the parameterized type
-     *
      * @return - the result of {@link #resolveParameterToType(Type, Type)} when this type itself is a type var.<br>
-     *         - the type but then with the matching type parameters replaced.<br>
-     *         - the same type when this type does not contain matching type parameters.
+     * - the type but then with the matching type parameters replaced.<br>
+     * - the same type when this type does not contain matching type parameters.
      */
     public Type resolveGenericTypeParameters(Type declared, Type parameterized) {
         if ( isTypeVar() || isArrayTypeVar() || isWildCardBoundByTypeVar() ) {
@@ -1526,7 +1529,7 @@ public class Type extends ModelElement implements Comparable<Type> {
     }
 
     public boolean isArrayTypeVar() {
-        return  isArrayType() && getComponentType().isTypeVar();
+        return isArrayType() && getComponentType().isTypeVar();
     }
 
     private static class TypeVarMatcher extends SimpleTypeVisitor8<ResolvedPair, Type> {
@@ -1537,7 +1540,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
         /**
          * @param typeFactory factory
-         * @param types type utils
+         * @param types       type utils
          * @param typeToMatch the typeVar or wildcard with typeVar bound
          */
         TypeVarMatcher(TypeFactory typeFactory, TypeUtils types, Type typeToMatch) {
@@ -1550,7 +1553,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         @Override
         public ResolvedPair visitTypeVariable(TypeVariable parameterized, Type declared) {
             if ( typeToMatch.isTypeVar() && types.isSameType( parameterized, typeToMatch.getTypeMirror() ) ) {
-                return new ResolvedPair(  typeFactory.getType( parameterized ), declared );
+                return new ResolvedPair( typeFactory.getType( parameterized ), declared );
             }
             return super.DEFAULT_VALUE;
         }
@@ -1558,16 +1561,16 @@ public class Type extends ModelElement implements Comparable<Type> {
         /**
          * If ? extends SomeTime equals the boundary set in typeVarToMatch (NOTE: you can't compare the wildcard itself)
          * then return a result;
-          */
+         */
         @Override
         public ResolvedPair visitWildcard(WildcardType parameterized, Type declared) {
             if ( typeToMatch.hasExtendsBound() && parameterized.getExtendsBound() != null
                 && types.isSameType( typeToMatch.getTypeBound().getTypeMirror(), parameterized.getExtendsBound() ) ) {
-                return new ResolvedPair( typeToMatch, declared);
+                return new ResolvedPair( typeToMatch, declared );
             }
             else if ( typeToMatch.hasSuperBound() && parameterized.getSuperBound() != null
                 && types.isSameType( typeToMatch.getTypeBound().getTypeMirror(), parameterized.getSuperBound() ) ) {
-                return new ResolvedPair( typeToMatch, declared);
+                return new ResolvedPair( typeToMatch, declared );
             }
             if ( parameterized.getExtendsBound() != null ) {
                 ResolvedPair match = visit( parameterized.getExtendsBound(), declared );
@@ -1575,7 +1578,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                     return new ResolvedPair( typeFactory.getType( parameterized ), declared );
                 }
             }
-            else if (parameterized.getSuperBound() != null ) {
+            else if ( parameterized.getSuperBound() != null ) {
                 ResolvedPair match = visit( parameterized.getSuperBound(), declared );
                 if ( match.match != null ) {
                     return new ResolvedPair( typeFactory.getType( parameterized ), declared );
@@ -1599,7 +1602,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         @Override
         public ResolvedPair visitDeclared(DeclaredType parameterized, Type declared) {
 
-            List<ResolvedPair> results = new ArrayList<>(  );
+            List<ResolvedPair> results = new ArrayList<>();
             if ( parameterized.getTypeArguments().isEmpty() ) {
                 return super.DEFAULT_VALUE;
             }
@@ -1627,7 +1630,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                         continue;
                     }
                     ResolvedPair result = visitDeclared( parameterized, declaredSuperType );
-                    if ( result != super.DEFAULT_VALUE  ) {
+                    if ( result != super.DEFAULT_VALUE ) {
                         results.add( result );
                     }
                 }
@@ -1637,7 +1640,7 @@ public class Type extends ModelElement implements Comparable<Type> {
                         continue;
                     }
                     ResolvedPair result = visitDeclared( (DeclaredType) parameterizedSuper, declared );
-                    if ( result != super.DEFAULT_VALUE  ) {
+                    if ( result != super.DEFAULT_VALUE ) {
                         results.add( result );
                     }
                 }
@@ -1653,7 +1656,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         private boolean isJavaLangObject(TypeMirror type) {
             if ( type instanceof DeclaredType ) {
                 return ( (TypeElement) ( (DeclaredType) type ).asElement() ).getQualifiedName()
-                                                                            .contentEquals( Object.class.getName() );
+                    .contentEquals( Object.class.getName() );
             }
             return false;
         }
@@ -1726,7 +1729,7 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     /**
      * It strips all the {@code []} from the {@code className}.
-     *
+     * <p>
      * E.g.
      * <pre>
      *     trimSimpleClassName("String[][][]") -> "String"
@@ -1734,7 +1737,6 @@ public class Type extends ModelElement implements Comparable<Type> {
      * </pre>
      *
      * @param className that needs to be trimmed
-     *
      * @return the trimmed {@code className}, or {@code null} if the {@code className} was {@code null}
      */
     private String trimSimpleClassName(String className) {
@@ -1797,9 +1799,9 @@ public class Type extends ModelElement implements Comparable<Type> {
     /**
      * return the list of permitted TypeMirrors for the java 17+ sealed class
      */
-    @SuppressWarnings( "unchecked" )
+    @SuppressWarnings("unchecked")
     public List<? extends TypeMirror> getPermittedSubclasses() {
-        if (SEALED_PERMITTED_SUBCLASSES_METHOD == null) {
+        if ( SEALED_PERMITTED_SUBCLASSES_METHOD == null ) {
             return emptyList();
         }
         try {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3852/Issue3852Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3852/Issue3852Mapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3852;
+
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValueMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Dennis Melzer
+ */
+@Mapper(
+    nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT,
+    injectionStrategy = InjectionStrategy.CONSTRUCTOR
+)
+public interface Issue3852Mapper {
+
+    Issue3852Mapper INSTANCE = Mappers.getMapper( Issue3852Mapper.class );
+
+    Target map(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3852/Issue3852Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3852/Issue3852Test.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3852;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithSpring;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Dennis Melzer
+ */
+@WithClasses({
+    Issue3852Mapper.class,
+    Source.class,
+    Target.class
+})
+@WithSpring
+@IssueKey("3852")
+public class Issue3852Test {
+
+    @ProcessorTest
+    public void shouldOptionalNotNull() {
+        Target target = Issue3852Mapper.INSTANCE.map( null );
+
+        assertThat( target.getSomeString() ).isEmpty();
+        assertThat( target.getSomeInteger() ).isEmpty();
+        assertThat( target.getSomeDouble() ).isEmpty();
+        assertThat( target.getSomeBoolean() ).isEmpty();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3852/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3852/Source.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3852;
+
+import java.util.Optional;
+
+/**
+ * @author Dennis Melzer
+ */
+public class Source {
+
+    private final Optional<String> someString;
+    private final Optional<Integer> someInteger;
+    private final Optional<Double> someDouble;
+    private final Optional<Boolean> someBoolean;
+
+    public Source(Optional<String> someString, Optional<Integer> someInteger, Optional<Double> someDouble,
+                  Optional<Boolean> someBoolean) {
+        this.someString = someString;
+        this.someInteger = someInteger;
+        this.someDouble = someDouble;
+        this.someBoolean = someBoolean;
+    }
+
+    public Optional<String> getSomeString() {
+        return someString;
+    }
+
+    public Optional<Integer> getSomeInteger() {
+        return someInteger;
+    }
+
+    public Optional<Double> getSomeDouble() {
+        return someDouble;
+    }
+
+    public Optional<Boolean> getSomeBoolean() {
+        return someBoolean;
+    }
+
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3852/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3852/Target.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3852;
+
+import java.util.Optional;
+
+/**
+ * @author Dennis Melzer
+ */
+public class Target {
+
+    private final Optional<String> someString;
+    private final Optional<Integer> someInteger;
+    private final Optional<Double> someDouble;
+    private final Optional<Boolean> someBoolean;
+
+    public Target(Optional<String> someString, Optional<Integer> someInteger, Optional<Double> someDouble,
+                  Optional<Boolean> someBoolean) {
+        this.someString = someString;
+        this.someInteger = someInteger;
+        this.someDouble = someDouble;
+        this.someBoolean = someBoolean;
+    }
+
+    public Optional<String> getSomeString() {
+        return someString;
+    }
+
+    public Optional<Integer> getSomeInteger() {
+        return someInteger;
+    }
+
+    public Optional<Double> getSomeDouble() {
+        return someDouble;
+    }
+
+    public Optional<Boolean> getSomeBoolean() {
+        return someBoolean;
+    }
+
+}


### PR DESCRIPTION
This pull request introduces support for handling not nullable `Optional` types in the MapStruct framework and includes related test cases. The most significant changes involve adding a new method to check for `Optional` types, modifying the handling of null values, and introducing test classes to validate the new functionality. Now the default is `Optional.empty()` instead of `null`

Fix #3852
