### PR TITLE
#2436 Apply defaultValue/defaultExpression when a source parameter is null

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -55,6 +55,8 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.model.dependency.GraphAnalyzer;
 import org.mapstruct.ap.internal.model.dependency.GraphAnalyzer.GraphAnalyzerBuilder;
+import org.mapstruct.ap.internal.model.presence.NullPresenceCheck;
+import org.mapstruct.ap.internal.model.presence.OptionalPresenceCheck;
 import org.mapstruct.ap.internal.model.source.BeanMappingOptions;
 import org.mapstruct.ap.internal.model.source.MappingOptions;
 import org.mapstruct.ap.internal.model.source.Method;
@@ -2332,6 +2334,22 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
 
     public PresenceCheck getPresenceCheckByParameter(Parameter parameter) {
         return presenceChecksByParameter.get( parameter.getName() );
+    }
+
+    /**
+     * Returns {@code true} if the presence check for the given parameter is a built-in
+     * null or optional presence check, as opposed to a custom
+     * {@link org.mapstruct.SourceParameterCondition} method. A custom condition can reject a non-null parameter
+     * for application-specific reasons, which must not be treated as a null source that triggers a default value.
+     * Used by the template to decide whether to generate a default value fallback
+     * in the else branch of the parameter presence check.
+     *
+     * @param parameter the source parameter
+     * @return {@code true} for built-in null/optional checks, {@code false} for custom condition methods
+     */
+    public boolean isBuiltInPresenceCheckByParameter(Parameter parameter) {
+        PresenceCheck check = getPresenceCheckByParameter( parameter );
+        return check instanceof NullPresenceCheck || check instanceof OptionalPresenceCheck;
     }
 
     public List<Parameter> getSourceParametersNeedingPresenceCheck() {

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -69,6 +69,11 @@
                             <@includeModel object=propertyMapping existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
                         </#list>
                         }
+                        <#if isBuiltInPresenceCheckByParameter(sourceParam)>
+                            <@renderDefaultValueFallback
+                                propertyMappings=constructorPropertyMappingsByParameter(sourceParam)
+                                existingInstanceMapping=existingInstanceMapping/>
+                        </#if>
                     </#if>
                 </#list>
                 <#list sourceParametersNotNeedingPresenceCheck as sourceParam>
@@ -94,6 +99,11 @@
                 </#list>
                 <#if mapNullToDefault>
                     }
+                    <#if isBuiltInPresenceCheckByParameter(sourceParameters[0])>
+                        <@renderDefaultValueFallback
+                            propertyMappings=constructorPropertyMappingsByParameter(sourceParameters[0])
+                            existingInstanceMapping=existingInstanceMapping/>
+                    </#if>
                 </#if>
             </#if>
             <#list constructorConstantMappings as constantMapping>
@@ -129,6 +139,12 @@
                         <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
                     </#list>
                 }
+                <#if !existingInstanceMapping && isBuiltInPresenceCheckByParameter(sourceParam)>
+                    <@renderDefaultValueFallback
+                        propertyMappings=propertyMappingsByParameter(sourceParam)
+                        targetBeanName=resultName
+                        existingInstanceMapping=existingInstanceMapping/>
+                </#if>
             </#if>
         </#list>
         <#list sourceParametersNotNeedingPresenceCheck as sourceParam>
@@ -149,6 +165,12 @@
             <@includeModel object=propertyMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping defaultValueAssignment=propertyMapping.defaultValueAssignment/>
         </#list>
         <#if mapNullToDefault>}</#if>
+        <#if mapNullToDefault && !existingInstanceMapping && isBuiltInPresenceCheckByParameter(sourceParameters[0])>
+            <@renderDefaultValueFallback
+                propertyMappings=propertyMappingsByParameter(sourceParameters[0])
+                targetBeanName=resultName
+                existingInstanceMapping=existingInstanceMapping/>
+        </#if>
     </#if>
     <#list constantMappings as constantMapping>
          <@includeModel object=constantMapping targetBeanName=resultName existingInstanceMapping=existingInstanceMapping/>
@@ -215,4 +237,28 @@
         </#if>
 <#--    </@compress>-->
 
