### PR TITLE
Add support for JSpecify nullness annotations (#1243)

### DIFF
--- a/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
@@ -333,6 +333,10 @@ When the source parameter of a mapping method is annotated `@NonNull` (directly 
 
 If a property mapping would assign a potentially `null` source value to a `@NonNull` constructor parameter, MapStruct raises a *compilation error*. Neither inserting a null check (which would leave the variable at `null` and violate the contract) nor passing the value through is safe. Provide a `defaultValue` or `defaultExpression` on the `@Mapping` to satisfy the parameter when the source is absent.
 
+==== Disabling JSpecify support
+
+All JSpecify-driven inference can be turned off by setting the processor option `-Amapstruct.disableJSpecify=true`. With the option enabled, MapStruct ignores every JSpecify annotation (`@NonNull`, `@Nullable`, `@NullMarked`, `@NullUnmarked`) and the compilation error for nullable sources mapped to `@NonNull` constructor parameters is not raised. Null-check generation falls back to the pre-JSpecify behavior driven by `NullValueCheckStrategy`. Use this flag when you need to freeze MapStruct's null-handling behavior while JSpecify annotations exist elsewhere on the classpath.
+
 [[source-presence-check]]
 === Source presence checking
 Some frameworks generate bean properties that have a source presence checker. Often this is in the form of a method `hasXYZ`, `XYZ` being a property on the source bean in a bean mapping method. MapStruct will call this `hasXYZ` instead of performing a `null` check when it finds such `hasXYZ` method.

--- a/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
@@ -299,6 +299,40 @@ The option `nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS` will always 
 
 The strategy works in a hierarchical fashion. `@Mapping#nullValueCheckStrategy` will override `@BeanMapping#nullValueCheckStrategy`, `@BeanMapping#nullValueCheckStrategy` will override `@Mapper#nullValueCheckStrategy` and `@Mapper#nullValueCheckStrategy` will override `@MapperConfig#nullValueCheckStrategy`.
 
+[[jspecify-nullness-annotations]]
+=== JSpecify nullness annotations
+
+MapStruct recognises https://jspecify.dev/[JSpecify] nullness annotations on source and target types and uses them to refine when null checks are generated. Only the annotations from `org.jspecify.annotations` are interpreted; MapStruct does not introduce a compile-time dependency on JSpecify, so consumers opt in by adding the dependency themselves.
+
+The following annotations participate:
+
+* `@NonNull`: the annotated value is guaranteed not to be `null`.
+* `@Nullable`: the annotated value may be `null`.
+* `@NullMarked`: within this scope (package, class, or method), unannotated reference types are treated as `@NonNull`.
+* `@NullUnmarked`: reverts to unknown nullability within its scope (overrides a `@NullMarked` outer scope).
+
+==== Property-level rules
+
+For a single property mapping:
+
+* If the source is `@NonNull`, the null check is skipped, since the value is treated as guaranteed non-null.
+* If the target is `@NonNull` (and the source is not `@NonNull`), a null check is always added so the target's contract is not violated.
+* In all other cases, the existing `NullValueCheckStrategy` decides.
+
+The existing safety guards (`defaultValue` / `defaultExpression`, primitive unboxing, and the relevant `NullValuePropertyMappingStrategy` modes) continue to apply.
+
+==== Scope: `@NullMarked` and `@NullUnmarked`
+
+`@NullMarked` and `@NullUnmarked` are resolved by walking from the annotated element outward: method, then declaring class, then outer classes, then package. The closest annotation wins: a `@NullUnmarked` method inside a `@NullMarked` class reverts only that method, while a `@Nullable` annotation on an individual type always overrides the surrounding scope.
+
+==== Method-level source parameter
+
+When the source parameter of a mapping method is annotated `@NonNull` (directly or via a `@NullMarked` scope), MapStruct skips the method-level null guard, since the caller is contractually obliged to pass a non-null value.
+
+==== Constructor parameter constraint
+
+If a property mapping would assign a potentially `null` source value to a `@NonNull` constructor parameter, MapStruct raises a *compilation error*. Neither inserting a null check (which would leave the variable at `null` and violate the contract) nor passing the value through is safe. Provide a `defaultValue` or `defaultExpression` on the `@Mapping` to satisfy the parameter when the source is absent.
+
 [[source-presence-check]]
 === Source presence checking
 Some frameworks generate bean properties that have a source presence checker. Often this is in the form of a method `hasXYZ`, `XYZ` being a property on the source bean in a bean mapping method. MapStruct will call this `hasXYZ` instead of performing a `null` check when it finds such `hasXYZ` method.

--- a/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-2-set-up.asciidoc
@@ -268,6 +268,11 @@ disableBuilders`
 |If set to `true`, then MapStruct will not use builder patterns when doing the mapping. This is equivalent to doing `@Mapper( builder = @Builder( disableBuilder = true ) )` for all of your mappers.
 |`false`
 
+|`mapstruct.
+disableJSpecify`
+|If set to `true`, MapStruct ignores all JSpecify nullness annotations (`@NonNull`, `@Nullable`, `@NullMarked`, `@NullUnmarked`) when deciding whether to generate null checks and does not raise the compilation error for a nullable source mapped to a `@NonNull` constructor parameter. Null-check generation falls back to the `NullValueCheckStrategy`-driven behavior.
+|`false`
+
 |`mapstruct.nullValueIterableMappingStrategy`
 |The strategy to be applied when `null` is passed as a source value to an iterable mapping.
 

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -266,6 +266,13 @@
                 <version>1.14.6</version>
             </dependency>
 
+            <!-- JSpecify -->
+            <dependency>
+                <groupId>org.jspecify</groupId>
+                <artifactId>jspecify</artifactId>
+                <version>1.0.0</version>
+            </dependency>
+
             <!-- Joda-Time -->
             <dependency>
                 <groupId>joda-time</groupId>

--- a/processor/pom.xml
+++ b/processor/pom.xml
@@ -148,6 +148,13 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- There is no compile dependency to JSpecify; It's only required for testing the null annotations -->
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <dependency>
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>

--- a/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/MappingProcessor.java
@@ -159,6 +159,7 @@ public class MappingProcessor extends AbstractProcessor {
             processingEnv.getTypeUtils(),
             processingEnv.getMessager(),
             options.isDisableBuilders(),
+            options.isDisableJSpecify(),
             options.isVerbose(),
             resolveAdditionalOptions( processingEnv.getOptions() )
         );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
@@ -27,6 +27,7 @@ import org.mapstruct.ap.internal.option.Options;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
 import org.mapstruct.ap.internal.util.ElementUtils;
 import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.Services;
 import org.mapstruct.ap.internal.util.TypeUtils;
 import org.mapstruct.ap.internal.version.VersionInformation;
@@ -111,6 +112,7 @@ public class MappingBuilderContext {
     private final FormattingMessager messager;
     private final VersionInformation versionInformation;
     private final AccessorNamingUtils accessorNaming;
+    private final NullabilityResolver nullabilityResolver;
     private final EnumMappingStrategy enumMappingStrategy;
     private final Map<String, EnumTransformationStrategy> enumTransformationStrategies;
     private final Options options;
@@ -129,6 +131,7 @@ public class MappingBuilderContext {
                           FormattingMessager messager,
                           VersionInformation versionInformation,
                           AccessorNamingUtils accessorNaming,
+                          NullabilityResolver nullabilityResolver,
                           EnumMappingStrategy enumMappingStrategy,
                           Map<String, EnumTransformationStrategy> enumTransformationStrategies,
                           Options options,
@@ -142,6 +145,7 @@ public class MappingBuilderContext {
         this.messager = messager;
         this.versionInformation = versionInformation;
         this.accessorNaming = accessorNaming;
+        this.nullabilityResolver = nullabilityResolver;
         this.enumMappingStrategy = enumMappingStrategy;
         this.enumTransformationStrategies = enumTransformationStrategies;
         this.options = options;
@@ -199,6 +203,10 @@ public class MappingBuilderContext {
 
     public AccessorNamingUtils getAccessorNaming() {
         return accessorNaming;
+    }
+
+    public NullabilityResolver getNullabilityResolver() {
+        return nullabilityResolver;
     }
 
     public EnumMappingStrategy getEnumMappingStrategy() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
@@ -19,7 +19,7 @@ import org.mapstruct.ap.internal.model.presence.AnyPresenceChecksPresenceCheck;
 import org.mapstruct.ap.internal.model.presence.NullPresenceCheck;
 import org.mapstruct.ap.internal.model.presence.OptionalPresenceCheck;
 import org.mapstruct.ap.internal.model.presence.SuffixPresenceCheck;
-import org.mapstruct.ap.internal.util.NullabilityUtils;
+import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.PresenceCheckAccessor;
 
@@ -78,10 +78,10 @@ public class NestedPropertyMappingMethod extends MappingMethod {
             for ( int i = 0; i < propertyEntries.size(); i++ ) {
                 PropertyEntry propertyEntry = propertyEntries.get( i );
                 PresenceCheck presenceCheck;
-                boolean currentEntryIsNonNull = NullabilityUtils.getNullability(
+                boolean currentEntryIsNonNull = ctx.getNullabilityResolver().getNullability(
                     propertyEntry.getReadAccessor().getElement(),
                     previousPropertyType::isNullMarked
-                ) == NullabilityUtils.Nullability.NON_NULL;
+                ) == NullabilityResolver.Nullability.NON_NULL;
 
                 if ( previousPropertyType.isOptionalType() ) {
                     String optionalValueSafeName = Strings.getSafeVariableName(

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/NestedPropertyMappingMethod.java
@@ -19,6 +19,7 @@ import org.mapstruct.ap.internal.model.presence.AnyPresenceChecksPresenceCheck;
 import org.mapstruct.ap.internal.model.presence.NullPresenceCheck;
 import org.mapstruct.ap.internal.model.presence.OptionalPresenceCheck;
 import org.mapstruct.ap.internal.model.presence.SuffixPresenceCheck;
+import org.mapstruct.ap.internal.util.NullabilityUtils;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.PresenceCheckAccessor;
 
@@ -73,9 +74,14 @@ public class NestedPropertyMappingMethod extends MappingMethod {
 
             String previousPropertyName = sourceParameter.getName();
             Type previousPropertyType = sourceParameter.getType();
+            boolean previousEntryIsNonNull = false;
             for ( int i = 0; i < propertyEntries.size(); i++ ) {
                 PropertyEntry propertyEntry = propertyEntries.get( i );
                 PresenceCheck presenceCheck;
+                boolean currentEntryIsNonNull = NullabilityUtils.getNullability(
+                    propertyEntry.getReadAccessor().getElement(),
+                    previousPropertyType::isNullMarked
+                ) == NullabilityUtils.Nullability.NON_NULL;
 
                 if ( previousPropertyType.isOptionalType() ) {
                     String optionalValueSafeName = Strings.getSafeVariableName(
@@ -112,9 +118,10 @@ public class NestedPropertyMappingMethod extends MappingMethod {
                 }
                 else {
                     presenceCheck = getPresenceCheck( propertyEntry, previousPropertyName );
-                    if ( i > 0 ) {
+                    if ( i > 0 && !previousEntryIsNonNull ) {
                         // If this is not the first property entry,
-                        // then we might need to combine the presence check with a null check of the previous property
+                        // then we need to combine the presence check with a null check of the previous property.
+                        // JSpecify: the null check is skipped when the previous accessor returns @NonNull.
                         if ( presenceCheck != null ) {
                             presenceCheck = new AnyPresenceChecksPresenceCheck( Arrays.asList(
                                 new NullPresenceCheck( previousPropertyName, true ),
@@ -140,6 +147,7 @@ public class NestedPropertyMappingMethod extends MappingMethod {
                         propertyEntry.getReadAccessor() ) );
                 previousPropertyName = safeName;
                 previousPropertyType = propertyEntry.getType();
+                previousEntryIsNonNull = currentEntryIsNonNull;
             }
             method.addThrownTypes( thrownTypes );
             return new NestedPropertyMappingMethod( method, safePropertyEntries );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PresenceCheckMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PresenceCheckMethodResolver.java
@@ -23,6 +23,7 @@ import org.mapstruct.ap.internal.model.source.selector.SelectedMethod;
 import org.mapstruct.ap.internal.model.source.selector.SelectionContext;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Message;
+import org.mapstruct.ap.internal.util.NullabilityUtils;
 
 /**
  * Factory for creating {@link PresenceCheck}s.
@@ -94,6 +95,15 @@ public final class PresenceCheckMethodResolver {
                 return new OptionalPresenceCheck( sourceParameter.getName(), ctx.getVersionInformation() );
             }
             else if ( !sourceParameter.getType().isPrimitive() ) {
+                // If the source parameter is @NonNull (JSpecify), skip the null guard entirely.
+                // Use the mapper type for @NullMarked scope resolution since the parameter
+                // is declared in the mapper interface.
+                if ( NullabilityUtils.getNullability(
+                    sourceParameter.getElement(),
+                    () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked() )
+                    == NullabilityUtils.Nullability.NON_NULL ) {
+                    return null;
+                }
                 return new NullPresenceCheck( sourceParameter.getName() );
             }
             return null;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PresenceCheckMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PresenceCheckMethodResolver.java
@@ -102,6 +102,12 @@ public final class PresenceCheckMethodResolver {
                     sourceParameter.getElement(),
                     () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked() )
                     == NullabilityUtils.Nullability.NON_NULL ) {
+                    ctx.getMessager().note( 2,
+                        Message.PROPERTYMAPPING_JSPECIFY_NOTE,
+                        "skipping method-level null guard",
+                        sourceParameter.getName(),
+                        "parameter is @NonNull"
+                    );
                     return null;
                 }
                 return new NullPresenceCheck( sourceParameter.getName() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PresenceCheckMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PresenceCheckMethodResolver.java
@@ -103,10 +103,8 @@ public final class PresenceCheckMethodResolver {
                     () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked() )
                     == NullabilityUtils.Nullability.NON_NULL ) {
                     ctx.getMessager().note( 2,
-                        Message.PROPERTYMAPPING_JSPECIFY_NOTE,
-                        "skipping method-level null guard",
-                        sourceParameter.getName(),
-                        "parameter is @NonNull"
+                        Message.PROPERTYMAPPING_JSPECIFY_SKIP_METHOD_GUARD_NON_NULL_PARAM,
+                        sourceParameter.getName()
                     );
                     return null;
                 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PresenceCheckMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PresenceCheckMethodResolver.java
@@ -23,7 +23,7 @@ import org.mapstruct.ap.internal.model.source.selector.SelectedMethod;
 import org.mapstruct.ap.internal.model.source.selector.SelectionContext;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Message;
-import org.mapstruct.ap.internal.util.NullabilityUtils;
+import org.mapstruct.ap.internal.util.NullabilityResolver;
 
 /**
  * Factory for creating {@link PresenceCheck}s.
@@ -98,10 +98,10 @@ public final class PresenceCheckMethodResolver {
                 // If the source parameter is @NonNull (JSpecify), skip the null guard entirely.
                 // Use the mapper type for @NullMarked scope resolution since the parameter
                 // is declared in the mapper interface.
-                if ( NullabilityUtils.getNullability(
+                if ( ctx.getNullabilityResolver().getNullability(
                     sourceParameter.getElement(),
                     () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked() )
-                    == NullabilityUtils.Nullability.NON_NULL ) {
+                    == NullabilityResolver.Nullability.NON_NULL ) {
                     ctx.getMessager().note( 2,
                         Message.PROPERTYMAPPING_JSPECIFY_SKIP_METHOD_GUARD_NON_NULL_PARAM,
                         sourceParameter.getName()

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -275,11 +275,12 @@ public class PropertyMapping extends ModelElement {
                 assignment = forge();
             }
 
-            // JSpecify: report error when a source that is not guaranteed @NonNull (either explicit
-            // @Nullable or unknown nullability outside a @NullMarked scope) is mapped to a @NonNull
-            // constructor parameter without a default value. A null check would leave the variable
-            // at null, violating the @NonNull contract, and passing the value through is equally
-            // invalid — defaultValue / defaultExpression are the supported remedies.
+            // JSpecify: raise a hard compile error when a source that is not guaranteed @NonNull
+            // (either explicit @Nullable or unknown nullability outside a @NullMarked scope) is
+            // mapped to a @NonNull constructor parameter without a default value. Neither a null
+            // check (which would leave the variable null, violating the @NonNull contract) nor
+            // passing the value through is safe here — defaultValue / defaultExpression are the
+            // supported remedies.
             // Skip when assignment resolution already failed: the user sees the primary
             // "can't find mapping" error and a duplicate would only obscure the root cause.
             if ( assignment != null
@@ -536,10 +537,8 @@ public class PropertyMapping extends ModelElement {
             NullabilityUtils.Nullability sourceNullability = getSourceJSpecifyNullability();
             if ( sourceNullability == NullabilityUtils.Nullability.NON_NULL ) {
                 ctx.getMessager().note( 2,
-                    Message.PROPERTYMAPPING_JSPECIFY_NOTE,
-                    "skipping null check",
-                    targetPropertyName,
-                    "source is @NonNull"
+                    Message.PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK_NON_NULL_SOURCE,
+                    targetPropertyName
                 );
                 return false;
             }
@@ -576,10 +575,12 @@ public class PropertyMapping extends ModelElement {
             Boolean jspecifyDecision = NullabilityUtils.requiresNullCheck( sourceNullability, targetNullability );
             if ( jspecifyDecision != null ) {
                 ctx.getMessager().note( 2,
-                    Message.PROPERTYMAPPING_JSPECIFY_NOTE,
-                    jspecifyDecision ? "adding null check" : "skipping null check",
+                    jspecifyDecision
+                        ? Message.PROPERTYMAPPING_JSPECIFY_ADD_NULL_CHECK
+                        : Message.PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK,
                     targetPropertyName,
-                    "source=" + sourceNullability + ", target=" + targetNullability
+                    sourceNullability,
+                    targetNullability
                 );
                 return jspecifyDecision;
             }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -51,7 +51,7 @@ import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.NativeTypes;
-import org.mapstruct.ap.internal.util.NullabilityUtils;
+import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.AccessorType;
@@ -286,12 +286,12 @@ public class PropertyMapping extends ModelElement {
             if ( assignment != null
                 && targetWriteAccessorType == AccessorType.PARAMETER
                 && !hasDefaultValueOrDefaultExpression() ) {
-                NullabilityUtils.Nullability sourceNullability = getSourceJSpecifyNullability();
-                NullabilityUtils.Nullability targetNullability = NullabilityUtils.getSetterNullability(
+                NullabilityResolver.Nullability sourceNullability = getSourceJSpecifyNullability();
+                NullabilityResolver.Nullability targetNullability = ctx.getNullabilityResolver().getSetterNullability(
                     targetWriteAccessor.getElement(), this::targetDeclaringTypeIsNullMarked
                 );
-                if ( sourceNullability != NullabilityUtils.Nullability.NON_NULL
-                    && targetNullability == NullabilityUtils.Nullability.NON_NULL ) {
+                if ( sourceNullability != NullabilityResolver.Nullability.NON_NULL
+                    && targetNullability == NullabilityResolver.Nullability.NON_NULL ) {
                     ctx.getMessager().printMessage(
                         method.getExecutable(),
                         positionHint,
@@ -480,8 +480,8 @@ public class PropertyMapping extends ModelElement {
                 boolean includeSourceNullCheck = !rhs.isSourceReferenceParameter();
                 if ( includeSourceNullCheck ) {
                     // JSpecify: source @NonNull means no null check needed
-                    NullabilityUtils.Nullability sourceNullability = getSourceJSpecifyNullability();
-                    if ( sourceNullability == NullabilityUtils.Nullability.NON_NULL ) {
+                    NullabilityResolver.Nullability sourceNullability = getSourceJSpecifyNullability();
+                    if ( sourceNullability == NullabilityResolver.Nullability.NON_NULL ) {
                         includeSourceNullCheck = false;
                     }
                 }
@@ -534,8 +534,8 @@ public class PropertyMapping extends ModelElement {
             }
 
             // JSpecify: source @NonNull means the value is guaranteed non-null, skip all checks
-            NullabilityUtils.Nullability sourceNullability = getSourceJSpecifyNullability();
-            if ( sourceNullability == NullabilityUtils.Nullability.NON_NULL ) {
+            NullabilityResolver.Nullability sourceNullability = getSourceJSpecifyNullability();
+            if ( sourceNullability == NullabilityResolver.Nullability.NON_NULL ) {
                 ctx.getMessager().note( 2,
                     Message.PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK_NON_NULL_SOURCE,
                     targetPropertyName
@@ -569,10 +569,11 @@ public class PropertyMapping extends ModelElement {
             }
 
             // JSpecify annotations take precedence over NullValueCheckStrategy
-            NullabilityUtils.Nullability targetNullability = NullabilityUtils.getSetterNullability(
+            NullabilityResolver resolver = ctx.getNullabilityResolver();
+            NullabilityResolver.Nullability targetNullability = resolver.getSetterNullability(
                 targetWriteAccessor.getElement(), this::targetDeclaringTypeIsNullMarked
             );
-            Boolean jspecifyDecision = NullabilityUtils.requiresNullCheck( sourceNullability, targetNullability );
+            Boolean jspecifyDecision = resolver.requiresNullCheck( sourceNullability, targetNullability );
             if ( jspecifyDecision != null ) {
                 ctx.getMessager().note( 2,
                     jspecifyDecision
@@ -593,9 +594,9 @@ public class PropertyMapping extends ModelElement {
             return false;
         }
 
-        private NullabilityUtils.Nullability getSourceJSpecifyNullability() {
+        private NullabilityResolver.Nullability getSourceJSpecifyNullability() {
             if ( sourceReference == null ) {
-                return NullabilityUtils.Nullability.UNKNOWN;
+                return NullabilityResolver.Nullability.UNKNOWN;
             }
             List<PropertyEntry> entries = sourceReference.getPropertyEntries();
             if ( !entries.isEmpty() ) {
@@ -603,19 +604,19 @@ public class PropertyMapping extends ModelElement {
                 // chain is @NonNull. If any intermediate accessor is @Nullable, the chain may
                 // yield null even when the deepest accessor is @NonNull.
                 Type enclosingType = sourceReference.getParameter().getType();
-                NullabilityUtils.Nullability chain = NullabilityUtils.Nullability.NON_NULL;
+                NullabilityResolver.Nullability chain = NullabilityResolver.Nullability.NON_NULL;
                 for ( PropertyEntry entry : entries ) {
                     if ( entry.getReadAccessor() == null ) {
-                        return NullabilityUtils.Nullability.UNKNOWN;
+                        return NullabilityResolver.Nullability.UNKNOWN;
                     }
-                    NullabilityUtils.Nullability current = NullabilityUtils.getNullability(
+                    NullabilityResolver.Nullability current = ctx.getNullabilityResolver().getNullability(
                         entry.getReadAccessor().getElement(), enclosingType::isNullMarked
                     );
-                    if ( current == NullabilityUtils.Nullability.NULLABLE ) {
-                        return NullabilityUtils.Nullability.NULLABLE;
+                    if ( current == NullabilityResolver.Nullability.NULLABLE ) {
+                        return NullabilityResolver.Nullability.NULLABLE;
                     }
-                    if ( current == NullabilityUtils.Nullability.UNKNOWN ) {
-                        chain = NullabilityUtils.Nullability.UNKNOWN;
+                    if ( current == NullabilityResolver.Nullability.UNKNOWN ) {
+                        chain = NullabilityResolver.Nullability.UNKNOWN;
                     }
                     enclosingType = entry.getType();
                 }
@@ -625,12 +626,12 @@ public class PropertyMapping extends ModelElement {
             // Use the mapper type for @NullMarked scope resolution since the parameter is declared there.
             Parameter parameter = sourceReference.getParameter();
             if ( parameter != null && parameter.getElement() != null ) {
-                return NullabilityUtils.getNullability(
+                return ctx.getNullabilityResolver().getNullability(
                     parameter.getElement(),
                     () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked()
                 );
             }
-            return NullabilityUtils.Nullability.UNKNOWN;
+            return NullabilityResolver.Nullability.UNKNOWN;
         }
 
         /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -50,6 +50,7 @@ import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.NativeTypes;
+import org.mapstruct.ap.internal.util.NullabilityUtils;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.AccessorType;
@@ -273,6 +274,26 @@ public class PropertyMapping extends ModelElement {
                 assignment = forge();
             }
 
+            // JSpecify: report error when mapping @Nullable source to @NonNull constructor parameter
+            // without a default value. A null check would leave the variable at null, violating the
+            // @NonNull contract, and passing the value through is equally invalid.
+            if ( targetWriteAccessorType == AccessorType.PARAMETER && !hasDefaultValueOrDefaultExpression() ) {
+                NullabilityUtils.Nullability sourceNullability = getSourceJSpecifyNullability();
+                NullabilityUtils.Nullability targetNullability = NullabilityUtils.getSetterNullability(
+                    targetWriteAccessor.getElement(), targetType::isNullMarked
+                );
+                if ( sourceNullability != NullabilityUtils.Nullability.NON_NULL
+                    && targetNullability == NullabilityUtils.Nullability.NON_NULL ) {
+                    ctx.getMessager().printMessage(
+                        method.getExecutable(),
+                        positionHint,
+                        Message.PROPERTYMAPPING_NULLABLE_SOURCE_TO_NON_NULL_CONSTRUCTOR_PARAM,
+                        sourcePropertyName != null ? sourcePropertyName : targetPropertyName,
+                        targetPropertyName
+                    );
+                }
+            }
+
             Type sourceType = rightHandSide.getSourceType();
             if ( assignment != null ) {
                 ctx.getMessager().note( 2,  Message.PROPERTYMAPPING_SELECT_NOTE,  assignment );
@@ -448,13 +469,21 @@ public class PropertyMapping extends ModelElement {
                     }
 
                 }
+                boolean includeSourceNullCheck = !rhs.isSourceReferenceParameter();
+                if ( includeSourceNullCheck ) {
+                    // JSpecify: source @NonNull means no null check needed
+                    NullabilityUtils.Nullability sourceNullability = getSourceJSpecifyNullability();
+                    if ( sourceNullability == NullabilityUtils.Nullability.NON_NULL ) {
+                        includeSourceNullCheck = false;
+                    }
+                }
                 return new UpdateWrapper(
                     rhs,
                     method.getThrownTypes(),
                     factory,
                     isFieldAssignment(),
                     targetType,
-                    !rhs.isSourceReferenceParameter(),
+                    includeSourceNullCheck,
                     nvpms == SET_TO_NULL && !targetType.isPrimitive(),
                     nvpms == SET_TO_DEFAULT,
                     hasTwoOrMoreSettersWithName()
@@ -496,9 +525,10 @@ public class PropertyMapping extends ModelElement {
                 return false;
             }
 
-            if ( nvcs == ALWAYS ) {
-                // NullValueCheckStrategy is ALWAYS -> do a null check
-                return true;
+            // JSpecify: source @NonNull means the value is guaranteed non-null, skip all checks
+            NullabilityUtils.Nullability sourceNullability = getSourceJSpecifyNullability();
+            if ( sourceNullability == NullabilityUtils.Nullability.NON_NULL ) {
+                return false;
             }
 
             if ( rhs.getSourcePresenceCheckerReference() != null ) {
@@ -526,7 +556,40 @@ public class PropertyMapping extends ModelElement {
                 return true;
             }
 
+            // JSpecify annotations take precedence over NullValueCheckStrategy
+            NullabilityUtils.Nullability targetNullability = NullabilityUtils.getSetterNullability(
+                targetWriteAccessor.getElement(), targetType::isNullMarked
+            );
+            Boolean jspecifyDecision = NullabilityUtils.requiresNullCheck( sourceNullability, targetNullability );
+            if ( jspecifyDecision != null ) {
+                return jspecifyDecision;
+            }
+
+            if ( nvcs == ALWAYS ) {
+                // NullValueCheckStrategy is ALWAYS -> do a null check
+                return true;
+            }
+
             return false;
+        }
+
+        private NullabilityUtils.Nullability getSourceJSpecifyNullability() {
+            if ( sourceReference != null && !sourceReference.getPropertyEntries().isEmpty() ) {
+                PropertyEntry deepestProperty = sourceReference.getDeepestProperty();
+                if ( deepestProperty != null && deepestProperty.getReadAccessor() != null ) {
+                    // Determine the enclosing type for @NullMarked scope lookup.
+                    // For simple properties (a.b), the enclosing type is the source parameter type.
+                    // For nested properties (a.b.c), the enclosing type is the parent entry's type.
+                    List<PropertyEntry> entries = sourceReference.getPropertyEntries();
+                    Type enclosingType = entries.size() > 1
+                        ? entries.get( entries.size() - 2 ).getType()
+                        : sourceReference.getParameter().getType();
+                    return NullabilityUtils.getNullability(
+                        deepestProperty.getReadAccessor().getElement(), enclosingType::isNullMarked
+                    );
+                }
+            }
+            return NullabilityUtils.Nullability.UNKNOWN;
         }
 
         private boolean hasDefaultValueOrDefaultExpression() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -275,9 +275,11 @@ public class PropertyMapping extends ModelElement {
                 assignment = forge();
             }
 
-            // JSpecify: report error when mapping @Nullable source to @NonNull constructor parameter
-            // without a default value. A null check would leave the variable at null, violating the
-            // @NonNull contract, and passing the value through is equally invalid.
+            // JSpecify: report error when a source that is not guaranteed @NonNull (either explicit
+            // @Nullable or unknown nullability outside a @NullMarked scope) is mapped to a @NonNull
+            // constructor parameter without a default value. A null check would leave the variable
+            // at null, violating the @NonNull contract, and passing the value through is equally
+            // invalid — defaultValue / defaultExpression are the supported remedies.
             if ( targetWriteAccessorType == AccessorType.PARAMETER && !hasDefaultValueOrDefaultExpression() ) {
                 NullabilityUtils.Nullability sourceNullability = getSourceJSpecifyNullability();
                 NullabilityUtils.Nullability targetNullability = NullabilityUtils.getSetterNullability(
@@ -529,6 +531,12 @@ public class PropertyMapping extends ModelElement {
             // JSpecify: source @NonNull means the value is guaranteed non-null, skip all checks
             NullabilityUtils.Nullability sourceNullability = getSourceJSpecifyNullability();
             if ( sourceNullability == NullabilityUtils.Nullability.NON_NULL ) {
+                ctx.getMessager().note( 2,
+                    Message.PROPERTYMAPPING_JSPECIFY_NOTE,
+                    "skipping null check",
+                    targetPropertyName,
+                    "source is @NonNull"
+                );
                 return false;
             }
 
@@ -563,6 +571,12 @@ public class PropertyMapping extends ModelElement {
             );
             Boolean jspecifyDecision = NullabilityUtils.requiresNullCheck( sourceNullability, targetNullability );
             if ( jspecifyDecision != null ) {
+                ctx.getMessager().note( 2,
+                    Message.PROPERTYMAPPING_JSPECIFY_NOTE,
+                    jspecifyDecision ? "adding null check" : "skipping null check",
+                    targetPropertyName,
+                    "source=" + sourceNullability + ", target=" + targetNullability
+                );
                 return jspecifyDecision;
             }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -597,21 +597,29 @@ public class PropertyMapping extends ModelElement {
             if ( sourceReference == null ) {
                 return NullabilityUtils.Nullability.UNKNOWN;
             }
-            if ( !sourceReference.getPropertyEntries().isEmpty() ) {
-                PropertyEntry deepestProperty = sourceReference.getDeepestProperty();
-                if ( deepestProperty != null && deepestProperty.getReadAccessor() != null ) {
-                    // Determine the enclosing type for @NullMarked scope lookup.
-                    // For simple properties (a.b), the enclosing type is the source parameter type.
-                    // For nested properties (a.b.c), the enclosing type is the parent entry's type.
-                    List<PropertyEntry> entries = sourceReference.getPropertyEntries();
-                    Type enclosingType = entries.size() > 1
-                        ? entries.get( entries.size() - 2 ).getType()
-                        : sourceReference.getParameter().getType();
-                    return NullabilityUtils.getNullability(
-                        deepestProperty.getReadAccessor().getElement(), enclosingType::isNullMarked
+            List<PropertyEntry> entries = sourceReference.getPropertyEntries();
+            if ( !entries.isEmpty() ) {
+                // A source chain can only be treated as @NonNull when every accessor along the
+                // chain is @NonNull. If any intermediate accessor is @Nullable, the chain may
+                // yield null even when the deepest accessor is @NonNull.
+                Type enclosingType = sourceReference.getParameter().getType();
+                NullabilityUtils.Nullability chain = NullabilityUtils.Nullability.NON_NULL;
+                for ( PropertyEntry entry : entries ) {
+                    if ( entry.getReadAccessor() == null ) {
+                        return NullabilityUtils.Nullability.UNKNOWN;
+                    }
+                    NullabilityUtils.Nullability current = NullabilityUtils.getNullability(
+                        entry.getReadAccessor().getElement(), enclosingType::isNullMarked
                     );
+                    if ( current == NullabilityUtils.Nullability.NULLABLE ) {
+                        return NullabilityUtils.Nullability.NULLABLE;
+                    }
+                    if ( current == NullabilityUtils.Nullability.UNKNOWN ) {
+                        chain = NullabilityUtils.Nullability.UNKNOWN;
+                    }
+                    enclosingType = entry.getType();
                 }
-                return NullabilityUtils.Nullability.UNKNOWN;
+                return chain;
             }
             // Direct parameter mapping: no property entries, the source is the parameter itself.
             // Use the mapper type for @NullMarked scope resolution since the parameter is declared there.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -15,6 +15,7 @@ import java.util.function.Supplier;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
+import javax.lang.model.element.TypeElement;
 
 import org.mapstruct.ap.internal.gem.BuilderGem;
 import org.mapstruct.ap.internal.gem.NullValueCheckStrategyGem;
@@ -280,7 +281,7 @@ public class PropertyMapping extends ModelElement {
             if ( targetWriteAccessorType == AccessorType.PARAMETER && !hasDefaultValueOrDefaultExpression() ) {
                 NullabilityUtils.Nullability sourceNullability = getSourceJSpecifyNullability();
                 NullabilityUtils.Nullability targetNullability = NullabilityUtils.getSetterNullability(
-                    targetWriteAccessor.getElement(), targetType::isNullMarked
+                    targetWriteAccessor.getElement(), this::targetDeclaringTypeIsNullMarked
                 );
                 if ( sourceNullability != NullabilityUtils.Nullability.NON_NULL
                     && targetNullability == NullabilityUtils.Nullability.NON_NULL ) {
@@ -558,7 +559,7 @@ public class PropertyMapping extends ModelElement {
 
             // JSpecify annotations take precedence over NullValueCheckStrategy
             NullabilityUtils.Nullability targetNullability = NullabilityUtils.getSetterNullability(
-                targetWriteAccessor.getElement(), targetType::isNullMarked
+                targetWriteAccessor.getElement(), this::targetDeclaringTypeIsNullMarked
             );
             Boolean jspecifyDecision = NullabilityUtils.requiresNullCheck( sourceNullability, targetNullability );
             if ( jspecifyDecision != null ) {
@@ -574,7 +575,10 @@ public class PropertyMapping extends ModelElement {
         }
 
         private NullabilityUtils.Nullability getSourceJSpecifyNullability() {
-            if ( sourceReference != null && !sourceReference.getPropertyEntries().isEmpty() ) {
+            if ( sourceReference == null ) {
+                return NullabilityUtils.Nullability.UNKNOWN;
+            }
+            if ( !sourceReference.getPropertyEntries().isEmpty() ) {
                 PropertyEntry deepestProperty = sourceReference.getDeepestProperty();
                 if ( deepestProperty != null && deepestProperty.getReadAccessor() != null ) {
                     // Determine the enclosing type for @NullMarked scope lookup.
@@ -588,8 +592,37 @@ public class PropertyMapping extends ModelElement {
                         deepestProperty.getReadAccessor().getElement(), enclosingType::isNullMarked
                     );
                 }
+                return NullabilityUtils.Nullability.UNKNOWN;
+            }
+            // Direct parameter mapping: no property entries, the source is the parameter itself.
+            // Use the mapper type for @NullMarked scope resolution since the parameter is declared there.
+            Parameter parameter = sourceReference.getParameter();
+            if ( parameter != null && parameter.getElement() != null ) {
+                return NullabilityUtils.getNullability(
+                    parameter.getElement(),
+                    () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked()
+                );
             }
             return NullabilityUtils.Nullability.UNKNOWN;
+        }
+
+        /**
+         * Resolves whether the type that declares the target write accessor (i.e. the bean that
+         * owns the setter or field) is in a JSpecify {@code @NullMarked} scope. This is the correct
+         * scope for deciding whether an unannotated setter parameter or field should be treated as
+         * {@code @NonNull} — walking from the property value type (e.g. {@code String}) does not
+         * reach the bean's declaration.
+         */
+        private boolean targetDeclaringTypeIsNullMarked() {
+            Element targetElement = targetWriteAccessor.getElement();
+            if ( targetElement == null ) {
+                return false;
+            }
+            Element declaring = targetElement.getEnclosingElement();
+            if ( !( declaring instanceof TypeElement ) ) {
+                return false;
+            }
+            return ctx.getTypeFactory().getType( declaring.asType() ).isNullMarked();
         }
 
         private boolean hasDefaultValueOrDefaultExpression() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -280,7 +280,11 @@ public class PropertyMapping extends ModelElement {
             // constructor parameter without a default value. A null check would leave the variable
             // at null, violating the @NonNull contract, and passing the value through is equally
             // invalid — defaultValue / defaultExpression are the supported remedies.
-            if ( targetWriteAccessorType == AccessorType.PARAMETER && !hasDefaultValueOrDefaultExpression() ) {
+            // Skip when assignment resolution already failed: the user sees the primary
+            // "can't find mapping" error and a duplicate would only obscure the root cause.
+            if ( assignment != null
+                && targetWriteAccessorType == AccessorType.PARAMETER
+                && !hasDefaultValueOrDefaultExpression() ) {
                 NullabilityUtils.Nullability sourceNullability = getSourceJSpecifyNullability();
                 NullabilityUtils.Nullability targetNullability = NullabilityUtils.getSetterNullability(
                     targetWriteAccessor.getElement(), this::targetDeclaringTypeIsNullMarked

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -329,13 +329,17 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     /**
      * Whether this type is within a JSpecify {@code @NullMarked} scope. Walks the enclosing-element
-     * chain (type, enclosing classes, package, module) and returns at the first annotation found:
-     * {@code @NullMarked} wins over nothing, but a closer {@code @NullUnmarked} overrides an outer
-     * {@code @NullMarked}. The result is cached on this {@code Type} instance (which is interned by
-     * {@code TypeFactory}), so repeated calls are {@code O(1)}.
+     * chain (this type, outer classes, package) and returns at the first {@code @NullMarked} or
+     * {@code @NullUnmarked} encountered &mdash; the closest annotation wins. Module-level annotations
+     * are only reached when the compiler populates {@code PackageElement.getEnclosingElement()}
+     * with a {@link javax.lang.model.element.ModuleElement} (JPMS only).
+     * <p>
+     * The result is memoized on this {@code Type} instance. {@link TypeFactory#getType} does not
+     * intern {@code Type} instances, so callers that invoke this repeatedly should cache the
+     * {@code Type} reference or the result.
      *
-     * @return {@code true} if this type or an enclosing element has {@code @NullMarked} and no
-     * closer enclosing element has {@code @NullUnmarked}; {@code false} otherwise
+     * @return {@code true} if the closest enclosing annotation is {@code @NullMarked};
+     * {@code false} if it is {@code @NullUnmarked} or if no such annotation was found
      */
     public boolean isNullMarked() {
         if ( isNullMarked == null ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -328,10 +328,14 @@ public class Type extends ModelElement implements Comparable<Type> {
     }
 
     /**
-     * Whether this type is within a JSpecify {@code @NullMarked} scope.
-     * The result is computed once and cached.
+     * Whether this type is within a JSpecify {@code @NullMarked} scope. Walks the enclosing-element
+     * chain (type, enclosing classes, package, module) and returns at the first annotation found:
+     * {@code @NullMarked} wins over nothing, but a closer {@code @NullUnmarked} overrides an outer
+     * {@code @NullMarked}. The result is cached on this {@code Type} instance (which is interned by
+     * {@code TypeFactory}), so repeated calls are {@code O(1)}.
      *
-     * @return {@code true} if this type or an enclosing element has {@code @NullMarked}
+     * @return {@code true} if this type or an enclosing element has {@code @NullMarked} and no
+     * closer enclosing element has {@code @NullUnmarked}; {@code false} otherwise
      */
     public boolean isNullMarked() {
         if ( isNullMarked == null ) {
@@ -347,8 +351,13 @@ public class Type extends ModelElement implements Comparable<Type> {
         Element current = typeElement;
         while ( current != null ) {
             for ( AnnotationMirror mirror : current.getAnnotationMirrors() ) {
-                String fqn = ( (TypeElement) mirror.getAnnotationType().asElement() )
-                    .getQualifiedName().toString();
+                Element annotationElement = mirror.getAnnotationType().asElement();
+                if ( !( annotationElement instanceof TypeElement ) ) {
+                    // Defensive: unresolved annotations (e.g. ErrorType during incremental
+                    // builds) can produce a non-TypeElement. Skip instead of crashing.
+                    continue;
+                }
+                String fqn = ( (TypeElement) annotationElement ).getQualifiedName().toString();
                 if ( JSpecifyConstants.NULL_MARKED_FQN.equals( fqn ) ) {
                     return true;
                 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
@@ -56,6 +57,7 @@ import org.mapstruct.ap.internal.util.AccessorNamingUtils;
 import org.mapstruct.ap.internal.util.ElementUtils;
 import org.mapstruct.ap.internal.util.Executables;
 import org.mapstruct.ap.internal.util.Filters;
+import org.mapstruct.ap.internal.util.JSpecifyConstants;
 import org.mapstruct.ap.internal.util.JavaStreamConstants;
 import org.mapstruct.ap.internal.util.NativeTypes;
 import org.mapstruct.ap.internal.util.Nouns;
@@ -159,6 +161,7 @@ public class Type extends ModelElement implements Comparable<Type> {
     private Type boxedEquivalent = null;
 
     private Boolean hasAccessibleConstructor;
+    private Boolean isNullMarked;
     private KotlinMetadata kotlinMetadata;
     private boolean kotlinMetadataInitialized;
 
@@ -322,6 +325,40 @@ public class Type extends ModelElement implements Comparable<Type> {
 
     public boolean isString() {
         return String.class.getName().equals( getFullyQualifiedName() );
+    }
+
+    /**
+     * Whether this type is within a JSpecify {@code @NullMarked} scope.
+     * The result is computed once and cached.
+     *
+     * @return {@code true} if this type or an enclosing element has {@code @NullMarked}
+     */
+    public boolean isNullMarked() {
+        if ( isNullMarked == null ) {
+            isNullMarked = resolveNullMarked();
+        }
+        return isNullMarked;
+    }
+
+    private boolean resolveNullMarked() {
+        if ( typeElement == null ) {
+            return false;
+        }
+        Element current = typeElement;
+        while ( current != null ) {
+            for ( AnnotationMirror mirror : current.getAnnotationMirrors() ) {
+                String fqn = ( (TypeElement) mirror.getAnnotationType().asElement() )
+                    .getQualifiedName().toString();
+                if ( JSpecifyConstants.NULL_MARKED_FQN.equals( fqn ) ) {
+                    return true;
+                }
+                if ( JSpecifyConstants.NULL_UNMARKED_FQN.equals( fqn ) ) {
+                    return false;
+                }
+            }
+            current = current.getEnclosingElement();
+        }
+        return false;
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/option/MappingOption.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/option/MappingOption.java
@@ -25,6 +25,7 @@ public enum MappingOption {
     NULL_VALUE_ITERABLE_MAPPING_STRATEGY("mapstruct.nullValueIterableMappingStrategy"),
     NULL_VALUE_MAP_MAPPING_STRATEGY("mapstruct.nullValueMapMappingStrategy"),
     DISABLE_LIFECYCLE_OVERLOAD_DEDUPLICATE_SELECTOR("mapstruct.disableLifecycleOverloadDeduplicateSelector"),
+    DISABLE_JSPECIFY("mapstruct.disableJSpecify"),
     ;
     // CHECKSTYLE:ON
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/option/Options.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/option/Options.java
@@ -74,6 +74,10 @@ public class Options {
         return parseBoolean( MappingOption.DISABLE_LIFECYCLE_OVERLOAD_DEDUPLICATE_SELECTOR );
     }
 
+    public boolean isDisableJSpecify() {
+        return parseBoolean( MappingOption.DISABLE_JSPECIFY );
+    }
+
     private boolean parseBoolean(MappingOption option) {
         if ( options.isEmpty() ) {
             return false;

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/DefaultModelElementProcessorContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/DefaultModelElementProcessorContext.java
@@ -23,6 +23,7 @@ import org.mapstruct.ap.internal.util.AccessorNamingUtils;
 import org.mapstruct.ap.internal.util.ElementUtils;
 import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.Message;
+import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.RoundContext;
 import org.mapstruct.ap.internal.util.TypeUtils;
 import org.mapstruct.ap.internal.version.VersionInformation;
@@ -44,6 +45,7 @@ public class DefaultModelElementProcessorContext implements ProcessorContext {
     private final TypeUtils delegatingTypes;
     private final ElementUtils delegatingElements;
     private final AccessorNamingUtils accessorNaming;
+    private final NullabilityResolver nullabilityResolver;
     private final RoundContext roundContext;
 
     public DefaultModelElementProcessorContext(ProcessingEnvironment processingEnvironment, Options options,
@@ -52,6 +54,7 @@ public class DefaultModelElementProcessorContext implements ProcessorContext {
         this.processingEnvironment = processingEnvironment;
         this.messager = new DelegatingMessager( processingEnvironment.getMessager(), options.isVerbose() );
         this.accessorNaming = roundContext.getAnnotationProcessorContext().getAccessorNaming();
+        this.nullabilityResolver = roundContext.getAnnotationProcessorContext().getNullabilityResolver();
         this.versionInformation = DefaultVersionInformation.fromProcessingEnvironment( processingEnvironment );
         this.delegatingTypes = TypeUtils.create( processingEnvironment, versionInformation );
         this.delegatingElements = ElementUtils.create( processingEnvironment, versionInformation, mapperElement );
@@ -96,6 +99,11 @@ public class DefaultModelElementProcessorContext implements ProcessorContext {
     @Override
     public AccessorNamingUtils getAccessorNaming() {
         return accessorNaming;
+    }
+
+    @Override
+    public NullabilityResolver getNullabilityResolver() {
+        return nullabilityResolver;
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -121,6 +121,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
             messager,
             versionInformation,
             accessorNaming,
+            context.getNullabilityResolver(),
             context.getEnumMappingStrategy(),
             context.getEnumTransformationStrategies(),
             options,

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/ModelElementProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/ModelElementProcessor.java
@@ -15,6 +15,7 @@ import org.mapstruct.ap.internal.option.Options;
 import org.mapstruct.ap.internal.util.AccessorNamingUtils;
 import org.mapstruct.ap.internal.util.ElementUtils;
 import org.mapstruct.ap.internal.util.FormattingMessager;
+import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.TypeUtils;
 import org.mapstruct.ap.internal.version.VersionInformation;
 import org.mapstruct.ap.spi.EnumMappingStrategy;
@@ -53,6 +54,8 @@ public interface ModelElementProcessor<P, R> {
         FormattingMessager getMessager();
 
         AccessorNamingUtils getAccessorNaming();
+
+        NullabilityResolver getNullabilityResolver();
 
         Map<String, EnumTransformationStrategy> getEnumTransformationStrategies();
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/AnnotationProcessorContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/AnnotationProcessorContext.java
@@ -48,22 +48,25 @@ public class AnnotationProcessorContext implements MapStructProcessingEnvironmen
     private Map<String, EnumTransformationStrategy> enumTransformationStrategies;
 
     private AccessorNamingUtils accessorNaming;
+    private NullabilityResolver nullabilityResolver;
     private Elements elementUtils;
     private Types typeUtils;
     private Messager messager;
     private boolean disableBuilder;
+    private boolean disableJSpecify;
     private boolean verbose;
 
     private Map<String, String> options;
 
     public AnnotationProcessorContext(Elements elementUtils, Types typeUtils, Messager messager, boolean disableBuilder,
-                                      boolean verbose, Map<String, String> options) {
+                                      boolean disableJSpecify, boolean verbose, Map<String, String> options) {
         astModifyingAnnotationProcessors = java.util.Collections.unmodifiableList(
             findAstModifyingAnnotationProcessors( messager ) );
         this.elementUtils = elementUtils;
         this.typeUtils = typeUtils;
         this.messager = messager;
         this.disableBuilder = disableBuilder;
+        this.disableJSpecify = disableJSpecify;
         this.verbose = verbose;
         this.options = java.util.Collections.unmodifiableMap( options );
     }
@@ -120,6 +123,7 @@ public class AnnotationProcessorContext implements MapStructProcessingEnvironmen
             );
         }
         this.accessorNaming = new AccessorNamingUtils( this.accessorNamingStrategy );
+        this.nullabilityResolver = new NullabilityResolver( !this.disableJSpecify );
 
         this.enumMappingStrategy = Services.get( EnumMappingStrategy.class, new DefaultEnumMappingStrategy() );
         this.enumMappingStrategy.init( this );
@@ -251,6 +255,11 @@ public class AnnotationProcessorContext implements MapStructProcessingEnvironmen
     public AccessorNamingUtils getAccessorNaming() {
         initialize();
         return accessorNaming;
+    }
+
+    public NullabilityResolver getNullabilityResolver() {
+        initialize();
+        return nullabilityResolver;
     }
 
     public AccessorNamingStrategy getAccessorNamingStrategy() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/JSpecifyConstants.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/JSpecifyConstants.java
@@ -12,14 +12,30 @@ package org.mapstruct.ap.internal.util;
  */
 public final class JSpecifyConstants {
 
-    private JSpecifyConstants() {
-    }
-
+    /**
+     * Fully qualified name of {@code org.jspecify.annotations.Nullable}.
+     */
     public static final String NULLABLE_FQN = "org.jspecify.annotations.Nullable";
 
+    /**
+     * Fully qualified name of {@code org.jspecify.annotations.NonNull}.
+     */
     public static final String NON_NULL_FQN = "org.jspecify.annotations.NonNull";
 
+    /**
+     * Fully qualified name of {@code org.jspecify.annotations.NullMarked}. Its presence on an
+     * element (or any enclosing element) means unannotated types in that scope are effectively
+     * {@code @NonNull}.
+     */
     public static final String NULL_MARKED_FQN = "org.jspecify.annotations.NullMarked";
 
+    /**
+     * Fully qualified name of {@code org.jspecify.annotations.NullUnmarked}. Its presence on an
+     * element (or an enclosing element closer than a {@code @NullMarked} one) reverts the scope
+     * back to unknown nullability.
+     */
     public static final String NULL_UNMARKED_FQN = "org.jspecify.annotations.NullUnmarked";
+
+    private JSpecifyConstants() {
+    }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/JSpecifyConstants.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/JSpecifyConstants.java
@@ -24,14 +24,14 @@ public final class JSpecifyConstants {
 
     /**
      * Fully qualified name of {@code org.jspecify.annotations.NullMarked}. Its presence on an
-     * element (or any enclosing element) means unannotated types in that scope are effectively
-     * {@code @NonNull}.
+     * element (or an enclosing element closer than any {@code @NullUnmarked} one) means unannotated
+     * types in that scope are effectively {@code @NonNull}.
      */
     public static final String NULL_MARKED_FQN = "org.jspecify.annotations.NullMarked";
 
     /**
      * Fully qualified name of {@code org.jspecify.annotations.NullUnmarked}. Its presence on an
-     * element (or an enclosing element closer than a {@code @NullMarked} one) reverts the scope
+     * element (or an enclosing element closer than any {@code @NullMarked} one) reverts the scope
      * back to unknown nullability.
      */
     public static final String NULL_UNMARKED_FQN = "org.jspecify.annotations.NullUnmarked";

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/JSpecifyConstants.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/JSpecifyConstants.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.util;
+
+/**
+ * Helper holding constants for working with JSpecify null annotations.
+ *
+ * @author Filip Hrisafov
+ */
+public final class JSpecifyConstants {
+
+    private JSpecifyConstants() {
+    }
+
+    public static final String NULLABLE_FQN = "org.jspecify.annotations.Nullable";
+
+    public static final String NON_NULL_FQN = "org.jspecify.annotations.NonNull";
+
+    public static final String NULL_MARKED_FQN = "org.jspecify.annotations.NullMarked";
+
+    public static final String NULL_UNMARKED_FQN = "org.jspecify.annotations.NullUnmarked";
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -97,6 +97,7 @@ public enum Message {
     PROPERTYMAPPING_EXPRESSION_AND_CONDITION_QUALIFIED_BY_NAME_BOTH_DEFINED( "Expression and condition qualified by name are both defined in @Mapping, either define an expression or a condition qualified by name." ),
     PROPERTYMAPPING_TARGET_HAS_NO_TARGET_PROPERTIES( "No target property found for target \"%s\".", Diagnostic.Kind.WARNING ),
     PROPERTYMAPPING_NULLABLE_SOURCE_TO_NON_NULL_CONSTRUCTOR_PARAM( "Can't map potentially nullable source property \"%s\" to @NonNull constructor parameter \"%s\". Consider adding a defaultValue or defaultExpression." ),
+    PROPERTYMAPPING_JSPECIFY_NOTE( "JSpecify %s for property \"%s\": %s.", Diagnostic.Kind.NOTE ),
 
     CONVERSION_LOSSY_WARNING( "%s has a possibly lossy conversion from %s to %s.", Diagnostic.Kind.WARNING ),
     CONVERSION_LOSSY_ERROR( "Can't map %s. It has a possibly lossy conversion from %s to %s." ),

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -97,7 +97,10 @@ public enum Message {
     PROPERTYMAPPING_EXPRESSION_AND_CONDITION_QUALIFIED_BY_NAME_BOTH_DEFINED( "Expression and condition qualified by name are both defined in @Mapping, either define an expression or a condition qualified by name." ),
     PROPERTYMAPPING_TARGET_HAS_NO_TARGET_PROPERTIES( "No target property found for target \"%s\".", Diagnostic.Kind.WARNING ),
     PROPERTYMAPPING_NULLABLE_SOURCE_TO_NON_NULL_CONSTRUCTOR_PARAM( "Can't map potentially nullable source property \"%s\" to @NonNull constructor parameter \"%s\". Consider adding a defaultValue or defaultExpression." ),
-    PROPERTYMAPPING_JSPECIFY_NOTE( "JSpecify %s for property \"%s\": %s.", Diagnostic.Kind.NOTE ),
+    PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK_NON_NULL_SOURCE( "JSpecify skipping null check for property \"%s\": source is @NonNull.", Diagnostic.Kind.NOTE ),
+    PROPERTYMAPPING_JSPECIFY_ADD_NULL_CHECK( "JSpecify adding null check for property \"%s\": source=%s, target=%s.", Diagnostic.Kind.NOTE ),
+    PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK( "JSpecify skipping null check for property \"%s\": source=%s, target=%s.", Diagnostic.Kind.NOTE ),
+    PROPERTYMAPPING_JSPECIFY_SKIP_METHOD_GUARD_NON_NULL_PARAM( "JSpecify skipping method-level null guard for property \"%s\": parameter is @NonNull.", Diagnostic.Kind.NOTE ),
 
     CONVERSION_LOSSY_WARNING( "%s has a possibly lossy conversion from %s to %s.", Diagnostic.Kind.WARNING ),
     CONVERSION_LOSSY_ERROR( "Can't map %s. It has a possibly lossy conversion from %s to %s." ),

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -96,6 +96,7 @@ public enum Message {
     PROPERTYMAPPING_NO_SUITABLE_COLLECTION_OR_MAP_CONSTRUCTOR( "%s does not have an accessible copy or no-args constructor." ),
     PROPERTYMAPPING_EXPRESSION_AND_CONDITION_QUALIFIED_BY_NAME_BOTH_DEFINED( "Expression and condition qualified by name are both defined in @Mapping, either define an expression or a condition qualified by name." ),
     PROPERTYMAPPING_TARGET_HAS_NO_TARGET_PROPERTIES( "No target property found for target \"%s\".", Diagnostic.Kind.WARNING ),
+    PROPERTYMAPPING_NULLABLE_SOURCE_TO_NON_NULL_CONSTRUCTOR_PARAM( "Can't map potentially nullable source property \"%s\" to @NonNull constructor parameter \"%s\". Consider adding a defaultValue or defaultExpression." ),
 
     CONVERSION_LOSSY_WARNING( "%s has a possibly lossy conversion from %s to %s.", Diagnostic.Kind.WARNING ),
     CONVERSION_LOSSY_ERROR( "Can't map %s. It has a possibly lossy conversion from %s to %s." ),

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/NullabilityResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/NullabilityResolver.java
@@ -16,32 +16,44 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeMirror;
 
 /**
- * Utility for detecting JSpecify nullness annotations on elements and computing
- * whether a null check is required for a source-to-target property mapping.
+ * Resolver for JSpecify nullness annotations on elements, used to decide whether a null
+ * check is required for a source-to-target property mapping.
+ * <p>
+ * A single instance is created per annotation-processor run and carries the
+ * {@link #enabled} flag derived from the {@code mapstruct.disableJSpecify} option. When
+ * disabled, all public entry points short-circuit to {@link Nullability#UNKNOWN} /
+ * {@code null}, which causes downstream callers to fall back to the pre-JSpecify
+ * {@code NullValueCheckStrategy}-based behavior.
  *
  * @author Filip Hrisafov
  */
-public final class NullabilityUtils {
+public class NullabilityResolver {
 
     /**
-     * Represents the nullability state of a source or target element.
+     * Represents the effective nullability of a source or target element.
      */
     public enum Nullability {
         /**
-         * The element is annotated with {@code @NonNull}.
+         * The element is effectively non-null — either directly annotated {@code @NonNull},
+         * or within a {@code @NullMarked} scope without a closer {@code @NullUnmarked} or
+         * {@code @Nullable} override.
          */
         NON_NULL,
         /**
-         * The element is annotated with {@code @Nullable}.
+         * The element is explicitly annotated {@code @Nullable}.
          */
         NULLABLE,
         /**
-         * No JSpecify nullability annotation is present on the element.
+         * Nullability is unspecified — no annotation applies and the element is not within
+         * an applicable {@code @NullMarked} scope (or JSpecify support is disabled).
          */
         UNKNOWN
     }
 
-    private NullabilityUtils() {
+    private final boolean enabled;
+
+    public NullabilityResolver(boolean enabled) {
+        this.enabled = enabled;
     }
 
     /**
@@ -52,9 +64,13 @@ public final class NullabilityUtils {
      * For setter parameters ({@link VariableElement}), this checks the parameter type's annotations.
      * For fields ({@link VariableElement}), this checks the field type's annotations.
      * <p>
-     * If no direct annotation is found, {@code enclosingTypeNullMarked} is consulted — when it
-     * returns {@code true}, unannotated types are effectively {@code @NonNull}. The supplier is
-     * invoked at most once, and only if no JSpecify annotation was found on the element or its type.
+     * If no direct annotation is found, the method walks the enclosing element chain looking
+     * for a method-level {@code @NullMarked} / {@code @NullUnmarked}. If nothing is found there
+     * either, {@code enclosingTypeNullMarked} is consulted — when it returns {@code true},
+     * unannotated types are effectively {@code @NonNull}. The supplier is invoked at most once.
+     * <p>
+     * When this resolver is disabled, {@link Nullability#UNKNOWN} is returned without any
+     * inspection — the supplier is not invoked.
      *
      * @param element                 the accessor element to inspect (getter method, setter parameter, or field);
      *                                may be {@code null} in which case {@link Nullability#UNKNOWN} is returned
@@ -62,8 +78,8 @@ public final class NullabilityUtils {
      *                                {@code @NullMarked} scope; must be non-{@code null}
      * @return the nullability state
      */
-    public static Nullability getNullability(Element element, BooleanSupplier enclosingTypeNullMarked) {
-        if ( element == null ) {
+    public Nullability getNullability(Element element, BooleanSupplier enclosingTypeNullMarked) {
+        if ( !enabled || element == null ) {
             return Nullability.UNKNOWN;
         }
 
@@ -111,6 +127,65 @@ public final class NullabilityUtils {
     }
 
     /**
+     * Determines the nullability of a write-accessor element — either a setter method or a field.
+     * <p>
+     * For setter methods ({@link ExecutableElement}) the nullability annotation lives on the
+     * parameter type, not on the method itself, so the first parameter's nullability is returned.
+     * For fields (or any other element type) the element's own type nullability is returned.
+     *
+     * @param element                 the write-accessor element (setter or field); may be
+     *                                {@code null} in which case {@link Nullability#UNKNOWN} is returned
+     * @param enclosingTypeNullMarked supplier for whether the enclosing bean type is in a
+     *                                {@code @NullMarked} scope; must be non-{@code null}
+     * @return the nullability state of the setter's parameter or of the field
+     */
+    public Nullability getSetterNullability(Element element, BooleanSupplier enclosingTypeNullMarked) {
+        if ( !enabled ) {
+            return Nullability.UNKNOWN;
+        }
+        if ( element instanceof ExecutableElement ) {
+            List<? extends VariableElement> parameters = ( (ExecutableElement) element ).getParameters();
+            if ( parameters.isEmpty() ) {
+                // A zero-parameter method is not a valid write accessor. Falling through to
+                // getNullability would inspect the return type, which is meaningless here.
+                return Nullability.UNKNOWN;
+            }
+            return getNullability( parameters.get( 0 ), enclosingTypeNullMarked );
+        }
+        // Field or other write accessor: consult the element's own type nullability.
+        return getNullability( element, enclosingTypeNullMarked );
+    }
+
+    /**
+     * Determines whether a null check is required for a property mapping based on JSpecify annotations
+     * on the source and target elements.
+     * <p>
+     * Only returns a non-null decision for the clear-cut cases:
+     * source {@code @NonNull} (skip check) or target {@code @NonNull} (always check).
+     * All other cases return {@code null} to defer to the existing {@code NullValueCheckStrategy}.
+     *
+     * @param sourceNullability the nullability of the source (getter return type / parameter)
+     * @param targetNullability the nullability of the target (setter parameter / field)
+     * @return {@code Boolean.TRUE} if a null check is needed, {@code Boolean.FALSE} if it should be skipped,
+     * or {@code null} if JSpecify annotations are not present and the existing strategy should be used
+     */
+    public Boolean requiresNullCheck(Nullability sourceNullability, Nullability targetNullability) {
+        if ( !enabled ) {
+            return null;
+        }
+        if ( sourceNullability == Nullability.NON_NULL ) {
+            // Source is guaranteed non-null, no null check needed
+            return Boolean.FALSE;
+        }
+        if ( targetNullability == Nullability.NON_NULL ) {
+            // Target requires non-null: always check (regardless of source annotation)
+            return Boolean.TRUE;
+        }
+        // All other cases: defer to existing NullValueCheckStrategy
+        return null;
+    }
+
+    /**
      * Walks from {@code element} up to (but not including) its declaring {@link TypeElement},
      * checking for {@code @NullMarked} / {@code @NullUnmarked} on intermediate elements
      * (e.g. the enclosing method of a parameter, or the element itself for a field / getter).
@@ -153,33 +228,6 @@ public final class NullabilityUtils {
         return null;
     }
 
-    /**
-     * Determines the nullability of a write-accessor element — either a setter method or a field.
-     * <p>
-     * For setter methods ({@link ExecutableElement}) the nullability annotation lives on the
-     * parameter type, not on the method itself, so the first parameter's nullability is returned.
-     * For fields (or any other element type) the element's own type nullability is returned.
-     *
-     * @param element                 the write-accessor element (setter or field); may be
-     *                                {@code null} in which case {@link Nullability#UNKNOWN} is returned
-     * @param enclosingTypeNullMarked supplier for whether the enclosing bean type is in a
-     *                                {@code @NullMarked} scope; must be non-{@code null}
-     * @return the nullability state of the setter's parameter or of the field
-     */
-    public static Nullability getSetterNullability(Element element, BooleanSupplier enclosingTypeNullMarked) {
-        if ( element instanceof ExecutableElement ) {
-            List<? extends VariableElement> parameters = ( (ExecutableElement) element ).getParameters();
-            if ( parameters.isEmpty() ) {
-                // A zero-parameter method is not a valid write accessor. Falling through to
-                // getNullability would inspect the return type, which is meaningless here.
-                return Nullability.UNKNOWN;
-            }
-            return getNullability( parameters.get( 0 ), enclosingTypeNullMarked );
-        }
-        // Field or other write accessor: consult the element's own type nullability.
-        return getNullability( element, enclosingTypeNullMarked );
-    }
-
     private static Nullability getNullabilityFromTypeMirror(TypeMirror typeMirror) {
         if ( typeMirror == null ) {
             return Nullability.UNKNOWN;
@@ -205,31 +253,5 @@ public final class NullabilityUtils {
             }
         }
         return Nullability.UNKNOWN;
-    }
-
-    /**
-     * Determines whether a null check is required for a property mapping based on JSpecify annotations
-     * on the source and target elements.
-     * <p>
-     * Only returns a non-null decision for the clear-cut cases:
-     * source {@code @NonNull} (skip check) or target {@code @NonNull} (always check).
-     * All other cases return {@code null} to defer to the existing {@code NullValueCheckStrategy}.
-     *
-     * @param sourceNullability the nullability of the source (getter return type / parameter)
-     * @param targetNullability the nullability of the target (setter parameter / field)
-     * @return {@code Boolean.TRUE} if a null check is needed, {@code Boolean.FALSE} if it should be skipped,
-     * or {@code null} if JSpecify annotations are not present and the existing strategy should be used
-     */
-    public static Boolean requiresNullCheck(Nullability sourceNullability, Nullability targetNullability) {
-        if ( sourceNullability == Nullability.NON_NULL ) {
-            // Source is guaranteed non-null, no null check needed
-            return Boolean.FALSE;
-        }
-        if ( targetNullability == Nullability.NON_NULL ) {
-            // Target requires non-null: always check (regardless of source annotation)
-            return Boolean.TRUE;
-        }
-        // All other cases: defer to existing NullValueCheckStrategy
-        return null;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/NullabilityUtils.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/NullabilityUtils.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.util;
+
+import java.util.List;
+import java.util.function.BooleanSupplier;
+import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.element.VariableElement;
+import javax.lang.model.type.TypeMirror;
+
+/**
+ * Utility for detecting JSpecify nullness annotations on elements and computing
+ * whether a null check is required for a source-to-target property mapping.
+ *
+ * @author Filip Hrisafov
+ */
+public final class NullabilityUtils {
+
+    /**
+     * Represents the nullability state of a source or target element.
+     */
+    public enum Nullability {
+        /**
+         * The element is annotated with {@code @NonNull}.
+         */
+        NON_NULL,
+        /**
+         * The element is annotated with {@code @Nullable}.
+         */
+        NULLABLE,
+        /**
+         * No JSpecify nullability annotation is present on the element.
+         */
+        UNKNOWN
+    }
+
+    private NullabilityUtils() {
+    }
+
+    /**
+     * Determines the nullability of an accessor element based on JSpecify annotations.
+     * <p>
+     * For getter methods ({@link ExecutableElement}), this checks the return type's annotations
+     * since JSpecify annotations are {@code TYPE_USE} annotations placed on the return type.
+     * For setter parameters ({@link VariableElement}), this checks the parameter type's annotations.
+     * For fields ({@link VariableElement}), this checks the field type's annotations.
+     * <p>
+     * If no direct annotation is found, {@code enclosingTypeNullMarked} is consulted — when it
+     * returns {@code true}, unannotated types are effectively {@code @NonNull}. The supplier is
+     * evaluated lazily and only when no direct annotation was found.
+     *
+     * @param element                 the accessor element to inspect (getter method, setter parameter, or field)
+     * @param enclosingTypeNullMarked supplier for whether the enclosing type is in a {@code @NullMarked} scope
+     * @return the nullability state
+     */
+    public static Nullability getNullability(Element element, BooleanSupplier enclosingTypeNullMarked) {
+        if ( element == null ) {
+            return Nullability.UNKNOWN;
+        }
+
+        // JSpecify annotations are TYPE_USE annotations.
+        // For getters: annotation is on the return type
+        // For setter parameters / fields: annotation is on the variable type
+        if ( element instanceof ExecutableElement ) {
+            // Getter method — check the return type annotations
+            TypeMirror returnType = ( (ExecutableElement) element ).getReturnType();
+            Nullability result = getNullabilityFromTypeMirror( returnType );
+            if ( result != Nullability.UNKNOWN ) {
+                return result;
+            }
+        }
+        else if ( element instanceof VariableElement ) {
+            // Setter parameter or field — check the variable type annotations
+            TypeMirror type = element.asType();
+            Nullability result = getNullabilityFromTypeMirror( type );
+            if ( result != Nullability.UNKNOWN ) {
+                return result;
+            }
+        }
+
+        // Fallback: check the element itself for declaration-level annotations.
+        // This covers nullability annotations that target METHOD, PARAMETER, or FIELD
+        // without TYPE_USE (e.g. javax.annotation.Nonnull).
+        Nullability fromElement = getNullabilityFromAnnotationMirrors( element.getAnnotationMirrors() );
+        if ( fromElement != Nullability.UNKNOWN ) {
+            return fromElement;
+        }
+
+        // No direct annotation found — in a @NullMarked scope, unannotated types are effectively @NonNull.
+        if ( enclosingTypeNullMarked.getAsBoolean() ) {
+            return Nullability.NON_NULL;
+        }
+
+        return Nullability.UNKNOWN;
+    }
+
+    /**
+     * Determines the nullability of a setter element based on its first parameter's JSpecify annotations.
+     * <p>
+     * For setter methods, the nullability annotation is on the parameter type, not the method itself.
+     *
+     * @param element                 the setter method element
+     * @param enclosingTypeNullMarked supplier for whether the enclosing type is in a {@code @NullMarked} scope
+     * @return the nullability state of the setter's parameter
+     */
+    public static Nullability getSetterNullability(Element element, BooleanSupplier enclosingTypeNullMarked) {
+        if ( element instanceof ExecutableElement ) {
+            List<? extends VariableElement> parameters = ( (ExecutableElement) element ).getParameters();
+            if ( !parameters.isEmpty() ) {
+                return getNullability( parameters.get( 0 ), enclosingTypeNullMarked );
+            }
+        }
+        // For fields, fall back to the element's own nullability
+        return getNullability( element, enclosingTypeNullMarked );
+    }
+
+    private static Nullability getNullabilityFromTypeMirror(TypeMirror typeMirror) {
+        if ( typeMirror == null ) {
+            return Nullability.UNKNOWN;
+        }
+        return getNullabilityFromAnnotationMirrors( typeMirror.getAnnotationMirrors() );
+    }
+
+    private static Nullability getNullabilityFromAnnotationMirrors(
+        List<? extends AnnotationMirror> annotationMirrors) {
+        for ( AnnotationMirror mirror : annotationMirrors ) {
+            String fqn = ( (TypeElement) mirror.getAnnotationType().asElement() ).getQualifiedName().toString();
+            if ( JSpecifyConstants.NON_NULL_FQN.equals( fqn ) ) {
+                return Nullability.NON_NULL;
+            }
+            if ( JSpecifyConstants.NULLABLE_FQN.equals( fqn ) ) {
+                return Nullability.NULLABLE;
+            }
+        }
+        return Nullability.UNKNOWN;
+    }
+
+    /**
+     * Determines whether a null check is required for a property mapping based on JSpecify annotations
+     * on the source and target elements.
+     * <p>
+     * Only returns a non-null decision for the clear-cut cases:
+     * source {@code @NonNull} (skip check) or target {@code @NonNull} (always check).
+     * All other cases return {@code null} to defer to the existing {@code NullValueCheckStrategy}.
+     *
+     * @param sourceNullability the nullability of the source (getter return type / parameter)
+     * @param targetNullability the nullability of the target (setter parameter / field)
+     * @return {@code Boolean.TRUE} if a null check is needed, {@code Boolean.FALSE} if it should be skipped,
+     * or {@code null} if JSpecify annotations are not present and the existing strategy should be used
+     */
+    public static Boolean requiresNullCheck(Nullability sourceNullability, Nullability targetNullability) {
+        if ( sourceNullability == Nullability.NON_NULL ) {
+            // Source is guaranteed non-null, no null check needed
+            return Boolean.FALSE;
+        }
+        if ( targetNullability == Nullability.NON_NULL ) {
+            // Target requires non-null: always check (regardless of source annotation)
+            return Boolean.TRUE;
+        }
+        // All other cases: defer to existing NullValueCheckStrategy
+        return null;
+    }
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/NullabilityUtils.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/NullabilityUtils.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.function.BooleanSupplier;
 import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
@@ -53,10 +54,12 @@ public final class NullabilityUtils {
      * <p>
      * If no direct annotation is found, {@code enclosingTypeNullMarked} is consulted — when it
      * returns {@code true}, unannotated types are effectively {@code @NonNull}. The supplier is
-     * evaluated lazily and only when no direct annotation was found.
+     * invoked at most once, and only if no JSpecify annotation was found on the element or its type.
      *
-     * @param element                 the accessor element to inspect (getter method, setter parameter, or field)
-     * @param enclosingTypeNullMarked supplier for whether the enclosing type is in a {@code @NullMarked} scope
+     * @param element                 the accessor element to inspect (getter method, setter parameter, or field);
+     *                                may be {@code null} in which case {@link Nullability#UNKNOWN} is returned
+     * @param enclosingTypeNullMarked supplier for whether the enclosing bean type is in a
+     *                                {@code @NullMarked} scope; must be non-{@code null}
      * @return the nullability state
      */
     public static Nullability getNullability(Element element, BooleanSupplier enclosingTypeNullMarked) {
@@ -84,15 +87,22 @@ public final class NullabilityUtils {
             }
         }
 
-        // Fallback: check the element itself for declaration-level annotations.
-        // This covers nullability annotations that target METHOD, PARAMETER, or FIELD
-        // without TYPE_USE (e.g. javax.annotation.Nonnull).
+        // Fallback: check declaration-level annotation mirrors. Some compilers (notably ECJ)
+        // surface JSpecify TYPE_USE annotations on the element rather than the type mirror.
         Nullability fromElement = getNullabilityFromAnnotationMirrors( element.getAnnotationMirrors() );
         if ( fromElement != Nullability.UNKNOWN ) {
             return fromElement;
         }
 
-        // No direct annotation found — in a @NullMarked scope, unannotated types are effectively @NonNull.
+        // Walk enclosing elements up to the declaring type to honor method-level
+        // @NullMarked / @NullUnmarked (e.g. a @NullUnmarked method inside a @NullMarked class
+        // must revert unannotated types back to unknown nullability).
+        Boolean elementScope = resolveElementScope( element );
+        if ( elementScope != null ) {
+            return elementScope ? Nullability.NON_NULL : Nullability.UNKNOWN;
+        }
+
+        // No element-level scope — consult the enclosing bean type's @NullMarked scope.
         if ( enclosingTypeNullMarked.getAsBoolean() ) {
             return Nullability.NON_NULL;
         }
@@ -101,22 +111,72 @@ public final class NullabilityUtils {
     }
 
     /**
-     * Determines the nullability of a setter element based on its first parameter's JSpecify annotations.
-     * <p>
-     * For setter methods, the nullability annotation is on the parameter type, not the method itself.
+     * Walks from {@code element} up to (but not including) its declaring {@link TypeElement},
+     * checking for {@code @NullMarked} / {@code @NullUnmarked} on intermediate elements
+     * (e.g. the enclosing method of a parameter, or the element itself for a field / getter).
      *
-     * @param element                 the setter method element
-     * @param enclosingTypeNullMarked supplier for whether the enclosing type is in a {@code @NullMarked} scope
-     * @return the nullability state of the setter's parameter
+     * @return {@code TRUE} when a closer {@code @NullMarked} is found, {@code FALSE} when a
+     * closer {@code @NullUnmarked} is found, or {@code null} when neither is present before
+     * the declaring type is reached (leaving the bean-type scope to decide).
+     */
+    private static Boolean resolveElementScope(Element element) {
+        Element current = element;
+        while ( current != null && !isTypeElement( current ) ) {
+            Boolean scope = findScopeAnnotation( current );
+            if ( scope != null ) {
+                return scope;
+            }
+            current = current.getEnclosingElement();
+        }
+        return null;
+    }
+
+    private static boolean isTypeElement(Element element) {
+        ElementKind kind = element.getKind();
+        return kind.isClass() || kind.isInterface();
+    }
+
+    private static Boolean findScopeAnnotation(Element element) {
+        for ( AnnotationMirror mirror : element.getAnnotationMirrors() ) {
+            Element annotationElement = mirror.getAnnotationType().asElement();
+            if ( !( annotationElement instanceof TypeElement ) ) {
+                continue;
+            }
+            String fqn = ( (TypeElement) annotationElement ).getQualifiedName().toString();
+            if ( JSpecifyConstants.NULL_MARKED_FQN.equals( fqn ) ) {
+                return Boolean.TRUE;
+            }
+            if ( JSpecifyConstants.NULL_UNMARKED_FQN.equals( fqn ) ) {
+                return Boolean.FALSE;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Determines the nullability of a write-accessor element — either a setter method or a field.
+     * <p>
+     * For setter methods ({@link ExecutableElement}) the nullability annotation lives on the
+     * parameter type, not on the method itself, so the first parameter's nullability is returned.
+     * For fields (or any other element type) the element's own type nullability is returned.
+     *
+     * @param element                 the write-accessor element (setter or field); may be
+     *                                {@code null} in which case {@link Nullability#UNKNOWN} is returned
+     * @param enclosingTypeNullMarked supplier for whether the enclosing bean type is in a
+     *                                {@code @NullMarked} scope; must be non-{@code null}
+     * @return the nullability state of the setter's parameter or of the field
      */
     public static Nullability getSetterNullability(Element element, BooleanSupplier enclosingTypeNullMarked) {
         if ( element instanceof ExecutableElement ) {
             List<? extends VariableElement> parameters = ( (ExecutableElement) element ).getParameters();
-            if ( !parameters.isEmpty() ) {
-                return getNullability( parameters.get( 0 ), enclosingTypeNullMarked );
+            if ( parameters.isEmpty() ) {
+                // A zero-parameter method is not a valid write accessor. Falling through to
+                // getNullability would inspect the return type, which is meaningless here.
+                return Nullability.UNKNOWN;
             }
+            return getNullability( parameters.get( 0 ), enclosingTypeNullMarked );
         }
-        // For fields, fall back to the element's own nullability
+        // Field or other write accessor: consult the element's own type nullability.
         return getNullability( element, enclosingTypeNullMarked );
     }
 
@@ -130,7 +190,13 @@ public final class NullabilityUtils {
     private static Nullability getNullabilityFromAnnotationMirrors(
         List<? extends AnnotationMirror> annotationMirrors) {
         for ( AnnotationMirror mirror : annotationMirrors ) {
-            String fqn = ( (TypeElement) mirror.getAnnotationType().asElement() ).getQualifiedName().toString();
+            Element annotationElement = mirror.getAnnotationType().asElement();
+            if ( !( annotationElement instanceof TypeElement ) ) {
+                // Defensive: during incremental builds the annotation may be an ErrorType
+                // whose element is not a TypeElement. Skip instead of failing with a CCE.
+                continue;
+            }
+            String fqn = ( (TypeElement) annotationElement ).getQualifiedName().toString();
             if ( JSpecifyConstants.NON_NULL_FQN.equals( fqn ) ) {
                 return Nullability.NON_NULL;
             }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/AddressBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/AddressBean.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public class AddressBean {
+
+    private String street;
+    private String city;
+
+    @NonNull
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    @Nullable
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ConstructorTargetBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ConstructorTargetBean.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public class ConstructorTargetBean {
+
+    private final String nonNullParam;
+    private final String nullableParam;
+    private final String unannotatedParam;
+
+    public ConstructorTargetBean(@NonNull String nonNullParam,
+                                 @Nullable String nullableParam,
+                                 String unannotatedParam) {
+        this.nonNullParam = nonNullParam;
+        this.nullableParam = nullableParam;
+        this.unannotatedParam = unannotatedParam;
+    }
+
+    public String getNonNullParam() {
+        return nonNullParam;
+    }
+
+    public String getNullableParam() {
+        return nullableParam;
+    }
+
+    public String getUnannotatedParam() {
+        return unannotatedParam;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ErroneousJSpecifyConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ErroneousJSpecifyConstructorMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Erroneous mapper: maps @Nullable source to @NonNull constructor parameter without default value.
+ */
+@Mapper
+public interface ErroneousJSpecifyConstructorMapper {
+
+    ErroneousJSpecifyConstructorMapper INSTANCE = Mappers.getMapper( ErroneousJSpecifyConstructorMapper.class );
+
+    @Mapping(target = "nonNullParam", source = "nullableValue")
+    @Mapping(target = "nullableParam", source = "nullableValue")
+    @Mapping(target = "unannotatedParam", source = "nonNullValue")
+    ConstructorTargetBean map(SourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ErroneousJSpecifyDirectParamConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ErroneousJSpecifyDirectParamConstructorMapper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Erroneous mapper: a {@code @Nullable} method parameter is mapped directly (no property entries)
+ * to a {@code @NonNull} constructor parameter without {@code defaultValue}.
+ */
+@Mapper
+public interface ErroneousJSpecifyDirectParamConstructorMapper {
+
+    ErroneousJSpecifyDirectParamConstructorMapper INSTANCE =
+        Mappers.getMapper( ErroneousJSpecifyDirectParamConstructorMapper.class );
+
+    @Mapping(target = "nonNullParam", source = "nullableValue")
+    @Mapping(target = "nullableParam", source = "nullableValue")
+    @Mapping(target = "unannotatedParam", source = "nullableValue")
+    ConstructorTargetBean map(@Nullable String nullableValue);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ErroneousJSpecifyUnforgeableMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ErroneousJSpecifyUnforgeableMapper.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+/**
+ * Erroneous mapper: the nullable source property cannot be mapped to the target constructor
+ * parameter's type at all (String -> AddressBean, with no mapping method declared). The
+ * "cannot find mapping" error must be the only diagnostic; the JSpecify
+ * "@NonNull constructor parameter" error must not also fire when assignment resolution failed.
+ */
+@Mapper
+public interface ErroneousJSpecifyUnforgeableMapper {
+
+    @Mapping(target = "payload", source = "nullableValue")
+    UnmappableConstructorTargetBean map(SourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/FlatTargetBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/FlatTargetBean.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+
+public class FlatTargetBean {
+
+    private String street;
+    private boolean streetSet;
+
+    private String city;
+    private boolean citySet;
+
+    private String nullableStreet;
+    private boolean nullableStreetSet;
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(@NonNull String street) {
+        this.streetSet = true;
+        this.street = street;
+    }
+
+    public boolean isStreetSet() {
+        return streetSet;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(@NonNull String city) {
+        this.citySet = true;
+        this.city = city;
+    }
+
+    public boolean isCitySet() {
+        return citySet;
+    }
+
+    public String getNullableStreet() {
+        return nullableStreet;
+    }
+
+    public void setNullableStreet(String nullableStreet) {
+        this.nullableStreetSet = true;
+        this.nullableStreet = nullableStreet;
+    }
+
+    public boolean isNullableStreetSet() {
+        return nullableStreetSet;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorDefaultValueMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorDefaultValueMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * A {@code defaultValue} on the mapping of a {@code @Nullable} source to a {@code @NonNull}
+ * constructor parameter must suppress the "potentially nullable source" compile error.
+ */
+@Mapper
+public interface JSpecifyConstructorDefaultValueMapper {
+
+    JSpecifyConstructorDefaultValueMapper INSTANCE =
+        Mappers.getMapper( JSpecifyConstructorDefaultValueMapper.class );
+
+    @Mapping(target = "nonNullParam", source = "nullableValue", defaultValue = "fallback")
+    @Mapping(target = "nullableParam", source = "nullableValue")
+    @Mapping(target = "unannotatedParam", source = "nonNullValue")
+    ConstructorTargetBean map(SourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper with constructor target to test JSpecify on constructor parameters.
+ * Only valid mappings: @NonNull source to @NonNull target, @Nullable to @Nullable.
+ */
+@Mapper
+public interface JSpecifyConstructorMapper {
+
+    JSpecifyConstructorMapper INSTANCE = Mappers.getMapper( JSpecifyConstructorMapper.class );
+
+    @Mapping(target = "nonNullParam", source = "nonNullValue")
+    @Mapping(target = "nullableParam", source = "nullableValue")
+    @Mapping(target = "unannotatedParam", source = "unannotatedValue")
+    ConstructorTargetBean map(SourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     ConstructorTargetBean.class
 })
 @WithJSpecify
-public class JSpecifyConstructorTest {
+class JSpecifyConstructorTest {
 
     @RegisterExtension
     final GeneratedSource generatedSource = new GeneratedSource();

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorTest.java
@@ -96,6 +96,20 @@ class JSpecifyConstructorTest {
     }
 
     @ProcessorTest
+    @WithClasses({ AddressBean.class, UnmappableConstructorTargetBean.class, ErroneousJSpecifyUnforgeableMapper.class })
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousJSpecifyUnforgeableMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                message = "Can't map property \"String nullableValue\" to \"AddressBean payload\". " +
+                    "Consider to declare/implement a mapping method: \"AddressBean map(String value)\".")
+        })
+    public void failedAssignmentDoesNotAlsoTriggerNullableToNonNullConstructorParamError() {
+        // The JSpecify @NonNull constructor-param error must not fire when the assignment
+        // itself could not be resolved; otherwise users see two errors for one underlying issue.
+    }
+
+    @ProcessorTest
     @WithClasses(JSpecifyConstructorDefaultValueMapper.class)
     public void defaultValueSuppressesNullableToNonNullConstructorParamError() {
         SourceBean source = new SourceBean();

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for JSpecify nullness annotations with constructor mappings.
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("1243")
+@WithClasses({
+    SourceBean.class,
+    ConstructorTargetBean.class
+})
+@WithJSpecify
+public class JSpecifyConstructorTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses(JSpecifyConstructorMapper.class)
+    public void verifyGeneratedCode() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyConstructorMapper.class );
+    }
+
+    @ProcessorTest
+    @WithClasses(JSpecifyConstructorMapper.class)
+    public void constructorMappingWithNonNullSource() {
+        SourceBean source = new SourceBean();
+        source.setNonNullValue( "value" );
+        source.setNullableValue( "nullable" );
+        source.setUnannotatedValue( "unannotated" );
+
+        ConstructorTargetBean target = JSpecifyConstructorMapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getNonNullParam() ).isEqualTo( "value" );
+        assertThat( target.getNullableParam() ).isEqualTo( "nullable" );
+        assertThat( target.getUnannotatedParam() ).isEqualTo( "unannotated" );
+    }
+
+    @ProcessorTest
+    @WithClasses(ErroneousJSpecifyConstructorMapper.class)
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousJSpecifyConstructorMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                message = "Can't map potentially nullable source property \"nullableValue\" to @NonNull " +
+                    "constructor parameter \"nonNullParam\". Consider adding a defaultValue or " +
+                    "defaultExpression.")
+        })
+    public void nullableSourceToNonNullConstructorParamShouldFail() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorTest.java
@@ -67,4 +67,44 @@ public class JSpecifyConstructorTest {
         })
     public void nullableSourceToNonNullConstructorParamShouldFail() {
     }
+
+    @ProcessorTest
+    @WithClasses(JSpecifyDirectParamConstructorMapper.class)
+    public void nonNullDirectParameterToNonNullConstructorParamCompiles() {
+        // A @NonNull method parameter (source has no property entries — it IS the parameter)
+        // must be accepted by a @NonNull constructor parameter without triggering the
+        // "potentially nullable source" error.
+        ConstructorTargetBean target = JSpecifyDirectParamConstructorMapper.INSTANCE.map(
+            "nn", "nullable", "plain" );
+
+        assertThat( target.getNonNullParam() ).isEqualTo( "nn" );
+        assertThat( target.getNullableParam() ).isEqualTo( "nullable" );
+        assertThat( target.getUnannotatedParam() ).isEqualTo( "plain" );
+    }
+
+    @ProcessorTest
+    @WithClasses(ErroneousJSpecifyDirectParamConstructorMapper.class)
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousJSpecifyDirectParamConstructorMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                message = "Can't map potentially nullable source property \"nullableValue\" to @NonNull " +
+                    "constructor parameter \"nonNullParam\". Consider adding a defaultValue or " +
+                    "defaultExpression.")
+        })
+    public void nullableDirectParameterToNonNullConstructorParamShouldFail() {
+    }
+
+    @ProcessorTest
+    @WithClasses(JSpecifyConstructorDefaultValueMapper.class)
+    public void defaultValueSuppressesNullableToNonNullConstructorParamError() {
+        SourceBean source = new SourceBean();
+        source.setNonNullValue( "present" );
+        // nullableValue left null on purpose — defaultValue "fallback" should kick in.
+
+        ConstructorTargetBean target = JSpecifyConstructorDefaultValueMapper.INSTANCE.map( source );
+
+        assertThat( target.getNonNullParam() ).isEqualTo( "fallback" );
+        assertThat( target.getUnannotatedParam() ).isEqualTo( "present" );
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDirectParamConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDirectParamConstructorMapper.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper that maps direct method parameters (no property entries) to constructor parameters.
+ * Verifies that a {@code @NonNull} source parameter is accepted by a {@code @NonNull}
+ * constructor parameter target.
+ */
+@Mapper
+public interface JSpecifyDirectParamConstructorMapper {
+
+    JSpecifyDirectParamConstructorMapper INSTANCE = Mappers.getMapper( JSpecifyDirectParamConstructorMapper.class );
+
+    @Mapping(target = "nonNullParam", source = "nonNullValue")
+    @Mapping(target = "nullableParam", source = "nullableValue")
+    @Mapping(target = "unannotatedParam", source = "unannotatedValue")
+    ConstructorTargetBean map(@NonNull String nonNullValue,
+                              @Nullable String nullableValue,
+                              String unannotatedValue);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Dedicated mapper for {@link JSpecifyDisabledTest} so that the test's JSpecify-disabled
+ * compilation result is isolated from tests that share {@link JSpecifyNullCheckMapper} and
+ * would otherwise keep the JSpecify-enabled {@code INSTANCE} cached in the JVM.
+ */
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface JSpecifyDisabledMapper {
+
+    JSpecifyDisabledMapper INSTANCE = Mappers.getMapper( JSpecifyDisabledMapper.class );
+
+    @Mapping(target = "nonNullTargetFromNullable", source = "nullableValue")
+    TargetBean map(SourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@code -Amapstruct.disableJSpecify=true} fully opts out of JSpecify-based
+ * null-check inference. With the flag on, mappers that would normally be affected by
+ * JSpecify fall back to the pre-JSpecify baseline.
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("1243")
+@WithJSpecify
+@ProcessorOption(name = "mapstruct.disableJSpecify", value = "true")
+class JSpecifyDisabledTest {
+
+    @ProcessorTest
+    @WithClasses({ SourceBean.class, TargetBean.class, JSpecifyDisabledMapper.class })
+    public void disabledFlagSkipsTargetNonNullInference() {
+        // With JSpecify enabled, mapping a @Nullable source onto a @NonNull target setter
+        // emits an "if (src != null)" guard. When disabled, the default NullValueCheckStrategy
+        // (ON_IMPLICIT_CONVERSION) applies and a direct String->String assignment gets no guard,
+        // so the setter is always invoked — even when the source is null.
+        SourceBean source = new SourceBean();
+        // nullableValue left null
+
+        TargetBean target = JSpecifyDisabledMapper.INSTANCE.map( source );
+
+        assertThat( target.isNonNullTargetFromNullableSet() ).isTrue();
+        assertThat( target.getNonNullTargetFromNullable() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses({
+        SourceBean.class,
+        ConstructorTargetBean.class,
+        ErroneousJSpecifyConstructorMapper.class
+    })
+    @ExpectedCompilationOutcome(value = CompilationResult.SUCCEEDED)
+    public void disabledFlagSkipsConstructorNonNullHardError() {
+        // The JSpecify-driven hard error for a @Nullable source mapped to a @NonNull constructor
+        // parameter is purely a JSpecify signal; with the flag disabled it must not be raised.
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNestedMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNestedMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper with nested property chains and JSpecify annotations.
+ * Tests that the deepest property's annotation is used for the null check decision.
+ */
+@Mapper
+public interface JSpecifyNestedMapper {
+
+    JSpecifyNestedMapper INSTANCE = Mappers.getMapper( JSpecifyNestedMapper.class );
+
+    // nonNullAddress.street: leaf @NonNull -> target @NonNull -> skip null check (source @NonNull)
+    @Mapping(target = "street", source = "nonNullAddress.street")
+    // nonNullAddress.city: leaf @Nullable -> target @NonNull -> null check
+    @Mapping(target = "city", source = "nonNullAddress.city")
+    // nonNullAddress.street: leaf @NonNull -> target unannotated -> skip null check (source @NonNull)
+    @Mapping(target = "nullableStreet", source = "nonNullAddress.street")
+    FlatTargetBean map(NestedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNestedTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNestedTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for JSpecify nullness annotations with nested property chains.
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("1243")
+@WithClasses({
+    AddressBean.class,
+    NestedSourceBean.class,
+    FlatTargetBean.class,
+    JSpecifyNestedMapper.class
+})
+@WithJSpecify
+public class JSpecifyNestedTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void verifyGeneratedCode() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyNestedMapper.class );
+    }
+
+    @ProcessorTest
+    public void nestedNonNullLeafSkipsNullCheck() {
+        AddressBean address = new AddressBean();
+        address.setStreet( "Main St" );
+
+        NestedSourceBean source = new NestedSourceBean();
+        source.setNonNullAddress( address );
+
+        FlatTargetBean target = JSpecifyNestedMapper.INSTANCE.map( source );
+
+        assertThat( target.isStreetSet() ).isTrue();
+        assertThat( target.getStreet() ).isEqualTo( "Main St" );
+    }
+
+    @ProcessorTest
+    public void nestedNullableLeafToNonNullTargetAddsNullCheck() {
+        AddressBean address = new AddressBean();
+        // city is null (@Nullable)
+
+        NestedSourceBean source = new NestedSourceBean();
+        source.setNonNullAddress( address );
+
+        FlatTargetBean target = JSpecifyNestedMapper.INSTANCE.map( source );
+
+        // city: source @Nullable -> target @NonNull -> null check -> setter not called
+        assertThat( target.isCitySet() ).isFalse();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNestedTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNestedTest.java
@@ -64,4 +64,20 @@ class JSpecifyNestedTest {
         // city: source @Nullable -> target @NonNull -> null check -> setter not called
         assertThat( target.isCitySet() ).isFalse();
     }
+
+    @ProcessorTest
+    @WithClasses(JSpecifyNullableIntermediateMapper.class)
+    public void nullableIntermediateMustNotSkipNullCheckOnNonNullLeaf() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyNullableIntermediateMapper.class );
+
+        // nullableAddress is @Nullable; its street is @NonNull; target setter is @NonNull.
+        // When the intermediate is null, the whole source chain yields null and the @NonNull
+        // target setter must NOT be invoked.
+        NestedSourceBean source = new NestedSourceBean();
+        // nullableAddress stays null
+
+        FlatTargetBean target = JSpecifyNullableIntermediateMapper.INSTANCE.map( source );
+
+        assertThat( target.isStreetSet() ).isFalse();
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNestedTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNestedTest.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     JSpecifyNestedMapper.class
 })
 @WithJSpecify
-public class JSpecifyNestedTest {
+class JSpecifyNestedTest {
 
     @RegisterExtension
     final GeneratedSource generatedSource = new GeneratedSource();

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullParamMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullParamMapper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper for testing JSpecify @NonNull on source parameter.
+ * The method-level null guard (if source == null return null) should be skipped.
+ */
+@Mapper
+public interface JSpecifyNonNullParamMapper {
+
+    JSpecifyNonNullParamMapper INSTANCE = Mappers.getMapper( JSpecifyNonNullParamMapper.class );
+
+    @Mapping(target = "nonNullTarget", source = "nonNullValue")
+    @Mapping(target = "nullableTarget", source = "nullableValue")
+    @Mapping(target = "unannotatedTarget", source = "unannotatedValue")
+    @Mapping(target = "nonNullTargetFromNullable", source = "nullableValue")
+    TargetBean map(@NonNull SourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper for testing JSpecify nullness annotation support on property level.
+ */
+@Mapper
+public interface JSpecifyNullCheckMapper {
+
+    JSpecifyNullCheckMapper INSTANCE = Mappers.getMapper( JSpecifyNullCheckMapper.class );
+
+    @Mapping(target = "nonNullTarget", source = "nonNullValue")
+    @Mapping(target = "nullableTarget", source = "nullableValue")
+    @Mapping(target = "unannotatedTarget", source = "unannotatedValue")
+    @Mapping(target = "nonNullTargetFromNullable", source = "nullableValue")
+    TargetBean map(SourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for JSpecify nullness annotation support in MapStruct.
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("1243")
+@WithClasses({
+    SourceBean.class,
+    TargetBean.class
+})
+@WithJSpecify
+public class JSpecifyNullCheckTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    // -- Property-level tests (JSpecifyNullCheckMapper) --
+
+    @ProcessorTest
+    @WithClasses(JSpecifyNullCheckMapper.class)
+    public void sourceNonNullGetterShouldSkipNullCheck() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyNullCheckMapper.class );
+
+        // Source @NonNull getter -> no null check, setter always called
+        SourceBean source = new SourceBean();
+        source.setNonNullValue( "value" );
+
+        TargetBean target = JSpecifyNullCheckMapper.INSTANCE.map( source );
+
+        assertThat( target.isNonNullTargetSet() ).isTrue();
+        assertThat( target.getNonNullTarget() ).isEqualTo( "value" );
+    }
+
+    @ProcessorTest
+    @WithClasses(JSpecifyNullCheckMapper.class)
+    public void sourceNullableTargetNonNullShouldAddNullCheck() {
+        // Source @Nullable getter + Target @NonNull setter -> null check added
+        // When source value is null, setter should NOT be called
+        SourceBean source = new SourceBean();
+
+        TargetBean target = JSpecifyNullCheckMapper.INSTANCE.map( source );
+
+        assertThat( target.isNonNullTargetFromNullableSet() ).isFalse();
+    }
+
+    @ProcessorTest
+    @WithClasses(JSpecifyNullCheckMapper.class)
+    public void sourceNullableTargetNullableDefersToStrategy() {
+        // Source @Nullable + Target @Nullable -> defers to NullValueCheckStrategy
+        // Default NVCS is ON_IMPLICIT_CONVERSION, direct String->String has no null check
+        SourceBean source = new SourceBean();
+
+        TargetBean target = JSpecifyNullCheckMapper.INSTANCE.map( source );
+
+        // With ON_IMPLICIT_CONVERSION, no null check for direct assignment -> setter called
+        assertThat( target.isNullableTargetSet() ).isTrue();
+    }
+
+    // -- JSpecify overrides NullValueCheckStrategy --
+
+    @ProcessorTest
+    @WithClasses(JSpecifyOverridesStrategyMapper.class)
+    public void jspecifyOverridesNullValueCheckStrategyAlways() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyOverridesStrategyMapper.class );
+
+        // Even with NullValueCheckStrategy.ALWAYS, source @NonNull should skip null check
+        SourceBean source = new SourceBean();
+        source.setNonNullValue( "value" );
+
+        TargetBean target = JSpecifyOverridesStrategyMapper.INSTANCE.map( source );
+
+        assertThat( target.isNonNullTargetSet() ).isTrue();
+    }
+
+    // -- Method-level parameter null check --
+
+    @ProcessorTest
+    @WithClasses(JSpecifyNonNullParamMapper.class)
+    public void nonNullParamShouldSkipMethodLevelNullGuard() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyNonNullParamMapper.class );
+    }
+
+    @ProcessorTest
+    @WithClasses(JSpecifyNullCheckMapper.class)
+    public void unannotatedParamShouldHaveMethodLevelNullGuard() {
+        // Unannotated source parameter -> normal "if (source == null) return null" guard
+        SourceBean source = new SourceBean();
+
+        TargetBean target = JSpecifyNullCheckMapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckTest.java
@@ -13,6 +13,7 @@ import org.mapstruct.ap.testutil.WithJSpecify;
 import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
 /**
  * Tests for JSpecify nullness annotation support in MapStruct.
@@ -94,6 +95,21 @@ public class JSpecifyNullCheckTest {
     @WithClasses(JSpecifyNonNullParamMapper.class)
     public void nonNullParamShouldSkipMethodLevelNullGuard() {
         generatedSource.addComparisonToFixtureFor( JSpecifyNonNullParamMapper.class );
+
+        // Non-null input: mapper maps through normally.
+        SourceBean source = new SourceBean();
+        source.setNonNullValue( "value" );
+        source.setUnannotatedValue( "plain" );
+
+        TargetBean target = JSpecifyNonNullParamMapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getNonNullTarget() ).isEqualTo( "value" );
+        assertThat( target.getUnannotatedTarget() ).isEqualTo( "plain" );
+
+        // Null input: because the method-level guard was skipped, the mapper must dereference
+        // the source and throw NPE rather than silently returning null.
+        assertThatNullPointerException().isThrownBy( () -> JSpecifyNonNullParamMapper.INSTANCE.map( null ) );
     }
 
     @ProcessorTest

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatNullPointerException;
     TargetBean.class
 })
 @WithJSpecify
-public class JSpecifyNullCheckTest {
+class JSpecifyNullCheckTest {
 
     @RegisterExtension
     final GeneratedSource generatedSource = new GeneratedSource();

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTargetScopeMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTargetScopeMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Target is a {@code @NullMarked} bean with an unannotated setter parameter
+ * ({@code setNonNullByDefault}), which JSpecify semantics promote to {@code @NonNull}.
+ * The source getter is explicitly {@code @Nullable}, so a null check must be generated.
+ */
+@Mapper
+public interface JSpecifyNullMarkedTargetScopeMapper {
+
+    JSpecifyNullMarkedTargetScopeMapper INSTANCE =
+        Mappers.getMapper( JSpecifyNullMarkedTargetScopeMapper.class );
+
+    @Mapping(target = "nonNullByDefault", source = "nullableValue")
+    @Mapping(target = "explicitlyNullable", ignore = true)
+    NullMarkedTargetBean map(SourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTest.java
@@ -25,7 +25,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @IssueKey("1243")
 @WithJSpecify
-public class JSpecifyNullMarkedTest {
+class JSpecifyNullMarkedTest {
 
     @RegisterExtension
     final GeneratedSource generatedSource = new GeneratedSource();

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTest.java
@@ -103,6 +103,22 @@ public class JSpecifyNullMarkedTest {
 
     @ProcessorTest
     @WithClasses({
+        SourceBean.class,
+        TargetBean.class,
+        JSpecifyNullUnmarkedMethodMapper.class
+    })
+    public void nullUnmarkedOnMethodReversesEnclosingNullMarkedScope() {
+        // The mapper interface is @NullMarked but the method is @NullUnmarked. The source
+        // parameter is unannotated: with method-level scope, its nullability must be UNKNOWN
+        // (not promoted), so the method-level null guard is generated. Passing null must
+        // return null rather than NPE.
+        TargetBean target = JSpecifyNullUnmarkedMethodMapper.INSTANCE.map( null );
+
+        assertThat( target ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses({
         NullUnmarkedSourceBean.class,
         TargetBean.class,
         JSpecifyNullUnmarkedMapper.class

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTest.java
@@ -182,7 +182,7 @@ class JSpecifyNullMarkedTest {
         // Same classes and mapper as packageLevelNullMarked but WITHOUT @WithPackageInfo.
         // Without the package-info.java being compiled, @NullMarked is not visible —
         // unannotated types have unknown nullability and the ALWAYS strategy produces null checks.
-        generatedSource.addComparisonToFixtureFor( PackageNullMarkedMapper.class, "withoutpackageinfo" );
+        generatedSource.addComparisonToFixtureFor( PackageNullMarkedMapper.class, "withoutPackageInfo" );
     }
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.test.nullcheck.jspecify.nullmarkedpackage.PackageNullMarkedMapper;
+import org.mapstruct.ap.test.nullcheck.jspecify.nullmarkedpackage.PackageNullMarkedSourceBean;
+import org.mapstruct.ap.test.nullcheck.jspecify.nullmarkedpackage.PackageNullMarkedTargetBean;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.WithPackageInfo;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for JSpecify {@code @NullMarked} / {@code @NullUnmarked} support.
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("1243")
+@WithJSpecify
+public class JSpecifyNullMarkedTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({ NullMarkedSourceBean.class, NullMarkedTargetBean.class, NullMarkedMapper.class })
+    public void nullMarkedSourceAndTarget() {
+        generatedSource.addComparisonToFixtureFor( NullMarkedMapper.class );
+
+        NullMarkedSourceBean source = new NullMarkedSourceBean();
+        source.setNonNullByDefault( "value" );
+
+        NullMarkedTargetBean target = NullMarkedMapper.INSTANCE.map( source );
+
+        // nonNullByDefault: source effectively @NonNull -> skip null check -> setter called
+        assertThat( target.isNonNullByDefaultSet() ).isTrue();
+        assertThat( target.getNonNullByDefault() ).isEqualTo( "value" );
+    }
+
+    @ProcessorTest
+    @WithClasses({ NullMarkedSourceBean.class, NullMarkedTargetBean.class, NullMarkedMapper.class })
+    public void nullMarkedNullableSourceToNonNullTarget() {
+        // @Nullable getter -> target effectively @NonNull -> null check added
+        NullMarkedSourceBean source = new NullMarkedSourceBean();
+        // explicitlyNullable is null
+
+        NullMarkedTargetBean target = NullMarkedMapper.INSTANCE.map( source );
+
+        // Target's setter for explicitlyNullable is @Nullable -> defers to strategy
+        // Default NVCS = ON_IMPLICIT_CONVERSION, direct String -> String -> no null check
+        assertThat( target.isExplicitlyNullableSet() ).isTrue();
+    }
+
+    @ProcessorTest
+    @WithClasses({ NullMarkedSourceBean.class, TargetBean.class, NullMarkedSourceToPlainTargetMapper.class })
+    public void nullMarkedSourceToPlainTarget() {
+        generatedSource.addComparisonToFixtureFor( NullMarkedSourceToPlainTargetMapper.class );
+
+        NullMarkedSourceBean source = new NullMarkedSourceBean();
+        source.setNonNullByDefault( "value" );
+
+        TargetBean target = NullMarkedSourceToPlainTargetMapper.INSTANCE.map( source );
+
+        // Source effectively @NonNull -> skip null check -> setter always called
+        assertThat( target.isUnannotatedTargetSet() ).isTrue();
+    }
+
+    @ProcessorTest
+    @WithClasses({ NullMarkedSourceBean.class, NullMarkedTargetBean.class, NullMarkedMapperWithParam.class })
+    public void nullMarkedMapperSkipsMethodLevelNullGuard() {
+        generatedSource.addComparisonToFixtureFor( NullMarkedMapperWithParam.class );
+    }
+
+    @ProcessorTest
+    @WithClasses({
+        PackageNullMarkedSourceBean.class,
+        PackageNullMarkedTargetBean.class,
+        PackageNullMarkedMapper.class
+    })
+    @WithPackageInfo(PackageNullMarkedSourceBean.class)
+    public void packageLevelNullMarked() {
+        generatedSource.addComparisonToFixtureFor( PackageNullMarkedMapper.class );
+
+        // @NullMarked package: unannotated types are effectively @NonNull.
+        // Mapper uses NullValueCheckStrategy.ALWAYS but JSpecify wins -> no null checks.
+        PackageNullMarkedSourceBean source = new PackageNullMarkedSourceBean();
+        // value is null
+
+        PackageNullMarkedTargetBean target = PackageNullMarkedMapper.INSTANCE.map( source );
+
+        // Unannotated getter is effectively @NonNull -> no null check despite ALWAYS strategy
+        // -> setter is called even when source value is null
+        assertThat( target.isValueSet() ).isTrue();
+    }
+
+    @ProcessorTest
+    @WithClasses({
+        PackageNullMarkedSourceBean.class,
+        PackageNullMarkedTargetBean.class,
+        PackageNullMarkedMapper.class
+    })
+    public void packageLevelNullMarkedWithoutPackageInfo() {
+        // Same classes and mapper as packageLevelNullMarked but WITHOUT @WithPackageInfo.
+        // Without the package-info.java being compiled, @NullMarked is not visible —
+        // unannotated types have unknown nullability and the ALWAYS strategy produces null checks.
+        generatedSource.addComparisonToFixtureFor( PackageNullMarkedMapper.class, "withoutpackageinfo" );
+    }
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullMarkedTest.java
@@ -103,6 +103,61 @@ public class JSpecifyNullMarkedTest {
 
     @ProcessorTest
     @WithClasses({
+        NullUnmarkedSourceBean.class,
+        TargetBean.class,
+        JSpecifyNullUnmarkedMapper.class
+    })
+    public void nullUnmarkedReversesEnclosingNullMarkedScope() {
+        // The source class is @NullUnmarked inside a @NullMarked outer class.
+        // Unannotated getter must be UNKNOWN, not promoted to @NonNull.
+        // With NVCS=ALWAYS, a null check is generated and the setter is NOT called when source is null.
+        NullUnmarkedSourceBean.Inner source = new NullUnmarkedSourceBean.Inner();
+        // value is null
+
+        TargetBean target = JSpecifyNullUnmarkedMapper.INSTANCE.map( source );
+
+        assertThat( target.isUnannotatedTargetSet() ).isFalse();
+    }
+
+    @ProcessorTest
+    @WithClasses({
+        SourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyNullMarkedTargetScopeMapper.class
+    })
+    public void nullMarkedTargetPromotesUnannotatedSetterParamToNonNull() {
+        // Target bean is @NullMarked; setNonNullByDefault has an unannotated String parameter
+        // which must be treated as @NonNull by JSpecify semantics. Source getter is @Nullable,
+        // so a null check must be generated and the setter must NOT be called when source is null.
+        SourceBean source = new SourceBean();
+        // nullableValue is null
+
+        NullMarkedTargetBean target = JSpecifyNullMarkedTargetScopeMapper.INSTANCE.map( source );
+
+        assertThat( target.isNonNullByDefaultSet() ).isFalse();
+    }
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        TargetBean.class,
+        JSpecifyNullableOverridesScopeMapper.class
+    })
+    public void explicitNullableOverridesNullMarkedScope() {
+        // Source getter is explicitly @Nullable inside a @NullMarked class — the explicit
+        // annotation must keep the source NULLABLE instead of being promoted to @NonNull
+        // by the scope. Target setter is explicitly @NonNull, so a null check is required.
+        NullMarkedSourceBean source = new NullMarkedSourceBean();
+        // explicitlyNullable is null
+
+        TargetBean target = JSpecifyNullableOverridesScopeMapper.INSTANCE.map( source );
+
+        // Null check generated -> setter must NOT be called when source value is null.
+        assertThat( target.isNonNullTargetFromNullableSet() ).isFalse();
+    }
+
+    @ProcessorTest
+    @WithClasses({
         PackageNullMarkedSourceBean.class,
         PackageNullMarkedTargetBean.class,
         PackageNullMarkedMapper.class

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullUnmarkedMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullUnmarkedMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValueCheckStrategy;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Source is a {@code @NullUnmarked} class nested inside a {@code @NullMarked} outer class.
+ * The unannotated getter must be treated as unknown nullability (not promoted to {@code @NonNull}).
+ * With {@code NullValueCheckStrategy.ALWAYS}, a null check must be generated.
+ */
+@Mapper(
+    nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS,
+    unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface JSpecifyNullUnmarkedMapper {
+
+    JSpecifyNullUnmarkedMapper INSTANCE = Mappers.getMapper( JSpecifyNullUnmarkedMapper.class );
+
+    @Mapping(target = "unannotatedTarget", source = "value")
+    TargetBean map(NullUnmarkedSourceBean.Inner source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullUnmarkedMethodMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullUnmarkedMethodMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NullUnmarked;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValueCheckStrategy;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper interface annotated with {@code @NullMarked} but the mapping method itself is
+ * {@code @NullUnmarked}. The unannotated source parameter inside the {@code @NullUnmarked}
+ * method must be treated as unknown nullability, so with {@code NullValueCheckStrategy.ALWAYS}
+ * the method-level null guard must still be generated.
+ */
+@NullMarked
+@Mapper(
+    nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS,
+    unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface JSpecifyNullUnmarkedMethodMapper {
+
+    JSpecifyNullUnmarkedMethodMapper INSTANCE = Mappers.getMapper( JSpecifyNullUnmarkedMethodMapper.class );
+
+    @NullUnmarked
+    @Mapping(target = "unannotatedTarget", source = "unannotatedValue")
+    TargetBean map(SourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableIntermediateMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableIntermediateMapper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Nested source chain where the intermediate accessor is {@code @Nullable} but the deepest
+ * accessor is {@code @NonNull}. The target setter is {@code @NonNull} — when the intermediate
+ * returns null, the setter must not be invoked.
+ */
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface JSpecifyNullableIntermediateMapper {
+
+    JSpecifyNullableIntermediateMapper INSTANCE = Mappers.getMapper( JSpecifyNullableIntermediateMapper.class );
+
+    // nullableAddress is @Nullable; street is @NonNull; target setStreet is @NonNull.
+    // Because the intermediate can be null, the null check must not be skipped.
+    @Mapping(target = "street", source = "nullableAddress.street")
+    FlatTargetBean map(NestedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableOverridesScopeMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableOverridesScopeMapper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.ReportingPolicy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Maps an explicitly {@code @Nullable} source property inside a {@code @NullMarked} scope
+ * to a {@code @NonNull} setter parameter. A null check must be generated because the
+ * explicit {@code @Nullable} overrides the enclosing {@code @NullMarked} scope, keeping
+ * the source nullability as {@code NULLABLE} instead of being promoted to {@code NON_NULL}.
+ */
+@Mapper(unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface JSpecifyNullableOverridesScopeMapper {
+
+    JSpecifyNullableOverridesScopeMapper INSTANCE =
+        Mappers.getMapper( JSpecifyNullableOverridesScopeMapper.class );
+
+    @Mapping(target = "nonNullTargetFromNullable", source = "explicitlyNullable")
+    TargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyOverridesStrategyMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyOverridesStrategyMapper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.NullValueCheckStrategy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper with NullValueCheckStrategy.ALWAYS that should be overridden by JSpecify annotations.
+ * Source @NonNull getter -> should NOT have null check despite ALWAYS strategy.
+ */
+@Mapper(nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
+public interface JSpecifyOverridesStrategyMapper {
+
+    JSpecifyOverridesStrategyMapper INSTANCE = Mappers.getMapper( JSpecifyOverridesStrategyMapper.class );
+
+    @Mapping(target = "nonNullTarget", source = "nonNullValue")
+    @Mapping(target = "nullableTarget", source = "nullableValue")
+    @Mapping(target = "unannotatedTarget", source = "unannotatedValue")
+    @Mapping(target = "nonNullTargetFromNullable", source = "nullableValue")
+    TargetBean map(SourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySafetyGuardMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySafetyGuardMapper.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Verifies that existing safety guards still trigger a null check when the source is
+ * {@code @Nullable}:
+ * <ul>
+ *   <li>Unboxing ({@code Integer} -&gt; {@code int})</li>
+ *   <li>{@code defaultValue}</li>
+ *   <li>{@link NullValuePropertyMappingStrategy#SET_TO_DEFAULT} on an update method</li>
+ * </ul>
+ */
+@Mapper
+public interface JSpecifySafetyGuardMapper {
+
+    JSpecifySafetyGuardMapper INSTANCE = Mappers.getMapper( JSpecifySafetyGuardMapper.class );
+
+    @Mapping(target = "unboxedNumber", source = "nullableNumber")
+    @Mapping(target = "textWithDefault", source = "nullableText", defaultValue = "default")
+    @Mapping(target = "textWithNvpms", ignore = true)
+    SafetyGuardTargetBean map(SafetyGuardSourceBean source);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_DEFAULT)
+    @Mapping(target = "unboxedNumber", ignore = true)
+    @Mapping(target = "textWithDefault", ignore = true)
+    @Mapping(target = "textWithNvpms", source = "nullableText")
+    void update(SafetyGuardSourceBean source, @MappingTarget SafetyGuardTargetBean target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySafetyGuardTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySafetyGuardTest.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the pre-existing safety guards in {@code PropertyMapping} (unboxing,
+ * {@code defaultValue}, {@code NullValuePropertyMappingStrategy.SET_TO_DEFAULT}) still
+ * generate a null check when the source is {@code @Nullable}.
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("1243")
+@WithClasses({
+    SafetyGuardSourceBean.class,
+    SafetyGuardTargetBean.class,
+    JSpecifySafetyGuardMapper.class
+})
+@WithJSpecify
+public class JSpecifySafetyGuardTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void nullableSourceToPrimitiveTargetKeepsUnboxingGuard() {
+        // Source @Nullable Integer is null; unboxing guard must prevent an NPE.
+        SafetyGuardSourceBean source = new SafetyGuardSourceBean();
+
+        SafetyGuardTargetBean target = JSpecifySafetyGuardMapper.INSTANCE.map( source );
+
+        assertThat( target.getUnboxedNumber() ).isZero();
+    }
+
+    @ProcessorTest
+    public void nullableSourceWithDefaultValueKeepsDefaultValueGuard() {
+        // Source @Nullable String is null; defaultValue must be applied.
+        SafetyGuardSourceBean source = new SafetyGuardSourceBean();
+
+        SafetyGuardTargetBean target = JSpecifySafetyGuardMapper.INSTANCE.map( source );
+
+        assertThat( target.getTextWithDefault() ).isEqualTo( "default" );
+    }
+
+    @ProcessorTest
+    public void nullableSourceWithSetToDefaultKeepsNvpmsGuard() {
+        // Source @Nullable String is null; NVPMS=SET_TO_DEFAULT must kick in on an update method
+        // (NVPMS is only honored for update methods) and reset the target to the String default.
+        SafetyGuardSourceBean source = new SafetyGuardSourceBean();
+        SafetyGuardTargetBean target = new SafetyGuardTargetBean();
+        target.setTextWithNvpms( "pre-existing" );
+
+        JSpecifySafetyGuardMapper.INSTANCE.update( source, target );
+
+        assertThat( target.getTextWithNvpms() ).isEmpty();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySafetyGuardTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySafetyGuardTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     JSpecifySafetyGuardMapper.class
 })
 @WithJSpecify
-public class JSpecifySafetyGuardTest {
+class JSpecifySafetyGuardTest {
 
     @RegisterExtension
     final GeneratedSource generatedSource = new GeneratedSource();

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyUpdateMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyUpdateMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper with update method and IGNORE strategy to test JSpecify interaction.
+ * NVPMS=IGNORE means: when source is null, leave target unchanged.
+ * Source @NonNull should still skip the null check (guaranteed non-null).
+ */
+@Mapper(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+public interface JSpecifyUpdateMapper {
+
+    JSpecifyUpdateMapper INSTANCE = Mappers.getMapper( JSpecifyUpdateMapper.class );
+
+    @Mapping(target = "nonNullTarget", source = "nonNullValue")
+    @Mapping(target = "nullableTarget", source = "nullableValue")
+    @Mapping(target = "unannotatedTarget", source = "unannotatedValue")
+    @Mapping(target = "nonNullTargetFromNullable", source = "nullableValue")
+    void update(SourceBean source, @MappingTarget TargetBean target);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyUpdateTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyUpdateTest.java
@@ -26,7 +26,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     JSpecifyUpdateMapper.class
 })
 @WithJSpecify
-public class JSpecifyUpdateTest {
+class JSpecifyUpdateTest {
 
     @RegisterExtension
     final GeneratedSource generatedSource = new GeneratedSource();

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyUpdateTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyUpdateTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests for JSpecify nullness annotations with update methods ({@code @MappingTarget}).
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("1243")
+@WithClasses({
+    SourceBean.class,
+    TargetBean.class,
+    JSpecifyUpdateMapper.class
+})
+@WithJSpecify
+public class JSpecifyUpdateTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void verifyGeneratedCode() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyUpdateMapper.class );
+    }
+
+    @ProcessorTest
+    public void sourceNonNullSkipsNullCheckInUpdateMethod() {
+        // Source @NonNull getter -> no null check, setter always called
+        SourceBean source = new SourceBean();
+        source.setNonNullValue( "updated" );
+
+        TargetBean target = new TargetBean();
+        JSpecifyUpdateMapper.INSTANCE.update( source, target );
+
+        assertThat( target.isNonNullTargetSet() ).isTrue();
+        assertThat( target.getNonNullTarget() ).isEqualTo( "updated" );
+    }
+
+    @ProcessorTest
+    public void sourceNullableWithIgnoreStrategyKeepsNullCheck() {
+        // Source @Nullable + NVPMS=IGNORE -> null check must be kept (safety guard)
+        // When source is null, target should be unchanged (IGNORE behavior)
+        SourceBean source = new SourceBean();
+        // nullableValue is null
+
+        TargetBean target = new TargetBean();
+        target.setNullableTarget( "original" );
+
+        JSpecifyUpdateMapper.INSTANCE.update( source, target );
+
+        // IGNORE strategy: null source should not overwrite -> original value preserved
+        assertThat( target.getNullableTarget() ).isEqualTo( "original" );
+    }
+
+    @ProcessorTest
+    public void sourceNullableTargetNonNullWithIgnoreStrategyKeepsNullCheck() {
+        // Source @Nullable + Target @NonNull + NVPMS=IGNORE -> null check kept
+        SourceBean source = new SourceBean();
+        // nullableValue is null
+
+        TargetBean target = new TargetBean();
+        target.setNonNullTargetFromNullable( "original" );
+
+        JSpecifyUpdateMapper.INSTANCE.update( source, target );
+
+        // null source should not overwrite (IGNORE + null check)
+        assertThat( target.getNonNullTargetFromNullable() ).isEqualTo( "original" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyVerboseNoteTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyVerboseNoteTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedNote;
+import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
+import org.mapstruct.ap.testutil.runner.Compiler;
+
+/**
+ * Verifies that JSpecify-driven null-check decisions emit verbose diagnostic notes
+ * (visible with {@code -Amapstruct.verbose=true}) so they are no longer silent.
+ *
+ * @author Filip Hrisafov
+ */
+@IssueKey("1243")
+@WithJSpecify
+public class JSpecifyVerboseNoteTest {
+
+    @ProcessorTest(Compiler.JDK)
+    @ProcessorOption(name = "mapstruct.verbose", value = "true")
+    @WithClasses({ SourceBean.class, TargetBean.class, JSpecifyNullCheckMapper.class })
+    @ExpectedNote("^-- MapStruct: JSpecify skipping null check for property \"nonNullTarget\": "
+        + "source is @NonNull\\.$")
+    @ExpectedNote("^-- MapStruct: JSpecify adding null check for property \"nonNullTargetFromNullable\": "
+        + "source=NULLABLE, target=NON_NULL\\.$")
+    public void emitsSetterDecisionNotes() {
+    }
+
+    @ProcessorTest(Compiler.JDK)
+    @ProcessorOption(name = "mapstruct.verbose", value = "true")
+    @WithClasses({ SourceBean.class, TargetBean.class, JSpecifyNonNullParamMapper.class })
+    @ExpectedNote("^-- MapStruct: JSpecify skipping method-level null guard for property \"source\": "
+        + "parameter is @NonNull\\.$")
+    public void emitsMethodLevelGuardSkipNote() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyVerboseNoteTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyVerboseNoteTest.java
@@ -29,7 +29,7 @@ class JSpecifyVerboseNoteTest {
     @ExpectedNote("^-- MapStruct: JSpecify skipping null check for property \"nonNullTarget\": "
         + "source is @NonNull\\.$")
     @ExpectedNote("^-- MapStruct: JSpecify adding null check for property \"nonNullTargetFromNullable\": "
-        + "source=NULLABLE, target=NON_NULL\\.$")
+        + "source=\\w+, target=\\w+\\.$")
     public void emitsSetterDecisionNotes() {
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyVerboseNoteTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyVerboseNoteTest.java
@@ -21,7 +21,7 @@ import org.mapstruct.ap.testutil.runner.Compiler;
  */
 @IssueKey("1243")
 @WithJSpecify
-public class JSpecifyVerboseNoteTest {
+class JSpecifyVerboseNoteTest {
 
     @ProcessorTest(Compiler.JDK)
     @ProcessorOption(name = "mapstruct.verbose", value = "true")

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NestedSourceBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NestedSourceBean.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public class NestedSourceBean {
+
+    private AddressBean nonNullAddress;
+    private AddressBean nullableAddress;
+
+    @NonNull
+    public AddressBean getNonNullAddress() {
+        return nonNullAddress;
+    }
+
+    public void setNonNullAddress(AddressBean nonNullAddress) {
+        this.nonNullAddress = nonNullAddress;
+    }
+
+    @Nullable
+    public AddressBean getNullableAddress() {
+        return nullableAddress;
+    }
+
+    public void setNullableAddress(AddressBean nullableAddress) {
+        this.nullableAddress = nullableAddress;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper using @NullMarked source and target beans.
+ */
+@Mapper
+public interface NullMarkedMapper {
+
+    NullMarkedMapper INSTANCE = Mappers.getMapper( NullMarkedMapper.class );
+
+    @Mapping(target = "nonNullByDefault", source = "nonNullByDefault")
+    @Mapping(target = "explicitlyNullable", source = "explicitlyNullable")
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedMapperWithParam.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedMapperWithParam.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper annotated with @NullMarked.
+ * Source parameter is effectively @NonNull -> method-level null guard should be skipped.
+ */
+@NullMarked
+@Mapper
+public interface NullMarkedMapperWithParam {
+
+    NullMarkedMapperWithParam INSTANCE = Mappers.getMapper( NullMarkedMapperWithParam.class );
+
+    @Mapping(target = "nonNullByDefault", source = "nonNullByDefault")
+    @Mapping(target = "explicitlyNullable", source = "explicitlyNullable")
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedSourceBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedSourceBean.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Source bean annotated with {@code @NullMarked}.
+ * All unannotated types are effectively {@code @NonNull}.
+ */
+@NullMarked
+public class NullMarkedSourceBean {
+
+    private String nonNullByDefault;
+    private String explicitlyNullable;
+
+    public String getNonNullByDefault() {
+        return nonNullByDefault;
+    }
+
+    public void setNonNullByDefault(String nonNullByDefault) {
+        this.nonNullByDefault = nonNullByDefault;
+    }
+
+    @Nullable
+    public String getExplicitlyNullable() {
+        return explicitlyNullable;
+    }
+
+    public void setExplicitlyNullable(@Nullable String explicitlyNullable) {
+        this.explicitlyNullable = explicitlyNullable;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedSourceToPlainTargetMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedSourceToPlainTargetMapper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Maps from a @NullMarked source to a plain (unannotated) target.
+ * Source unannotated getters are effectively @NonNull -> skip null check.
+ * Source @Nullable getter to unannotated target -> defer to strategy.
+ */
+@Mapper
+public interface NullMarkedSourceToPlainTargetMapper {
+
+    NullMarkedSourceToPlainTargetMapper INSTANCE = Mappers.getMapper( NullMarkedSourceToPlainTargetMapper.class );
+
+    @Mapping(target = "unannotatedTarget", source = "nonNullByDefault")
+    @Mapping(target = "nullableTarget", source = "explicitlyNullable")
+    @Mapping(target = "nonNullTarget", ignore = true)
+    @Mapping(target = "nonNullTargetFromNullable", ignore = true)
+    TargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedTargetBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedTargetBean.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Target bean annotated with {@code @NullMarked}.
+ * All unannotated setter parameters are effectively {@code @NonNull}.
+ */
+@NullMarked
+public class NullMarkedTargetBean {
+
+    private String nonNullByDefault;
+    private boolean nonNullByDefaultSet;
+
+    private String explicitlyNullable;
+    private boolean explicitlyNullableSet;
+
+    public String getNonNullByDefault() {
+        return nonNullByDefault;
+    }
+
+    public void setNonNullByDefault(String nonNullByDefault) {
+        this.nonNullByDefaultSet = true;
+        this.nonNullByDefault = nonNullByDefault;
+    }
+
+    public boolean isNonNullByDefaultSet() {
+        return nonNullByDefaultSet;
+    }
+
+    @Nullable
+    public String getExplicitlyNullable() {
+        return explicitlyNullable;
+    }
+
+    public void setExplicitlyNullable(@Nullable String explicitlyNullable) {
+        this.explicitlyNullableSet = true;
+        this.explicitlyNullable = explicitlyNullable;
+    }
+
+    public boolean isExplicitlyNullableSet() {
+        return explicitlyNullableSet;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullUnmarkedSourceBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullUnmarkedSourceBean.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NullUnmarked;
+
+/**
+ * A {@code @NullMarked} outer class with a {@code @NullUnmarked} nested class.
+ * The nested class's unannotated getter must have unknown nullability — the closer
+ * {@code @NullUnmarked} takes precedence over the outer {@code @NullMarked} scope.
+ */
+@NullMarked
+public final class NullUnmarkedSourceBean {
+
+    private NullUnmarkedSourceBean() {
+    }
+
+    @NullUnmarked
+    public static class Inner {
+
+        private String value;
+
+        public String getValue() {
+            return value;
+        }
+
+        public void setValue(String value) {
+            this.value = value;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/SafetyGuardSourceBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/SafetyGuardSourceBean.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Source bean for verifying that existing safety guards (unboxing, defaultValue, NVPMS)
+ * still emit null checks when the source is {@code @Nullable}.
+ */
+public class SafetyGuardSourceBean {
+
+    private Integer nullableNumber;
+    private String nullableText;
+
+    @Nullable
+    public Integer getNullableNumber() {
+        return nullableNumber;
+    }
+
+    public void setNullableNumber(@Nullable Integer nullableNumber) {
+        this.nullableNumber = nullableNumber;
+    }
+
+    @Nullable
+    public String getNullableText() {
+        return nullableText;
+    }
+
+    public void setNullableText(@Nullable String nullableText) {
+        this.nullableText = nullableText;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/SafetyGuardTargetBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/SafetyGuardTargetBean.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+public class SafetyGuardTargetBean {
+
+    private int unboxedNumber;
+    private String textWithDefault;
+    private String textWithNvpms;
+
+    public int getUnboxedNumber() {
+        return unboxedNumber;
+    }
+
+    public void setUnboxedNumber(int unboxedNumber) {
+        this.unboxedNumber = unboxedNumber;
+    }
+
+    public String getTextWithDefault() {
+        return textWithDefault;
+    }
+
+    public void setTextWithDefault(String textWithDefault) {
+        this.textWithDefault = textWithDefault;
+    }
+
+    public String getTextWithNvpms() {
+        return textWithNvpms;
+    }
+
+    public void setTextWithNvpms(String textWithNvpms) {
+        this.textWithNvpms = textWithNvpms;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/SourceBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/SourceBean.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public class SourceBean {
+
+    private String nonNullValue;
+    private String nullableValue;
+    private String unannotatedValue;
+
+    @NonNull
+    public String getNonNullValue() {
+        return nonNullValue;
+    }
+
+    public void setNonNullValue(String nonNullValue) {
+        this.nonNullValue = nonNullValue;
+    }
+
+    @Nullable
+    public String getNullableValue() {
+        return nullableValue;
+    }
+
+    public void setNullableValue(String nullableValue) {
+        this.nullableValue = nullableValue;
+    }
+
+    public String getUnannotatedValue() {
+        return unannotatedValue;
+    }
+
+    public void setUnannotatedValue(String unannotatedValue) {
+        this.unannotatedValue = unannotatedValue;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/TargetBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/TargetBean.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public class TargetBean {
+
+    private String nonNullTarget;
+    private boolean nonNullTargetSet;
+
+    private String nullableTarget;
+    private boolean nullableTargetSet;
+
+    private String nonNullTargetFromNullable;
+    private boolean nonNullTargetFromNullableSet;
+
+    private String unannotatedTarget;
+    private boolean unannotatedTargetSet;
+
+    public String getNonNullTarget() {
+        return nonNullTarget;
+    }
+
+    public void setNonNullTarget(@NonNull String nonNullTarget) {
+        this.nonNullTargetSet = true;
+        this.nonNullTarget = nonNullTarget;
+    }
+
+    public boolean isNonNullTargetSet() {
+        return nonNullTargetSet;
+    }
+
+    public String getNullableTarget() {
+        return nullableTarget;
+    }
+
+    public void setNullableTarget(@Nullable String nullableTarget) {
+        this.nullableTargetSet = true;
+        this.nullableTarget = nullableTarget;
+    }
+
+    public boolean isNullableTargetSet() {
+        return nullableTargetSet;
+    }
+
+    public String getNonNullTargetFromNullable() {
+        return nonNullTargetFromNullable;
+    }
+
+    public void setNonNullTargetFromNullable(@NonNull String nonNullTargetFromNullable) {
+        this.nonNullTargetFromNullableSet = true;
+        this.nonNullTargetFromNullable = nonNullTargetFromNullable;
+    }
+
+    public boolean isNonNullTargetFromNullableSet() {
+        return nonNullTargetFromNullableSet;
+    }
+
+    public String getUnannotatedTarget() {
+        return unannotatedTarget;
+    }
+
+    public void setUnannotatedTarget(String unannotatedTarget) {
+        this.unannotatedTargetSet = true;
+        this.unannotatedTarget = unannotatedTarget;
+    }
+
+    public boolean isUnannotatedTargetSet() {
+        return unannotatedTargetSet;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/UnmappableConstructorTargetBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/UnmappableConstructorTargetBean.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+
+public class UnmappableConstructorTargetBean {
+
+    private final AddressBean payload;
+
+    public UnmappableConstructorTargetBean(@NonNull AddressBean payload) {
+        this.payload = payload;
+    }
+
+    public AddressBean getPayload() {
+        return payload;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify.nullmarkedpackage;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValueCheckStrategy;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Mapper in a @NullMarked package with NullValueCheckStrategy.ALWAYS.
+ * Since the package is @NullMarked, unannotated types are effectively @NonNull
+ * and no null checks are produced despite the ALWAYS strategy.
+ */
+@Mapper(nullValueCheckStrategy = NullValueCheckStrategy.ALWAYS)
+public interface PackageNullMarkedMapper {
+
+    PackageNullMarkedMapper INSTANCE = Mappers.getMapper( PackageNullMarkedMapper.class );
+
+    PackageNullMarkedTargetBean map(PackageNullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedSourceBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedSourceBean.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify.nullmarkedpackage;
+
+/**
+ * Source bean in a @NullMarked package.
+ * Unannotated getter is effectively @NonNull.
+ */
+public class PackageNullMarkedSourceBean {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedTargetBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedTargetBean.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify.nullmarkedpackage;
+
+/**
+ * Target bean in a @NullMarked package.
+ * Unannotated setter parameter is effectively @NonNull.
+ */
+public class PackageNullMarkedTargetBean {
+
+    private String value;
+    private boolean valueSet;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.valueSet = true;
+        this.value = value;
+    }
+
+    public boolean isValueSet() {
+        return valueSet;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/package-info.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/package-info.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+@NullMarked
+package org.mapstruct.ap.test.nullcheck.jspecify.nullmarkedpackage;
+
+import org.jspecify.annotations.NullMarked;

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithJSpecify.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithJSpecify.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Meta annotation that adds the needed JSpecify Dependencies
+ *
+ * @author Filip Hrisafov
+ */
+@Target({ ElementType.TYPE, ElementType.METHOD })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@WithTestDependency({
+    "jspecify"
+})
+public @interface WithJSpecify {
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/WithPackageInfo.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/WithPackageInfo.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.testutil;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Specifies packages whose {@code package-info.java} should be included in the test compilation.
+ * The value is a class from the package whose {@code package-info.java} should be compiled.
+ *
+ * @author Filip Hrisafov
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.TYPE, ElementType.METHOD })
+public @interface WithPackageInfo {
+
+    /**
+     * A class from each package whose {@code package-info.java} should be compiled.
+     *
+     * @return classes identifying the packages
+     */
+    Class<?>[] value();
+}

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilationRequest.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilationRequest.java
@@ -21,11 +21,13 @@ public class CompilationRequest {
     private final Collection<String> testDependencies;
     private final Collection<String> processorDependencies;
     private final Collection<String> kotlinSources;
+    private final Set<String> packageInfoPackages;
 
     CompilationRequest(Compiler compiler, Set<Class<?>> sourceClasses, Map<Class<?>, Class<?>> services,
                        List<String> processorOptions, Collection<String> testDependencies,
                        Collection<String> processorDependencies,
-                       Collection<String> kotlinSources) {
+                       Collection<String> kotlinSources,
+                       Set<String> packageInfoPackages) {
         this.compiler = compiler;
         this.sourceClasses = sourceClasses;
         this.services = services;
@@ -33,6 +35,7 @@ public class CompilationRequest {
         this.testDependencies = testDependencies;
         this.processorDependencies = processorDependencies;
         this.kotlinSources = kotlinSources;
+        this.packageInfoPackages = packageInfoPackages;
     }
 
     @Override
@@ -44,6 +47,7 @@ public class CompilationRequest {
         result = prime * result + ( ( services == null ) ? 0 : services.hashCode() );
         result = prime * result + ( ( sourceClasses == null ) ? 0 : sourceClasses.hashCode() );
         result = prime * result + ( ( testDependencies == null ) ? 0 : testDependencies.hashCode() );
+        result = prime * result + ( ( packageInfoPackages == null ) ? 0 : packageInfoPackages.hashCode() );
         return result;
     }
 
@@ -66,7 +70,8 @@ public class CompilationRequest {
             && testDependencies.equals( other.testDependencies )
             && processorDependencies.equals( other.processorDependencies )
             && sourceClasses.equals( other.sourceClasses )
-            && kotlinSources.equals( other.kotlinSources );
+            && kotlinSources.equals( other.kotlinSources )
+            && packageInfoPackages.equals( other.packageInfoPackages );
     }
 
     public Set<Class<?>> getSourceClasses() {
@@ -95,5 +100,9 @@ public class CompilationRequest {
 
     public Compiler getCompiler() {
         return compiler;
+    }
+
+    public Set<String> getPackageInfoPackages() {
+        return packageInfoPackages;
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
@@ -42,6 +42,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.mapstruct.ap.testutil.WithClasses;
 import org.mapstruct.ap.testutil.WithKotlinSources;
+import org.mapstruct.ap.testutil.WithPackageInfo;
 import org.mapstruct.ap.testutil.WithProcessorDependency;
 import org.mapstruct.ap.testutil.WithServiceImplementation;
 import org.mapstruct.ap.testutil.WithTestDependency;
@@ -470,10 +471,10 @@ abstract class CompilingExtension implements BeforeEachCallback {
         return String.format( "-A%s=%s", processorOption.name(), processorOption.value() );
     }
 
-    protected static Set<File> getSourceFiles(Collection<Class<?>> classes) {
-        Set<File> sourceFiles = new HashSet<>( classes.size() );
+    protected static Set<File> getSourceFiles(CompilationRequest compilationRequest) {
+        Set<File> sourceFiles = new HashSet<>();
 
-        for ( Class<?> clazz : classes ) {
+        for ( Class<?> clazz : compilationRequest.getSourceClasses() ) {
             sourceFiles.add(
                 new File(
                     SOURCE_DIR + File.separator + clazz.getName().replace( ".", File.separator )
@@ -482,7 +483,36 @@ abstract class CompilingExtension implements BeforeEachCallback {
             );
         }
 
+        for ( String packageName : compilationRequest.getPackageInfoPackages() ) {
+            sourceFiles.add(
+                new File(
+                    SOURCE_DIR + File.separator + packageName.replace( ".", File.separator )
+                        + File.separator + "package-info.java"
+                )
+            );
+        }
+
         return sourceFiles;
+    }
+
+    private Set<String> getPackageInfoPackages(Method testMethod, Class<?> testClass) {
+        Set<String> packages = new HashSet<>();
+
+        findAnnotation( testMethod, WithPackageInfo.class )
+            .ifPresent( annotation -> {
+                for ( Class<?> clazz : annotation.value() ) {
+                    packages.add( clazz.getPackage().getName() );
+                }
+            } );
+
+        findAnnotation( testClass, WithPackageInfo.class )
+            .ifPresent( annotation -> {
+                for ( Class<?> clazz : annotation.value() ) {
+                    packages.add( clazz.getPackage().getName() );
+                }
+            } );
+
+        return packages;
     }
 
     private Collection<String> getKotlinSources(ExtensionContext context) {
@@ -510,7 +540,8 @@ abstract class CompilingExtension implements BeforeEachCallback {
             getProcessorOptions( testMethod, testClass ),
             getAdditionalTestDependencies( testMethod, testClass ),
             getAdditionalProcessorDependencies( testMethod, testClass ),
-            getKotlinSources( context )
+            getKotlinSources( context ),
+            getPackageInfoPackages( testMethod, testClass )
         );
 
         ExtensionContext.Store rootStore = context.getRoot().getStore( NAMESPACE );

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/EclipseCompilingExtension.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/EclipseCompilingExtension.java
@@ -72,7 +72,7 @@ class EclipseCompilingExtension extends CompilingExtension {
         return clHelper.compileInOtherClassloader(
             compilationRequest,
             getTestCompilationClasspath( compilationRequest, classOutputDir ),
-            getSourceFiles( compilationRequest.getSourceClasses() ),
+            getSourceFiles( compilationRequest ),
             SOURCE_DIR,
             sourceOutputDir,
             classOutputDir );

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/GeneratedSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/GeneratedSource.java
@@ -10,7 +10,6 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import org.junit.jupiter.api.extension.AfterTestExecutionCallback;
@@ -46,7 +45,7 @@ public class GeneratedSource implements BeforeTestExecutionCallback, AfterTestEx
 
     private Compiler compiler;
 
-    private List<Class<?>> fixturesFor = new ArrayList<>();
+    private List<FixtureComparison> fixturesFor = new ArrayList<>();
 
     @Override
     public void beforeTestExecution(ExtensionContext context) throws Exception {
@@ -82,7 +81,25 @@ public class GeneratedSource implements BeforeTestExecutionCallback, AfterTestEx
      * @return the same rule for chaining
      */
     public GeneratedSource addComparisonToFixtureFor(Class<?>... fixturesFor) {
-        this.fixturesFor.addAll( Arrays.asList( fixturesFor ) );
+        for ( Class<?> fixture : fixturesFor ) {
+            this.fixturesFor.add( new FixtureComparison( fixture, null ) );
+        }
+        return this;
+    }
+
+    /**
+     * Adds a mapper that needs to be compared against a fixture with a variant suffix.
+     * <p>
+     * The fixture is looked up at {@code fixtures/<FQN>Impl_{variant}.java} instead of the default
+     * {@code fixtures/<FQN>Impl.java}. Use this to have multiple fixtures for the same mapper class
+     * (e.g. for testing different compilation inputs that produce different generated code).
+     *
+     * @param fixtureFor the class to compare
+     * @param variant the fixture variant (suffix appended to the file name before {@code .java})
+     * @return the same rule for chaining
+     */
+    public GeneratedSource addComparisonToFixtureFor(Class<?> fixtureFor, String variant) {
+        this.fixturesFor.add( new FixtureComparison( fixtureFor, variant ) );
         return this;
     }
 
@@ -120,26 +137,29 @@ public class GeneratedSource implements BeforeTestExecutionCallback, AfterTestEx
     }
 
     private void handleFixtureComparison() {
-        for ( Class<?> fixture : fixturesFor ) {
-            String fixtureName = getMapperName( fixture );
+        for ( FixtureComparison fixture : fixturesFor ) {
+            String fixtureName = getFixtureName( fixture.mapperClass, fixture.variant );
             URL expectedFile = getExpectedResource( fixtureName );
             if ( expectedFile == null ) {
                 fail( String.format(
                     "No reference file could be found for Mapper %s. You should create a file %s",
-                    fixture.getName(),
+                    fixture.mapperClass.getName(),
                     FIXTURES_ROOT + fixtureName
                 ) );
             }
             else {
                 File expectedResource = new File( URLDecoder.decode( expectedFile.getFile(), StandardCharsets.UTF_8 ) );
-                forMapper( fixture ).hasSameMapperContent( expectedResource );
+                forMapper( fixture.mapperClass ).hasSameMapperContent( expectedResource );
             }
-            fixture.getPackage().getName();
         }
-
     }
 
-    private URL getExpectedResource( String fixtureName ) {
+    private String getFixtureName(Class<?> mapperClass, String variant) {
+        String suffix = variant != null ? "Impl_" + variant + ".java" : "Impl.java";
+        return mapperClass.getName().replace( '.', '/' ).concat( suffix );
+    }
+
+    private URL getExpectedResource(String fixtureName) {
         ClassLoader classLoader = getClass().getClassLoader();
         for ( int version = Runtime.version().feature(); version >= 11 && compiler != Compiler.ECLIPSE; version-- ) {
             URL resource = classLoader.getResource( FIXTURES_ROOT + "/" + version + "/" + fixtureName );
@@ -149,5 +169,15 @@ public class GeneratedSource implements BeforeTestExecutionCallback, AfterTestEx
         }
 
         return classLoader.getResource( FIXTURES_ROOT + fixtureName );
+    }
+
+    private static final class FixtureComparison {
+        private final Class<?> mapperClass;
+        private final String variant;
+
+        FixtureComparison(Class<?> mapperClass, String variant) {
+            this.mapperClass = mapperClass;
+            this.variant = variant;
+        }
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/JdkCompilingExtension.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/JdkCompilingExtension.java
@@ -52,7 +52,7 @@ class JdkCompilingExtension extends CompilingExtension {
         StandardJavaFileManager fileManager = compiler.getStandardFileManager( null, null, StandardCharsets.UTF_8 );
 
         Iterable<? extends JavaFileObject> compilationUnits =
-            fileManager.getJavaFileObjectsFromFiles( getSourceFiles( compilationRequest.getSourceClasses() ) );
+            fileManager.getJavaFileObjectsFromFiles( getSourceFiles( compilationRequest ) );
 
         try {
             fileManager.setLocation(

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyConstructorMapperImpl.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-04-06T21:16:16+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyConstructorMapperImpl implements JSpecifyConstructorMapper {
+
+    @Override
+    public ConstructorTargetBean map(SourceBean source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        String nonNullParam = null;
+        String nullableParam = null;
+        String unannotatedParam = null;
+
+        nonNullParam = source.getNonNullValue();
+        nullableParam = source.getNullableValue();
+        unannotatedParam = source.getUnannotatedValue();
+
+        ConstructorTargetBean constructorTargetBean = new ConstructorTargetBean( nonNullParam, nullableParam, unannotatedParam );
+
+        return constructorTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNestedMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNestedMapperImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-04-12T21:28:54+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyNestedMapperImpl implements JSpecifyNestedMapper {
+
+    @Override
+    public FlatTargetBean map(NestedSourceBean source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        FlatTargetBean flatTargetBean = new FlatTargetBean();
+
+        flatTargetBean.setStreet( sourceNonNullAddressStreet( source ) );
+        String city = sourceNonNullAddressCity( source );
+        if ( city != null ) {
+            flatTargetBean.setCity( city );
+        }
+        flatTargetBean.setNullableStreet( sourceNonNullAddressStreet( source ) );
+
+        return flatTargetBean;
+    }
+
+    private String sourceNonNullAddressStreet(NestedSourceBean nestedSourceBean) {
+        AddressBean nonNullAddress = nestedSourceBean.getNonNullAddress();
+        return nonNullAddress.getStreet();
+    }
+
+    private String sourceNonNullAddressCity(NestedSourceBean nestedSourceBean) {
+        AddressBean nonNullAddress = nestedSourceBean.getNonNullAddress();
+        return nonNullAddress.getCity();
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullParamMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullParamMapperImpl.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-03-15T07:45:45+0100",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyNonNullParamMapperImpl implements JSpecifyNonNullParamMapper {
+
+    @Override
+    public TargetBean map(SourceBean source) {
+
+        TargetBean targetBean = new TargetBean();
+
+        targetBean.setNonNullTarget( source.getNonNullValue() );
+        targetBean.setNullableTarget( source.getNullableValue() );
+        targetBean.setUnannotatedTarget( source.getUnannotatedValue() );
+        if ( source.getNullableValue() != null ) {
+            targetBean.setNonNullTargetFromNullable( source.getNullableValue() );
+        }
+
+        return targetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckMapperImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-03-14T18:40:10+0100",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyNullCheckMapperImpl implements JSpecifyNullCheckMapper {
+
+    @Override
+    public TargetBean map(SourceBean source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        TargetBean targetBean = new TargetBean();
+
+        targetBean.setNonNullTarget( source.getNonNullValue() );
+        targetBean.setNullableTarget( source.getNullableValue() );
+        targetBean.setUnannotatedTarget( source.getUnannotatedValue() );
+        if ( source.getNullableValue() != null ) {
+            targetBean.setNonNullTargetFromNullable( source.getNullableValue() );
+        }
+
+        return targetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableIntermediateMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableIntermediateMapperImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-04-16T23:54:17+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyNullableIntermediateMapperImpl implements JSpecifyNullableIntermediateMapper {
+
+    @Override
+    public FlatTargetBean map(NestedSourceBean source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        FlatTargetBean flatTargetBean = new FlatTargetBean();
+
+        String street = sourceNullableAddressStreet( source );
+        if ( street != null ) {
+            flatTargetBean.setStreet( street );
+        }
+
+        return flatTargetBean;
+    }
+
+    private String sourceNullableAddressStreet(NestedSourceBean nestedSourceBean) {
+        AddressBean nullableAddress = nestedSourceBean.getNullableAddress();
+        if ( nullableAddress == null ) {
+            return null;
+        }
+        return nullableAddress.getStreet();
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyOverridesStrategyMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyOverridesStrategyMapperImpl.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-03-15T07:45:45+0100",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyOverridesStrategyMapperImpl implements JSpecifyOverridesStrategyMapper {
+
+    @Override
+    public TargetBean map(SourceBean source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        TargetBean targetBean = new TargetBean();
+
+        targetBean.setNonNullTarget( source.getNonNullValue() );
+        if ( source.getNullableValue() != null ) {
+            targetBean.setNullableTarget( source.getNullableValue() );
+        }
+        if ( source.getUnannotatedValue() != null ) {
+            targetBean.setUnannotatedTarget( source.getUnannotatedValue() );
+        }
+        if ( source.getNullableValue() != null ) {
+            targetBean.setNonNullTargetFromNullable( source.getNullableValue() );
+        }
+
+        return targetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyUpdateMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyUpdateMapperImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-03-15T15:17:03+0100",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyUpdateMapperImpl implements JSpecifyUpdateMapper {
+
+    @Override
+    public void update(SourceBean source, TargetBean target) {
+        if ( source == null ) {
+            return;
+        }
+
+        target.setNonNullTarget( source.getNonNullValue() );
+        if ( source.getNullableValue() != null ) {
+            target.setNullableTarget( source.getNullableValue() );
+        }
+        if ( source.getUnannotatedValue() != null ) {
+            target.setUnannotatedTarget( source.getUnannotatedValue() );
+        }
+        if ( source.getNullableValue() != null ) {
+            target.setNonNullTargetFromNullable( source.getNullableValue() );
+        }
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedMapperImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-03-15T14:57:22+0100",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class NullMarkedMapperImpl implements NullMarkedMapper {
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedMapperWithParamImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedMapperWithParamImpl.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-03-15T15:08:00+0100",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class NullMarkedMapperWithParamImpl implements NullMarkedMapperWithParam {
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedSourceToPlainTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedSourceToPlainTargetMapperImpl.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-03-15T14:57:24+0100",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class NullMarkedSourceToPlainTargetMapperImpl implements NullMarkedSourceToPlainTargetMapper {
+
+    @Override
+    public TargetBean map(NullMarkedSourceBean source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        TargetBean targetBean = new TargetBean();
+
+        targetBean.setUnannotatedTarget( source.getNonNullByDefault() );
+        targetBean.setNullableTarget( source.getExplicitlyNullable() );
+
+        return targetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedMapperImpl.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify.nullmarkedpackage;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-04-12T19:58:32+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class PackageNullMarkedMapperImpl implements PackageNullMarkedMapper {
+
+    @Override
+    public PackageNullMarkedTargetBean map(PackageNullMarkedSourceBean source) {
+
+        PackageNullMarkedTargetBean packageNullMarkedTargetBean = new PackageNullMarkedTargetBean();
+
+        packageNullMarkedTargetBean.setValue( source.getValue() );
+
+        return packageNullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedMapperImpl_withoutPackageInfo.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedMapperImpl_withoutPackageInfo.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify.nullmarkedpackage;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-04-12T20:03:08+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class PackageNullMarkedMapperImpl implements PackageNullMarkedMapper {
+
+    @Override
+    public PackageNullMarkedTargetBean map(PackageNullMarkedSourceBean source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        PackageNullMarkedTargetBean packageNullMarkedTargetBean = new PackageNullMarkedTargetBean();
+
+        if ( source.getValue() != null ) {
+            packageNullMarkedTargetBean.setValue( source.getValue() );
+        }
+
+        return packageNullMarkedTargetBean;
+    }
+}


### PR DESCRIPTION
Long overdue, I finally got the time to dig into support for `NonNull` / `Nullable`. I've decided to only support JSpecify for now, since it seems the ecosystem has converged on that.

-----

Detect `@NonNull`, `@Nullable`, `@NullMarked` and `@NullUnmarked` from org.jspecify.annotations to control null check generation in mapping code.

Property-level null checks:
- Source `@NonNull`: skip null check (value guaranteed non-null)
- Target `@NonNull`: always add null check (must protect non-null target)
- All other cases: defer to existing `NullValueCheckStrategy`
- Safety guards (default values, unboxing, NVPMS) are preserved

Method-level source parameter:
- `@NonNull` parameter: skip the method-level null guard

`@NullMarked` / `@NullUnmarked` scope:
- In a `@NullMarked` class or package, unannotated types are effectively `@NonNull`
- `@NullUnmarked` reverts to unknown nullability within its scope
- `@Nullable` on a specific type overrides the scope
- Scope is resolved by walking the enclosing element chain (method -> class -> outer class -> package) and the result is cached on Type.isNullMarked()

Constructor parameters:
- Report a compile error when mapping a potentially nullable source to a @NonNull constructor parameter without a defaultValue, since a null check would leave the variable at null violating the contract
Fixes #1243

---

Would like to get the feedback from the community on this one. 

---

Some open things that could go in followup PRs:

- [ ] Tests with Kotlin nullable / non-null types