### PR TITLE
Add JDK 25 and 26 to workflow matrix, drop integration testing on JDK 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [21]
+        java: [21, 25, 26]
     name: 'Linux JDK ${{ matrix.java }}'
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ 8, 11, 17 ]
+        java: [ 8, 17 ]
     name: 'Linux JDK ${{ matrix.java }}'
     runs-on: ubuntu-latest
     steps:

--- a/integrationtest/src/test/resources/lombokModuleTest/pom.xml
+++ b/integrationtest/src/test/resources/lombokModuleTest/pom.xml
@@ -61,7 +61,7 @@
                                 <annotationProcessorPath>
                                     <groupId>org.projectlombok</groupId>
                                     <artifactId>lombok</artifactId>
-                                    <version>1.18.22</version>
+                                    <version>1.18.38</version>
                                 </annotationProcessorPath>
                                 <annotationProcessorPath>
                                     <groupId>org.projectlombok</groupId>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -243,7 +243,7 @@
             <dependency>
                 <groupId>org.projectlombok</groupId>
                 <artifactId>lombok</artifactId>
-                <version>1.18.30</version>
+                <version>1.18.38</version>
             </dependency>
             <dependency>
                 <groupId>org.immutables</groupId>


### PR DESCRIPTION
Upgrade Lombok to 1.18.38 since older versions fail with ExceptionInInitializerError on com.sun.tools.javac.code.TypeTag when compiling under JDK 25/26.