+</#macro>
+<#macro renderDefaultValueFallback propertyMappings targetBeanName="" existingInstanceMapping=false>
+    <#local hasDefaultValueAssignment = false>
+    <#list propertyMappings as propertyMapping>
+        <#if propertyMapping.defaultValueAssignment??>
+            <#local hasDefaultValueAssignment = true>
+            <#break>
+        </#if>
+    </#list>
+    <#if hasDefaultValueAssignment>
+        else {
+            <#list propertyMappings as propertyMapping>
+                <#if propertyMapping.defaultValueAssignment??>
+                    <@includeModel object=propertyMapping.defaultValueAssignment
+                        targetBeanName=targetBeanName
+                        existingInstanceMapping=existingInstanceMapping
+                        targetReadAccessorName=propertyMapping.targetReadAccessorName
+                        targetWriteAccessorName=propertyMapping.targetWriteAccessorName
+                        targetPropertyName=propertyMapping.name
+                        targetType=propertyMapping.targetType/>
+                </#if>
+            </#list>
+        }
+    </#if>
 </#macro>

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/ConstructorTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/ConstructorTarget.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+public class ConstructorTarget {
+
+    private final String property1;
+    private final String property2;
+
+    public ConstructorTarget(String property1, String property2) {
+        this.property1 = property1;
+        this.property2 = property2;
+    }
+
+    public String getProperty1() {
+        return property1;
+    }
+
+    public String getProperty2() {
+        return property2;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436ConditionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436ConditionMapper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.SourceParameterCondition;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue2436ConditionMapper {
+
+    Issue2436ConditionMapper INSTANCE = Mappers.getMapper( Issue2436ConditionMapper.class );
+
+    @Mapping(target = "property1", source = "source1.property1", defaultValue = "default1")
+    @Mapping(target = "property2", source = "source2.property2", defaultValue = "default2")
+    @Mapping(target = "property3", ignore = true)
+    Target map(Source1 source1, Source2 source2);
+
+    @SourceParameterCondition
+    default boolean isValid(Source1 source1) {
+        return source1 != null && source1.getProperty1() != null;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436ConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436ConstructorMapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue2436ConstructorMapper {
+
+    Issue2436ConstructorMapper INSTANCE = Mappers.getMapper( Issue2436ConstructorMapper.class );
+
+    @Mapping(target = "property1", source = "source1.property1", defaultValue = "default1")
+    @Mapping(target = "property2", source = "source2.property2", defaultValue = "default2")
+    ConstructorTarget map(Source1 source1, Source2 source2);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436ConstructorReturnDefaultMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436ConstructorReturnDefaultMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValueMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue2436ConstructorReturnDefaultMapper {
+
+    Issue2436ConstructorReturnDefaultMapper INSTANCE =
+        Mappers.getMapper( Issue2436ConstructorReturnDefaultMapper.class );
+
+    @BeanMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+    @Mapping(target = "property1", source = "source1.property1", defaultValue = "default1")
+    @Mapping(target = "property2", source = "source1.property1", defaultExpression = "java(\"default2\")")
+    ConstructorTarget map(Source1 source1);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436Mapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue2436Mapper {
+
+    Issue2436Mapper INSTANCE = Mappers.getMapper( Issue2436Mapper.class );
+
+    @Mapping(target = "property1", source = "source1.property1", defaultValue = "default1")
+    @Mapping(target = "property2", source = "source2.property2", defaultExpression = "java(\"default2\")")
+    @Mapping(target = "property3", source = "source1.property1")
+    Target map(Source1 source1, Source2 source2);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436OptionalMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436OptionalMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+import java.util.Optional;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValueMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue2436OptionalMapper {
+
+    Issue2436OptionalMapper INSTANCE = Mappers.getMapper( Issue2436OptionalMapper.class );
+
+    @BeanMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+    @Mapping(target = "property1", source = "source1.property1", defaultValue = "default1")
+    @Mapping(target = "property2", ignore = true)
+    @Mapping(target = "property3", ignore = true)
+    Target map(Optional<Source1> source1);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436ReturnDefaultMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436ReturnDefaultMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValueMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue2436ReturnDefaultMapper {
+
+    Issue2436ReturnDefaultMapper INSTANCE = Mappers.getMapper( Issue2436ReturnDefaultMapper.class );
+
+    @BeanMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+    @Mapping(target = "property1", source = "source1.property1", defaultValue = "default1")
+    @Mapping(target = "property2", source = "source1.property1")
+    @Mapping(target = "property3", ignore = true)
+    Target map(Source1 source1);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436Test.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+import java.util.Optional;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test for applying defaultValue / defaultExpression when a source parameter is null.
+ */
+@IssueKey("2436")
+@WithClasses({
+    Source1.class,
+    Source2.class,
+    Target.class,
+    ConstructorTarget.class
+})
+class Issue2436Test {
+
+    @ProcessorTest
+    @WithClasses(Issue2436Mapper.class)
+    void multiSourceWithFirstSourceNull() {
+        Source2 source2 = new Source2();
+        source2.setProperty2( "value2" );
+
+        Target target = Issue2436Mapper.INSTANCE.map( null, source2 );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getProperty1() ).isEqualTo( "default1" );
+        assertThat( target.getProperty2() ).isEqualTo( "value2" );
+        assertThat( target.getProperty3() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436Mapper.class)
+    void multiSourceWithSecondSourceNull() {
+        Source1 source1 = new Source1();
+        source1.setProperty1( "value1" );
+
+        Target target = Issue2436Mapper.INSTANCE.map( source1, null );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getProperty1() ).isEqualTo( "value1" );
+        assertThat( target.getProperty2() ).isEqualTo( "default2" );
+        assertThat( target.getProperty3() ).isEqualTo( "value1" );
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436Mapper.class)
+    void multiSourceWithPropertyNullKeepsPropertyLevelDefault() {
+        Source1 source1 = new Source1();
+        Source2 source2 = new Source2();
+
+        Target target = Issue2436Mapper.INSTANCE.map( source1, source2 );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getProperty1() ).isEqualTo( "default1" );
+        assertThat( target.getProperty2() ).isEqualTo( "default2" );
+        assertThat( target.getProperty3() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436Mapper.class)
+    void multiSourceWithValuesPresent() {
+        Source1 source1 = new Source1();
+        source1.setProperty1( "value1" );
+        Source2 source2 = new Source2();
+        source2.setProperty2( "value2" );
+
+        Target target = Issue2436Mapper.INSTANCE.map( source1, source2 );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getProperty1() ).isEqualTo( "value1" );
+        assertThat( target.getProperty2() ).isEqualTo( "value2" );
+        assertThat( target.getProperty3() ).isEqualTo( "value1" );
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436ConstructorMapper.class)
+    void constructorMultiSourceWithFirstSourceNull() {
+        Source2 source2 = new Source2();
+        source2.setProperty2( "value2" );
+
+        ConstructorTarget target = Issue2436ConstructorMapper.INSTANCE.map( null, source2 );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getProperty1() ).isEqualTo( "default1" );
+        assertThat( target.getProperty2() ).isEqualTo( "value2" );
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436ReturnDefaultMapper.class)
+    void singleSourceReturnDefaultWithNullSource() {
+        Target target = Issue2436ReturnDefaultMapper.INSTANCE.map( null );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getProperty1() ).isEqualTo( "default1" );
+        assertThat( target.getProperty2() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436ConditionMapper.class)
+    void conditionFalseDoesNotApplyDefault() {
+        Source1 source1 = new Source1();
+        // property1 is null, so @SourceParameterCondition returns false
+        Source2 source2 = new Source2();
+        source2.setProperty2( "value2" );
+
+        Target target = Issue2436ConditionMapper.INSTANCE.map( source1, source2 );
+
+        assertThat( target ).isNotNull();
+        // condition false → source1 mappings are skipped entirely (no default applied)
+        assertThat( target.getProperty1() ).isNull();
+        assertThat( target.getProperty2() ).isEqualTo( "value2" );
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436ConditionMapper.class)
+    void conditionTrueAppliesSourceValue() {
+        Source1 source1 = new Source1();
+        source1.setProperty1( "value1" );
+        // property1 is non-null, so @SourceParameterCondition returns true
+        Source2 source2 = new Source2();
+        source2.setProperty2( "value2" );
+
+        Target target = Issue2436ConditionMapper.INSTANCE.map( source1, source2 );
+
+        assertThat( target ).isNotNull();
+        // condition true → source1 mappings proceed normally, actual value wins over default
+        assertThat( target.getProperty1() ).isEqualTo( "value1" );
+        assertThat( target.getProperty2() ).isEqualTo( "value2" );
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436ConstructorMapper.class)
+    void constructorMultiSourceWithSecondSourceNull() {
+        Source1 source1 = new Source1();
+        source1.setProperty1( "value1" );
+
+        ConstructorTarget target = Issue2436ConstructorMapper.INSTANCE.map( source1, null );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getProperty1() ).isEqualTo( "value1" );
+        assertThat( target.getProperty2() ).isEqualTo( "default2" );
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436ConstructorReturnDefaultMapper.class)
+    void singleSourceConstructorReturnDefaultWithNullSourceAppliesValueAndExpressionDefaults() {
+        ConstructorTarget target = Issue2436ConstructorReturnDefaultMapper.INSTANCE.map( null );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getProperty1() ).isEqualTo( "default1" );
+        assertThat( target.getProperty2() ).isEqualTo( "default2" );
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436OptionalMapper.class)
+    void emptyOptionalSourceAppliesDefault() {
+        Target target = Issue2436OptionalMapper.INSTANCE.map( Optional.empty() );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getProperty1() ).isEqualTo( "default1" );
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436UpdateMapper.class)
+    void updateWithNullSourceKeepsExistingTargetValue() {
+        Source2 source2 = new Source2();
+        source2.setProperty2( "value2" );
+
+        Target target = new Target();
+        target.setProperty1( "existing" );
+
+        Issue2436UpdateMapper.INSTANCE.update( null, source2, target );
+
+        assertThat( target.getProperty1() ).isEqualTo( "existing" );
+        assertThat( target.getProperty2() ).isEqualTo( "value2" );
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue2436Mapper.class)
+    void allSourcesNullReturnsNull() {
+        Target target = Issue2436Mapper.INSTANCE.map( null, null );
+
+        assertThat( target ).isNull();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436UpdateMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Issue2436UpdateMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValueMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue2436UpdateMapper {
+
+    Issue2436UpdateMapper INSTANCE = Mappers.getMapper( Issue2436UpdateMapper.class );
+
+    @BeanMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_DEFAULT)
+    @Mapping(target = "property1", source = "source1.property1", defaultValue = "default1")
+    @Mapping(target = "property2", source = "source2.property2")
+    @Mapping(target = "property3", ignore = true)
+    void update(Source1 source1, Source2 source2, @MappingTarget Target target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Source1.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Source1.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+public class Source1 {
+
+    private String property1;
+
+    public String getProperty1() {
+        return property1;
+    }
+
+    public void setProperty1(String property1) {
+        this.property1 = property1;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Source2.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Source2.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+public class Source2 {
+
+    private String property2;
+
+    public String getProperty2() {
+        return property2;
+    }
+
+    public void setProperty2(String property2) {
+        this.property2 = property2;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_2436/Target.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._2436;
+
+public class Target {
+
+    private String property1;
+    private String property2;
+    private String property3;
+
+    public String getProperty1() {
+        return property1;
+    }
+
+    public void setProperty1(String property1) {
+        this.property1 = property1;
+    }
+
+    public String getProperty2() {
+        return property2;
+    }
+
+    public void setProperty2(String property2) {
+        this.property2 = property2;
+    }
+
+    public String getProperty3() {
+        return property3;
+    }
+
+    public void setProperty3(String property3) {
+        this.property3 = property3;
+    }
+}

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
@@ -44,6 +44,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 domain.setStringsWithDefault( helper.toList( "3" ) );
             }
         }
+        else {
+            domain.setStringsWithDefault( helper.toList( "3" ) );
+        }
 
         return domain;
     }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
@@ -44,6 +44,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 domain.setStringsWithDefault( helper.toList( "3" ) );
             }
         }
+        else {
+            domain.setStringsWithDefault( helper.toList( "3" ) );
+        }
 
         return domain;
     }


### PR DESCRIPTION
When a source parameter itself is `null` in a multi-source mapping, or in a single-source mapping with `RETURN_DEFAULT`, the generated code now applies `defaultValue` / `defaultExpression` instead of skipping those assignments.

The root cause was that the parameter-level presence checks in `BeanMappingMethod.ftl` had no fallback branch. If the source parameter was `null`, the whole block was skipped, including any configured defaults.

This change adds fallback handling for the parameter-level presence check branches in `BeanMappingMethod.ftl`, and adds `isBuiltInPresenceCheckByParameter()` in `BeanMappingMethod.java` so that custom `@SourceParameterCondition` methods keep their existing behavior.

The `_913` fixtures are updated as well. Only the `create` path changes here; `update` / `updateWithReturn` stay unchanged because they are guarded by `existingInstanceMapping`.

Tests cover:
- multi-source mappings with either source parameter `null`
- constructor mappings
- single-source `RETURN_DEFAULT`
- single-source constructor `RETURN_DEFAULT`
- `@SourceParameterCondition` true/false behavior
- the unchanged all-sources-null early return

Closes #2436
