### PR TITLE
Add test case for property named default

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/kotlin/data/DefaultProperty.kt
+++ b/processor/src/test/java/org/mapstruct/ap/test/kotlin/data/DefaultProperty.kt
@@ -1,0 +1,16 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.kotlin.data
+
+/**
+ * @author Filip Hrisafov
+ */
+data class DefaultPropertySource(val default: Boolean, val identifier: String?)
+
+class DefaultPropertyTarget(
+    var default: Boolean,
+    var identifier: String?
+)

--- a/processor/src/test/java/org/mapstruct/ap/test/kotlin/data/DefaultPropertyMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/kotlin/data/DefaultPropertyMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.kotlin.data;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Filip Hrisafov
+ */
+@Mapper
+public interface DefaultPropertyMapper {
+
+    DefaultPropertyMapper INSTANCE = Mappers.getMapper( DefaultPropertyMapper.class );
+
+    DefaultPropertyTarget map(DefaultPropertySource source);
+
+    DefaultPropertySource map(DefaultPropertyTarget target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/kotlin/data/KotlinDataTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/kotlin/data/KotlinDataTest.java
@@ -469,4 +469,53 @@ class KotlinDataTest {
             assertThat( source.getAge() ).isEqualTo( 20 );
         }
     }
+
+    @Nested
+    @WithClasses({
+        DefaultPropertyMapper.class,
+    })
+    @WithKotlinSources("DefaultProperty.kt")
+    class Default {
+
+        @ProcessorTest
+        @WithKotlin
+        void shouldCompileWithoutWarnings() {
+
+            DefaultPropertyTarget target = DefaultPropertyMapper.INSTANCE.map( new DefaultPropertySource(
+                true,
+                "test"
+            ) );
+            assertThat( target ).isNotNull();
+            assertThat( target.getDefault() ).isTrue();
+            assertThat( target.getIdentifier() ).isEqualTo( "test" );
+
+            DefaultPropertySource source = DefaultPropertyMapper.INSTANCE.map( new DefaultPropertyTarget(
+                false,
+                "private"
+            ) );
+            assertThat( source ).isNotNull();
+            assertThat( source.getDefault() ).isFalse();
+            assertThat( source.getIdentifier() ).isEqualTo( "private" );
+
+        }
+
+        @ProcessorTest
+        void shouldCompileWithoutKotlin() {
+            DefaultPropertyTarget target = DefaultPropertyMapper.INSTANCE.map( new DefaultPropertySource(
+                true,
+                "test"
+            ) );
+            assertThat( target ).isNotNull();
+            assertThat( target.getDefault() ).isTrue();
+            assertThat( target.getIdentifier() ).isEqualTo( "test" );
+
+            DefaultPropertySource source = DefaultPropertyMapper.INSTANCE.map( new DefaultPropertyTarget(
+                false,
+                "private"
+            ) );
+            assertThat( source ).isNotNull();
+            assertThat( source.getDefault() ).isFalse();
+            assertThat( source.getIdentifier() ).isEqualTo( "private" );
+        }
+    }
 }


### PR DESCRIPTION
This is related to #2529.

In a nutshell I could not reproduce the issue, but it's good to have the test case nevertheless.