### PR TITLE
Use Optional#orElseThrow instead of Optional#get in generated code

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/conversion/TypeToOptionalConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/conversion/TypeToOptionalConversion.java
@@ -36,11 +36,10 @@ public class TypeToOptionalConversion extends SimpleConversion {
 
     @Override
     protected String getFromExpression(ConversionContext conversionContext) {
-        StringBuilder sb = new StringBuilder("<SOURCE>.get");
         Type optionalBaseType = conversionContext.getSourceType().getOptionalBaseType();
         if ( optionalBaseType.isPrimitive() ) {
-            sb.append( "As" ).append( Strings.capitalize( optionalBaseType.getName() ) );
+            return "<SOURCE>.getAs" + Strings.capitalize( optionalBaseType.getName() ) + "()";
         }
-        return sb.append( "()" ).toString();
+        return "<SOURCE>.orElseThrow()";
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -394,7 +394,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                         ParameterBinding.fromParameter( parameter ) :
                         ParameterBinding.fromTypeAndName(
                             parameter.getType(),
-                            parameter.getOriginalName() + ".get()"
+                            parameter.getOriginalName() + ".orElseThrow()"
                         ) )
                     .collect( Collectors.toList() );
             List<LifecycleCallbackMethodReference> afterMappingMethods = LifecycleMethodResolver.afterMappingMethods(

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
@@ -86,7 +86,7 @@ public class NestedPropertyMappingMethod extends MappingMethod {
 
                     presenceCheck = getPresenceCheck( propertyEntry, optionalValueSafeName );
 
-                    String optionalValueSource = previousPropertyName + ".get()";
+                    String optionalValueSource = previousPropertyName + ".orElseThrow()";
                     boolean doesNotNeedFollowUpProperty = false;
                     if ( i == propertyEntries.size() - 1 ) {
                         // If this is the last property, and we do not have a presence check,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -740,7 +740,7 @@ public class PropertyMapping extends ModelElement {
                                     variableName,
                                     ctx.getVersionInformation()
                                 ) );
-                                variableName = variableName + ".get()";
+                                variableName = variableName + ".orElseThrow()";
                             }
                             else {
                                 presenceChecks.add( new NullPresenceCheck( variableName ) );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/OptionalGetWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/OptionalGetWrapper.java
@@ -30,7 +30,7 @@ public class OptionalGetWrapper extends AssignmentWrapper {
     @Override
     public String toString() {
         if ( optionalType.getFullyQualifiedName().equals( "java.util.Optional" ) ) {
-            return getAssignment() + ".get()";
+            return getAssignment() + ".orElseThrow()";
         }
         return getAssignment() + ".getAs" + Strings.capitalize( optionalType.getOptionalBaseType().getName() ) + "()";
     }

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -62,7 +62,7 @@
                         if ( <@includeModel object=getPresenceCheckByParameter(sourceParam) /> ) {
                         <#assign sourceParamReassignment = getSourceParameterReassignment(sourceParam)!'' />
                         <#if sourceParamReassignment?has_content>
-                            <@includeModel object=sourceParamReassignment.type /> ${sourceParamReassignment.name} = ${sourceParam.name}.get();
+                            <@includeModel object=sourceParamReassignment.type /> ${sourceParamReassignment.name} = ${sourceParam.name}.orElseThrow();
 
                         </#if>
                         <#list constructorPropertyMappingsByParameter(sourceParam) as propertyMapping>
@@ -86,7 +86,7 @@
                 <#if mapNullToDefault>if ( <@includeModel object=getPresenceCheckByParameter(sourceParameters[0]) /> ) {</#if>
                 <#assign sourceParamReassignment = getSourceParameterReassignment(sourceParameters[0])!'' />
                 <#if sourceParamReassignment?has_content>
-                    <@includeModel object=sourceParamReassignment.type /> ${sourceParamReassignment.name} = ${sourceParameters[0].name}.get();
+                    <@includeModel object=sourceParamReassignment.type /> ${sourceParamReassignment.name} = ${sourceParameters[0].name}.orElseThrow();
 
                 </#if>
                 <#list constructorPropertyMappingsByParameter(sourceParameters[0]) as propertyMapping>
@@ -122,7 +122,7 @@
                 if ( <@includeModel object=getPresenceCheckByParameter(sourceParam) /> ) {
                     <#assign sourceParamReassignment = getSourceParameterReassignment(sourceParam)!'' />
                     <#if sourceParamReassignment?has_content>
-                        <@includeModel object=sourceParamReassignment.type /> ${sourceParamReassignment.name} = ${sourceParam.name}.get();
+                        <@includeModel object=sourceParamReassignment.type /> ${sourceParamReassignment.name} = ${sourceParam.name}.orElseThrow();
 
                     </#if>
                     <#list propertyMappingsByParameter(sourceParam) as propertyMapping>
@@ -142,7 +142,7 @@
         <#if mapNullToDefault>if ( <@includeModel object=getPresenceCheckByParameter(sourceParameters[0]) /> ) {</#if>
         <#assign sourceParamReassignment = getSourceParameterReassignment(sourceParameters[0])!'' />
         <#if sourceParamReassignment?has_content>
-            <@includeModel object=sourceParamReassignment.type /> ${sourceParamReassignment.name} = ${sourceParameters[0].name}.get();
+            <@includeModel object=sourceParamReassignment.type /> ${sourceParamReassignment.name} = ${sourceParameters[0].name}.orElseThrow();
 
         </#if>
         <#list propertyMappingsByParameter(sourceParameters[0]) as propertyMapping>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/OptionalGetWrapper.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/OptionalGetWrapper.ftl
@@ -10,6 +10,6 @@
 <#if optionalType.optionalBaseType.isPrimitive()>
 ${assignment}.getAs${optionalType.optionalBaseType.name?cap_first}()
 <#else>
-${assignment}.get()
+${assignment}.orElseThrow()
 </#if>
 </@compress>

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/java8time/OptionalSourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/java8time/OptionalSourceTargetMapperImpl.java
@@ -42,46 +42,46 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
         Target target = new Target();
 
         if ( source.getZonedDateTime().isPresent() ) {
-            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime().get() ) );
+            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime().orElseThrow() ) );
         }
         if ( source.getLocalDateTime().isPresent() ) {
-            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime().get() ) );
+            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime().orElseThrow() ) );
         }
         if ( source.getLocalDate().isPresent() ) {
-            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate().get() ) );
+            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate().orElseThrow() ) );
         }
         if ( source.getLocalTime().isPresent() ) {
-            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime().get() ) );
+            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime().orElseThrow() ) );
         }
         if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().orElseThrow() ) );
         }
         if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
