### PR TITLE
#4042 Specify OpenJDK 21 for Jitpack build

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+    - openjdk21


### PR DESCRIPTION
Existing default of JDK 8 due to a maven plugin dependency having a post-Java 8 JAR version

Successful build of this branch: https://jitpack.io/com/github/nealeu/mapstruct/gh-4042-jitpack-jdk21-facedb548d-1/build.log

Fixes: #4042 