### PR TITLE
upgrade freemarker to 2.3.34

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -119,7 +119,7 @@
             <dependency>
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
-                <version>2.3.32</version>
+                <version>2.3.34</version>
             </dependency>
             <dependency>
                 <groupId>org.assertj</groupId>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/Annotation.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/Annotation.ftl
@@ -7,12 +7,10 @@
 -->
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.Annotation" -->
 <#switch properties?size>
-    <#case 0>
+    <#on 0>
         @<@includeModel object=type/><#rt>
-    <#break>
-    <#case 1>
+    <#on 1>
         @<@includeModel object=type/>(<@includeModel object=properties[0]/>)<#rt>
-    <#break>
     <#default>
         @<@includeModel object=type/>(
             <#list properties as property>


### PR DESCRIPTION
I upgrade freemarker to the latest version 2.3.34.
In version [2.3.34.](https://freemarker.apache.org/docs/versions_2_3_34.html) the new on syntax was introduced ([freemarker PR-144](https://github.com/apache/freemarker/pull/114)). I applied the new syntax to `Annotation.ftl`.