### PR TITLE
use multi-catch in generated code

### DIFF
--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/Java8FunctionWrapper.ftl
@@ -6,6 +6,7 @@
 
 -->
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.Java8FunctionWrapper" -->
+<#import "../macro/CommonMacros.ftl" as lib>
 <#assign sourceVarName><#if assignment.sourceLocalVarName?? >${assignment.sourceLocalVarName}<#else>${assignment.sourceReference}</#if></#assign>
 <#if (thrownTypes?size == 0) >
     <#compress>
@@ -17,14 +18,9 @@
 <#else>
     <#compress>
         ${sourceVarName} -> {
-            try {
+            <@lib.handleExceptions>
                 return <@_assignment/>;
-            }
-            <#list thrownTypes as exceptionType>
-            catch ( <@includeModel object=exceptionType/> e ) {
-                throw new RuntimeException( e );
-            }
-            </#list>
+            </@lib.handleExceptions>
         }
     </#compress>
 </#if>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/LocalVarWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/LocalVarWrapper.ftl
@@ -6,18 +6,14 @@
 
 -->
 <#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.assignment.LocalVarWrapper" -->
+<#import "../macro/CommonMacros.ftl" as lib>
 <#if (thrownTypes?size == 0) >
     <#if !ext.isTargetDefined?? ><@includeModel object=ext.targetType/></#if> ${ext.targetWriteAccessorName} = <@_assignment/>;
 <#else>
     <#if !ext.isTargetDefined?? ><@includeModel object=ext.targetType/> ${ext.targetWriteAccessorName};</#if>
-    try {
+    <@lib.handleExceptions>
         ${ext.targetWriteAccessorName} = <@_assignment/>;
-    }
-    <#list thrownTypes as exceptionType>
-    catch ( <@includeModel object=exceptionType/> e ) {
-       throw new RuntimeException( e );
-    }
-    </#list>
+    </@lib.handleExceptions>
 </#if>
 <#macro _assignment>
     <@includeModel object=assignment

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
@@ -104,11 +104,16 @@
         try {
             <#nested>
         }
-        <#list thrownTypes as exceptionType>
-        catch ( <@includeModel object=exceptionType/> e ) {
+        <@compress single_line=true>catch (
+            <#list thrownTypes as exceptionType>
+                <#if exceptionType_index &gt; 0> | </#if>
+                <@includeModel object=exceptionType/>
+            </#list>
+            e ) {
+        </@compress>
+
             throw new RuntimeException( e );
         }
-        </#list>
   </#if>
 </#macro>
 <#--

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/collection/adder/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/collection/adder/SourceTargetMapperImpl.java
@@ -59,10 +59,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
         try {
             source1.setPets( petMapper.toSourcePets( source.getPets() ) );
         }
-        catch ( CatException e ) {
-            throw new RuntimeException( e );
-        }
-        catch ( DogException e ) {
+        catch ( CatException | DogException e ) {
             throw new RuntimeException( e );
         }
 
@@ -82,10 +79,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
                 }
             }
         }
-        catch ( CatException e ) {
-            throw new RuntimeException( e );
-        }
-        catch ( DogException e ) {
+        catch ( CatException | DogException e ) {
             throw new RuntimeException( e );
         }
     }
@@ -161,10 +155,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
                 }
             }
         }
-        catch ( CatException e ) {
-            throw new RuntimeException( e );
-        }
-        catch ( DogException e ) {
+        catch ( CatException | DogException e ) {
             throw new RuntimeException( e );
         }
 
@@ -184,10 +175,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
                 target.addPet( petMapper.toPet( source.getPet() ) );
             }
         }
-        catch ( CatException e ) {
-            throw new RuntimeException( e );
-        }
-        catch ( DogException e ) {
+        catch ( CatException | DogException e ) {
             throw new RuntimeException( e );
         }
 


### PR DESCRIPTION
Since MapStruct requires at least Java 8, multi‑catch can be used in the generated code.
I changed the code in `CommonMacros.ftl` to use multi‑catch when catching more than one exception, instead of generating multiple catch blocks.
To make this consistent, I replaced the duplicated catch code in `Java8FunctionWrapper.ftl `and `LocalVarWrapper.ftl` with the `handleExceptions` macro.

