### PR TITLE
#3908: Add similar suggestion for unknown property in @Ignored

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -1284,6 +1284,9 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                     Message msg;
                     String[] args;
 
+                    Set<String> readAccessors = resultTypeToMap.getPropertyReadAccessors().keySet();
+                    String mostSimilarProperty = Strings.getMostSimilarWord( targetPropertyName, readAccessors );
+
                     Element elementForMessage = mapping.getElement();
                     if ( elementForMessage == null ) {
                         elementForMessage = method.getExecutable();
@@ -1293,13 +1296,11 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                         msg = Message.BEANMAPPING_UNKNOWN_PROPERTY_IN_IGNORED;
                         args = new String[] {
                             targetPropertyName,
-                            resultTypeToMap.describe()
+                            resultTypeToMap.describe(),
+                            mostSimilarProperty
                         };
                     }
                     else {
-                        Set<String> readAccessors = resultTypeToMap.getPropertyReadAccessors().keySet();
-                        String mostSimilarProperty = Strings.getMostSimilarWord( targetPropertyName, readAccessors );
-
                         if ( targetRef.getPathProperties().isEmpty() ) {
                             msg = Message.BEANMAPPING_UNKNOWN_PROPERTY_IN_RESULTTYPE;
                             args = new String[] {
@@ -1321,12 +1322,13 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                         }
                     }
 
-                    ctx.getMessager().printMessage(
-                        elementForMessage,
-                        mapping.getMirror(),
-                        mapping.getTargetAnnotationValue(),
-                        msg,
-                        args
+                    ctx.getMessager()
+                        .printMessage(
+                            elementForMessage,
+                            mapping.getMirror(),
+                            mapping.getTargetAnnotationValue(),
+                            msg,
+                            args
                     );
                     return true;
                 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -45,7 +45,7 @@ public enum Message {
     BEANMAPPING_CYCLE_BETWEEN_PROPERTIES( "Cycle(s) between properties given via dependsOn(): %s." ),
     BEANMAPPING_UNKNOWN_PROPERTY_IN_DEPENDS_ON( "\"%s\" is no property of the method return type." ),
     BEANMAPPING_IGNORE_BY_DEFAULT_WITH_MAPPING_TARGET_THIS( "Using @BeanMapping( ignoreByDefault = true ) with @Mapping( target = \".\", ... ) is not allowed. You'll need to explicitly ignore the target properties that should be ignored instead." ),
-    BEANMAPPING_UNKNOWN_PROPERTY_IN_IGNORED("No property named \"%s\" exists in @Ignored for target type \"%s\""),
+    BEANMAPPING_UNKNOWN_PROPERTY_IN_IGNORED("No property named \"%s\" exists in @Ignored for target type \"%s\". Did you mean \"%s\"?"),
 
     CONDITION_MISSING_APPLIES_TO_STRATEGY("'appliesTo' has to have at least one value in @Condition" ),
     CONDITION_SOURCE_PARAMETERS_INVALID_PARAMETER("Parameter \"%s\" cannot be used with the ConditionStrategy#SOURCE_PARAMETERS. Only source and @Context parameters are allowed for conditions applicable to source parameters." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3902/ErroneousIssue3902Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3902/ErroneousIssue3902Mapper.java
@@ -25,6 +25,9 @@ public interface ErroneousIssue3902Mapper {
     @Ignored(targets = {"name", "address", "foo"})
     ZooDto mapWithMultipleKnownAndOneUnknown(Zoo source);
 
+    @Ignored(targets = {"name", "addres"})
+    ZooDto mapWithTypo(Zoo source);
+
     class Zoo {
         private String name;
         private String address;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3902/Issue3902Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3902/Issue3902Test.java
@@ -32,14 +32,14 @@ public class Issue3902Test {
                             kind = javax.tools.Diagnostic.Kind.ERROR,
                             line = 23,
                             message = "No property named \"foo\" exists in @Ignored for target type " +
-                                    "\"ErroneousIssue3902Mapper.ZooDto\""
+                                    "\"ErroneousIssue3902Mapper.ZooDto\". Did you mean \"name\"?"
                     ),
                     @Diagnostic(
                             type = ErroneousIssue3902Mapper.class,
                             kind = javax.tools.Diagnostic.Kind.ERROR,
                             line = 23,
                             message = "No property named \"bar\" exists in @Ignored for target type " +
-                                    "\"ErroneousIssue3902Mapper.ZooDto\""
+                                    "\"ErroneousIssue3902Mapper.ZooDto\". Did you mean \"name\"?"
                     ),
 
                     // Test case: mapWithMultipleKnownAndOneUnknown
@@ -48,7 +48,16 @@ public class Issue3902Test {
                             kind = javax.tools.Diagnostic.Kind.ERROR,
                             line = 26,
                             message = "No property named \"foo\" exists in @Ignored for target type " +
-                                    "\"ErroneousIssue3902Mapper.ZooDto\""
+                                    "\"ErroneousIssue3902Mapper.ZooDto\". Did you mean \"name\"?"
+                    ),
+
+                    // Test case: mapWithTypo
+                    @Diagnostic(
+                            type = ErroneousIssue3902Mapper.class,
+                            kind = javax.tools.Diagnostic.Kind.ERROR,
+                            line = 29,
+                            message = "No property named \"addres\" exists in @Ignored for target type "
+                                    + "\"ErroneousIssue3902Mapper.ZooDto\". Did you mean \"address\"?"
                     )
             }
     )


### PR DESCRIPTION
### Summary
fix #3908 (follow up#3902) add `mostSimilarProperty` message 
Ex) No property named "foo" exists in @Ignored for target type "ErroneousIssue3902Mapper.ZooDto" Did you mean "name"?

The implementation refactors the `handleDefinedMapping` method to reuse the existing `getMostSimilarWord` logic for the `@Ignored` case.

Test cases have been updated and expanded to verify that the suggestions are working correctly, especially for typos.