### PR TITLE
refactor TypeFactory.getTypeParameters

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/TypeFactory.java
@@ -523,15 +523,12 @@ public class TypeFactory {
         }
 
         DeclaredType declaredType = (DeclaredType) mirror;
-        List<Type> typeParameters = new ArrayList<>( declaredType.getTypeArguments().size() );
+        List<? extends TypeMirror> typeArguments = declaredType.getTypeArguments();
+        List<Type> typeParameters = new ArrayList<>( typeArguments.size() );
 
-        for ( TypeMirror typeParameter : declaredType.getTypeArguments() ) {
-            if ( isImplementationType ) {
-                typeParameters.add( getType( typeParameter ).getTypeBound() );
-            }
-            else {
-                typeParameters.add( getType( typeParameter ) );
-            }
+        for ( TypeMirror typeParameter : typeArguments) {
+            Type type = getType( typeParameter );
+            typeParameters.add( isImplementationType ? type.getTypeBound() : type );
         }
 
         return typeParameters;


### PR DESCRIPTION
Improves readability and avoids unnecessary overhead:
- Stores `typeArguments` in a local variable (since calling `getTypeArguments()` is not cached in eclipse compiler)
- Replace if/else with a ternary expression
- Avoids repeated `getType(...)` calls

No functional changes.