+            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().orElseThrow().toInstant() ) );
         }
         if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
+            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().orElseThrow().toInstant( ZoneOffset.UTC ) ) );
         }
         if ( source.getForDateConversionWithLocalDate().isPresent() ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
         if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
         if ( source.getForDateConversionWithInstant().isPresent() ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
+            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().orElseThrow() ) );
         }
         if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
+            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().orElseThrow().atStartOfDay() );
         }
         if ( source.getForInstantConversionWithString().isPresent() ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
+            target.setForInstantConversionWithString( source.getForInstantConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForPeriodConversionWithString().isPresent() ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
+            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForDurationConversionWithString().isPresent() ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
+            target.setForDurationConversionWithString( source.getForDurationConversionWithString().orElseThrow().toString() );
         }
 
         return target;
@@ -96,46 +96,46 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
         Target target = new Target();
 
         if ( source.getZonedDateTime().isPresent() ) {
-            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime().get() ) );
+            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime().orElseThrow() ) );
         }
         if ( source.getLocalDateTime().isPresent() ) {
-            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime().get() ) );
+            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime().orElseThrow() ) );
         }
         if ( source.getLocalDate().isPresent() ) {
-            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate().get() ) );
+            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate().orElseThrow() ) );
         }
         if ( source.getLocalTime().isPresent() ) {
-            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime().get() ) );
+            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime().orElseThrow() ) );
         }
         if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().orElseThrow() ) );
         }
         if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
