### PR TITLE
Remove unnecessary keySet() invocation

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedTargetPropertyMappingHolder.java
@@ -151,8 +151,7 @@ public class NestedTargetPropertyMappingHolder {
                     entryByTP.getValue(),
                     groupedByTP.singleTargetReferences.get( targetProperty )
                 );
-                boolean multipleSourceParametersForTP =
-                    groupedBySourceParam.groupedBySourceParameter.keySet().size() > 1;
+                boolean multipleSourceParametersForTP = groupedBySourceParam.groupedBySourceParameter.size() > 1;
 
                 // All not processed mappings that should have been applied to all are part of the unprocessed
                 // defined targets


### PR DESCRIPTION
The size of the `keySet` is always equal to the size of the map, so the call to `keySet() `can be skipped.