### PR TITLE
Fixed primitive early return if all ref types are null

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -26,7 +26,7 @@
 
     	</#if>
     </#list>
-    <#if !mapNullToDefault && !sourcePresenceChecks.empty>
+    <#if !mapNullToDefault && sourcePresenceChecks?has_content && sourcePresenceChecks?size == sourceParameters?size>
     if ( <#list sourcePresenceChecks as sourcePresenceCheck><@includeModel object=sourcePresenceCheck.negate() /><#if sourcePresenceCheck_has_next> && </#if></#list> ) {
         <#if returnType.name == "void">
             return;

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3992/MultiSourceWithPrimitiveMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3992/MultiSourceWithPrimitiveMapper.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3992;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * @author Soumik Sarker
+ */
+@Mapper
+public interface MultiSourceWithPrimitiveMapper {
+
+    MultiSourceWithPrimitiveMapper INSTANCE = Mappers.getMapper( MultiSourceWithPrimitiveMapper.class );
+
+    Target map(String sku, String name, Long categoryId, int size, int pageNumber, boolean draft);
+
+    class Target {
+        private String sku;
+        private String name;
+        private Long categoryId;
+        private int size;
+        private int pageNumber;
+        private boolean draft;
+
+        // Getters and Setters
+        public String getSku() 
+        {
+            return sku;
+        }
+
+        public void setSku(String sku) 
+        {
+            this.sku = sku;
+        }
+
+        public String getName() 
+        {
+            return name;
+        }
+
+        public void setName(String name) 
+        {
+            this.name = name;
+        }
+
+        public Long getCategoryId() 
+        {
+            return categoryId;
+        }
+
+        public void setCategoryId(Long categoryId) 
+        {
+            this.categoryId = categoryId;
+        }
+
+        public int getSize()
+        {
+            return size;
+        }
+
+        public void setSize(int size) 
+        {
+            this.size = size;
+        }
+
+        public int getPageNumber() 
+        {
+            return pageNumber;
+        }
+
+        public void setPageNumber(int pageNumber) 
+        {
+            this.pageNumber = pageNumber;
+        }
+
+        public boolean isDraft() 
+        {
+            return draft;
+        }
+
+        public void setDraft(boolean draft) 
+        {
+            this.draft = draft;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3992/MultiSourceWithPrimitiveMapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3992/MultiSourceWithPrimitiveMapperTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3992;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for primitive parameters when generating early return
+ *
+ * @author Soumik Sarker
+ */
+public class MultiSourceWithPrimitiveMapperTest {
+
+    @IssueKey("3992")
+    @ProcessorTest
+    @WithClasses({
+        MultiSourceWithPrimitiveMapper.class
+    })
+    void shouldMapPrimitivesEvenIfAllReferenceParametersAreNull() {
+        MultiSourceWithPrimitiveMapper.Target target = MultiSourceWithPrimitiveMapper.INSTANCE.map(
+            null, null, null, 10, 2, true
+        );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getSku() ).isNull();
+        assertThat( target.getName() ).isNull();
+        assertThat( target.getCategoryId() ).isNull();
+        assertThat( target.getSize() ).isEqualTo( 10 );
+        assertThat( target.getPageNumber() ).isEqualTo( 2 );
+        assertThat( target.isDraft() ).isTrue();
+    }
+}


### PR DESCRIPTION
fixes #3992 
Updated the check in the ftl file to only generate an early return-null block if every single parameter is subject to a null check. If there are parameters that don't need null checks (like primitives), keep going and map them.