+            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().orElseThrow().toInstant() ) );
         }
         if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
+            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().orElseThrow().toInstant( ZoneOffset.UTC ) ) );
         }
         if ( source.getForDateConversionWithLocalDate().isPresent() ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
         if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
         if ( source.getForDateConversionWithInstant().isPresent() ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
+            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().orElseThrow() ) );
         }
         if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
+            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().orElseThrow().atStartOfDay() );
         }
         if ( source.getForInstantConversionWithString().isPresent() ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
+            target.setForInstantConversionWithString( source.getForInstantConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForPeriodConversionWithString().isPresent() ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
+            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForDurationConversionWithString().isPresent() ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
+            target.setForDurationConversionWithString( source.getForDurationConversionWithString().orElseThrow().toString() );
         }
 
         return target;
@@ -150,46 +150,46 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
         Target target = new Target();
 
         if ( source.getZonedDateTime().isPresent() ) {
-            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime().get() ) );
+            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime().orElseThrow() ) );
         }
         if ( source.getLocalDateTime().isPresent() ) {
-            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime().get() ) );
+            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime().orElseThrow() ) );
         }
         if ( source.getLocalDate().isPresent() ) {
-            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate().get() ) );
+            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate().orElseThrow() ) );
         }
         if ( source.getLocalTime().isPresent() ) {
-            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime().get() ) );
+            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime().orElseThrow() ) );
         }
         if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().orElseThrow() ) );
         }
         if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
+            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().orElseThrow().toInstant() ) );
         }
         if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
+            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().orElseThrow().toInstant( ZoneOffset.UTC ) ) );
         }
         if ( source.getForDateConversionWithLocalDate().isPresent() ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
         if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
         if ( source.getForDateConversionWithInstant().isPresent() ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
+            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().orElseThrow() ) );
         }
         if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
+            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().orElseThrow().atStartOfDay() );
         }
         if ( source.getForInstantConversionWithString().isPresent() ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
+            target.setForInstantConversionWithString( source.getForInstantConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForPeriodConversionWithString().isPresent() ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
+            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForDurationConversionWithString().isPresent() ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
+            target.setForDurationConversionWithString( source.getForDurationConversionWithString().orElseThrow().toString() );
         }
 
         return target;
@@ -204,46 +204,46 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
         Target target = new Target();
 
         if ( source.getLocalDateTime().isPresent() ) {
-            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime().get() ) );
+            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime().orElseThrow() ) );
         }
         if ( source.getZonedDateTime().isPresent() ) {
-            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime().get() ) );
+            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime().orElseThrow() ) );
         }
         if ( source.getLocalDate().isPresent() ) {
-            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate().get() ) );
+            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate().orElseThrow() ) );
         }
         if ( source.getLocalTime().isPresent() ) {
-            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime().get() ) );
+            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime().orElseThrow() ) );
         }
         if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().orElseThrow() ) );
         }
         if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
+            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().orElseThrow().toInstant() ) );
         }
         if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
+            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().orElseThrow().toInstant( ZoneOffset.UTC ) ) );
         }
         if ( source.getForDateConversionWithLocalDate().isPresent() ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
         if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
         if ( source.getForDateConversionWithInstant().isPresent() ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
+            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().orElseThrow() ) );
         }
         if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
+            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().orElseThrow().atStartOfDay() );
         }
         if ( source.getForInstantConversionWithString().isPresent() ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
+            target.setForInstantConversionWithString( source.getForInstantConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForPeriodConversionWithString().isPresent() ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
+            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForDurationConversionWithString().isPresent() ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
+            target.setForDurationConversionWithString( source.getForDurationConversionWithString().orElseThrow().toString() );
         }
 
         return target;
@@ -258,46 +258,46 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
         Target target = new Target();
 
         if ( source.getLocalDate().isPresent() ) {
-            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate().get() ) );
+            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate().orElseThrow() ) );
         }
         if ( source.getZonedDateTime().isPresent() ) {
-            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime().get() ) );
+            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime().orElseThrow() ) );
         }
         if ( source.getLocalDateTime().isPresent() ) {
-            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime().get() ) );
+            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime().orElseThrow() ) );
         }
         if ( source.getLocalTime().isPresent() ) {
-            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime().get() ) );
+            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime().orElseThrow() ) );
         }
         if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().orElseThrow() ) );
         }
         if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
