### PR TITLE
remove deprecated Number api usage from tests

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/test/selection/twosteperror/ErroneousMapperMC.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/selection/twosteperror/ErroneousMapperMC.java
@@ -22,7 +22,7 @@ public interface ErroneousMapperMC {
     }
 
     default Double methodX2(SourceType s) {
-        return new Double( s.t1 );
+        return Double.valueOf( s.t1 );
     }
 
     // CHECKSTYLE:OFF

--- a/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceConstantsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/constants/SourceConstantsTest.java
@@ -47,7 +47,7 @@ public class SourceConstantsTest {
         assertThat( target.getStringConstant() ).isEqualTo( "stringConstant" );
         assertThat( target.getEmptyStringConstant() ).isEqualTo( "" );
         assertThat( target.getIntegerConstant() ).isEqualTo( 14 );
-        assertThat( target.getLongWrapperConstant() ).isEqualTo( new Long( 3001L ) );
+        assertThat( target.getLongWrapperConstant() ).isEqualTo( Long.valueOf( 3001L ) );
         assertThat( target.getDateConstant() ).isEqualTo( getDate( "dd-MM-yyyy", "09-01-2014" ) );
         assertThat( target.getNameConstants() ).isEqualTo( Arrays.asList( "jack", "jill", "tom" ) );
         assertThat( target.getCountry() ).isEqualTo( CountryEnum.THE_NETHERLANDS );


### PR DESCRIPTION
Using the constructor of any number type is deprecated and results in a compilation warning.