### PR TITLE
fix: inherit config should be automatically selected based on method inheritance

### DIFF
--- a/core/src/main/java/org/mapstruct/InheritConfiguration.java
+++ b/core/src/main/java/org/mapstruct/InheritConfiguration.java
@@ -15,6 +15,11 @@ import java.lang.annotation.Target;
  * from another mapping method (declared on the same mapper type) or prototype method (declared on a mapper config class
  * referenced via {@link Mapper#config()}) to the annotated method as well.
  * <p>
+ * If multiple candidate methods are obtained based on the source type and target type matching,
+ * and there is an inheritance relationship between them,
+ * the most specific method (leaf node of the inheritance tree) will be selected.
+ * If there are still multiple candidate methods after selection, it is considered ambiguous.
+ * <p>
  * If no method can be identified unambiguously as configuration source (i.e. several candidate methods with matching
  * source and target type exist), the name of the method to inherit from must be specified via {@link #name()}.
  * <p>

--- a/core/src/main/java/org/mapstruct/InheritInverseConfiguration.java
+++ b/core/src/main/java/org/mapstruct/InheritInverseConfiguration.java
@@ -16,11 +16,15 @@ import java.lang.annotation.Target;
  * type or indicated through a parameter annotated with {@link MappingTarget}) and the annotated method's target type as
  * source type.
  * <p>
+ * If multiple candidate methods are obtained based on the source type and target type matching,
+ * and there is an inheritance relationship between them,
+ * the most specific method (leaf node of the inheritance tree) will be selected.
+ * If there are still multiple candidate methods after selection,
+ * the name of the method to inherit the configuration from must be specified via {@link #name()}
+ * <p>
  * Any mappings given on the annotated method itself are added to those mappings inherited from the inverse method. In
  * case of a conflict local mappings take precedence over inherited mappings.
  * <p>
- * If more than one matching inverse method exists, the name of the method to inherit the configuration from must be
- * specified via {@link #name()}
  * <p>
  * {@link Mapping#expression()}, {@link Mapping#constant()}, {@link Mapping#defaultExpression()} and
  * {@link Mapping#defaultValue()} are not inverse inherited

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/SourceMethod.java
@@ -67,6 +67,9 @@ public class SourceMethod implements Method {
     private List<SourceMethod> applicablePrototypeMethods;
     private List<SourceMethod> applicableReversePrototypeMethods;
 
+    private SourceMethod forwardInheritedFromMethod;
+    private SourceMethod inverseInheritedFromMethod;
+
     private Boolean isValueMapping;
     private Boolean isIterableMapping;
     private Boolean isMapMapping;
@@ -611,5 +614,17 @@ public class SourceMethod implements Method {
                 .collect( Collectors.joining( ", " ) );
             return getResultType().describe() + " " + mapper + getName() + "(" + sourceTypes + ")";
         }
+    }
+
+    public void setForwardInheritedFromMethod(SourceMethod sourceMethod) {
+        this.forwardInheritedFromMethod = sourceMethod;
+    }
+
+    public void setInverseInheritedFromMethod(SourceMethod sourceMethod) {
+        this.inverseInheritedFromMethod = sourceMethod;
+    }
+
+    public SourceMethod getInheritedFromMethod(boolean isInverse) {
+        return isInverse ? forwardInheritedFromMethod : inverseInheritedFromMethod;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3611/Issue3611Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3611/Issue3611Mapper.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3611;
+
+import org.mapstruct.InheritInverseConfiguration;
+import org.mapstruct.Mapper;
+import org.mapstruct.MapperConfig;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingInheritanceStrategy;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(config = Issue3611Mapper.MapstructConfig.class)
+public interface Issue3611Mapper {
+    Issue3611Mapper INSTANCE = Mappers.getMapper( Issue3611Mapper.class );
+
+    @Mapping(source = "sourceAttribute", target = "targetAttribute")
+    Target convert(Source source);
+
+    @InheritInverseConfiguration
+    Source inverseConvert(Target target);
+
+    class BaseClass {
+        private String type;
+        private String baseAttribute;
+
+        public BaseClass() {
+        }
+
+        public BaseClass(String type, String baseAttribute) {
+            this.type = type;
+            this.baseAttribute = baseAttribute;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public String getBaseAttribute() {
+            return baseAttribute;
+        }
+
+        public void setBaseAttribute(String baseAttribute) {
+            this.baseAttribute = baseAttribute;
+        }
+    }
+
+    class Source extends BaseClass {
+        private String sourceAttribute;
+
+        public Source(String type, String baseAttribute, String sourceAttribute) {
+            super( type, baseAttribute );
+            this.sourceAttribute = sourceAttribute;
+        }
+
+        public String getSourceAttribute() {
+            return sourceAttribute;
+        }
+
+        public void setSourceAttribute(String sourceAttribute) {
+            this.sourceAttribute = sourceAttribute;
+        }
+    }
+
+    class Target extends BaseClass {
+        private String targetAttribute;
+
+        public Target(String type, String baseAttribute, String targetAttribute) {
+            super( type, baseAttribute );
+            this.targetAttribute = targetAttribute;
+        }
+
+        public String getTargetAttribute() {
+            return targetAttribute;
+        }
+
+        public void setTargetAttribute(String targetAttribute) {
+            this.targetAttribute = targetAttribute;
+        }
+    }
+
+    @MapperConfig(
+        unmappedTargetPolicy = ReportingPolicy.ERROR,
+        mappingInheritanceStrategy = MappingInheritanceStrategy.AUTO_INHERIT_FROM_CONFIG
+    )
+    interface MapstructConfig {
+
+        @Mapping(target = "type", ignore = true)
+        BaseClass convert(BaseClass dto);
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3611/Issue3611Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3611/Issue3611Test.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3611;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("3611")
+@WithClasses({
+    Issue3611Mapper.class
+})
+public class Issue3611Test {
+
+    @ProcessorTest
+    public void shouldInverseConvert() {
+        Issue3611Mapper.Target target = new Issue3611Mapper.Target( "type", "baseAttribute", "sourceAttribute" );
+
+        Issue3611Mapper.Source source = Issue3611Mapper.INSTANCE.inverseConvert( target );
+
+        assertThat( source ).isNotNull();
+        assertThat( source.getType() ).isNull();
+        assertThat( source.getBaseAttribute() ).isEqualTo( "baseAttribute" );
+        assertThat( source.getSourceAttribute() ).isEqualTo( "sourceAttribute" );
+    }
+}


### PR DESCRIPTION
fix: https://github.com/mapstruct/mapstruct/issues/3611

for `@InheritInverseConfiguration` or `@InheritConfiguration`, if multiple candidate methods are obtained based on the source type and target type matching, and there is an inheritance relationship between them, the most specific method (leaf node of the inheritance tree) will be selected. 

If there are still multiple candidate methods after selection, it is considered ambiguous.