### PR TITLE
fix self check in equals of Type

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -1303,8 +1303,8 @@ public class Type extends ModelElement implements Comparable<Type> {
         Type other = (Type) obj;
 
         if ( this.isWildCardBoundByTypeVar() && other.isWildCardBoundByTypeVar() ) {
-            return  ( this.hasExtendsBound() == this.hasExtendsBound()
-                || this.hasSuperBound() == this.hasSuperBound() )
+            return  ( this.hasExtendsBound() == other.hasExtendsBound()
+                || this.hasSuperBound() == other.hasSuperBound() )
                 && typeUtils.isSameType( getTypeBound().getTypeMirror(), other.getTypeBound().getTypeMirror() );
         }
         else {


### PR DESCRIPTION
While investigating #3994, I noticed that in `Type.equals`, `hasExtendsBound()` and `hasSuperBound()` are compared to themselves, which always evaluates to `true`.

As far as I can tell, equals is currently only used for `Map` comparisons. Nevertheless, this behavior seems wrong.