### PR TITLE
upgrade Visitor6 to Visitor8

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
@@ -30,7 +30,7 @@ import javax.lang.model.element.Name;
 import javax.lang.model.element.QualifiedNameable;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.ElementKindVisitor6;
+import javax.lang.model.util.ElementKindVisitor8;
 import javax.tools.Diagnostic.Kind;
 
 import org.mapstruct.ap.internal.gem.MapperGem;
@@ -402,7 +402,7 @@ public class MappingProcessor extends AbstractProcessor {
 
     private TypeElement asTypeElement(Element element) {
         return element.accept(
-            new ElementKindVisitor6<TypeElement, Void>() {
+            new ElementKindVisitor8<TypeElement, Void>() {
                 @Override
                 public TypeElement visitTypeAsInterface(TypeElement e, Void p) {
                     return e;

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/AccessorNamingUtils.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/AccessorNamingUtils.java
@@ -10,8 +10,8 @@ import javax.lang.model.element.TypeElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
-import javax.lang.model.util.SimpleElementVisitor6;
-import javax.lang.model.util.SimpleTypeVisitor6;
+import javax.lang.model.util.SimpleElementVisitor8;
+import javax.lang.model.util.SimpleTypeVisitor8;
 
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.AccessorType;
@@ -84,7 +84,7 @@ public final class AccessorNamingUtils {
 
     private static String getQualifiedName(TypeMirror type) {
         DeclaredType declaredType = type.accept(
-            new SimpleTypeVisitor6<DeclaredType, Void>() {
+            new SimpleTypeVisitor8<DeclaredType, Void>() {
                 @Override
                 public DeclaredType visitDeclared(DeclaredType t, Void p) {
                     return t;
@@ -98,7 +98,7 @@ public final class AccessorNamingUtils {
         }
 
         TypeElement typeElement = declaredType.asElement().accept(
-            new SimpleElementVisitor6<TypeElement, Void>() {
+            new SimpleElementVisitor8<TypeElement, Void>() {
                 @Override
                 public TypeElement visitType(TypeElement e, Void p) {
                     return e;

--- a/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
@@ -14,8 +14,8 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
-import javax.lang.model.util.SimpleElementVisitor6;
-import javax.lang.model.util.SimpleTypeVisitor6;
+import javax.lang.model.util.SimpleElementVisitor8;
+import javax.lang.model.util.SimpleTypeVisitor8;
 import javax.lang.model.util.Types;
 
 import kotlin.Metadata;
@@ -273,7 +273,7 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
      */
     protected static String getQualifiedName(TypeMirror type) {
         DeclaredType declaredType = type.accept(
-            new SimpleTypeVisitor6<DeclaredType, Void>() {
+            new SimpleTypeVisitor8<DeclaredType, Void>() {
                 @Override
                 public DeclaredType visitDeclared(DeclaredType t, Void p) {
                     return t;
@@ -287,7 +287,7 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
         }
 
         TypeElement typeElement = declaredType.asElement().accept(
-            new SimpleElementVisitor6<TypeElement, Void>() {
+            new SimpleElementVisitor8<TypeElement, Void>() {
                 @Override
                 public TypeElement visitType(TypeElement e, Void p) {
                     return e;

--- a/processor/src/main/java/org/mapstruct/ap/spi/DefaultBuilderProvider.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/DefaultBuilderProvider.java
@@ -21,8 +21,8 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.ElementFilter;
 import javax.lang.model.util.Elements;
-import javax.lang.model.util.SimpleElementVisitor6;
-import javax.lang.model.util.SimpleTypeVisitor6;
+import javax.lang.model.util.SimpleElementVisitor8;
+import javax.lang.model.util.SimpleTypeVisitor8;
 import javax.lang.model.util.Types;
 
 /**
@@ -126,7 +126,7 @@ public class DefaultBuilderProvider implements BuilderProvider {
         }
 
         return declaredType.asElement().accept(
-            new SimpleElementVisitor6<TypeElement, Void>() {
+            new SimpleElementVisitor8<TypeElement, Void>() {
                 @Override
                 public TypeElement visitType(TypeElement e, Void p) {
                     return e;
@@ -148,7 +148,7 @@ public class DefaultBuilderProvider implements BuilderProvider {
             throw new TypeHierarchyErroneousException( type );
         }
         return type.accept(
-            new SimpleTypeVisitor6<DeclaredType, Void>() {
+            new SimpleTypeVisitor8<DeclaredType, Void>() {
                 @Override
                 public DeclaredType visitDeclared(DeclaredType t, Void p) {
                     return t;


### PR DESCRIPTION
`*Visitor6` are deprecated. Since java 1.6 is no longer supported, they can be upgraded to java 1.8 `*Visitor8`