### PR TITLE
feat: add qualified to @ValueMapping to inserting methods in the switch-default branch

### DIFF
--- a/core/src/main/java/org/mapstruct/ValueMapping.java
+++ b/core/src/main/java/org/mapstruct/ValueMapping.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
@@ -121,4 +122,25 @@ public @interface ValueMapping {
      */
     String target();
 
+    /**
+     * Only effective when {@code source } = {@link MappingConstants#ANY_UNMAPPED }
+     * or {@link MappingConstants#ANY_REMAINING }.
+     * <p>
+     * Specifies qualifier annotations to select a user-defined handler method,
+     * which will be invoked in the {@code default} branch of the generated {@code switch} statement
+     * for unmapped enum values.
+     *
+     * @return the qualifiers
+     * @see Qualifier
+     */
+    Class<? extends Annotation>[] qualifiedBy() default {};
+
+    /**
+     * Similar to {@link #qualifiedBy()}, but used in combination with {@code @}{@link Named} in case no custom
+     * qualifier annotation is defined.
+     *
+     * @return the qualifiers
+     * @see Named
+     */
+    String[] qualifiedByName() default {};
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/DefaultValueMappingMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/DefaultValueMappingMethodResolver.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.lang.model.element.AnnotationMirror;
+
+import org.mapstruct.ap.internal.model.common.Parameter;
+import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.model.source.Method;
+import org.mapstruct.ap.internal.model.source.ParameterProvidedMethods;
+import org.mapstruct.ap.internal.model.source.SelectionParameters;
+import org.mapstruct.ap.internal.model.source.SourceMethod;
+import org.mapstruct.ap.internal.model.source.selector.MethodSelectors;
+import org.mapstruct.ap.internal.model.source.selector.SelectedMethod;
+import org.mapstruct.ap.internal.model.source.selector.SelectionContext;
+import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.Message;
+
+import static org.mapstruct.ap.internal.util.Collections.first;
+
+/**
+ * Utility for resolving handler methods for unmapped enum branches in
+ * {@link org.mapstruct.ValueMapping}.
+ * <p>
+ * Specifically used for cases like:
+ * <pre>{@code
+ *   @ValueMapping(
+ *     source = MappingConstants.ANY_UNMAPPED,
+ *     qualifiedByName = "unknownMapping"
+ *   )}
+ * </pre>
+ * When {@code MappingConstants#ANY_UNMAPPED} is specified, this resolver finds a user-defined
+ * method (typically annotated with {@link org.mapstruct.Named}) to be invoked in the
+ * default branch of the generated switch statement.
+ *
+ * <p>
+ * The handler method's parameters will be filled by the source parameters of the mapping method
+ * where possible. If the handler method has a return value (i.e., its return type is not void),
+ * a return statement will be generated and no further statements will be executed in the default
+ * branch. If the handler method is void, it will be invoked for side effects (such as logging)
+ * and subsequent statements in the default branch will still be executed.
+ * <p>
+ *
+ * <p>
+ * This behavior is consistent with MapStruct's handling of {@link org.mapstruct.AfterMapping} and
+ * {@link org.mapstruct.BeforeMapping} lifecycle methods.
+ * <p>
+ * This allows users to insert custom logic (such as logging, exception handling, etc.)
+ * for unmapped enum values during mapping.
+ */
+public final class DefaultValueMappingMethodResolver {
+
+    private DefaultValueMappingMethodResolver() {
+    }
+
+    /**
+     * Finds a matching method for unmapped branch handling.
+     *
+     * @param method                The mapping method.
+     * @param selectionParameters   Selection parameters for method matching.
+     * @param ctx                   Builder context.
+     * @return The matched MethodReference, or null if none found.
+     */
+    public static MethodReference getMatchingMethods(Method method, SelectionParameters selectionParameters,
+                                                     AnnotationMirror positionHint, MappingBuilderContext ctx) {
+        if (selectionParameters.getQualifiers().isEmpty() && selectionParameters.getQualifyingNames().isEmpty()) {
+            return null;
+        }
+        List<SourceMethod> namedMethods = getAllAvailableMethods( method, ctx.getSourceModel() );
+        MethodSelectors selectors = new MethodSelectors( ctx.getTypeUtils(), ctx.getElementUtils(), ctx.getMessager() );
+        Type targetType = method.getReturnType();
+        List<SelectedMethod<SourceMethod>> matchingMethods = selectors.getMatchingMethods(
+            namedMethods,
+            SelectionContext.forDefaultValueMappingMethod(
+                method,
+                targetType,
+                selectionParameters,
+                ctx.getTypeFactory()
+            )
+        );
+        if ( matchingMethods.isEmpty() ) {
+            return null;
+        }
+
+        reportErrorWhenAmbiguous( method, matchingMethods, targetType, positionHint, ctx );
+
+        List<MethodReference> result = new ArrayList<>(matchingMethods.size());
+        for ( SelectedMethod<SourceMethod> candidate : matchingMethods ) {
+            Parameter providingParameter =
+                method.getContextProvidedMethods().getParameterForProvidedMethod( candidate.getMethod() );
+
+            MapperReference mapperReference = MapperReference.findMapperReference(
+                ctx.getMapperReferences(), candidate.getMethod() );
+
+            result.add( new MethodReference(
+                candidate.getMethod(),
+                mapperReference,
+                providingParameter,
+                candidate.getParameterBindings()
+            ) );
+        }
+        return first( result );
+    }
+
+    private static <T extends Method> void reportErrorWhenAmbiguous(Method mappingMethod,
+                                                                    List<SelectedMethod<T>> candidates,
+                                                                    Type target,
+                                                                    AnnotationMirror positionHint,
+                                                                    MappingBuilderContext ctx) {
+        // raise an error if more than one mapping method is suitable
+        if ( candidates.size() <= 1 ) {
+            return;
+        }
+        FormattingMessager messager = ctx.getMessager();
+        messager.printMessage(
+            mappingMethod.getExecutable(),
+            positionHint,
+            Message.GENERAL_AMBIGUOUS_MAPPING_METHOD,
+            null,
+            target.describe(),
+            join( candidates, ctx )
+        );
+    }
+
+    private static <T extends Method> String join(List<SelectedMethod<T>> candidates, MappingBuilderContext ctx) {
+        int reportingLimitAmbiguous = ctx.getOptions().isVerbose() ? Integer.MAX_VALUE : 5;
+        String candidateStr = candidates.stream()
+            .limit( reportingLimitAmbiguous )
+            .map( m -> m.getMethod().describe() )
+            .collect( Collectors.joining( ", " ) );
+
+        if ( candidates.size() > reportingLimitAmbiguous ) {
+            candidateStr += String.format( "... and %s more", candidates.size() - reportingLimitAmbiguous );
+        }
+        return candidateStr;
+    }
+
+    /**
+     * Gets all available methods from context and source.
+     *
+     * @param method             The mapping method.
+     * @param sourceModelMethods Source methods from the model.
+     * @return List of SourceMethod.
+     */
+    private static List<SourceMethod> getAllAvailableMethods(
+        Method method,
+        List<SourceMethod> sourceModelMethods) {
+        ParameterProvidedMethods contextProvidedMethods = method.getContextProvidedMethods();
+        List<SourceMethod> allMethods = new ArrayList<>();
+        if ( !contextProvidedMethods.isEmpty() ) {
+            allMethods.addAll(
+                contextProvidedMethods.getAllProvidedMethodsInParameterOrder( method.getContextParameters() )
+            );
+        }
+        allMethods.addAll( sourceModelMethods );
+        return allMethods;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ValueMappingMethod.java
@@ -137,10 +137,28 @@ public class ValueMappingMethod extends MappingMethod {
                 annotations,
                 mappingEntries,
                 valueMappings.nullValueTarget,
-                valueMappings.defaultTargetValue,
+                getDefaultMappingEntry(),
                 determineUnexpectedValueMappingException(),
                 beforeMappingMethods,
                 afterMappingMethods
+            );
+        }
+
+        private MappingEntry getDefaultMappingEntry() {
+            MethodReference reference = null;
+            ValueMappingOptions defaultTargetOptions = valueMappings.defaultTarget;
+            if ( defaultTargetOptions != null ) {
+                reference = DefaultValueMappingMethodResolver.getMatchingMethods(
+                    method,
+                    defaultTargetOptions.getSelectionParameters(),
+                    defaultTargetOptions.getMirror(),
+                    ctx
+                );
+            }
+            return new MappingEntry(
+                null,
+                valueMappings.defaultTargetValue != null ? valueMappings.defaultTargetValue : THROW_EXCEPTION,
+                reference
             );
         }
 
@@ -551,14 +569,14 @@ public class ValueMappingMethod extends MappingMethod {
                                List<Annotation> annotations,
                                List<MappingEntry> enumMappings,
                                String nullTarget,
-                               String defaultTarget,
+                               MappingEntry defaultTarget,
                                Type unexpectedValueMappingException,
                                List<LifecycleCallbackMethodReference> beforeMappingMethods,
                                List<LifecycleCallbackMethodReference> afterMappingMethods) {
         super( method, beforeMappingMethods, afterMappingMethods );
         this.valueMappings = enumMappings;
         this.nullTarget = new MappingEntry( null, nullTarget );
-        this.defaultTarget = new MappingEntry( null, defaultTarget != null ? defaultTarget : THROW_EXCEPTION);
+        this.defaultTarget = defaultTarget;
         this.unexpectedValueMappingException = unexpectedValueMappingException;
         this.overridden = method.overridesMethod();
         this.annotations = annotations;
@@ -618,6 +636,7 @@ public class ValueMappingMethod extends MappingMethod {
         private final String source;
         private final String target;
         private boolean targetAsException = false;
+        private MethodReference targetReference;
 
         MappingEntry(String source, String target) {
             this.source = source;
@@ -630,6 +649,12 @@ public class ValueMappingMethod extends MappingMethod {
             else {
                 this.target = null;
             }
+            this.targetReference = null;
+        }
+
+        MappingEntry(String source, String target, MethodReference targetReference) {
+            this( source, target );
+            this.targetReference = targetReference;
         }
 
         public boolean isTargetAsException() {
@@ -642,6 +667,10 @@ public class ValueMappingMethod extends MappingMethod {
 
         public String getTarget() {
             return target;
+        }
+
+        public MethodReference getTargetReference() {
+            return targetReference;
         }
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/SelectionContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/SelectionContext.java
@@ -105,6 +105,25 @@ public class SelectionContext {
         );
     }
 
+    public static SelectionContext forDefaultValueMappingMethod(Method mappingMethod, Type targetType,
+                                                                SelectionParameters selectionParameters,
+                                                                TypeFactory typeFactory) {
+        SelectionCriteria criteria = SelectionCriteria.forDefaultValueMappingMethod( selectionParameters );
+        return new SelectionContext(
+            null,
+            criteria,
+            mappingMethod,
+            targetType,
+            mappingMethod.getResultType(),
+            () -> getAvailableParameterBindingsFromMethod(
+                mappingMethod,
+                targetType,
+                criteria.getSourceRHS(),
+                typeFactory
+            )
+        );
+    }
+
     public static SelectionContext forLifecycleMethods(Method mappingMethod, Type targetType,
                                                        SelectionParameters selectionParameters,
                                                        TypeFactory typeFactory) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/SelectionCriteria.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/selector/SelectionCriteria.java
@@ -7,7 +7,6 @@ package org.mapstruct.ap.internal.model.source.selector;
 
 import java.util.Collections;
 import java.util.List;
-
 import javax.lang.model.type.TypeMirror;
 
 import org.mapstruct.ap.internal.model.common.SourceRHS;
@@ -158,6 +157,10 @@ public class SelectionCriteria {
 
     public static SelectionCriteria forLifecycleMethods(SelectionParameters selectionParameters) {
         return new SelectionCriteria( selectionParameters, null, null, Type.LIFECYCLE_CALLBACK );
+    }
+
+    public static SelectionCriteria forDefaultValueMappingMethod(SelectionParameters selectionParameters) {
+        return new SelectionCriteria( selectionParameters, null, null, null );
     }
 
     public static SelectionCriteria forPresenceCheckMethods(SelectionParameters selectionParameters) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -786,13 +786,13 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
 
         @Override
         protected void addInstance(ValueMappingGem gem, Element source, Set<ValueMappingOptions> mappings) {
-            ValueMappingOptions valueMappingOptions = ValueMappingOptions.fromMappingGem( gem );
+            ValueMappingOptions valueMappingOptions = ValueMappingOptions.fromMappingGem( gem, typeUtils );
             mappings.add( valueMappingOptions );
         }
 
         @Override
         protected void addInstances(ValueMappingsGem gems, Element source, Set<ValueMappingOptions> mappings) {
-            ValueMappingOptions.fromMappingsGem( gems, (ExecutableElement) source, messager, mappings );
+            ValueMappingOptions.fromMappingsGem( gems, (ExecutableElement) source, messager, mappings, typeUtils );
         }
     }
 

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/ValueMappingMethod.ftl
@@ -28,7 +28,7 @@
         case <@writeSource source=valueMapping.source/>: <#if valueMapping.targetAsException >throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} );<#else>${resultName} = <@writeTarget target=valueMapping.target/>;
         break;</#if>
     </#list>
-    default: <#if defaultTarget.targetAsException >throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} )<#else>${resultName} = <@writeTarget target=defaultTarget.target/></#if>;
+        <@writeDefaultBranch/>
     }
     <#list beforeMappingReferencesWithMappingTarget as callback>
         <#if callback_index = 0>
@@ -72,4 +72,26 @@
             <#if exceptionType_has_next>, </#if><#t>
         </#list>
     </@compress>
+</#macro>
+
+<#macro writeDefaultBranch >
+    default:<#t>
+    <#if defaultTarget.targetReference ??>
+        <#if !defaultTarget.targetReference.returnType.isVoid()>
+ return <@includeModel object=defaultTarget.targetReference/>;
+        <#else><#nt>
+            <@includeModel object=defaultTarget.targetReference/>;<#lt>
+            <#if !defaultTarget.targetAsException>
+                ${resultName} = <@writeTarget target=defaultTarget.target/>;<#lt>
+            <#else><#t>
+                throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} );<#lt>
+            </#if>
+        </#if>
+    <#else>
+        <#if defaultTarget.targetAsException>
+ throw new <@includeModel object=unexpectedValueMappingException />( "Unexpected enum constant: " + ${sourceParameter.name} );
+        <#else>
+ ${resultName} = <@writeTarget target=defaultTarget.target/>;
+        </#if>
+    </#if>
 </#macro>

--- a/processor/src/test/java/org/mapstruct/ap/test/value/qualifier/DefaultValueMappingMethodMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/qualifier/DefaultValueMappingMethodMapper.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.value.qualifier;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingConstants;
+import org.mapstruct.Named;
+import org.mapstruct.ValueMapping;
+import org.mapstruct.ap.test.factories.qualified.TestQualifier;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface DefaultValueMappingMethodMapper {
+    enum SourceType { A, B, C }
+
+    enum TargetType { X, Y, Z }
+
+    List<String> INVOKE_LIST = new ArrayList<>();
+
+    DefaultValueMappingMethodMapper INSTANCE = Mappers.getMapper( DefaultValueMappingMethodMapper.class );
+
+    @ValueMapping(source = "A", target = "X")
+    @ValueMapping(source = MappingConstants.ANY_UNMAPPED, target = "Z", qualifiedByName = "defaultHandlerWithReturn")
+    DefaultValueMappingMethodMapper.TargetType map(DefaultValueMappingMethodMapper.SourceType source);
+
+    @ValueMapping(source = "A", target = "X")
+    @ValueMapping(source = MappingConstants.ANY_REMAINING, target = "Z", qualifiedBy = TestQualifier.class)
+    DefaultValueMappingMethodMapper.TargetType mapNoReturn(DefaultValueMappingMethodMapper.SourceType source);
+
+    @Named("defaultHandlerWithReturn")
+    default DefaultValueMappingMethodMapper.TargetType defaultHandler(
+            DefaultValueMappingMethodMapper.SourceType source) {
+        INVOKE_LIST.add( "defaultHandlerWithReturn" );
+        return TargetType.Y;
+    }
+
+    @TestQualifier
+    default void defaultHandlerNoReturn(DefaultValueMappingMethodMapper.SourceType source) {
+        INVOKE_LIST.add( "defaultHandlerNoReturn" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/value/qualifier/Issued3831Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/value/qualifier/Issued3831Test.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.value.qualifier;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.factories.qualified.TestQualifier;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+
+@IssueKey("3831")
+@WithClasses({ TestQualifier.class })
+public class Issued3831Test {
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource().addComparisonToFixtureFor(
+            DefaultValueMappingMethodMapper.class
+    );
+
+    @ProcessorTest
+    @WithClasses({ DefaultValueMappingMethodMapper.class })
+    public void testDefaultHandlerCalled() {
+        DefaultValueMappingMethodMapper.TargetType result = DefaultValueMappingMethodMapper.INSTANCE.map(
+            DefaultValueMappingMethodMapper.SourceType.B );
+
+        assertThat( result ).isEqualTo( DefaultValueMappingMethodMapper.TargetType.Y );
+        assertThat( DefaultValueMappingMethodMapper.INVOKE_LIST ).contains( "defaultHandlerWithReturn" );
+        DefaultValueMappingMethodMapper.INVOKE_LIST.clear();
+    }
+
+    @ProcessorTest
+    @WithClasses({ DefaultValueMappingMethodMapper.class })
+    public void testDefaultHandlerCalledNoReturn() {
+        DefaultValueMappingMethodMapper.TargetType result = DefaultValueMappingMethodMapper.INSTANCE.mapNoReturn(
+            DefaultValueMappingMethodMapper.SourceType.C );
+
+        assertThat( result ).isEqualTo( DefaultValueMappingMethodMapper.TargetType.Z );
+        assertThat( DefaultValueMappingMethodMapper.INVOKE_LIST ).contains( "defaultHandlerNoReturn" );
+        DefaultValueMappingMethodMapper.INVOKE_LIST.clear();
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/qualifier/DefaultValueMappingMethodMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/value/qualifier/DefaultValueMappingMethodMapperImpl.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.value.qualifier;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2025-05-21T15:20:53+0800",
+    comments = "version: , compiler: Eclipse JDT (Batch) 3.20.0.v20191203-2131, environment: Java 23.0.2 (Homebrew)"
+)
+public class DefaultValueMappingMethodMapperImpl implements DefaultValueMappingMethodMapper {
+
+    @Override
+    public DefaultValueMappingMethodMapper.TargetType map(DefaultValueMappingMethodMapper.SourceType source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        DefaultValueMappingMethodMapper.TargetType targetType;
+
+        switch ( source ) {
+            case A: targetType = DefaultValueMappingMethodMapper.TargetType.X;
+            break;
+            default: return defaultHandler( source );
+        }
+
+        return targetType;
+    }
+
+    @Override
+    public DefaultValueMappingMethodMapper.TargetType mapNoReturn(DefaultValueMappingMethodMapper.SourceType source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        DefaultValueMappingMethodMapper.TargetType targetType;
+
+        switch ( source ) {
+            case A: targetType = DefaultValueMappingMethodMapper.TargetType.X;
+            break;
+            default:
+            defaultHandlerNoReturn( source );
+            targetType = DefaultValueMappingMethodMapper.TargetType.Z;
+        }
+
+        return targetType;
+    }
+}


### PR DESCRIPTION
close: https://github.com/mapstruct/mapstruct/issues/3831

I added `qualifiedBy `and `qualifiedByName `to `@ValueMapping`.

`MappingResolverImpl#getTargetAssignment` cannot handle this situation because the scenario of inserting method for `switch-default` branch is similar to `LifecycleMethod`, not `MappingMethod`, so `DefaultValueMappingMethodResolver` is added to handle collection methods. It is very similar to `LifecycleMethodResolver`.

plz review. @filiphr 