### PR TITLE
fix: methods contained in @Context classes don't support generics

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MethodRetrievalProcessor.java
@@ -201,8 +201,7 @@ public class MethodRetrievalProcessor implements ModelElementProcessor<Void, Lis
                         typeFactory.getType( mapper ),
                         mapperToImplement,
                         mapperOptions,
-                        prototypeMethods
-                    ) );
+                        prototypeMethods ) );
                 }
                 else {
                     messager.printMessage(

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/BaseMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/BaseMapper.java
@@ -1,0 +1,12 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3711;
+
+import org.mapstruct.Context;
+
+interface BaseMapper<T, E> {
+    E toEntity(T s, @Context JpaContext<E> ctx);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/Issue3711Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/Issue3711Test.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3711;
+
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses({
+    ParentEntity.class,
+    ParentDto.class,
+    JpaContext.class,
+    SourceTargetMapper.class,
+    BaseMapper.class,
+})
+public class Issue3711Test {
+    @ProcessorTest
+    public void shouldGenerateContextMethod() {
+        JpaContext<ParentEntity> jpaContext = new JpaContext<>();
+        SourceTargetMapper.INSTANCE.toEntity( new ParentDto(), jpaContext );
+
+        assertThat( jpaContext.getInvokeMethods() )
+            .containsExactly( "beforeMapping", "afterMapping" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/Issue3711Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/Issue3711Test.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct.ap.test.bugs._3711;
 
+import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
 
@@ -17,13 +18,14 @@ import static org.assertj.core.api.Assertions.assertThat;
     SourceTargetMapper.class,
     BaseMapper.class,
 })
-public class Issue3711Test {
+@IssueKey("3711")
+class Issue3711Test {
     @ProcessorTest
-    public void shouldGenerateContextMethod() {
+    void shouldGenerateContextMethod() {
         JpaContext<ParentEntity> jpaContext = new JpaContext<>();
         SourceTargetMapper.INSTANCE.toEntity( new ParentDto(), jpaContext );
 
-        assertThat( jpaContext.getInvokeMethods() )
+        assertThat( jpaContext.getInvokedMethods() )
             .containsExactly( "beforeMapping", "afterMapping" );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/JpaContext.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/JpaContext.java
@@ -13,19 +13,19 @@ import org.mapstruct.BeforeMapping;
 import org.mapstruct.MappingTarget;
 
 public class JpaContext<T> {
-    private List<String> invokeMethods = new ArrayList<>();
+    private final List<String> invokedMethods = new ArrayList<>();
 
     @BeforeMapping
     void beforeMapping(@MappingTarget T parentEntity) {
-        invokeMethods.add( "beforeMapping" );
+        invokedMethods.add( "beforeMapping" );
     }
 
     @AfterMapping
     void afterMapping(@MappingTarget T parentEntity) {
-        invokeMethods.add( "afterMapping" );
+        invokedMethods.add( "afterMapping" );
     }
 
-    public List<String> getInvokeMethods() {
-        return invokeMethods;
+    public List<String> getInvokedMethods() {
+        return invokedMethods;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/JpaContext.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/JpaContext.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3711;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.mapstruct.AfterMapping;
+import org.mapstruct.BeforeMapping;
+import org.mapstruct.MappingTarget;
+
+public class JpaContext<T> {
+    private List<String> invokeMethods = new ArrayList<>();
+
+    @BeforeMapping
+    void beforeMapping(@MappingTarget T parentEntity) {
+        invokeMethods.add( "beforeMapping" );
+    }
+
+    @AfterMapping
+    void afterMapping(@MappingTarget T parentEntity) {
+        invokeMethods.add( "afterMapping" );
+    }
+
+    public List<String> getInvokeMethods() {
+        return invokeMethods;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/ParentDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/ParentDto.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3711;
+
+public class ParentDto {
+    String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/ParentDto.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/ParentDto.java
@@ -6,7 +6,7 @@
 package org.mapstruct.ap.test.bugs._3711;
 
 public class ParentDto {
-    String value;
+    private String value;
 
     public String getValue() {
         return value;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/ParentEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/ParentEntity.java
@@ -6,7 +6,7 @@
 package org.mapstruct.ap.test.bugs._3711;
 
 public class ParentEntity {
-    String value;
+    private String value;
 
     public String getValue() {
         return value;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/ParentEntity.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/ParentEntity.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3711;
+
+public class ParentEntity {
+    String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/SourceTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3711/SourceTargetMapper.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3711;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface SourceTargetMapper extends BaseMapper<ParentDto, ParentEntity> {
+    SourceTargetMapper INSTANCE = Mappers.getMapper( SourceTargetMapper.class );
+
+    ParentEntity toDTO(ParentDto dto);
+}


### PR DESCRIPTION
fix: https://github.com/mapstruct/mapstruct/issues/3711

The bug is caused by not handling generics properly when generating context methods