+            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().orElseThrow().toInstant() ) );
         }
         if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
+            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().orElseThrow().toInstant( ZoneOffset.UTC ) ) );
         }
         if ( source.getForDateConversionWithLocalDate().isPresent() ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
         if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
         if ( source.getForDateConversionWithInstant().isPresent() ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
+            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().orElseThrow() ) );
         }
         if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
+            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().orElseThrow().atStartOfDay() );
         }
         if ( source.getForInstantConversionWithString().isPresent() ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
+            target.setForInstantConversionWithString( source.getForInstantConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForPeriodConversionWithString().isPresent() ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
+            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForDurationConversionWithString().isPresent() ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
+            target.setForDurationConversionWithString( source.getForDurationConversionWithString().orElseThrow().toString() );
         }
 
         return target;
@@ -312,46 +312,46 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
         Target target = new Target();
 
         if ( source.getLocalTime().isPresent() ) {
-            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime().get() ) );
+            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime().orElseThrow() ) );
         }
         if ( source.getZonedDateTime().isPresent() ) {
-            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime().get() ) );
+            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime().orElseThrow() ) );
         }
         if ( source.getLocalDateTime().isPresent() ) {
-            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime().get() ) );
+            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime().orElseThrow() ) );
         }
         if ( source.getLocalDate().isPresent() ) {
-            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate().get() ) );
+            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate().orElseThrow() ) );
         }
         if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().orElseThrow() ) );
         }
         if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
+            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().orElseThrow().toInstant() ) );
         }
         if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
+            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().orElseThrow().toInstant( ZoneOffset.UTC ) ) );
         }
         if ( source.getForDateConversionWithLocalDate().isPresent() ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
         if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().orElseThrow().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
         if ( source.getForDateConversionWithInstant().isPresent() ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
+            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().orElseThrow() ) );
         }
         if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
+            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().orElseThrow().atStartOfDay() );
         }
         if ( source.getForInstantConversionWithString().isPresent() ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
+            target.setForInstantConversionWithString( source.getForInstantConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForPeriodConversionWithString().isPresent() ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
+            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().orElseThrow().toString() );
         }
         if ( source.getForDurationConversionWithString().isPresent() ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
+            target.setForDurationConversionWithString( source.getForDurationConversionWithString().orElseThrow().toString() );
         }
 
         return target;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/beforeafter/OptionalBeforeAfterMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/beforeafter/OptionalBeforeAfterMapperImpl.java
