### PR TITLE
skip coverage upload to codecov on contributors repositories

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         if: matrix.java == 21
         run: ./mvnw jacoco:report
       - name: 'Upload coverage to Codecov'
-        if: matrix.java == 21
+        if: matrix.java == 21 && github.repository == 'mapstruct/mapstruct'
         uses: codecov/codecov-action@v2
       - name: 'Publish Snapshots'
         if: matrix.java == 21 && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'mapstruct/mapstruct'


### PR DESCRIPTION
Like in mapstruct/mapstruct-idea#252, upload coverage to codecov is failing from contributors repositories, see [https://github.com/hduelme/mapstruct/actions/runs/20571229857/job/59078754665](https://github.com/hduelme/mapstruct/actions/runs/20571229857/job/59078754665), with _429  - Rate limit reached_.

I disabled the upload for  contributors repositories, see [https://github.com/hduelme/mapstruct/actions/runs/20622913081/job/59228250813](https://github.com/hduelme/mapstruct/actions/runs/20622913081/job/59228250813)

To ensure correct upload the action should be updated and a token should be added [https://docs.codecov.com/docs/adding-the-codecov-token#github-actions](https://docs.codecov.com/docs/adding-the-codecov-token#github-actions). In addition the `fail_ci_if_error` flag could be set.