### PR TITLE
use StandardCharsets.UTF_8 in tests

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
@@ -10,6 +10,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -237,7 +238,7 @@ abstract class CompilingExtension implements BeforeEachCallback {
 
             int errors = checker.process( findGeneratedFiles( new File( sourceOutputDir ) ) );
             if ( errors > 0 ) {
-                String errorLog = errorStream.toString( "UTF-8" );
+                String errorLog = errorStream.toString( StandardCharsets.UTF_8 );
                 fail( "Expected checkstyle compliant output, but got errors:\n" + errorLog );
             }
         }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/GeneratedSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/GeneratedSource.java
@@ -6,9 +6,9 @@
 package org.mapstruct.ap.testutil.runner;
 
 import java.io.File;
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -119,7 +119,7 @@ public class GeneratedSource implements BeforeTestExecutionCallback, AfterTestEx
         return new JavaFileAssert( new File( sourceOutputDir.get() + "/" + path ) );
     }
 
-    private void handleFixtureComparison() throws UnsupportedEncodingException {
+    private void handleFixtureComparison() {
         for ( Class<?> fixture : fixturesFor ) {
             String fixtureName = getMapperName( fixture );
             URL expectedFile = getExpectedResource( fixtureName );
@@ -131,7 +131,7 @@ public class GeneratedSource implements BeforeTestExecutionCallback, AfterTestEx
                 ) );
             }
             else {
-                File expectedResource = new File( URLDecoder.decode( expectedFile.getFile(), "UTF-8" ) );
+                File expectedResource = new File( URLDecoder.decode( expectedFile.getFile(), StandardCharsets.UTF_8 ) );
                 forMapper( fixture ).hasSameMapperContent( expectedResource );
             }
             fixture.getPackage().getName();


### PR DESCRIPTION
Since java 1.6 is no longer supported, `StandardCharsets` can be used instead of string lookup.