@@ -33,7 +33,7 @@ public class OptionalBeforeAfterMapperImpl implements OptionalBeforeAfterMapper 
         deepNonOptionalToOptional = subTypeToSubTypeOptional( source.getDeepNonOptionalToOptional() );
         shallowOptionalToOptional = source.getShallowOptionalToOptional();
         if ( source.getShallowOptionalToNonOptional().isPresent() ) {
-            shallowOptionalToNonOptional = source.getShallowOptionalToNonOptional().get();
+            shallowOptionalToNonOptional = source.getShallowOptionalToNonOptional().orElseThrow();
         }
         if ( source.getShallowNonOptionalToOptional() != null ) {
             shallowNonOptionalToOptional = Optional.of( source.getShallowNonOptionalToOptional() );
@@ -54,7 +54,7 @@ public class OptionalBeforeAfterMapperImpl implements OptionalBeforeAfterMapper 
 
         String value = null;
 
-        Source.SubType optionalValue = optional.get();
+        Source.SubType optionalValue = optional.orElseThrow();
 
         value = optionalValue.getValue();
 
@@ -81,7 +81,7 @@ public class OptionalBeforeAfterMapperImpl implements OptionalBeforeAfterMapper 
 
         String value = null;
 
-        Source.SubType optionalValue = optional.get();
+        Source.SubType optionalValue = optional.orElseThrow();
 
         value = optionalValue.getValue();
 

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/differenttypes/OptionalDifferentTypesMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/differenttypes/OptionalDifferentTypesMapperImpl.java
@@ -48,7 +48,7 @@ public class OptionalDifferentTypesMapperImpl implements OptionalDifferentTypesM
 
         String value = null;
 
-        Source.SubType optionalValue = optional.get();
+        Source.SubType optionalValue = optional.orElseThrow();
 
         value = optionalValue.getValue();
 
@@ -64,7 +64,7 @@ public class OptionalDifferentTypesMapperImpl implements OptionalDifferentTypesM
 
         String value = null;
 
-        Source.SubType optionalValue = optional.get();
+        Source.SubType optionalValue = optional.orElseThrow();
 
         value = optionalValue.getValue();
 

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nested/OptionalNestedMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nested/OptionalNestedMapperImpl.java
@@ -25,7 +25,7 @@ public class OptionalNestedMapperImpl implements OptionalNestedMapper {
 
         Optional<String> value = sourceOptionalToNonOptionalValue( source );
         if ( value.isPresent() ) {
-            target.setOptionalToNonOptional( value.get() );
+            target.setOptionalToNonOptional( value.orElseThrow() );
         }
         target.setOptionalToOptional( sourceOptionalToOptionalValue( source ) );
         target.setNonOptionalToNonOptional( sourceNonOptionalToNonOptionalValue( source ) );
@@ -42,7 +42,7 @@ public class OptionalNestedMapperImpl implements OptionalNestedMapper {
         if ( optionalToNonOptional.isEmpty() ) {
             return Optional.empty();
         }
-        return optionalToNonOptional.get().getValue();
+        return optionalToNonOptional.orElseThrow().getValue();
     }
 
     private Optional<String> sourceOptionalToOptionalValue(Source source) {
@@ -50,7 +50,7 @@ public class OptionalNestedMapperImpl implements OptionalNestedMapper {
         if ( optionalToOptional.isEmpty() ) {
             return Optional.empty();
         }
-        return optionalToOptional.get().getValue();
+        return optionalToOptional.orElseThrow().getValue();
     }
 
     private String sourceNonOptionalToNonOptionalValue(Source source) {
@@ -58,7 +58,7 @@ public class OptionalNestedMapperImpl implements OptionalNestedMapper {
         if ( nonOptionalToNonOptional.isEmpty() ) {
             return null;
         }
-        return nonOptionalToNonOptional.get().getValue();
+        return nonOptionalToNonOptional.orElseThrow().getValue();
     }
 
     private String sourceNonOptionalToOptionalValue(Source source) {
@@ -66,6 +66,6 @@ public class OptionalNestedMapperImpl implements OptionalNestedMapper {
         if ( nonOptionalToOptional.isEmpty() ) {
             return null;
         }
-        return nonOptionalToOptional.get().getValue();
+        return nonOptionalToOptional.orElseThrow().getValue();
     }
 }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nested/OptionalNestedPresenceCheckFirstMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nested/OptionalNestedPresenceCheckFirstMapperImpl.java
@@ -24,19 +24,19 @@ public class OptionalNestedPresenceCheckFirstMapperImpl implements OptionalNeste
         TargetAggregate targetAggregate = new TargetAggregate();
 
         if ( song.hasTitle() ) {
-            targetAggregate.setSongTitle( song.getTitle().get() );
+            targetAggregate.setSongTitle( song.getTitle().orElseThrow() );
         }
         String name = songArtistName( song );
-        if ( song.hasArtist() && song.getArtist().isPresent() && song.getArtist().get().hasName() ) {
+        if ( song.hasArtist() && song.getArtist().isPresent() && song.getArtist().orElseThrow().hasName() ) {
             targetAggregate.setArtistName( name );
         }
         String name1 = songArtistLabelStudioName( song );
-        if ( song.hasArtist() && song.getArtist().isPresent() && song.getArtist().get().hasLabel() && song.getArtist().get().getLabel().isPresent() && song.getArtist().get().getLabel().get().hasStudio() ) {
+        if ( song.hasArtist() && song.getArtist().isPresent() && song.getArtist().orElseThrow().hasLabel() && song.getArtist().orElseThrow().getLabel().isPresent() && song.getArtist().orElseThrow().getLabel().orElseThrow().hasStudio() ) {
             targetAggregate.setRecordedAt( name1 );
         }
         Optional<String> city = songArtistLabelStudioCity( song );
-        if ( song.hasArtist() && song.getArtist().isPresent() && song.getArtist().get().hasLabel() && song.getArtist().get().getLabel().isPresent() && song.getArtist().get().getLabel().get().hasStudio() && song.getArtist().get().getLabel().get().getStudio().isPresent() && song.getArtist().get().getLabel().get().getStudio().get().hasCity() ) {
-            targetAggregate.setCity( city.get() );
+        if ( song.hasArtist() && song.getArtist().isPresent() && song.getArtist().orElseThrow().hasLabel() && song.getArtist().orElseThrow().getLabel().isPresent() && song.getArtist().orElseThrow().getLabel().orElseThrow().hasStudio() && song.getArtist().orElseThrow().getLabel().orElseThrow().getStudio().isPresent() && song.getArtist().orElseThrow().getLabel().orElseThrow().getStudio().orElseThrow().hasCity() ) {
+            targetAggregate.setCity( city.orElseThrow() );
         }
 
         return targetAggregate;
@@ -50,7 +50,7 @@ public class OptionalNestedPresenceCheckFirstMapperImpl implements OptionalNeste
         if ( artist.isEmpty() ) {
             return null;
         }
-        Artist artistValue = artist.get();
+        Artist artistValue = artist.orElseThrow();
         if ( !artistValue.hasName() ) {
             return null;
         }
@@ -65,7 +65,7 @@ public class OptionalNestedPresenceCheckFirstMapperImpl implements OptionalNeste
         if ( artist.isEmpty() ) {
             return null;
         }
-        Artist artistValue = artist.get();
+        Artist artistValue = artist.orElseThrow();
         if ( !artistValue.hasLabel() ) {
             return null;
         }
@@ -73,7 +73,7 @@ public class OptionalNestedPresenceCheckFirstMapperImpl implements OptionalNeste
         if ( label.isEmpty() ) {
             return null;
         }
-        Artist.Label labelValue = label.get();
+        Artist.Label labelValue = label.orElseThrow();
         if ( !labelValue.hasStudio() ) {
             return null;
         }
@@ -81,7 +81,7 @@ public class OptionalNestedPresenceCheckFirstMapperImpl implements OptionalNeste
         if ( studio.isEmpty() ) {
             return null;
         }
-        return studio.get().getName();
+        return studio.orElseThrow().getName();
     }
 
     private Optional<String> songArtistLabelStudioCity(Source source) {
@@ -92,7 +92,7 @@ public class OptionalNestedPresenceCheckFirstMapperImpl implements OptionalNeste
         if ( artist.isEmpty() ) {
             return Optional.empty();
         }
-        Artist artistValue = artist.get();
+        Artist artistValue = artist.orElseThrow();
         if ( !artistValue.hasLabel() ) {
             return Optional.empty();
         }
@@ -100,7 +100,7 @@ public class OptionalNestedPresenceCheckFirstMapperImpl implements OptionalNeste
         if ( label.isEmpty() ) {
             return Optional.empty();
         }
-        Artist.Label labelValue = label.get();
+        Artist.Label labelValue = label.orElseThrow();
         if ( !labelValue.hasStudio() ) {
             return Optional.empty();
         }
@@ -108,7 +108,7 @@ public class OptionalNestedPresenceCheckFirstMapperImpl implements OptionalNeste
         if ( studio.isEmpty() ) {
             return Optional.empty();
         }
-        Artist.Studio studioValue = studio.get();
+        Artist.Studio studioValue = studio.orElseThrow();
         if ( !studioValue.hasCity() ) {
             return Optional.empty();
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nested/OptionalNestedPresenceCheckMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nested/OptionalNestedPresenceCheckMapperImpl.java
@@ -28,7 +28,7 @@ public class OptionalNestedPresenceCheckMapperImpl implements OptionalNestedPres
         targetAggregate.setRecordedAt( songArtistLabelStudioName( song ) );
         Optional<String> city = songArtistLabelStudioCity( song );
         if ( city.isPresent() ) {
-            targetAggregate.setCity( city.get() );
+            targetAggregate.setCity( city.orElseThrow() );
         }
 
         return targetAggregate;
@@ -39,7 +39,7 @@ public class OptionalNestedPresenceCheckMapperImpl implements OptionalNestedPres
         if ( artist.isEmpty() ) {
             return null;
         }
-        Artist artistValue = artist.get();
+        Artist artistValue = artist.orElseThrow();
         if ( !artistValue.hasName() ) {
             return null;
         }
@@ -51,7 +51,7 @@ public class OptionalNestedPresenceCheckMapperImpl implements OptionalNestedPres
         if ( artist.isEmpty() ) {
             return null;
         }
-        Artist artistValue = artist.get();
+        Artist artistValue = artist.orElseThrow();
         if ( !artistValue.hasLabel() ) {
             return null;
         }
@@ -59,7 +59,7 @@ public class OptionalNestedPresenceCheckMapperImpl implements OptionalNestedPres
         if ( label.isEmpty() ) {
             return null;
         }
-        Artist.Label labelValue = label.get();
+        Artist.Label labelValue = label.orElseThrow();
         if ( !labelValue.hasStudio() ) {
             return null;
         }
@@ -67,7 +67,7 @@ public class OptionalNestedPresenceCheckMapperImpl implements OptionalNestedPres
         if ( studio.isEmpty() ) {
             return null;
         }
-        return studio.get().getName();
+        return studio.orElseThrow().getName();
     }
 
     private Optional<String> songArtistLabelStudioCity(Source source) {
@@ -75,7 +75,7 @@ public class OptionalNestedPresenceCheckMapperImpl implements OptionalNestedPres
         if ( artist.isEmpty() ) {
             return Optional.empty();
         }
-        Artist artistValue = artist.get();
+        Artist artistValue = artist.orElseThrow();
         if ( !artistValue.hasLabel() ) {
             return Optional.empty();
         }
@@ -83,7 +83,7 @@ public class OptionalNestedPresenceCheckMapperImpl implements OptionalNestedPres
         if ( label.isEmpty() ) {
             return Optional.empty();
         }
-        Artist.Label labelValue = label.get();
+        Artist.Label labelValue = label.orElseThrow();
         if ( !labelValue.hasStudio() ) {
             return Optional.empty();
         }
@@ -91,7 +91,7 @@ public class OptionalNestedPresenceCheckMapperImpl implements OptionalNestedPres
         if ( studio.isEmpty() ) {
             return Optional.empty();
         }
-        Artist.Studio studioValue = studio.get();
+        Artist.Studio studioValue = studio.orElseThrow();
         if ( !studioValue.hasCity() ) {
             return Optional.empty();
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nullcheckalways/OptionalNullCheckAlwaysMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nullcheckalways/OptionalNullCheckAlwaysMapperImpl.java
@@ -27,7 +27,7 @@ public class OptionalNullCheckAlwaysMapperImpl implements OptionalNullCheckAlway
             target.setOptionalToOptional( source.getOptionalToOptional() );
         }
         if ( source.getOptionalToNonOptional().isPresent() ) {
-            target.setOptionalToNonOptional( source.getOptionalToNonOptional().get() );
+            target.setOptionalToNonOptional( source.getOptionalToNonOptional().orElseThrow() );
         }
         if ( source.getNonOptionalToOptional() != null ) {
             target.setNonOptionalToOptional( Optional.of( source.getNonOptionalToOptional() ) );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/sametype/OptionalSameTypeMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/sametype/OptionalSameTypeMapperImpl.java
@@ -27,7 +27,7 @@ public class OptionalSameTypeMapperImpl implements OptionalSameTypeMapper {
 
         constructorOptionalToOptional = source.getConstructorOptionalToOptional();
         if ( source.getConstructorOptionalToNonOptional().isPresent() ) {
-            constructorOptionalToNonOptional = source.getConstructorOptionalToNonOptional().get();
+            constructorOptionalToNonOptional = source.getConstructorOptionalToNonOptional().orElseThrow();
         }
         if ( source.getConstructorNonOptionalToOptional() != null ) {
             constructorNonOptionalToOptional = Optional.of( source.getConstructorNonOptionalToOptional() );
@@ -37,14 +37,14 @@ public class OptionalSameTypeMapperImpl implements OptionalSameTypeMapper {
 
         target.setOptionalToOptional( source.getOptionalToOptional() );
         if ( source.getOptionalToNonOptional().isPresent() ) {
-            target.setOptionalToNonOptional( source.getOptionalToNonOptional().get() );
+            target.setOptionalToNonOptional( source.getOptionalToNonOptional().orElseThrow() );
         }
         if ( source.getNonOptionalToOptional() != null ) {
             target.setNonOptionalToOptional( Optional.of( source.getNonOptionalToOptional() ) );
         }
         target.publicOptionalToOptional = source.publicOptionalToOptional;
         if ( source.publicOptionalToNonOptional.isPresent() ) {
-            target.publicOptionalToNonOptional = source.publicOptionalToNonOptional.get();
+            target.publicOptionalToNonOptional = source.publicOptionalToNonOptional.orElseThrow();
         }
         if ( source.publicNonOptionalToOptional != null ) {
             target.publicNonOptionalToOptional = Optional.of( source.publicNonOptionalToOptional );


### PR DESCRIPTION
## Summary

Replace all `Optional#get()` calls in MapStruct-generated mapper code with `Optional#orElseThrow()`.

## Problem

MapStruct generated code used `Optional#get()` to unwrap Optional values. This method is discouraged — it throws `NoSuchElementException` with no message and triggers IDE/linter warnings when called without a preceding `isPresent()` check.

## Changes

Seven source locations were updated:

| File | What changed |
|------|-------------|
| `TypeToOptionalConversion.java` | `<SOURCE>.get()` → `<SOURCE>.orElseThrow()` for non-primitive Optional conversions |
| `OptionalGetWrapper.java` | `+ ".get()"` → `+ ".orElseThrow()"` in `toString()` |
| `OptionalGetWrapper.ftl` | `${assignment}.get()` → `${assignment}.orElseThrow()` |
| `BeanMappingMethod.java` | `+ ".get()"` → `+ ".orElseThrow()"` in parameter binding |
| `BeanMappingMethod.ftl` | 4 occurrences of `.get()` → `.orElseThrow()` for source param reassignment |
| `NestedPropertyMappingMethod.java` | `+ ".get()"` → `+ ".orElseThrow()"` |
| `PropertyMapping.java` | `+ ".get()"` → `+ ".orElseThrow()"` |

8 test snapshot fixtures were updated to match the new generated output.

## Why this is safe

- `Optional#orElseThrow()` (no-arg) is semantically identical to `Optional#get()` — both throw `NoSuchElementException` when the value is absent.
- It has been available since Java 10. MapStruct now requires Java 21, so it is always present.
- All call sites already guard Optional access with presence checks (`isPresent()`, `isEmpty()`, `hasXxx()`), so behavior is unchanged.

## Testing

```
mvn test -pl processor
```

Result: **3467 tests, 0 failures, 0 errors.**

## Files changed

- 7 processor source files (`.java` + `.ftl`)
- 8 test snapshot fixtures

## Related issues

Fixes #3976