### PR TITLE
update codecov-action to v5 and use token

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,7 +30,10 @@ jobs:
         run: ./mvnw jacoco:report
       - name: 'Upload coverage to Codecov'
         if: matrix.java == 21 && github.repository == 'mapstruct/mapstruct'
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
       - name: 'Publish Snapshots'
         if: matrix.java == 21 && github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'mapstruct/mapstruct'
         run: ./mvnw -s etc/ci-settings.xml -DskipTests=true -DskipDistribution=true deploy


### PR DESCRIPTION
As mentioned in #3966, I updated the `codecov/codecov-action` to the newest version v5 and added the token and the `fail_ci_if_error` flag.