### PR TITLE
upgrade integration tests to junit5

### DIFF
--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/GradleIncrementalCompilationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/GradleIncrementalCompilationTest.java
@@ -13,47 +13,49 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.apache.commons.io.FileUtils;
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.condition.DisabledForJreRange;
 import org.junit.jupiter.api.condition.JRE;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.runners.Parameterized.Parameters;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
 import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
-import static org.hamcrest.core.StringContains.containsString;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * <p>This is supposed to be run from the mapstruct root project folder.
  * Otherwise, use <code>-Dmapstruct_root=path_to_project</code>.
  */
 @DisabledForJreRange(min = JRE.JAVA_11)
-public class GradleIncrementalCompilationTest {
+class GradleIncrementalCompilationTest {
     private static Path rootPath;
-    private static String projectDir = "integrationtest/src/test/resources/gradleIncrementalCompilationTest";
-    private static String compileTaskName = "compileJava";
+    private static final String PROJECT_DIR = "integrationtest/src/test/resources/gradleIncrementalCompilationTest";
+    private static final String COMPILE_TASK_NAME = "compileJava";
 
     @TempDir
-    File testBuildDir;
+    private File testBuildDir;
     @TempDir
-    File testProjectDir;
+    private File testProjectDir;
 
     private GradleRunner runner;
     private File sourceDirectory;
     private List<String> compileArgs; // Gradle compile task arguments
 
-    @Parameters(name = "Gradle {0}")
-    public static List<String> gradleVersions() {
-        return Arrays.asList( "5.0", "6.0" );
+    static Stream<Arguments> gradleVersions() {
+        return Stream.of(
+                Arguments.of( Named.of( "Gradle 5.0", "5.0" ) ),
+                Arguments.of( Named.of( "Gradle 6.0", "6.0" ) ) );
     }
 
     private void replaceInFile(File file, CharSequence target, CharSequence replacement) throws IOException {
@@ -68,15 +70,13 @@ public class GradleIncrementalCompilationTest {
     }
 
     private void assertCompileOutcome(BuildResult result, TaskOutcome outcome) {
-        assertEquals( outcome, result.task( ":" + compileTaskName ).getOutcome() );
+        assertEquals( outcome, result.task( ":" + COMPILE_TASK_NAME ).getOutcome() );
     }
 
     private void assertRecompiled(BuildResult result, int recompiledCount) {
         assertCompileOutcome( result, recompiledCount > 0 ? SUCCESS : UP_TO_DATE );
-        assertThat(
-            result.getOutput(),
-            containsString( String.format( "Incremental compilation of %d classes completed", recompiledCount ) )
-        );
+        assertThat( result.getOutput() )
+                .contains( String.format( "Incremental compilation of %d classes completed", recompiledCount ) );
     }
 
     private List<String> buildCompileArgs() {
@@ -85,11 +85,11 @@ public class GradleIncrementalCompilationTest {
 
         // Inject the path to the folder containing the mapstruct-processor JAR
         String jarDirectoryArg = "-PmapstructRootPath=" + rootPath.toString();
-        return Arrays.asList( compileTaskName, buildDirPropertyArg, jarDirectoryArg );
+        return Arrays.asList( COMPILE_TASK_NAME, buildDirPropertyArg, jarDirectoryArg );
     }
 
     @BeforeAll
-    public static void setupClass() throws Exception {
+    static void setupClass() {
         rootPath = Paths.get( System.getProperty( "mapstruct_root", "." ) ).toAbsolutePath();
     }
 
@@ -102,7 +102,7 @@ public class GradleIncrementalCompilationTest {
             testProjectDir.mkdirs();
         }
         // Copy test project files to the temp dir
-        Path gradleProjectPath = rootPath.resolve( projectDir );
+        Path gradleProjectPath = rootPath.resolve( PROJECT_DIR );
         FileUtils.copyDirectory( gradleProjectPath.toFile(), testProjectDir );
         compileArgs = buildCompileArgs();
         sourceDirectory = new File( testProjectDir, "src/main/java" );
@@ -111,7 +111,7 @@ public class GradleIncrementalCompilationTest {
 
     @ParameterizedTest
     @MethodSource("gradleVersions")
-    public void testBuildSucceeds(String gradleVersion) throws IOException {
+    void testBuildSucceeds(String gradleVersion) throws IOException {
         setup( gradleVersion );
         // Make sure the test build setup actually compiles
         BuildResult buildResult = getRunner().build();
@@ -120,7 +120,7 @@ public class GradleIncrementalCompilationTest {
 
     @ParameterizedTest
     @MethodSource("gradleVersions")
-    public void testUpToDate(String gradleVersion) throws IOException {
+    void testUpToDate(String gradleVersion) throws IOException {
         setup( gradleVersion );
         getRunner().build();
         BuildResult secondBuildResult = getRunner().build();
@@ -129,7 +129,7 @@ public class GradleIncrementalCompilationTest {
 
     @ParameterizedTest
     @MethodSource("gradleVersions")
-    public void testChangeConstant(String gradleVersion) throws IOException {
+    void testChangeConstant(String gradleVersion) throws IOException {
         setup( gradleVersion );
         getRunner().build();
         // Change return value in class Target
@@ -143,7 +143,7 @@ public class GradleIncrementalCompilationTest {
 
     @ParameterizedTest
     @MethodSource("gradleVersions")
-    public void testChangeTargetField(String gradleVersion) throws IOException {
+    void testChangeTargetField(String gradleVersion) throws IOException {
         setup( gradleVersion );
         getRunner().build();
         // Change target field in mapper interface
@@ -157,7 +157,7 @@ public class GradleIncrementalCompilationTest {
 
     @ParameterizedTest
     @MethodSource("gradleVersions")
-    public void testChangeUnrelatedFile(String gradleVersion) throws IOException {
+    void testChangeUnrelatedFile(String gradleVersion) throws IOException {
         setup( gradleVersion );
         getRunner().build();
         File unrelatedFile = new File( sourceDirectory, "org/mapstruct/itest/gradle/lib/UnrelatedComponent.java" );

--- a/integrationtest/src/test/resources/autoValueBuilderTest/src/test/java/org/mapstruct/itest/auto/value/AutoValueMapperTest.java
+++ b/integrationtest/src/test/resources/autoValueBuilderTest/src/test/java/org/mapstruct/itest/auto/value/AutoValueMapperTest.java
@@ -5,7 +5,7 @@
  */
 package org.mapstruct.itest.auto.value;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,10 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Eric Martineau
  */
-public class AutoValueMapperTest {
+class AutoValueMapperTest {
 
     @Test
-    public void testSimpleImmutableBuilderHappyPath() {
+    void testSimpleImmutableBuilderHappyPath() {
         PersonDto personDto = PersonMapper.INSTANCE.toDto( Person.builder()
             .age( 33 )
             .name( "Bob" )
@@ -32,7 +32,7 @@ public class AutoValueMapperTest {
     }
 
     @Test
-    public void testLombokToImmutable() {
+    void testLombokToImmutable() {
         Person person = PersonMapper.INSTANCE.fromDto( new PersonDto( "Bob", 33, new AddressDto( "Wild Drive" ) ) );
         assertThat( person.getAge() ).isEqualTo( 33 );
         assertThat( person.getName() ).isEqualTo( "Bob" );

--- a/integrationtest/src/test/resources/cdiTest/pom.xml
+++ b/integrationtest/src/test/resources/cdiTest/pom.xml
@@ -30,8 +30,8 @@
             <artifactId>javax.inject</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -45,8 +45,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-core</artifactId>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-core</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrationtest/src/test/resources/cdiTest/src/test/java/org/mapstruct/itest/cdi/CdiBasedMapperTest.java
+++ b/integrationtest/src/test/resources/cdiTest/src/test/java/org/mapstruct/itest/cdi/CdiBasedMapperTest.java
@@ -10,12 +10,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import javax.inject.Inject;
 
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.itest.cdi.other.DateMapper;
 
 /**
@@ -23,8 +23,8 @@ import org.mapstruct.itest.cdi.other.DateMapper;
  *
  * @author Gunnar Morling
  */
-@RunWith( Arquillian.class )
-public class CdiBasedMapperTest {
+@ExtendWith( ArquillianExtension.class )
+class CdiBasedMapperTest {
 
     @Inject
     private SourceTargetMapper mapper;
@@ -45,7 +45,7 @@ public class CdiBasedMapperTest {
     }
 
     @Test
-    public void shouldCreateCdiBasedMapper() {
+    void shouldCreateCdiBasedMapper() {
         Source source = new Source();
 
         Target target = mapper.sourceToTarget( source );
@@ -56,7 +56,7 @@ public class CdiBasedMapperTest {
     }
 
     @Test
-    public void shouldInjectDecorator() {
+    void shouldInjectDecorator() {
         Source source = new Source();
 
         Target target = decoratedMapper.sourceToTarget( source );

--- a/integrationtest/src/test/resources/defaultPackage/test/java/DefaultPackageTest.java
+++ b/integrationtest/src/test/resources/defaultPackage/test/java/DefaultPackageTest.java
@@ -4,7 +4,7 @@
  * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
  */
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -12,10 +12,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Filip Hrisafov
  */
 
-public class DefaultPackageTest {
+class DefaultPackageTest {
 
     @Test
-    public void shouldWorkCorrectlyInDefaultPackage() {
+    void shouldWorkCorrectlyInDefaultPackage() {
         DefaultPackageObject.CarDto carDto = DefaultPackageObject.CarMapper.INSTANCE.carToCarDto(
             new DefaultPackageObject.Car(
                 "Morris",

--- a/integrationtest/src/test/resources/expressionTextBlocksTest/src/test/java/org/mapstruct/itest/textBlocks/TextBlocksTest.java
+++ b/integrationtest/src/test/resources/expressionTextBlocksTest/src/test/java/org/mapstruct/itest/textBlocks/TextBlocksTest.java
@@ -9,12 +9,12 @@ import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class TextBlocksTest {
+class TextBlocksTest {
 
     @Test
-    public void textBlockExpressionShouldWork() {
+    void textBlockExpressionShouldWork() {
         Car car = new Car();
         car.setWheelPosition( new WheelPosition( "left" ) );
 

--- a/integrationtest/src/test/resources/externalbeanjar/mapper/src/test/java/org/mapstruct/itest/externalbeanjar/ConversionTest.java
+++ b/integrationtest/src/test/resources/externalbeanjar/mapper/src/test/java/org/mapstruct/itest/externalbeanjar/ConversionTest.java
@@ -8,15 +8,15 @@ package org.mapstruct.itest.simple;
 import java.math.BigDecimal;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.itest.externalbeanjar.Source;
 import org.mapstruct.itest.externalbeanjar.Issue1121Mapper;
 import org.mapstruct.itest.externalbeanjar.Target;
 
-public class ConversionTest {
+class ConversionTest {
 
     @Test
-    public void shouldApplyConversions() {
+    void shouldApplyConversions() {
         Source source = new Source();
         source.setBigDecimal( new BigDecimal( "42" ) );
 

--- a/integrationtest/src/test/resources/faultyAstModifyingAnnotationProcessorTest/generator/pom.xml
+++ b/integrationtest/src/test/resources/faultyAstModifyingAnnotationProcessorTest/generator/pom.xml
@@ -27,8 +27,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrationtest/src/test/resources/faultyAstModifyingAnnotationProcessorTest/usage/pom.xml
+++ b/integrationtest/src/test/resources/faultyAstModifyingAnnotationProcessorTest/usage/pom.xml
@@ -21,8 +21,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrationtest/src/test/resources/faultyAstModifyingAnnotationProcessorTest/usage/src/test/java/org/mapstruct/itest/faultyAstModifyingProcessor/usage/FaultyAstModifyingTestTest.java
+++ b/integrationtest/src/test/resources/faultyAstModifyingAnnotationProcessorTest/usage/src/test/java/org/mapstruct/itest/faultyAstModifyingProcessor/usage/FaultyAstModifyingTestTest.java
@@ -5,7 +5,7 @@
  */
 package org.mapstruct.itest.faultyAstModifyingProcessor.usage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,10 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Filip Hrisafov
  */
-public class FaultyAstModifyingTestTest {
+class FaultyAstModifyingTestTest {
 
     @Test
-    public void testMapping() {
+    void testMapping() {
         Order order = new Order();
         order.setItem( "my item" );
 

--- a/integrationtest/src/test/resources/freeBuilderBuilderTest/src/test/java/org/mapstruct/itest/freebuilder/FreeBuilderMapperTest.java
+++ b/integrationtest/src/test/resources/freeBuilderBuilderTest/src/test/java/org/mapstruct/itest/freebuilder/FreeBuilderMapperTest.java
@@ -5,7 +5,7 @@
  */
 package org.mapstruct.itest.freebuilder;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,10 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Eric Martineau
  */
-public class FreeBuilderMapperTest {
+class FreeBuilderMapperTest {
 
     @Test
-    public void testSimpleImmutableBuilderHappyPath() {
+    void testSimpleImmutableBuilderHappyPath() {
         PersonDto personDto = PersonMapper.INSTANCE.toDto( Person.builder()
             .setAge( 33 )
             .setName( "Bob" )
@@ -32,7 +32,7 @@ public class FreeBuilderMapperTest {
     }
 
     @Test
-    public void testLombokToImmutable() {
+    void testLombokToImmutable() {
         Person person = PersonMapper.INSTANCE.fromDto( new PersonDto( "Bob", 33, new AddressDto( "Wild Drive" ) ) );
         assertThat( person.getAge() ).isEqualTo( 33 );
         assertThat( person.getName() ).isEqualTo( "Bob" );

--- a/integrationtest/src/test/resources/fullFeatureTest/src/test/java/org/mapstruct/itest/simple/AnimalTest.java
+++ b/integrationtest/src/test/resources/fullFeatureTest/src/test/java/org/mapstruct/itest/simple/AnimalTest.java
@@ -7,7 +7,7 @@ package org.mapstruct.ap.test.ignore;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import org.mapstruct.ap.test.ignore.AnimalMapper;
 import org.mapstruct.ap.test.ignore.Animal;
@@ -18,10 +18,10 @@ import org.mapstruct.ap.test.ignore.AnimalDto;
  *
  * @author Gunnar Morling
  */
-public class AnimalTest {
+class AnimalTest {
 
     @Test
-    public void shouldNotPropagateIgnoredPropertyGivenViaTargetAttribute() {
+    void shouldNotPropagateIgnoredPropertyGivenViaTargetAttribute() {
         Animal animal = new Animal( "Bruno", 100, 23, "black" );
 
         AnimalDto animalDto = AnimalMapper.INSTANCE.animalToDto( animal );
@@ -34,7 +34,7 @@ public class AnimalTest {
     }
 
     @Test
-    public void shouldNotPropagateIgnoredPropertyInReverseMappingWhenSourceAndTargetAreSpecified() {
+    void shouldNotPropagateIgnoredPropertyInReverseMappingWhenSourceAndTargetAreSpecified() {
         AnimalDto animalDto = new AnimalDto( "Bruno", 100, 23, "black" );
 
         Animal animal = AnimalMapper.INSTANCE.animalDtoToAnimal( animalDto );

--- a/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/ImmutablesMapperTest.java
+++ b/integrationtest/src/test/resources/immutablesBuilderTest/mapper/src/test/java/org/mapstruct/itest/immutables/ImmutablesMapperTest.java
@@ -5,7 +5,7 @@
  */
 package org.mapstruct.itest.immutables;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,10 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Eric Martineau
  */
-public class ImmutablesMapperTest {
+class ImmutablesMapperTest {
 
     @Test
-    public void testSimpleImmutableBuilderHappyPath() {
+    void testSimpleImmutableBuilderHappyPath() {
         PersonDto personDto = PersonMapper.INSTANCE.toDto( ImmutablePerson.builder()
             .age( 33 )
             .name( "Bob" )
@@ -32,7 +32,7 @@ public class ImmutablesMapperTest {
     }
 
     @Test
-    public void testLombokToImmutable() {
+    void testLombokToImmutable() {
         Person person = PersonMapper.INSTANCE.fromDto( new PersonDto( "Bob", 33, new AddressDto( "Wild Drive" ) ) );
         assertThat( person.getAge() ).isEqualTo( 33 );
         assertThat( person.getName() ).isEqualTo( "Bob" );

--- a/integrationtest/src/test/resources/jakartaJaxbTest/src/test/java/org/mapstruct/itest/jakarta/jaxb/JakartaJaxbBasedMapperTest.java
+++ b/integrationtest/src/test/resources/jakartaJaxbTest/src/test/java/org/mapstruct/itest/jakarta/jaxb/JakartaJaxbBasedMapperTest.java
@@ -18,7 +18,7 @@ import jakarta.xml.bind.JAXBElement;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Marshaller;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.itest.jakarta.jaxb.xsd.test1.ObjectFactory;
 import org.mapstruct.itest.jakarta.jaxb.xsd.test1.OrderType;
 import org.mapstruct.itest.jakarta.jaxb.xsd.underscores.SubType;
@@ -28,10 +28,10 @@ import org.mapstruct.itest.jakarta.jaxb.xsd.underscores.SubType;
  *
  * @author Iaroslav Bogdanchikov
  */
-public class JakartaJaxbBasedMapperTest {
+class JakartaJaxbBasedMapperTest {
 
     @Test
-    public void shouldMapJakartaJaxb() throws ParseException, JAXBException {
+    void shouldMapJakartaJaxb() throws ParseException, JAXBException {
 
         SourceTargetMapper mapper = SourceTargetMapper.INSTANCE;
 
@@ -81,7 +81,7 @@ public class JakartaJaxbBasedMapperTest {
     }
 
     @Test
-    public void underscores() throws ParseException, JAXBException {
+    void underscores() throws ParseException, JAXBException {
 
         SourceTargetMapper mapper = SourceTargetMapper.INSTANCE;
 

--- a/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_603/Issue603Test.java
+++ b/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_603/Issue603Test.java
@@ -5,15 +5,14 @@
  */
 package org.mapstruct.ap.test.bugs._603;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class Issue603Test {
+class Issue603Test {
 
     @Test
-    public void shouldMapDataFromJava8Interface() {
+    void shouldMapDataFromJava8Interface() {
 
         final Source source = new Source();
 

--- a/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_636/Issue636Test.java
+++ b/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/ap/test/bugs/_636/Issue636Test.java
@@ -5,14 +5,14 @@
  */
 package org.mapstruct.ap.test.bugs._636;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class Issue636Test {
+class Issue636Test {
 
     @Test
-    public void shouldMapDataFromJava8Interface() {
+    void shouldMapDataFromJava8Interface() {
 
         final long idFoo = 123;
         final String idBar = "Bar456";

--- a/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/itest/java8/Java8MapperTest.java
+++ b/integrationtest/src/test/resources/java8Test/src/test/java/org/mapstruct/itest/java8/Java8MapperTest.java
@@ -7,17 +7,17 @@ package org.mapstruct.itest.java8;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Test for generation of Java8 based mapper implementations.
  *
  * @author Christian Schuster
  */
-public class Java8MapperTest {
+class Java8MapperTest {
 
     @Test
-    public void shouldMapWithRepeatedMappingAnnotation() {
+    void shouldMapWithRepeatedMappingAnnotation() {
         Java8Mapper mapper = Java8Mapper.INSTANCE;
 
         Source source = new Source();

--- a/integrationtest/src/test/resources/jaxbTest/src/test/java/org/mapstruct/itest/jaxb/JaxbBasedMapperTest.java
+++ b/integrationtest/src/test/resources/jaxbTest/src/test/java/org/mapstruct/itest/jaxb/JaxbBasedMapperTest.java
@@ -18,7 +18,7 @@ import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.itest.jaxb.xsd.test1.ObjectFactory;
 import org.mapstruct.itest.jaxb.xsd.test1.OrderType;
 import org.mapstruct.itest.jaxb.xsd.underscores.SubType;
@@ -28,9 +28,9 @@ import org.mapstruct.itest.jaxb.xsd.underscores.SubType;
  *
  * @author Sjaak Derksen
  */
-public class JaxbBasedMapperTest {
+class JaxbBasedMapperTest {
     @Test
-    public void shouldMapJaxb() throws ParseException, JAXBException {
+    void shouldMapJaxb() throws ParseException, JAXBException {
 
         SourceTargetMapper mapper = SourceTargetMapper.INSTANCE;
 
@@ -80,7 +80,7 @@ public class JaxbBasedMapperTest {
     }
 
     @Test
-    public void underscores() throws ParseException, JAXBException {
+    void underscores() throws ParseException, JAXBException {
 
         SourceTargetMapper mapper = SourceTargetMapper.INSTANCE;
 

--- a/integrationtest/src/test/resources/jsr330Test/pom.xml
+++ b/integrationtest/src/test/resources/jsr330Test/pom.xml
@@ -18,6 +18,10 @@
 
     <artifactId>jsr330Test</artifactId>
     <packaging>jar</packaging>
+
+    <properties>
+        <org.junit.jupiter.version>${org.junit6.jupiter.version}</org.junit.jupiter.version>
+    </properties>
     
     <dependencies>
         <dependency>

--- a/integrationtest/src/test/resources/jsr330Test/src/test/java/org/mapstruct/itest/jsr330/Jsr330BasedMapperTest.java
+++ b/integrationtest/src/test/resources/jsr330Test/src/test/java/org/mapstruct/itest/jsr330/Jsr330BasedMapperTest.java
@@ -8,13 +8,13 @@ package org.mapstruct.itest.jsr330;
 import jakarta.inject.Inject;
 import jakarta.inject.Named;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.itest.jsr330.Jsr330BasedMapperTest.SpringTestConfig;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -24,8 +24,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andreas Gudian
  */
 @ContextConfiguration(classes = SpringTestConfig.class)
-@RunWith(SpringJUnit4ClassRunner.class)
-public class Jsr330BasedMapperTest {
+@ExtendWith(SpringExtension.class)
+class Jsr330BasedMapperTest {
     @Configuration
     @ComponentScan(basePackageClasses = Jsr330BasedMapperTest.class)
     public static class SpringTestConfig {
@@ -43,7 +43,7 @@ public class Jsr330BasedMapperTest {
     private SecondDecoratedSourceTargetMapper secondDecoratedMapper;
 
     @Test
-    public void shouldInjectJsr330BasedMapper() {
+    void shouldInjectJsr330BasedMapper() {
         Source source = new Source();
 
         Target target = mapper.sourceToTarget( source );
@@ -54,7 +54,7 @@ public class Jsr330BasedMapperTest {
     }
 
     @Test
-    public void shouldInjectDecorator() {
+    void shouldInjectDecorator() {
         Source source = new Source();
 
         Target target = decoratedMapper.sourceToTarget( source );
@@ -71,7 +71,7 @@ public class Jsr330BasedMapperTest {
     }
 
     @Test
-    public void shouldInjectSecondDecorator() {
+    void shouldInjectSecondDecorator() {
         Source source = new Source();
 
         Target target = secondDecoratedMapper.sourceToTarget( source );

--- a/integrationtest/src/test/resources/kotlinDataTest/src/test/java/org/mapstruct/itest/kotlin/data/KotlinDataTest.java
+++ b/integrationtest/src/test/resources/kotlinDataTest/src/test/java/org/mapstruct/itest/kotlin/data/KotlinDataTest.java
@@ -7,15 +7,15 @@ package org.mapstruct.itest.kotlin.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.itest.kotlin.data.CustomerDto;
 import org.mapstruct.itest.kotlin.data.CustomerEntity;
 import org.mapstruct.itest.kotlin.data.CustomerMapper;
 
-public class KotlinDataTest {
+class KotlinDataTest {
 
     @Test
-    public void shouldMapData() {
+    void shouldMapData() {
         CustomerEntity customer = CustomerMapper.INSTANCE.fromRecord( new CustomerDto( "Kermit", "kermit@test.com" ) );
 
         assertThat( customer ).isNotNull();
@@ -24,7 +24,7 @@ public class KotlinDataTest {
     }
 
     @Test
-    public void shouldMapIntoData() {
+    void shouldMapIntoData() {
         CustomerEntity entity = new CustomerEntity();
         entity.setName( "Kermit" );
         entity.setMail( "kermit@test.com" );

--- a/integrationtest/src/test/resources/lombokBuilderTest/src/test/java/org/mapstruct/itest/lombok/LombokMapperTest.java
+++ b/integrationtest/src/test/resources/lombokBuilderTest/src/test/java/org/mapstruct/itest/lombok/LombokMapperTest.java
@@ -5,7 +5,7 @@
  */
 package org.mapstruct.itest.lombok;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,10 +15,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Eric Martineau
  */
-public class LombokMapperTest {
+class LombokMapperTest {
 
     @Test
-    public void testSimpleImmutableBuilderHappyPath() {
+    void testSimpleImmutableBuilderHappyPath() {
         PersonDto personDto = PersonMapper.INSTANCE.toDto( Person.foo()
             .age( 33 )
             .name( "Bob" )
@@ -33,7 +33,7 @@ public class LombokMapperTest {
     }
 
     @Test
-    public void testLombokToImmutable() {
+    void testLombokToImmutable() {
         Person person = PersonMapper.INSTANCE.fromDto( new PersonDto( "Bob", 33, new AddressDto( "Wild Drive" ) ) );
         assertThat( person.getAge() ).isEqualTo( 33 );
         assertThat( person.getName() ).isEqualTo( "Bob" );

--- a/integrationtest/src/test/resources/lombokModuleTest/src/test/java/org/mapstruct/itest/lombok/LombokMapperTest.java
+++ b/integrationtest/src/test/resources/lombokModuleTest/src/test/java/org/mapstruct/itest/lombok/LombokMapperTest.java
@@ -5,7 +5,7 @@
  */
 package org.mapstruct.itest.lombok;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.factory.Mappers;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -15,10 +15,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Eric Martineau
  */
-public class LombokMapperTest {
+class LombokMapperTest {
 
     @Test
-    public void testSimpleImmutableBuilderHappyPath() {
+    void testSimpleImmutableBuilderHappyPath() {
         PersonDto personDto = PersonMapper.INSTANCE.toDto( new Person( "Bob", 33, new Address( "Wild Drive" ) ) );
         assertThat( personDto.getAge() ).isEqualTo( 33 );
         assertThat( personDto.getName() ).isEqualTo( "Bob" );
@@ -27,7 +27,7 @@ public class LombokMapperTest {
     }
 
     @Test
-    public void testLombokToImmutable() {
+    void testLombokToImmutable() {
         Person person = PersonMapper.INSTANCE.fromDto( new PersonDto( "Bob", 33, new AddressDto( "Wild Drive" ) ) );
         assertThat( person.getAge() ).isEqualTo( 33 );
         assertThat( person.getName() ).isEqualTo( "Bob" );

--- a/integrationtest/src/test/resources/moduleInfoTest/src/test/java/org/mapstruct/itest/modules/ModulesTest.java
+++ b/integrationtest/src/test/resources/moduleInfoTest/src/test/java/org/mapstruct/itest/modules/ModulesTest.java
@@ -7,15 +7,15 @@ package org.mapstruct.itest.modules;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.itest.modules.CustomerDto;
 import org.mapstruct.itest.modules.CustomerEntity;
 import org.mapstruct.itest.modules.CustomerMapper;
 
-public class ModulesTest {
+class ModulesTest {
 
     @Test
-    public void shouldMapRecord() {
+    void shouldMapRecord() {
         CustomerDto dto = new CustomerDto();
         dto.setName( "Kermit" );
         dto.setEmail( "kermit@test.com" );

--- a/integrationtest/src/test/resources/namingStrategyTest/usage/src/test/java/org/mapstruct/itest/naming/NamingTest.java
+++ b/integrationtest/src/test/resources/namingStrategyTest/usage/src/test/java/org/mapstruct/itest/naming/NamingTest.java
@@ -7,7 +7,7 @@ package org.mapstruct.itest.naming;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.itest.naming.GolfPlayer;
 import org.mapstruct.itest.naming.GolfPlayerDto;
 import org.mapstruct.itest.naming.GolfPlayerMapper;
@@ -17,10 +17,10 @@ import org.mapstruct.itest.naming.GolfPlayerMapper;
  *
  * @author Gunnar Morling
  */
-public class NamingTest {
+class NamingTest {
 
     @Test
-    public void shouldApplyCustomNamingStrategy() {
+    void shouldApplyCustomNamingStrategy() {
         GolfPlayer player = new GolfPlayer()
             .withName( "Jared" )
             .withHandicap( 9.2D );

--- a/integrationtest/src/test/resources/pom.xml
+++ b/integrationtest/src/test/resources/pom.xml
@@ -26,6 +26,7 @@
         <mapstruct.version>${mapstruct.version}</mapstruct.version>
         <compiler-id></compiler-id>
         <compiler-source-target-version></compiler-source-target-version>
+        <org.junit6.jupiter.version>6.0.3</org.junit6.jupiter.version>
     </properties>
 
     <profiles>
@@ -135,8 +136,8 @@
 
         <!-- Testing -->
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrationtest/src/test/resources/protobufBuilderTest/src/test/java/org/mapstruct/itest/protobuf/ProtobufMapperTest.java
+++ b/integrationtest/src/test/resources/protobufBuilderTest/src/test/java/org/mapstruct/itest/protobuf/ProtobufMapperTest.java
@@ -5,7 +5,7 @@
  */
 package org.mapstruct.itest.protobuf;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,10 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Christian Bandowski
  */
-public class ProtobufMapperTest {
+class ProtobufMapperTest {
 
     @Test
-    public void testSimpleImmutableBuilderHappyPath() {
+    void testSimpleImmutableBuilderHappyPath() {
         PersonDto personDto = PersonMapper.INSTANCE.toDto( PersonProtos.Person.newBuilder()
             .setAge( 33 )
             .setName( "Bob" )
@@ -33,7 +33,7 @@ public class ProtobufMapperTest {
     }
 
     @Test
-    public void testLombokToImmutable() {
+    void testLombokToImmutable() {
         PersonProtos.Person person = PersonMapper.INSTANCE.fromDto( new PersonDto( "Bob", 33, new AddressDto( "Wild Drive" ) ) );
 
         assertThat( person.getAge() ).isEqualTo( 33 );

--- a/integrationtest/src/test/resources/recordsCrossModuleInterfaceTest/module-2/src/test/java/org/mapstruct/itest/records/module2/RecordsTest.java
+++ b/integrationtest/src/test/resources/recordsCrossModuleInterfaceTest/module-2/src/test/java/org/mapstruct/itest/records/module2/RecordsTest.java
@@ -7,14 +7,14 @@ package org.mapstruct.itest.records.module2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.itest.records.module1.SourceRootRecord;
 import org.mapstruct.itest.records.module1.SourceNestedRecord;
 
-public class RecordsTest {
+class RecordsTest {
 
     @Test
-    public void shouldMap() {
+    void shouldMap() {
         SourceRootRecord source = new SourceRootRecord( new SourceNestedRecord( "test" ) );
         TargetRootRecord target = RecordInterfaceIssueMapper.INSTANCE.map( source );
 

--- a/integrationtest/src/test/resources/recordsCrossModuleTest/mapper/src/test/java/org/mapstruct/itest/records/mapper/RecordsTest.java
+++ b/integrationtest/src/test/resources/recordsCrossModuleTest/mapper/src/test/java/org/mapstruct/itest/records/mapper/RecordsTest.java
@@ -7,15 +7,15 @@ package org.mapstruct.itest.records.mapper;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.itest.records.api.CustomerDto;
 import org.mapstruct.itest.records.mapper.CustomerEntity;
 import org.mapstruct.itest.records.mapper.CustomerMapper;
 
-public class RecordsTest {
+class RecordsTest {
 
     @Test
-    public void shouldMapRecord() {
+    void shouldMapRecord() {
         CustomerEntity customer = CustomerMapper.INSTANCE.fromRecord( new CustomerDto( "Kermit", "kermit@test.com" ) );
 
         assertThat( customer ).isNotNull();
@@ -24,7 +24,7 @@ public class RecordsTest {
     }
 
     @Test
-    public void shouldMapIntoRecord() {
+    void shouldMapIntoRecord() {
         CustomerEntity entity = new CustomerEntity();
         entity.setName( "Kermit" );
         entity.setMail( "kermit@test.com" );

--- a/integrationtest/src/test/resources/recordsTest/src/test/java/org/mapstruct/itest/records/RecordsTest.java
+++ b/integrationtest/src/test/resources/recordsTest/src/test/java/org/mapstruct/itest/records/RecordsTest.java
@@ -9,15 +9,15 @@ import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.itest.records.CustomerDto;
 import org.mapstruct.itest.records.CustomerEntity;
 import org.mapstruct.itest.records.CustomerMapper;
 
-public class RecordsTest {
+class RecordsTest {
 
     @Test
-    public void shouldMapRecord() {
+    void shouldMapRecord() {
         CustomerEntity customer = CustomerMapper.INSTANCE.fromRecord( new CustomerDto( "Kermit", "kermit@test.com" ) );
 
         assertThat( customer ).isNotNull();
@@ -26,7 +26,7 @@ public class RecordsTest {
     }
 
     @Test
-    public void shouldMapIntoRecord() {
+    void shouldMapIntoRecord() {
         CustomerEntity entity = new CustomerEntity();
         entity.setName( "Kermit" );
         entity.setMail( "kermit@test.com" );
@@ -39,7 +39,7 @@ public class RecordsTest {
     }
 
     @Test
-    public void shouldMapIntoGenericRecord() {
+    void shouldMapIntoGenericRecord() {
         CustomerEntity entity = new CustomerEntity();
         entity.setName( "Kermit" );
         entity.setMail( "kermit@test.com" );
@@ -51,7 +51,7 @@ public class RecordsTest {
     }
 
     @Test
-    public void shouldMapIntoRecordWithList() {
+    void shouldMapIntoRecordWithList() {
         Car car = new Car();
         car.setWheelPositions( Arrays.asList( new WheelPosition( "left" ) ) );
 
@@ -63,7 +63,7 @@ public class RecordsTest {
     }
 
     @Test
-    public void shouldMapMemberRecord() {
+    void shouldMapMemberRecord() {
         MemberEntity member = MemberMapper.INSTANCE.fromRecord( new MemberDto( true, false ) );
 
         assertThat( member ).isNotNull();
@@ -72,7 +72,7 @@ public class RecordsTest {
     }
 
     @Test
-    public void shouldMapIntoMemberRecord() {
+    void shouldMapIntoMemberRecord() {
         MemberEntity entity = new MemberEntity();
         entity.setIsActive( false );
         entity.setPremium( true );
@@ -80,12 +80,12 @@ public class RecordsTest {
         MemberDto value = MemberMapper.INSTANCE.toRecord( entity );
 
         assertThat( value ).isNotNull();
-        assertThat( value.isActive() ).isEqualTo( false );
-        assertThat( value.premium() ).isEqualTo( true );
+        assertThat( value.isActive() ).isFalse();
+        assertThat( value.premium() ).isTrue();
     }
 
     @Test
-    public void shouldUseDefaultConstructor() {
+    void shouldUseDefaultConstructor() {
         Task entity = new Task( "some-id", 1000L );
 
         TaskDto value = TaskMapper.INSTANCE.toRecord( entity );

--- a/integrationtest/src/test/resources/recordsTest/src/test/java/org/mapstruct/itest/records/nested/NestedRecordsTest.java
+++ b/integrationtest/src/test/resources/recordsTest/src/test/java/org/mapstruct/itest/records/nested/NestedRecordsTest.java
@@ -9,12 +9,12 @@ import java.util.Arrays;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class NestedRecordsTest {
+class NestedRecordsTest {
 
     @Test
-    public void shouldMapRecord() {
+    void shouldMapRecord() {
         CareProvider source = new CareProvider( "kermit", new Address( "Sesame Street", "New York" ) );
         CareProviderDto target = CareProviderMapper.INSTANCE.map( source );
 

--- a/integrationtest/src/test/resources/sealedSubclassTest/src/test/java/org/mapstruct/itest/sealedsubclass/SealedSubclassTest.java
+++ b/integrationtest/src/test/resources/sealedSubclassTest/src/test/java/org/mapstruct/itest/sealedsubclass/SealedSubclassTest.java
@@ -7,12 +7,12 @@ package org.mapstruct.itest.sealedsubclass;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
-public class SealedSubclassTest {
+class SealedSubclassTest {
 
     @Test
-    public void mappingIsDoneUsingSubclassMapping() {
+    void mappingIsDoneUsingSubclassMapping() {
         VehicleCollection vehicles = new VehicleCollection();
         vehicles.getVehicles().add( new Car() );
         vehicles.getVehicles().add( new Bike() );
@@ -28,7 +28,7 @@ public class SealedSubclassTest {
     }
 
     @Test
-    public void inverseMappingIsDoneUsingSubclassMapping() {
+    void inverseMappingIsDoneUsingSubclassMapping() {
         VehicleCollectionDto vehicles = new VehicleCollectionDto();
         vehicles.getVehicles().add( new CarDto() );
         vehicles.getVehicles().add( new BikeDto() );
@@ -44,7 +44,7 @@ public class SealedSubclassTest {
     }
 
     @Test
-    public void subclassMappingInheritsInverseMapping() {
+    void subclassMappingInheritsInverseMapping() {
         VehicleCollectionDto vehiclesDto = new VehicleCollectionDto();
         CarDto carDto = new CarDto();
         carDto.setMaker( "BenZ" );

--- a/integrationtest/src/test/resources/simpleTest/src/test/java/org/mapstruct/itest/simple/ConversionTest.java
+++ b/integrationtest/src/test/resources/simpleTest/src/test/java/org/mapstruct/itest/simple/ConversionTest.java
@@ -7,15 +7,15 @@ package org.mapstruct.itest.simple;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.itest.simple.Source;
 import org.mapstruct.itest.simple.SourceTargetMapper;
 import org.mapstruct.itest.simple.Target;
 
-public class ConversionTest {
+class ConversionTest {
 
     @Test
-    public void shouldApplyConversions() {
+    void shouldApplyConversions() {
         Source source = new Source();
         source.setFoo( 42 );
         source.setBar( 23L );
@@ -30,18 +30,18 @@ public class ConversionTest {
     }
 
     @Test
-    public void shouldHandleNulls() {
+    void shouldHandleNulls() {
         Source source = new Source();
         Target target = SourceTargetMapper.INSTANCE.sourceToTarget( source );
 
         assertThat( target ).isNotNull();
         assertThat( target.getFoo() ).isEqualTo( Long.valueOf( 1 ) );
-        assertThat( target.getBar() ).isEqualTo( 0 );
+        assertThat( target.getBar() ).isZero();
         assertThat( target.getZip() ).isEqualTo( "0" );
     }
 
     @Test
-    public void shouldApplyConversionsToMappedProperties() {
+    void shouldApplyConversionsToMappedProperties() {
         Source source = new Source();
         source.setQax( 42 );
         source.setBaz( 23L );
@@ -54,7 +54,7 @@ public class ConversionTest {
     }
 
     @Test
-    public void shouldApplyConversionsForReverseMapping() {
+    void shouldApplyConversionsForReverseMapping() {
         Target target = new Target();
         target.setFoo( 42L );
         target.setBar( 23 );
@@ -69,7 +69,7 @@ public class ConversionTest {
     }
 
     @Test
-    public void shouldApplyConversionsToMappedPropertiesForReverseMapping() {
+    void shouldApplyConversionsToMappedPropertiesForReverseMapping() {
         Target target = new Target();
         target.setQax( 42 );
         target.setBaz( 23L );
@@ -82,7 +82,7 @@ public class ConversionTest {
     }
 
     @Test
-    public void shouldWorkWithAbstractClass() {
+    void shouldWorkWithAbstractClass() {
         Source source = new Source();
         source.setFoo( 42 );
         source.setBar( 23L );

--- a/integrationtest/src/test/resources/springTest/pom.xml
+++ b/integrationtest/src/test/resources/springTest/pom.xml
@@ -18,6 +18,10 @@
 
     <artifactId>springTest</artifactId>
     <packaging>jar</packaging>
+
+    <properties>
+        <org.junit.jupiter.version>${org.junit6.jupiter.version}</org.junit.jupiter.version>
+    </properties>
     
     <dependencies>
         <dependency>

--- a/integrationtest/src/test/resources/springTest/src/test/java/org/mapstruct/itest/spring/SpringBasedMapperTest.java
+++ b/integrationtest/src/test/resources/springTest/src/test/java/org/mapstruct/itest/spring/SpringBasedMapperTest.java
@@ -5,14 +5,14 @@
  */
 package org.mapstruct.itest.spring;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.itest.spring.SpringBasedMapperTest.SpringTestConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -22,8 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Andreas Gudian
  */
 @ContextConfiguration(classes = SpringTestConfig.class)
-@RunWith(SpringJUnit4ClassRunner.class)
-public class SpringBasedMapperTest {
+@ExtendWith(SpringExtension.class)
+class SpringBasedMapperTest {
 
     @Configuration
     @ComponentScan(basePackageClasses = SpringBasedMapperTest.class)
@@ -40,7 +40,7 @@ public class SpringBasedMapperTest {
     private SecondDecoratedSourceTargetMapper secondDecoratedMapper;
 
     @Test
-    public void shouldInjectSpringBasedMapper() {
+    void shouldInjectSpringBasedMapper() {
         Source source = new Source();
 
         Target target = mapper.sourceToTarget( source );
@@ -51,7 +51,7 @@ public class SpringBasedMapperTest {
     }
 
     @Test
-    public void shouldInjectDecorator() {
+    void shouldInjectDecorator() {
         Source source = new Source();
 
         Target target = decoratedMapper.sourceToTarget( source );
@@ -68,7 +68,7 @@ public class SpringBasedMapperTest {
     }
 
     @Test
-    public void shouldInjectSecondDecorator() {
+    void shouldInjectSecondDecorator() {
         Source source = new Source();
 
         Target target = secondDecoratedMapper.sourceToTarget( source );

--- a/integrationtest/src/test/resources/superTypeGenerationTest/generator/pom.xml
+++ b/integrationtest/src/test/resources/superTypeGenerationTest/generator/pom.xml
@@ -21,8 +21,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrationtest/src/test/resources/superTypeGenerationTest/usage/pom.xml
+++ b/integrationtest/src/test/resources/superTypeGenerationTest/usage/pom.xml
@@ -21,8 +21,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrationtest/src/test/resources/superTypeGenerationTest/usage/src/test/java/org/mapstruct/itest/supertypegeneration/usage/GeneratedBasesTest.java
+++ b/integrationtest/src/test/resources/superTypeGenerationTest/usage/src/test/java/org/mapstruct/itest/supertypegeneration/usage/GeneratedBasesTest.java
@@ -5,9 +5,9 @@
  */
 package org.mapstruct.itest.supertypegeneration.usage;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 import org.mapstruct.itest.supertypegeneration.usage.Order;
 import org.mapstruct.itest.supertypegeneration.usage.OrderDto;
 import org.mapstruct.itest.supertypegeneration.usage.OrderMapper;
@@ -18,10 +18,10 @@ import org.mapstruct.itest.supertypegeneration.usage.OrderMapper;
  *
  * @author Gunnar Morling
  */
-public class GeneratedBasesTest {
+class GeneratedBasesTest {
 
 	@Test
-	public void considersPropertiesOnGeneratedSourceAndTargetTypes() {
+	void considersPropertiesOnGeneratedSourceAndTargetTypes() {
 		Order order = new Order();
 		order.setItem( "my item" );
 		order.setBaseName2( "my base name 2" );

--- a/integrationtest/src/test/resources/targetTypeGenerationTest/generator/pom.xml
+++ b/integrationtest/src/test/resources/targetTypeGenerationTest/generator/pom.xml
@@ -21,8 +21,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrationtest/src/test/resources/targetTypeGenerationTest/usage/pom.xml
+++ b/integrationtest/src/test/resources/targetTypeGenerationTest/usage/pom.xml
@@ -21,8 +21,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrationtest/src/test/resources/targetTypeGenerationTest/usage/src/test/java/org/mapstruct/itest/targettypegeneration/usage/GeneratedTargetTypeTest.java
+++ b/integrationtest/src/test/resources/targetTypeGenerationTest/usage/src/test/java/org/mapstruct/itest/targettypegeneration/usage/GeneratedTargetTypeTest.java
@@ -5,9 +5,9 @@
  */
 package org.mapstruct.itest.targettypegeneration.usage;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 /**
  * Integration test for using MapStruct with another annotation processor that generates the target type of a mapping
@@ -15,10 +15,10 @@ import org.junit.Test;
  *
  * @author Gunnar Morling
  */
-public class GeneratedTargetTypeTest {
+class GeneratedTargetTypeTest {
 
     @Test
-    public void considersPropertiesOnGeneratedSourceAndTargetTypes() {
+    void considersPropertiesOnGeneratedSourceAndTargetTypes() {
         Order order = new Order();
         order.setItem( "my item" );
 

--- a/integrationtest/src/test/resources/usesTypeGenerationTest/generator/pom.xml
+++ b/integrationtest/src/test/resources/usesTypeGenerationTest/generator/pom.xml
@@ -21,8 +21,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrationtest/src/test/resources/usesTypeGenerationTest/usage/pom.xml
+++ b/integrationtest/src/test/resources/usesTypeGenerationTest/usage/pom.xml
@@ -21,8 +21,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/integrationtest/src/test/resources/usesTypeGenerationTest/usage/src/test/java/org/mapstruct/itest/usestypegeneration/usage/GeneratedUsesTypeTest.java
+++ b/integrationtest/src/test/resources/usesTypeGenerationTest/usage/src/test/java/org/mapstruct/itest/usestypegeneration/usage/GeneratedUsesTypeTest.java
@@ -5,7 +5,7 @@
  */
 package org.mapstruct.itest.usestypegeneration.usage;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -14,10 +14,10 @@ import static org.assertj.core.api.Assertions.assertThat;
  *
  * @author Filip Hrisafov
  */
-public class GeneratedUsesTypeTest {
+class GeneratedUsesTypeTest {
 
     @Test
-    public void considersPropertiesOnGeneratedSourceAndTargetTypes() {
+    void considersPropertiesOnGeneratedSourceAndTargetTypes() {
         Order order = new Order();
         order.setItem( "my item" );
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -142,11 +142,6 @@
                 <version>${org.mapstruct.gem.version}</version>
             </dependency>
             <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-                <version>4.13.1</version>
-            </dependency>
-            <dependency>
                 <groupId>com.puppycrawl.tools</groupId>
                 <artifactId>checkstyle</artifactId>
                 <version>${com.puppycrawl.tools.checkstyle.version}</version>
@@ -201,7 +196,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.6.0.Final</version>
+                <version>1.7.2.Final</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
The compile tests were still using `JUnit4`. This PR fully migrates the integration tests to `JUnit5`.
To achieve this:
- Upgraded `Arquillian` to version `1.7.2.Final` (newer versions currently cause issues with `@WithCdi`)
- Updated Spring tests to use `JUnit6` by overriding the `org.junit.jupiter.version` property. (`springframework` version  7 requires  `JUnit6`)
- Applied `JUnit5` conventions and code style across the test suite