### PR TITLE
improve performance of Type.describe() by removing regex matching

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -1331,7 +1331,7 @@ public class Type extends ModelElement implements Comparable<Type> {
         }
         else {
             // name allows for inner classes
-            String name = getFullyQualifiedName().replaceFirst( "^" + getPackageName() + ".", "" );
+            String name = getNameKeepingInnerClasses();
             List<Type> typeParams = getTypeParameters();
             if ( typeParams.isEmpty() ) {
                 return name;
@@ -1341,6 +1341,15 @@ public class Type extends ModelElement implements Comparable<Type> {
                 return String.format( "%s<%s>", name, params );
             }
         }
+    }
+
+    private String getNameKeepingInnerClasses() {
+        String packageNamePrefix = getPackageName() + ".";
+        String fullyQualifiedName = getFullyQualifiedName();
+        if (fullyQualifiedName.startsWith( packageNamePrefix ) ) {
+            return fullyQualifiedName.substring( packageNamePrefix.length() );
+        }
+        return fullyQualifiedName;
     }
 
     /**


### PR DESCRIPTION
In `Type.describe(),` the `packageName` should be removed from the beginning of the `fullyQualifiedName`.
The current implementation uses a regex for this, which results in a regex compilation on every call. In addition, the dots in the regex are not escaped, which could theoretically lead to overmatching (even though this should never happen).

I changed the implementation to remove the `packageName` if the `fullyQualifiedName` actually starts with it, by using `substring`.