### PR TITLE
#1018 Use diamond operator for `new` expressions in generated code

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -46,6 +46,7 @@ import org.mapstruct.ap.internal.model.beanmapping.TargetReference;
 import org.mapstruct.ap.internal.model.common.Assignment;
 import org.mapstruct.ap.internal.model.common.BuilderType;
 import org.mapstruct.ap.internal.model.common.FormattingParameters;
+import org.mapstruct.ap.internal.model.common.NewInstanceCreation;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.ParameterBinding;
 import org.mapstruct.ap.internal.model.common.PresenceCheck;
@@ -97,6 +98,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
     private final List<PropertyMapping> constructorConstantMappings;
     private final List<SubclassMapping> subclassMappings;
     private final Type returnTypeToConstruct;
+    private final NewInstanceCreation newInstance;
     private final BuilderType returnTypeBuilder;
     private final MethodReference finalizerMethod;
     private final String finalizedResultName;
@@ -2184,6 +2186,9 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             }
         }
         this.returnTypeToConstruct = returnTypeToConstruct;
+        this.newInstance = ( returnTypeToConstruct != null && getFactoryMethod() == null )
+            ? NewInstanceCreation.forType( returnTypeToConstruct )
+            : null;
         this.subclassMappings = subclassMappings;
         this.sourceParametersReassignments = sourceParametersReassignments;
     }
@@ -2246,6 +2251,10 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         return returnTypeToConstruct;
     }
 
+    public NewInstanceCreation getNewInstance() {
+        return newInstance;
+    }
+
     public boolean hasSubclassMappings() {
         return !subclassMappings.isEmpty();
     }
@@ -2279,7 +2288,12 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         }
 
         if ( returnTypeToConstruct != null  ) {
-            types.addAll( returnTypeToConstruct.getImportTypes() );
+            if ( newInstance != null ) {
+                types.addAll( newInstance.getImportTypes() );
+            }
+            else {
+                types.addAll( returnTypeToConstruct.getImportTypes() );
+            }
         }
         if ( returnTypeBuilder != null ) {
             types.add( returnTypeBuilder.getOwningType() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -2288,12 +2288,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
         }
 
         if ( returnTypeToConstruct != null  ) {
-            if ( newInstance != null ) {
-                types.addAll( newInstance.getImportTypes() );
-            }
-            else {
-                types.addAll( returnTypeToConstruct.getImportTypes() );
-            }
+            types.addAll( newInstance != null ? newInstance.getImportTypes() : returnTypeToConstruct.getImportTypes() );
         }
         if ( returnTypeBuilder != null ) {
             types.add( returnTypeBuilder.getOwningType() );

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableCreation.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableCreation.java
@@ -9,6 +9,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.ModelElement;
+import org.mapstruct.ap.internal.model.common.NewInstanceCreation;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.Type;
 
@@ -27,6 +28,7 @@ public class IterableCreation extends ModelElement {
     private final Type resultType;
     private final Parameter sourceParameter;
     private final MethodReference factoryMethod;
+    private final NewInstanceCreation newInstance;
     private final boolean canUseSize;
     private final boolean loadFactorAdjustment;
 
@@ -34,6 +36,7 @@ public class IterableCreation extends ModelElement {
         this.resultType = resultType;
         this.sourceParameter = sourceParameter;
         this.factoryMethod = factoryMethod;
+        this.newInstance = factoryMethod == null ? NewInstanceCreation.forType( resultType ) : null;
         this.canUseSize = ( sourceParameter.getType().isCollectionOrMapType() ||
             sourceParameter.getType().isArrayType() )
             && resultType.getImplementation() != null && resultType.getImplementation().hasInitialCapacityConstructor();
@@ -57,6 +60,10 @@ public class IterableCreation extends ModelElement {
         return this.factoryMethod;
     }
 
+    public NewInstanceCreation getNewInstance() {
+        return newInstance;
+    }
+
     public boolean isCanUseSize() {
         return canUseSize;
     }
@@ -68,8 +75,8 @@ public class IterableCreation extends ModelElement {
     @Override
     public Set<Type> getImportTypes() {
         Set<Type> types = new HashSet<>();
-        if ( factoryMethod == null && resultType.getImplementationType() != null ) {
-            types.addAll( resultType.getImplementationType().getImportTypes() );
+        if ( newInstance != null ) {
+            types.addAll( newInstance.getImportTypes() );
         }
 
         if ( isEnumSet() ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.java
@@ -61,7 +61,7 @@ public class ExistingInstanceSetterWrapperForCollectionsAndMaps
     public Set<Type> getImportTypes() {
         Set<Type> imported = new HashSet<>( super.getImportTypes() );
         if ( isMapNullToDefault() && ( targetType.getImplementationType() != null ) ) {
-            imported.add( targetType.getImplementationType() );
+            imported.addAll( getNewInstance().getImportTypes() );
         }
         return imported;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.Assignment;
+import org.mapstruct.ap.internal.model.common.NewInstanceCreation;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
 
@@ -26,6 +27,7 @@ public class SetterWrapperForCollectionsAndMapsWithNullCheck extends WrapperForC
 
     private final Type targetType;
     private final TypeFactory typeFactory;
+    private final NewInstanceCreation newInstance;
 
     public SetterWrapperForCollectionsAndMapsWithNullCheck(Assignment decoratedAssignment,
         List<Type> thrownTypesToExclude,
@@ -40,19 +42,14 @@ public class SetterWrapperForCollectionsAndMapsWithNullCheck extends WrapperForC
         );
         this.targetType = targetType;
         this.typeFactory = typeFactory;
+        this.newInstance = NewInstanceCreation.forType( targetType );
     }
 
     @Override
     public Set<Type> getImportTypes() {
         Set<Type> imported = new HashSet<>( super.getImportTypes() );
         if ( isDirectAssignment() ) {
-            if ( targetType.getImplementationType() != null ) {
-                imported.addAll( targetType.getImplementationType().getImportTypes() );
-            }
-            else {
-                imported.addAll( targetType.getImportTypes() );
-            }
-
+            imported.addAll( newInstance.getImportTypes() );
             if ( isEnumSet() ) {
                 imported.add( typeFactory.getType( EnumSet.class ) );
             }
@@ -61,6 +58,10 @@ public class SetterWrapperForCollectionsAndMapsWithNullCheck extends WrapperForC
             imported.addAll( getNullCheckLocalVarType().getImportTypes() );
         }
         return imported;
+    }
+
+    public NewInstanceCreation getNewInstance() {
+        return newInstance;
     }
 
     public boolean isDirectAssignment() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/UpdateWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/UpdateWrapper.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.mapstruct.ap.internal.model.common.Assignment;
+import org.mapstruct.ap.internal.model.common.NewInstanceCreation;
 import org.mapstruct.ap.internal.model.common.Type;
 
 /**
@@ -22,7 +23,7 @@ public class UpdateWrapper extends AssignmentWrapper {
 
     private final List<Type> thrownTypesToExclude;
     private final Assignment factoryMethod;
-    private final Type targetImplementationType;
+    private final NewInstanceCreation newInstance;
     private final boolean includeSourceNullCheck;
     private final boolean setExplicitlyToNull;
     private final boolean setExplicitlyToDefault;
@@ -40,25 +41,11 @@ public class UpdateWrapper extends AssignmentWrapper {
         super( decoratedAssignment, fieldAssignment );
         this.thrownTypesToExclude = thrownTypesToExclude;
         this.factoryMethod = factoryMethod;
-        this.targetImplementationType = determineImplType( factoryMethod, targetType );
+        this.newInstance = ( factoryMethod == null ) ? NewInstanceCreation.forType( targetType ) : null;
         this.includeSourceNullCheck = includeSourceNullCheck;
         this.setExplicitlyToDefault = setExplicitlyToDefault;
         this.setExplicitlyToNull = setExplicitlyToNull;
         this.mustCastForNull = mustCastForNull;
-    }
-
-    private static Type determineImplType(Assignment factoryMethod, Type targetType) {
-        if ( factoryMethod != null ) {
-            //If we have factory method then we won't use the targetType
-            return null;
-        }
-        if ( targetType.getImplementationType() != null ) {
-            // it's probably a collection or something
-            return targetType.getImplementationType();
-        }
-
-        // no factory method means we create a new instance ourselves and thus need to import the type
-        return targetType;
     }
 
     @Override
@@ -81,15 +68,18 @@ public class UpdateWrapper extends AssignmentWrapper {
         if ( factoryMethod != null ) {
             imported.addAll( factoryMethod.getImportTypes() );
         }
-        if ( targetImplementationType != null ) {
-            imported.add( targetImplementationType );
-            imported.addAll( targetImplementationType.getTypeParameters() );
+        if ( newInstance != null ) {
+            imported.addAll( newInstance.getImportTypes() );
         }
         return imported;
     }
 
     public Assignment getFactoryMethod() {
         return factoryMethod;
+    }
+
+    public NewInstanceCreation getNewInstance() {
+        return newInstance;
     }
 
     public boolean isIncludeSourceNullCheck() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/NewInstanceCreation.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/NewInstanceCreation.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.model.common;
+
+import java.util.Set;
+
+/**
+ * Model element representing the head of a {@code new T<>(...)} expression. It always renders the diamond
+ * operator for generic types, leaving any type-argument inference to the surrounding Java context.
+ * <p>
+ * The caller is responsible for emitting the parenthesised argument list after the model.
+ * <p>
+ * Imports contributed by this element only include the raw constructor type, not its type parameters: the
+ * generated source never references the parameter classes through this expression, so they are not needed
+ * here. If the surrounding code references a type parameter elsewhere (e.g. in a variable declaration or a
+ * method signature), that reference contributes its own imports through its own model element.
+ *
+ * @author Filip Hrisafov
+ */
+public class NewInstanceCreation extends ModelElement {
+
+    private final Type type;
+    private final Type rawType;
+
+    private NewInstanceCreation(Type type) {
+        this.type = type;
+        this.rawType = type.asRawType();
+    }
+
+    /**
+     * Creates a {@link NewInstanceCreation} for the given target type. If the target has an implementation
+     * type (e.g. {@code Collection} -> {@code ArrayList}), the implementation type is used.
+     *
+     * @param targetType the target type to be instantiated; must not be {@code null}
+     * @return a new model
+     */
+    public static NewInstanceCreation forType(Type targetType) {
+        Type effective = targetType.getImplementationType() != null
+            ? targetType.getImplementationType()
+            : targetType;
+        return new NewInstanceCreation( effective );
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public Type getRawType() {
+        return rawType;
+    }
+
+    public boolean isGeneric() {
+        return !type.getTypeParameters().isEmpty();
+    }
+
+    @Override
+    public Set<Type> getImportTypes() {
+        return rawType.getImportTypes();
+    }
+}

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/BeanMappingMethod.ftl
@@ -106,7 +106,7 @@
 
             <@includeModel object=returnTypeToConstruct/> ${resultName} = <@includeModel object=factoryMethod targetType=returnTypeToConstruct/>;
         <#else >
-            <@includeModel object=returnTypeToConstruct/> ${resultName} = <#if factoryMethod??><@includeModel object=factoryMethod targetType=returnTypeToConstruct/><#else>new <@includeModel object=returnTypeToConstruct/>()</#if>;
+            <@includeModel object=returnTypeToConstruct/> ${resultName} = <#if factoryMethod??><@includeModel object=factoryMethod targetType=returnTypeToConstruct/><#else><@includeModel object=newInstance/>()</#if>;
         </#if>
 
     </#if>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableCreation.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableCreation.ftl
@@ -15,10 +15,10 @@
         <#if resultType.implementation.factoryMethodName?? && ext.useSizeIfPossible?? && ext.useSizeIfPossible && canUseSize>
             <@includeModel object=resultType.implementationType raw=true />.${resultType.implementation.factoryMethodName}( <@sizeForCreation /> )
         <#else>
-            new <@includeModel object=resultType.implementationType/><#if ext.useSizeIfPossible?? && ext.useSizeIfPossible && canUseSize>( <@sizeForCreation /> )<#else>()</#if>
+            <@includeModel object=newInstance/><#if ext.useSizeIfPossible?? && ext.useSizeIfPossible && canUseSize>( <@sizeForCreation /> )<#else>()</#if>
         </#if>
     <#else>
-    new <@includeModel object=resultType/>()
+    <@includeModel object=newInstance/>()
     </#if>
 </@compress>
 <#macro sizeForCreation>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/ExistingInstanceSetterWrapperForCollectionsAndMaps.ftl
@@ -46,6 +46,6 @@
     <#if enumSet>
       EnumSet.copyOf( ${nullCheckLocalVarName} )
     <#else>
-      new <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if>( ${nullCheckLocalVarName} )
+      <@includeModel object=newInstance/>( ${nullCheckLocalVarName} )
     </#if>
 </@compress></#macro>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/NewInstanceSetterWrapperForCollectionsAndMaps.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/NewInstanceSetterWrapperForCollectionsAndMaps.ftl
@@ -16,7 +16,7 @@
 -->
 <#macro callTargetWriteAccessor>
   <@lib.handleLocalVarNullCheck needs_explicit_local_var=directAssignment>
-      <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if> ${instanceVar} = new <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if>();
+      <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if> ${instanceVar} = <@includeModel object=newInstance/>();
       ${instanceVar}.<#if ext.targetType.collectionType>addAll<#else>putAll</#if>( ${nullCheckLocalVarName} );
       <#if ext.targetBeanName?has_content>${ext.targetBeanName}.</#if>${ext.targetWriteAccessorName}<@lib.handleWrite>${instanceVar}</@lib.handleWrite>;
   </@lib.handleLocalVarNullCheck>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/assignment/SetterWrapperForCollectionsAndMapsWithNullCheck.ftl
@@ -26,6 +26,6 @@
     <#if enumSet>
       EnumSet.copyOf( ${nullCheckLocalVarName} )
     <#else>
-      new <#if ext.targetType.implementationType??><@includeModel object=ext.targetType.implementationType/><#else><@includeModel object=ext.targetType/></#if>( ${nullCheckLocalVarName} )
+      <@includeModel object=newInstance/>( ${nullCheckLocalVarName} )
     </#if>
 </@compress></#macro>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/common/NewInstanceCreation.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/common/NewInstanceCreation.ftl
@@ -1,0 +1,11 @@
+<#--
+
+    Copyright MapStruct Authors.
+
+    Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+
+-->
+<#-- @ftlvariable name="" type="org.mapstruct.ap.internal.model.common.NewInstanceCreation" -->
+<@compress single_line=true>
+new <@includeModel object=rawType/><#if generic><></#if>
+</@compress>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/macro/CommonMacros.ftl
@@ -170,11 +170,13 @@ Performs a default assignment with a default value.
   macro: constructTargetObject
 
   purpose: Either call the constructor of the target object directly or of the implementing type.
+           Emits the diamond operator for generic types so type-arguments are inferred from the
+           assignment context.
 -->
 <#-- @ftlvariable name="targetType" type="org.mapstruct.ap.internal.model.common.Type" -->
 <#macro constructTargetObject targetType><@compress single_line=true>
     <#if targetType.implementationType??>
-        new <@includeModel object=targetType.implementationType/>()
+        new <@includeModel object=targetType.implementationType raw=true/><#if targetType.implementationType.typeParameters?size != 0><></#if>()
     <#elseif targetType.arrayType>
         new <@includeModel object=targetType.componentType/>[0]
     <#elseif targetType.sensibleDefault??>
@@ -182,7 +184,7 @@ Performs a default assignment with a default value.
     <#elseif targetType.optionalType>
         <@includeModel object=targetType.asRawType()/>.of( <@constructTargetObject targetType=targetType.optionalBaseType/> )
     <#else>
-        new <@includeModel object=targetType/>()
+        new <@includeModel object=targetType raw=true/><#if targetType.typeParameters?size != 0><></#if>()
     </#if>
 </@compress></#macro>
 <#--

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/wildcard/BoundCopyMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/wildcard/BoundCopyMapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.generics.wildcard;
+
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface BoundCopyMapper {
+
+    CollectionSuperTypes copySuperCollection(CollectionSuperTypes collectionSuperTypes);
+
+    CollectionExtendTypes copyExtendsCollection(CollectionExtendTypes collectionExtendTypes);
+
+    MapSuperType copySuperMap(MapSuperType mapSuperType);
+
+    MapExtendType copyExtendMap(MapExtendType mapExtendType);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/wildcard/BoundDirectCopyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/wildcard/BoundDirectCopyTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.generics.wildcard;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+/**
+ * @author hduelme
+ *
+ */
+public class BoundDirectCopyTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource().addComparisonToFixtureFor(
+            BoundCopyMapper.class
+    );
+
+    @ProcessorTest
+    @WithClasses({
+            SimpleObject.class,
+            CollectionSuperTypes.class,
+            CollectionExtendTypes.class,
+            MapSuperType.class,
+            MapExtendType.class,
+            BoundCopyMapper.class
+    })
+    public void shouldCopyBoundedDirectly() {
+
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/wildcard/MapExtendType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/wildcard/MapExtendType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.generics.wildcard;
+
+import java.util.Map;
+
+public class MapExtendType {
+
+    private Map<? extends SimpleObject, ? extends SimpleObject> simpleMap;
+
+    public Map<? extends SimpleObject, ? extends SimpleObject> getSimpleMap() {
+        return simpleMap;
+    }
+
+    public void setSimpleMap(
+            Map<? extends SimpleObject, ? extends SimpleObject> simpleMap) {
+        this.simpleMap = simpleMap;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/generics/wildcard/MapSuperType.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/generics/wildcard/MapSuperType.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.generics.wildcard;
+
+import java.util.Map;
+
+public class MapSuperType {
+
+    private Map<? super SimpleObject, ? super SimpleObject> simpleMap;
+
+    public Map<? super SimpleObject, ? super SimpleObject> getSimpleMap() {
+        return simpleMap;
+    }
+
+    public void setSimpleMap(
+            Map<? super SimpleObject, ? super SimpleObject> simpleMap) {
+        this.simpleMap = simpleMap;
+    }
+}

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_1453/Issue1453MapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_1453/Issue1453MapperImpl.java
@@ -40,7 +40,7 @@ public class Issue1453MapperImpl implements Issue1453Mapper {
             return null;
         }
 
-        List<AuctionDto> list = new ArrayList<AuctionDto>( auctions.size() );
+        List<AuctionDto> list = new ArrayList<>( auctions.size() );
         for ( Auction auction : auctions ) {
             list.add( map( auction ) );
         }
@@ -54,7 +54,7 @@ public class Issue1453MapperImpl implements Issue1453Mapper {
             return null;
         }
 
-        List<? super AuctionDto> list = new ArrayList<AuctionDto>( auctions.size() );
+        List<? super AuctionDto> list = new ArrayList<>( auctions.size() );
         for ( Auction auction : auctions ) {
             list.add( map( auction ) );
         }
@@ -113,7 +113,7 @@ public class Issue1453MapperImpl implements Issue1453Mapper {
             return null;
         }
 
-        List<PaymentDto> list1 = new ArrayList<PaymentDto>( list.size() );
+        List<PaymentDto> list1 = new ArrayList<>( list.size() );
         for ( Payment payment : list ) {
             list1.add( paymentToPaymentDto( payment ) );
         }

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
@@ -30,21 +30,21 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
 
         if ( source.hasStrings() ) {
             List<String> list = source.getStrings();
-            domain.setStrings( new LinkedHashSet<String>( list ) );
+            domain.setStrings( new LinkedHashSet<>( list ) );
         }
         if ( source.hasStrings() ) {
             domain.setLongs( stringListToLongSet( source.getStrings() ) );
         }
         if ( source.hasStringsInitialized() ) {
             List<String> list1 = source.getStringsInitialized();
-            domain.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+            domain.setStringsInitialized( new LinkedHashSet<>( list1 ) );
         }
         if ( source.hasStringsInitialized() ) {
             domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
         }
         if ( source.hasStringsWithDefault() ) {
             List<String> list2 = source.getStringsWithDefault();
-            domain.setStringsWithDefault( new ArrayList<String>( list2 ) );
+            domain.setStringsWithDefault( new ArrayList<>( list2 ) );
         }
         else {
             domain.setStringsWithDefault( helper.toList( "3" ) );
@@ -68,7 +68,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStrings() ) {
                 List<String> list = source.getStrings();
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -91,7 +91,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStringsInitialized() ) {
                 List<String> list1 = source.getStringsInitialized();
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -117,7 +117,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStringsWithDefault() ) {
                 List<String> list2 = source.getStringsWithDefault();
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -140,7 +140,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStrings() ) {
                 List<String> list = source.getStrings();
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -163,7 +163,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStringsInitialized() ) {
                 List<String> list1 = source.getStringsInitialized();
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -189,7 +189,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStringsWithDefault() ) {
                 List<String> list2 = source.getStringsWithDefault();
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
@@ -28,17 +28,17 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
         if ( source != null ) {
             List<String> list = source.getStrings();
             if ( list != null ) {
-                domain.setStrings( new LinkedHashSet<String>( list ) );
+                domain.setStrings( new LinkedHashSet<>( list ) );
             }
             domain.setLongs( stringListToLongSet( source.getStrings() ) );
             List<String> list1 = source.getStringsInitialized();
             if ( list1 != null ) {
-                domain.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                domain.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
             domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
             List<String> list2 = source.getStringsWithDefault();
             if ( list2 != null ) {
-                domain.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                domain.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 domain.setStringsWithDefault( helper.toList( "3" ) );
@@ -59,16 +59,16 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getStrings().addAll( list );
                 }
                 else {
-                    target.setStrings( new LinkedHashSet<String>() );
+                    target.setStrings( new LinkedHashSet<>() );
                 }
             }
             else {
                 List<String> list = source.getStrings();
                 if ( list != null ) {
-                    target.setStrings( new LinkedHashSet<String>( list ) );
+                    target.setStrings( new LinkedHashSet<>( list ) );
                 }
                 else {
-                    target.setStrings( new LinkedHashSet<String>() );
+                    target.setStrings( new LinkedHashSet<>() );
                 }
             }
             if ( target.getLongs() != null ) {
@@ -78,7 +78,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getLongs().addAll( set );
                 }
                 else {
-                    target.setLongs( new LinkedHashSet<Long>() );
+                    target.setLongs( new LinkedHashSet<>() );
                 }
             }
             else {
@@ -87,7 +87,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongs( set );
                 }
                 else {
-                    target.setLongs( new LinkedHashSet<Long>() );
+                    target.setLongs( new LinkedHashSet<>() );
                 }
             }
             if ( target.getStringsInitialized() != null ) {
@@ -97,16 +97,16 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getStringsInitialized().addAll( list1 );
                 }
                 else {
-                    target.setStringsInitialized( new LinkedHashSet<String>() );
+                    target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
             else {
                 List<String> list1 = source.getStringsInitialized();
                 if ( list1 != null ) {
-                    target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                    target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
                 }
                 else {
-                    target.setStringsInitialized( new LinkedHashSet<String>() );
+                    target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
             if ( target.getLongsInitialized() != null ) {
@@ -116,7 +116,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getLongsInitialized().addAll( set1 );
                 }
                 else {
-                    target.setLongsInitialized( new LinkedHashSet<Long>() );
+                    target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
             else {
@@ -125,7 +125,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongsInitialized( set1 );
                 }
                 else {
-                    target.setLongsInitialized( new LinkedHashSet<Long>() );
+                    target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
             if ( target.getStringsWithDefault() != null ) {
@@ -141,7 +141,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             else {
                 List<String> list2 = source.getStringsWithDefault();
                 if ( list2 != null ) {
-                    target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                    target.setStringsWithDefault( new ArrayList<>( list2 ) );
                 }
                 else {
                     target.setStringsWithDefault( helper.toList( "3" ) );
@@ -161,16 +161,16 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getStrings().addAll( list );
                 }
                 else {
-                    target.setStrings( new LinkedHashSet<String>() );
+                    target.setStrings( new LinkedHashSet<>() );
                 }
             }
             else {
                 List<String> list = source.getStrings();
                 if ( list != null ) {
-                    target.setStrings( new LinkedHashSet<String>( list ) );
+                    target.setStrings( new LinkedHashSet<>( list ) );
                 }
                 else {
-                    target.setStrings( new LinkedHashSet<String>() );
+                    target.setStrings( new LinkedHashSet<>() );
                 }
             }
             if ( target.getLongs() != null ) {
@@ -180,7 +180,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getLongs().addAll( set );
                 }
                 else {
-                    target.setLongs( new LinkedHashSet<Long>() );
+                    target.setLongs( new LinkedHashSet<>() );
                 }
             }
             else {
@@ -189,7 +189,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongs( set );
                 }
                 else {
-                    target.setLongs( new LinkedHashSet<Long>() );
+                    target.setLongs( new LinkedHashSet<>() );
                 }
             }
             if ( target.getStringsInitialized() != null ) {
@@ -199,16 +199,16 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getStringsInitialized().addAll( list1 );
                 }
                 else {
-                    target.setStringsInitialized( new LinkedHashSet<String>() );
+                    target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
             else {
                 List<String> list1 = source.getStringsInitialized();
                 if ( list1 != null ) {
-                    target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                    target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
                 }
                 else {
-                    target.setStringsInitialized( new LinkedHashSet<String>() );
+                    target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
             if ( target.getLongsInitialized() != null ) {
@@ -218,7 +218,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getLongsInitialized().addAll( set1 );
                 }
                 else {
-                    target.setLongsInitialized( new LinkedHashSet<Long>() );
+                    target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
             else {
@@ -227,7 +227,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongsInitialized( set1 );
                 }
                 else {
-                    target.setLongsInitialized( new LinkedHashSet<Long>() );
+                    target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
             if ( target.getStringsWithDefault() != null ) {
@@ -243,7 +243,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             else {
                 List<String> list2 = source.getStringsWithDefault();
                 if ( list2 != null ) {
-                    target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                    target.setStringsWithDefault( new ArrayList<>( list2 ) );
                 }
                 else {
                     target.setStringsWithDefault( helper.toList( "3" ) );
@@ -256,7 +256,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
 
     protected Set<Long> stringListToLongSet(List<String> list) {
         if ( list == null ) {
-            return new LinkedHashSet<Long>();
+            return new LinkedHashSet<>();
         }
 
         Set<Long> set = LinkedHashSet.newLinkedHashSet( list.size() );

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
@@ -30,17 +30,17 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
 
         List<String> list = source.getStrings();
         if ( list != null ) {
-            domain.setStrings( new LinkedHashSet<String>( list ) );
+            domain.setStrings( new LinkedHashSet<>( list ) );
         }
         domain.setLongs( stringListToLongSet( source.getStrings() ) );
         List<String> list1 = source.getStringsInitialized();
         if ( list1 != null ) {
-            domain.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+            domain.setStringsInitialized( new LinkedHashSet<>( list1 ) );
         }
         domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
         List<String> list2 = source.getStringsWithDefault();
         if ( list2 != null ) {
-            domain.setStringsWithDefault( new ArrayList<String>( list2 ) );
+            domain.setStringsWithDefault( new ArrayList<>( list2 ) );
         }
         else {
             domain.setStringsWithDefault( helper.toList( "3" ) );
@@ -68,7 +68,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list = source.getStrings();
             if ( list != null ) {
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -100,7 +100,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list1 = source.getStringsInitialized();
             if ( list1 != null ) {
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -132,7 +132,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list2 = source.getStringsWithDefault();
             if ( list2 != null ) {
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -159,7 +159,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list = source.getStrings();
             if ( list != null ) {
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -191,7 +191,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list1 = source.getStringsInitialized();
             if ( list1 != null ) {
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -223,7 +223,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list2 = source.getStringsWithDefault();
             if ( list2 != null ) {
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
@@ -30,21 +30,21 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
 
         if ( source.hasStrings() ) {
             List<String> list = source.getStrings();
-            domain.setStrings( new LinkedHashSet<String>( list ) );
+            domain.setStrings( new LinkedHashSet<>( list ) );
         }
         if ( source.hasStrings() ) {
             domain.setLongs( stringListToLongSet( source.getStrings() ) );
         }
         if ( source.hasStringsInitialized() ) {
             List<String> list1 = source.getStringsInitialized();
-            domain.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+            domain.setStringsInitialized( new LinkedHashSet<>( list1 ) );
         }
         if ( source.hasStringsInitialized() ) {
             domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
         }
         if ( source.hasStringsWithDefault() ) {
             List<String> list2 = source.getStringsWithDefault();
-            domain.setStringsWithDefault( new ArrayList<String>( list2 ) );
+            domain.setStringsWithDefault( new ArrayList<>( list2 ) );
         }
         else {
             domain.setStringsWithDefault( helper.toList( "3" ) );
@@ -68,7 +68,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStrings() ) {
                 List<String> list = source.getStrings();
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -91,7 +91,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStringsInitialized() ) {
                 List<String> list1 = source.getStringsInitialized();
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -117,7 +117,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStringsWithDefault() ) {
                 List<String> list2 = source.getStringsWithDefault();
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -140,7 +140,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStrings() ) {
                 List<String> list = source.getStrings();
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -163,7 +163,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStringsInitialized() ) {
                 List<String> list1 = source.getStringsInitialized();
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -189,7 +189,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStringsWithDefault() ) {
                 List<String> list2 = source.getStringsWithDefault();
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/collection/defaultimplementation/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/collection/defaultimplementation/SourceTargetMapperImpl.java
@@ -68,7 +68,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        List<TargetFoo> list = new ArrayList<TargetFoo>( foos.size() );
+        List<TargetFoo> list = new ArrayList<>( foos.size() );
         for ( SourceFoo sourceFoo : foos ) {
             list.add( sourceFooToTargetFoo( sourceFoo ) );
         }
@@ -96,7 +96,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        Collection<TargetFoo> collection = new ArrayList<TargetFoo>( foos.size() );
+        Collection<TargetFoo> collection = new ArrayList<>( foos.size() );
         for ( SourceFoo sourceFoo : foos ) {
             collection.add( sourceFooToTargetFoo( sourceFoo ) );
         }
@@ -110,7 +110,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        ArrayList<TargetFoo> iterable = new ArrayList<TargetFoo>();
+        ArrayList<TargetFoo> iterable = new ArrayList<>();
         for ( SourceFoo sourceFoo : foos ) {
             iterable.add( sourceFooToTargetFoo( sourceFoo ) );
         }
@@ -150,7 +150,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        SortedSet<TargetFoo> sortedSet = new TreeSet<TargetFoo>();
+        SortedSet<TargetFoo> sortedSet = new TreeSet<>();
         for ( SourceFoo sourceFoo : foos ) {
             sortedSet.add( sourceFooToTargetFoo( sourceFoo ) );
         }
@@ -164,7 +164,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        NavigableSet<TargetFoo> navigableSet = new TreeSet<TargetFoo>();
+        NavigableSet<TargetFoo> navigableSet = new TreeSet<>();
         for ( SourceFoo sourceFoo : foos ) {
             navigableSet.add( sourceFooToTargetFoo( sourceFoo ) );
         }
@@ -195,7 +195,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        SortedMap<String, TargetFoo> sortedMap = new TreeMap<String, TargetFoo>();
+        SortedMap<String, TargetFoo> sortedMap = new TreeMap<>();
 
         for ( java.util.Map.Entry<Long, SourceFoo> entry : foos.entrySet() ) {
             String key = String.valueOf( entry.getKey() );
@@ -212,7 +212,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        NavigableMap<String, TargetFoo> navigableMap = new TreeMap<String, TargetFoo>();
+        NavigableMap<String, TargetFoo> navigableMap = new TreeMap<>();
 
         for ( java.util.Map.Entry<Long, SourceFoo> entry : foos.entrySet() ) {
             String key = String.valueOf( entry.getKey() );
@@ -229,7 +229,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        ConcurrentMap<String, TargetFoo> concurrentMap = new ConcurrentHashMap<String, TargetFoo>( Math.max( (int) ( foos.size() / .75f ) + 1, 16 ) );
+        ConcurrentMap<String, TargetFoo> concurrentMap = new ConcurrentHashMap<>( Math.max( (int) ( foos.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<Long, SourceFoo> entry : foos.entrySet() ) {
             String key = String.valueOf( entry.getKey() );
@@ -246,7 +246,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        ConcurrentNavigableMap<String, TargetFoo> concurrentNavigableMap = new ConcurrentSkipListMap<String, TargetFoo>();
+        ConcurrentNavigableMap<String, TargetFoo> concurrentNavigableMap = new ConcurrentSkipListMap<>();
 
         for ( java.util.Map.Entry<Long, SourceFoo> entry : foos.entrySet() ) {
             String key = String.valueOf( entry.getKey() );

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/conversion/numbers/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/conversion/numbers/SourceTargetMapperImpl.java
@@ -357,7 +357,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        List<String> list = new ArrayList<String>( source.size() );
+        List<String> list = new ArrayList<>( source.size() );
         for ( Float float1 : source ) {
             list.add( new DecimalFormat( "##.00" ).format( float1 ) );
         }
@@ -371,7 +371,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        List<Float> list = new ArrayList<Float>( source.size() );
+        List<Float> list = new ArrayList<>( source.size() );
         for ( String string : source ) {
             try {
                 list.add( new DecimalFormat( "##.00" ).parse( string ).floatValue() );
@@ -390,7 +390,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        List<String> list = new ArrayList<String>( source.size() );
+        List<String> list = new ArrayList<>( source.size() );
         for ( BigDecimal bigDecimal : source ) {
             list.add( createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "fr" ) ).format( bigDecimal ) );
         }
@@ -404,7 +404,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        List<BigDecimal> list = new ArrayList<BigDecimal>( source.size() );
+        List<BigDecimal> list = new ArrayList<>( source.size() );
         for ( String string : source ) {
             try {
                 list.add( (BigDecimal) createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "fr" ) ).parse( string ) );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/array/ScienceMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/array/ScienceMapperImpl.java
@@ -81,7 +81,7 @@ public class ScienceMapperImpl implements ScienceMapper {
             return null;
         }
 
-        List<ScientistDto> list = new ArrayList<ScientistDto>( scientists.length );
+        List<ScientistDto> list = new ArrayList<>( scientists.length );
         for ( Scientist scientist : scientists ) {
             list.add( scientistToDto( scientist ) );
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1453/Issue1453MapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1453/Issue1453MapperImpl.java
@@ -40,7 +40,7 @@ public class Issue1453MapperImpl implements Issue1453Mapper {
             return null;
         }
 
-        List<AuctionDto> list = new ArrayList<AuctionDto>( auctions.size() );
+        List<AuctionDto> list = new ArrayList<>( auctions.size() );
         for ( Auction auction : auctions ) {
             list.add( map( auction ) );
         }
@@ -54,7 +54,7 @@ public class Issue1453MapperImpl implements Issue1453Mapper {
             return null;
         }
 
-        List<? super AuctionDto> list = new ArrayList<AuctionDto>( auctions.size() );
+        List<? super AuctionDto> list = new ArrayList<>( auctions.size() );
         for ( Auction auction : auctions ) {
             list.add( map( auction ) );
         }
@@ -68,7 +68,7 @@ public class Issue1453MapperImpl implements Issue1453Mapper {
             return null;
         }
 
-        Map<AuctionDto, AuctionDto> map = new LinkedHashMap<AuctionDto, AuctionDto>( Math.max( (int) ( auctions.size() / .75f ) + 1, 16 ) );
+        Map<AuctionDto, AuctionDto> map = new LinkedHashMap<>( Math.max( (int) ( auctions.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<? extends Auction, ? extends Auction> entry : auctions.entrySet() ) {
             AuctionDto key = map( entry.getKey() );
@@ -85,7 +85,7 @@ public class Issue1453MapperImpl implements Issue1453Mapper {
             return null;
         }
 
-        Map<? super AuctionDto, ? super AuctionDto> map = new LinkedHashMap<AuctionDto, AuctionDto>( Math.max( (int) ( auctions.size() / .75f ) + 1, 16 ) );
+        Map<? super AuctionDto, ? super AuctionDto> map = new LinkedHashMap<>( Math.max( (int) ( auctions.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<Auction, Auction> entry : auctions.entrySet() ) {
             AuctionDto key = map( entry.getKey() );
@@ -113,7 +113,7 @@ public class Issue1453MapperImpl implements Issue1453Mapper {
             return null;
         }
 
-        List<PaymentDto> list1 = new ArrayList<PaymentDto>( list.size() );
+        List<PaymentDto> list1 = new ArrayList<>( list.size() );
         for ( Payment payment : list ) {
             list1.add( paymentToPaymentDto( payment ) );
         }
@@ -126,7 +126,7 @@ public class Issue1453MapperImpl implements Issue1453Mapper {
             return null;
         }
 
-        Map<PaymentDto, PaymentDto> map1 = new LinkedHashMap<PaymentDto, PaymentDto>( Math.max( (int) ( map.size() / .75f ) + 1, 16 ) );
+        Map<PaymentDto, PaymentDto> map1 = new LinkedHashMap<>( Math.max( (int) ( map.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<Payment, Payment> entry : map.entrySet() ) {
             PaymentDto key = paymentToPaymentDto( entry.getKey() );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1685/UserMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1685/UserMapperImpl.java
@@ -157,7 +157,7 @@ public class UserMapperImpl implements UserMapper {
         contactDataDTO.setAddress( user.getAddress() );
         List<String> list = user.getPreferences();
         if ( list != null ) {
-            contactDataDTO.setPreferences( new ArrayList<String>( list ) );
+            contactDataDTO.setPreferences( new ArrayList<>( list ) );
         }
         String[] settings = user.getSettings();
         if ( settings != null ) {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1707/ConverterImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1707/ConverterImpl.java
@@ -24,7 +24,7 @@ public class ConverterImpl extends Converter {
             return null;
         }
 
-        Set<Target> set = new LinkedHashSet<Target>();
+        Set<Target> set = new LinkedHashSet<>();
 
         set.addAll( source.map( source1 -> convert( source1 ) )
             .collect( Collectors.toCollection( LinkedHashSet<Target>::new ) )

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_3591/ContainerBeanMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_3591/ContainerBeanMapperImpl.java
@@ -72,7 +72,7 @@ public class ContainerBeanMapperImpl implements ContainerBeanMapper {
             return null;
         }
 
-        Map<String, ContainerBeanDto> map1 = new LinkedHashMap<String, ContainerBeanDto>( Math.max( (int) ( map.size() / .75f ) + 1, 16 ) );
+        Map<String, ContainerBeanDto> map1 = new LinkedHashMap<>( Math.max( (int) ( map.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<String, ContainerBean> entry : map.entrySet() ) {
             String key = entry.getKey();

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
@@ -30,21 +30,21 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
 
         if ( source.hasStrings() ) {
             List<String> list = source.getStrings();
-            domain.setStrings( new LinkedHashSet<String>( list ) );
+            domain.setStrings( new LinkedHashSet<>( list ) );
         }
         if ( source.hasStrings() ) {
             domain.setLongs( stringListToLongSet( source.getStrings() ) );
         }
         if ( source.hasStringsInitialized() ) {
             List<String> list1 = source.getStringsInitialized();
-            domain.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+            domain.setStringsInitialized( new LinkedHashSet<>( list1 ) );
         }
         if ( source.hasStringsInitialized() ) {
             domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
         }
         if ( source.hasStringsWithDefault() ) {
             List<String> list2 = source.getStringsWithDefault();
-            domain.setStringsWithDefault( new ArrayList<String>( list2 ) );
+            domain.setStringsWithDefault( new ArrayList<>( list2 ) );
         }
         else {
             domain.setStringsWithDefault( helper.toList( "3" ) );
@@ -68,7 +68,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStrings() ) {
                 List<String> list = source.getStrings();
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -91,7 +91,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStringsInitialized() ) {
                 List<String> list1 = source.getStringsInitialized();
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -117,7 +117,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStringsWithDefault() ) {
                 List<String> list2 = source.getStringsWithDefault();
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -140,7 +140,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStrings() ) {
                 List<String> list = source.getStrings();
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -163,7 +163,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStringsInitialized() ) {
                 List<String> list1 = source.getStringsInitialized();
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -189,7 +189,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         else {
             if ( source.hasStringsWithDefault() ) {
                 List<String> list2 = source.getStringsWithDefault();
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -204,7 +204,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
             return null;
         }
 
-        Set<Long> set = new LinkedHashSet<Long>( Math.max( (int) ( list.size() / .75f ) + 1, 16 ) );
+        Set<Long> set = new LinkedHashSet<>( Math.max( (int) ( list.size() / .75f ) + 1, 16 ) );
         for ( String string : list ) {
             set.add( Long.parseLong( string ) );
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
@@ -28,17 +28,17 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
         if ( source != null ) {
             List<String> list = source.getStrings();
             if ( list != null ) {
-                domain.setStrings( new LinkedHashSet<String>( list ) );
+                domain.setStrings( new LinkedHashSet<>( list ) );
             }
             domain.setLongs( stringListToLongSet( source.getStrings() ) );
             List<String> list1 = source.getStringsInitialized();
             if ( list1 != null ) {
-                domain.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                domain.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
             domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
             List<String> list2 = source.getStringsWithDefault();
             if ( list2 != null ) {
-                domain.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                domain.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 domain.setStringsWithDefault( helper.toList( "3" ) );
@@ -59,16 +59,16 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getStrings().addAll( list );
                 }
                 else {
-                    target.setStrings( new LinkedHashSet<String>() );
+                    target.setStrings( new LinkedHashSet<>() );
                 }
             }
             else {
                 List<String> list = source.getStrings();
                 if ( list != null ) {
-                    target.setStrings( new LinkedHashSet<String>( list ) );
+                    target.setStrings( new LinkedHashSet<>( list ) );
                 }
                 else {
-                    target.setStrings( new LinkedHashSet<String>() );
+                    target.setStrings( new LinkedHashSet<>() );
                 }
             }
             if ( target.getLongs() != null ) {
@@ -78,7 +78,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getLongs().addAll( set );
                 }
                 else {
-                    target.setLongs( new LinkedHashSet<Long>() );
+                    target.setLongs( new LinkedHashSet<>() );
                 }
             }
             else {
@@ -87,7 +87,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongs( set );
                 }
                 else {
-                    target.setLongs( new LinkedHashSet<Long>() );
+                    target.setLongs( new LinkedHashSet<>() );
                 }
             }
             if ( target.getStringsInitialized() != null ) {
@@ -97,16 +97,16 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getStringsInitialized().addAll( list1 );
                 }
                 else {
-                    target.setStringsInitialized( new LinkedHashSet<String>() );
+                    target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
             else {
                 List<String> list1 = source.getStringsInitialized();
                 if ( list1 != null ) {
-                    target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                    target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
                 }
                 else {
-                    target.setStringsInitialized( new LinkedHashSet<String>() );
+                    target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
             if ( target.getLongsInitialized() != null ) {
@@ -116,7 +116,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getLongsInitialized().addAll( set1 );
                 }
                 else {
-                    target.setLongsInitialized( new LinkedHashSet<Long>() );
+                    target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
             else {
@@ -125,7 +125,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongsInitialized( set1 );
                 }
                 else {
-                    target.setLongsInitialized( new LinkedHashSet<Long>() );
+                    target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
             if ( target.getStringsWithDefault() != null ) {
@@ -141,7 +141,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             else {
                 List<String> list2 = source.getStringsWithDefault();
                 if ( list2 != null ) {
-                    target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                    target.setStringsWithDefault( new ArrayList<>( list2 ) );
                 }
                 else {
                     target.setStringsWithDefault( helper.toList( "3" ) );
@@ -161,16 +161,16 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getStrings().addAll( list );
                 }
                 else {
-                    target.setStrings( new LinkedHashSet<String>() );
+                    target.setStrings( new LinkedHashSet<>() );
                 }
             }
             else {
                 List<String> list = source.getStrings();
                 if ( list != null ) {
-                    target.setStrings( new LinkedHashSet<String>( list ) );
+                    target.setStrings( new LinkedHashSet<>( list ) );
                 }
                 else {
-                    target.setStrings( new LinkedHashSet<String>() );
+                    target.setStrings( new LinkedHashSet<>() );
                 }
             }
             if ( target.getLongs() != null ) {
@@ -180,7 +180,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getLongs().addAll( set );
                 }
                 else {
-                    target.setLongs( new LinkedHashSet<Long>() );
+                    target.setLongs( new LinkedHashSet<>() );
                 }
             }
             else {
@@ -189,7 +189,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongs( set );
                 }
                 else {
-                    target.setLongs( new LinkedHashSet<Long>() );
+                    target.setLongs( new LinkedHashSet<>() );
                 }
             }
             if ( target.getStringsInitialized() != null ) {
@@ -199,16 +199,16 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getStringsInitialized().addAll( list1 );
                 }
                 else {
-                    target.setStringsInitialized( new LinkedHashSet<String>() );
+                    target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
             else {
                 List<String> list1 = source.getStringsInitialized();
                 if ( list1 != null ) {
-                    target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                    target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
                 }
                 else {
-                    target.setStringsInitialized( new LinkedHashSet<String>() );
+                    target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
             if ( target.getLongsInitialized() != null ) {
@@ -218,7 +218,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.getLongsInitialized().addAll( set1 );
                 }
                 else {
-                    target.setLongsInitialized( new LinkedHashSet<Long>() );
+                    target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
             else {
@@ -227,7 +227,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongsInitialized( set1 );
                 }
                 else {
-                    target.setLongsInitialized( new LinkedHashSet<Long>() );
+                    target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
             if ( target.getStringsWithDefault() != null ) {
@@ -243,7 +243,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
             else {
                 List<String> list2 = source.getStringsWithDefault();
                 if ( list2 != null ) {
-                    target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                    target.setStringsWithDefault( new ArrayList<>( list2 ) );
                 }
                 else {
                     target.setStringsWithDefault( helper.toList( "3" ) );
@@ -256,10 +256,10 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
 
     protected Set<Long> stringListToLongSet(List<String> list) {
         if ( list == null ) {
-            return new LinkedHashSet<Long>();
+            return new LinkedHashSet<>();
         }
 
-        Set<Long> set = new LinkedHashSet<Long>( Math.max( (int) ( list.size() / .75f ) + 1, 16 ) );
+        Set<Long> set = new LinkedHashSet<>( Math.max( (int) ( list.size() / .75f ) + 1, 16 ) );
         for ( String string : list ) {
             set.add( Long.parseLong( string ) );
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
@@ -30,17 +30,17 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
 
         List<String> list = source.getStrings();
         if ( list != null ) {
-            domain.setStrings( new LinkedHashSet<String>( list ) );
+            domain.setStrings( new LinkedHashSet<>( list ) );
         }
         domain.setLongs( stringListToLongSet( source.getStrings() ) );
         List<String> list1 = source.getStringsInitialized();
         if ( list1 != null ) {
-            domain.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+            domain.setStringsInitialized( new LinkedHashSet<>( list1 ) );
         }
         domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
         List<String> list2 = source.getStringsWithDefault();
         if ( list2 != null ) {
-            domain.setStringsWithDefault( new ArrayList<String>( list2 ) );
+            domain.setStringsWithDefault( new ArrayList<>( list2 ) );
         }
         else {
             domain.setStringsWithDefault( helper.toList( "3" ) );
@@ -68,7 +68,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list = source.getStrings();
             if ( list != null ) {
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -100,7 +100,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list1 = source.getStringsInitialized();
             if ( list1 != null ) {
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -132,7 +132,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list2 = source.getStringsWithDefault();
             if ( list2 != null ) {
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -159,7 +159,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list = source.getStrings();
             if ( list != null ) {
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -191,7 +191,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list1 = source.getStringsInitialized();
             if ( list1 != null ) {
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -223,7 +223,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
         else {
             List<String> list2 = source.getStringsWithDefault();
             if ( list2 != null ) {
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -238,7 +238,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             return null;
         }
 
-        Set<Long> set = new LinkedHashSet<Long>( Math.max( (int) ( list.size() / .75f ) + 1, 16 ) );
+        Set<Long> set = new LinkedHashSet<>( Math.max( (int) ( list.size() / .75f ) + 1, 16 ) );
         for ( String string : list ) {
             set.add( Long.parseLong( string ) );
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
@@ -30,21 +30,21 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
 
         if ( source.hasStrings() ) {
             List<String> list = source.getStrings();
-            domain.setStrings( new LinkedHashSet<String>( list ) );
+            domain.setStrings( new LinkedHashSet<>( list ) );
         }
         if ( source.hasStrings() ) {
             domain.setLongs( stringListToLongSet( source.getStrings() ) );
         }
         if ( source.hasStringsInitialized() ) {
             List<String> list1 = source.getStringsInitialized();
-            domain.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+            domain.setStringsInitialized( new LinkedHashSet<>( list1 ) );
         }
         if ( source.hasStringsInitialized() ) {
             domain.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
         }
         if ( source.hasStringsWithDefault() ) {
             List<String> list2 = source.getStringsWithDefault();
-            domain.setStringsWithDefault( new ArrayList<String>( list2 ) );
+            domain.setStringsWithDefault( new ArrayList<>( list2 ) );
         }
         else {
             domain.setStringsWithDefault( helper.toList( "3" ) );
@@ -68,7 +68,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStrings() ) {
                 List<String> list = source.getStrings();
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -91,7 +91,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStringsInitialized() ) {
                 List<String> list1 = source.getStringsInitialized();
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -117,7 +117,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStringsWithDefault() ) {
                 List<String> list2 = source.getStringsWithDefault();
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -140,7 +140,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStrings() ) {
                 List<String> list = source.getStrings();
-                target.setStrings( new LinkedHashSet<String>( list ) );
+                target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
         if ( target.getLongs() != null ) {
@@ -163,7 +163,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStringsInitialized() ) {
                 List<String> list1 = source.getStringsInitialized();
-                target.setStringsInitialized( new LinkedHashSet<String>( list1 ) );
+                target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
         if ( target.getLongsInitialized() != null ) {
@@ -189,7 +189,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         else {
             if ( source.hasStringsWithDefault() ) {
                 List<String> list2 = source.getStringsWithDefault();
-                target.setStringsWithDefault( new ArrayList<String>( list2 ) );
+                target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -204,7 +204,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
             return null;
         }
 
-        Set<Long> set = new LinkedHashSet<Long>( Math.max( (int) ( list.size() / .75f ) + 1, 16 ) );
+        Set<Long> set = new LinkedHashSet<>( Math.max( (int) ( list.size() / .75f ) + 1, 16 ) );
         for ( String string : list ) {
             set.add( Long.parseLong( string ) );
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/collection/defaultimplementation/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/collection/defaultimplementation/SourceTargetMapperImpl.java
@@ -68,7 +68,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        List<TargetFoo> list = new ArrayList<TargetFoo>( foos.size() );
+        List<TargetFoo> list = new ArrayList<>( foos.size() );
         for ( SourceFoo sourceFoo : foos ) {
             list.add( sourceFooToTargetFoo( sourceFoo ) );
         }
@@ -82,7 +82,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        Set<TargetFoo> set = new LinkedHashSet<TargetFoo>( Math.max( (int) ( foos.size() / .75f ) + 1, 16 ) );
+        Set<TargetFoo> set = new LinkedHashSet<>( Math.max( (int) ( foos.size() / .75f ) + 1, 16 ) );
         for ( SourceFoo sourceFoo : foos ) {
             set.add( sourceFooToTargetFoo( sourceFoo ) );
         }
@@ -96,7 +96,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        Collection<TargetFoo> collection = new ArrayList<TargetFoo>( foos.size() );
+        Collection<TargetFoo> collection = new ArrayList<>( foos.size() );
         for ( SourceFoo sourceFoo : foos ) {
             collection.add( sourceFooToTargetFoo( sourceFoo ) );
         }
@@ -110,7 +110,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        ArrayList<TargetFoo> iterable = new ArrayList<TargetFoo>();
+        ArrayList<TargetFoo> iterable = new ArrayList<>();
         for ( SourceFoo sourceFoo : foos ) {
             iterable.add( sourceFooToTargetFoo( sourceFoo ) );
         }
@@ -150,7 +150,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        SortedSet<TargetFoo> sortedSet = new TreeSet<TargetFoo>();
+        SortedSet<TargetFoo> sortedSet = new TreeSet<>();
         for ( SourceFoo sourceFoo : foos ) {
             sortedSet.add( sourceFooToTargetFoo( sourceFoo ) );
         }
@@ -164,7 +164,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        NavigableSet<TargetFoo> navigableSet = new TreeSet<TargetFoo>();
+        NavigableSet<TargetFoo> navigableSet = new TreeSet<>();
         for ( SourceFoo sourceFoo : foos ) {
             navigableSet.add( sourceFooToTargetFoo( sourceFoo ) );
         }
@@ -178,7 +178,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        Map<String, TargetFoo> map = new LinkedHashMap<String, TargetFoo>( Math.max( (int) ( foos.size() / .75f ) + 1, 16 ) );
+        Map<String, TargetFoo> map = new LinkedHashMap<>( Math.max( (int) ( foos.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<Long, SourceFoo> entry : foos.entrySet() ) {
             String key = String.valueOf( entry.getKey() );
@@ -195,7 +195,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        SortedMap<String, TargetFoo> sortedMap = new TreeMap<String, TargetFoo>();
+        SortedMap<String, TargetFoo> sortedMap = new TreeMap<>();
 
         for ( java.util.Map.Entry<Long, SourceFoo> entry : foos.entrySet() ) {
             String key = String.valueOf( entry.getKey() );
@@ -212,7 +212,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        NavigableMap<String, TargetFoo> navigableMap = new TreeMap<String, TargetFoo>();
+        NavigableMap<String, TargetFoo> navigableMap = new TreeMap<>();
 
         for ( java.util.Map.Entry<Long, SourceFoo> entry : foos.entrySet() ) {
             String key = String.valueOf( entry.getKey() );
@@ -229,7 +229,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        ConcurrentMap<String, TargetFoo> concurrentMap = new ConcurrentHashMap<String, TargetFoo>( Math.max( (int) ( foos.size() / .75f ) + 1, 16 ) );
+        ConcurrentMap<String, TargetFoo> concurrentMap = new ConcurrentHashMap<>( Math.max( (int) ( foos.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<Long, SourceFoo> entry : foos.entrySet() ) {
             String key = String.valueOf( entry.getKey() );
@@ -246,7 +246,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        ConcurrentNavigableMap<String, TargetFoo> concurrentNavigableMap = new ConcurrentSkipListMap<String, TargetFoo>();
+        ConcurrentNavigableMap<String, TargetFoo> concurrentNavigableMap = new ConcurrentSkipListMap<>();
 
         for ( java.util.Map.Entry<Long, SourceFoo> entry : foos.entrySet() ) {
             String key = String.valueOf( entry.getKey() );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/numbers/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/numbers/SourceTargetMapperImpl.java
@@ -357,7 +357,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        List<String> list = new ArrayList<String>( source.size() );
+        List<String> list = new ArrayList<>( source.size() );
         for ( Float float1 : source ) {
             list.add( new DecimalFormat( "##.00" ).format( float1 ) );
         }
@@ -371,7 +371,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        List<Float> list = new ArrayList<Float>( source.size() );
+        List<Float> list = new ArrayList<>( source.size() );
         for ( String string : source ) {
             try {
                 list.add( new DecimalFormat( "##.00" ).parse( string ).floatValue() );
@@ -390,7 +390,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        List<String> list = new ArrayList<String>( source.size() );
+        List<String> list = new ArrayList<>( source.size() );
         for ( BigDecimal bigDecimal : source ) {
             list.add( createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "fr" ) ).format( bigDecimal ) );
         }
@@ -404,7 +404,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        List<BigDecimal> list = new ArrayList<BigDecimal>( source.size() );
+        List<BigDecimal> list = new ArrayList<>( source.size() );
         for ( String string : source ) {
             try {
                 list.add( (BigDecimal) createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "fr" ) ).parse( string ) );
@@ -423,7 +423,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        Map<String, String> map = new LinkedHashMap<String, String>( Math.max( (int) ( source.size() / .75f ) + 1, 16 ) );
+        Map<String, String> map = new LinkedHashMap<>( Math.max( (int) ( source.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<Float, Float> entry : source.entrySet() ) {
             String key = new DecimalFormat( "##.00" ).format( entry.getKey() );
@@ -440,7 +440,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        Map<String, String> map = new LinkedHashMap<String, String>( Math.max( (int) ( source.size() / .75f ) + 1, 16 ) );
+        Map<String, String> map = new LinkedHashMap<>( Math.max( (int) ( source.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<BigDecimal, BigDecimal> entry : source.entrySet() ) {
             String key = createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "fr" ) ).format( entry.getKey() );
@@ -457,7 +457,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        Map<Float, Float> map = new LinkedHashMap<Float, Float>( Math.max( (int) ( source.size() / .75f ) + 1, 16 ) );
+        Map<Float, Float> map = new LinkedHashMap<>( Math.max( (int) ( source.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<String, String> entry : source.entrySet() ) {
             Float key;
@@ -486,7 +486,7 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
             return null;
         }
 
-        Map<BigDecimal, BigDecimal> map = new LinkedHashMap<BigDecimal, BigDecimal>( Math.max( (int) ( source.size() / .75f ) + 1, 16 ) );
+        Map<BigDecimal, BigDecimal> map = new LinkedHashMap<>( Math.max( (int) ( source.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<String, String> entry : source.entrySet() ) {
             BigDecimal key;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/defaultcomponentmodel/InstanceIterableMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/defaultcomponentmodel/InstanceIterableMapperImpl.java
@@ -24,7 +24,7 @@ public class InstanceIterableMapperImpl implements InstanceIterableMapper {
             return null;
         }
 
-        List<Target> list1 = new ArrayList<Target>( list.size() );
+        List<Target> list1 = new ArrayList<>( list.size() );
         for ( Source source : list ) {
             list1.add( instanceMapper.map( source ) );
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/defaultcomponentmodel/NonInstanceIterableMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/defaultcomponentmodel/NonInstanceIterableMapperImpl.java
@@ -25,7 +25,7 @@ public class NonInstanceIterableMapperImpl implements NonInstanceIterableMapper 
             return null;
         }
 
-        List<Target> list1 = new ArrayList<Target>( list.size() );
+        List<Target> list1 = new ArrayList<>( list.size() );
         for ( Source source : list ) {
             list1.add( nonInstanceMapper.map( source ) );
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/defaultcomponentmodel/NonPublicIterableMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/defaultcomponentmodel/NonPublicIterableMapperImpl.java
@@ -25,7 +25,7 @@ public class NonPublicIterableMapperImpl implements NonPublicIterableMapper {
             return null;
         }
 
-        List<Target> list1 = new ArrayList<Target>( list.size() );
+        List<Target> list1 = new ArrayList<>( list.size() );
         for ( Source source : list ) {
             list1.add( nonPublicMapper.map( source ) );
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/generics/wildcard/BoundCopyMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/generics/wildcard/BoundCopyMapperImpl.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.generics.wildcard;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-03-30T02:05:36+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.5 (Eclipse Adoptium)"
+)
+public class BoundCopyMapperImpl implements BoundCopyMapper {
+
+    @Override
+    public CollectionSuperTypes copySuperCollection(CollectionSuperTypes collectionSuperTypes) {
+        if ( collectionSuperTypes == null ) {
+            return null;
+        }
+
+        CollectionSuperTypes collectionSuperTypes1 = new CollectionSuperTypes();
+
+        Collection<? super SimpleObject> collection = collectionSuperTypes.getSimpleObjectsCollection();
+        if ( collection != null ) {
+            collectionSuperTypes1.setSimpleObjectsCollection( new ArrayList<>( collection ) );
+        }
+
+        return collectionSuperTypes1;
+    }
+
+    @Override
+    public CollectionExtendTypes copyExtendsCollection(CollectionExtendTypes collectionExtendTypes) {
+        if ( collectionExtendTypes == null ) {
+            return null;
+        }
+
+        CollectionExtendTypes collectionExtendTypes1 = new CollectionExtendTypes();
+
+        Collection<? extends SimpleObject> collection = collectionExtendTypes.getSimpleObjectsCollection();
+        if ( collection != null ) {
+            collectionExtendTypes1.setSimpleObjectsCollection( new ArrayList<>( collection ) );
+        }
+
+        return collectionExtendTypes1;
+    }
+
+    @Override
+    public MapSuperType copySuperMap(MapSuperType mapSuperType) {
+        if ( mapSuperType == null ) {
+            return null;
+        }
+
+        MapSuperType mapSuperType1 = new MapSuperType();
+
+        Map<? super SimpleObject, ? super SimpleObject> map = mapSuperType.getSimpleMap();
+        if ( map != null ) {
+            mapSuperType1.setSimpleMap( new LinkedHashMap<>( map ) );
+        }
+
+        return mapSuperType1;
+    }
+
+    @Override
+    public MapExtendType copyExtendMap(MapExtendType mapExtendType) {
+        if ( mapExtendType == null ) {
+            return null;
+        }
+
+        MapExtendType mapExtendType1 = new MapExtendType();
+
+        Map<? extends SimpleObject, ? extends SimpleObject> map = mapExtendType.getSimpleMap();
+        if ( map != null ) {
+            mapExtendType1.setSimpleMap( new LinkedHashMap<>( map ) );
+        }
+
+        return mapExtendType1;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoMapperClassicImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoMapperClassicImpl.java
@@ -82,7 +82,7 @@ public class UserDtoMapperClassicImpl implements UserDtoMapperClassic {
             return null;
         }
 
-        List<WheelDto> list = new ArrayList<WheelDto>( wheels.size() );
+        List<WheelDto> list = new ArrayList<>( wheels.size() );
         for ( Wheel wheel : wheels ) {
             list.add( mapWheel( wheel ) );
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoMapperSmartImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoMapperSmartImpl.java
@@ -65,7 +65,7 @@ public class UserDtoMapperSmartImpl implements UserDtoMapperSmart {
             return null;
         }
 
-        List<WheelDto> list1 = new ArrayList<WheelDto>( list.size() );
+        List<WheelDto> list1 = new ArrayList<>( list.size() );
         for ( Wheel wheel : list ) {
             list1.add( wheelToWheelDto( wheel ) );
         }
@@ -152,7 +152,7 @@ public class UserDtoMapperSmartImpl implements UserDtoMapperSmart {
             return null;
         }
 
-        List<org.mapstruct.ap.test.nestedbeans.other.WheelDto> list1 = new ArrayList<org.mapstruct.ap.test.nestedbeans.other.WheelDto>( list.size() );
+        List<org.mapstruct.ap.test.nestedbeans.other.WheelDto> list1 = new ArrayList<>( list.size() );
         for ( Wheel wheel : list ) {
             list1.add( wheelToWheelDto1( wheel ) );
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoUpdateMapperSmartImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoUpdateMapperSmartImpl.java
@@ -75,7 +75,7 @@ public class UserDtoUpdateMapperSmartImpl implements UserDtoUpdateMapperSmart {
             return null;
         }
 
-        List<WheelDto> list1 = new ArrayList<WheelDto>( list.size() );
+        List<WheelDto> list1 = new ArrayList<>( list.size() );
         for ( Wheel wheel : list ) {
             list1.add( wheelToWheelDto( wheel ) );
         }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/CompanyMapper1Impl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/CompanyMapper1Impl.java
@@ -83,7 +83,7 @@ public class CompanyMapper1Impl implements CompanyMapper1 {
             return null;
         }
 
-        Map<SecretaryEntity, EmployeeEntity> map1 = new LinkedHashMap<SecretaryEntity, EmployeeEntity>( Math.max( (int) ( map.size() / .75f ) + 1, 16 ) );
+        Map<SecretaryEntity, EmployeeEntity> map1 = new LinkedHashMap<>( Math.max( (int) ( map.size() / .75f ) + 1, 16 ) );
 
         for ( java.util.Map.Entry<SecretaryDto, EmployeeDto> entry : map.entrySet() ) {
             SecretaryEntity key = secretaryDtoToSecretaryEntity( entry.getKey() );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/DepartmentMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/DepartmentMapperImpl.java
@@ -33,7 +33,7 @@ public class DepartmentMapperImpl implements DepartmentMapper {
         entity.setName( dto.getName() );
         if ( dto.getEmployees() != null ) {
             if ( entity.getEmployees() == null ) {
-                entity.setEmployees( new ArrayList<EmployeeEntity>() );
+                entity.setEmployees( new ArrayList<>() );
             }
             externalHandWrittenMapper.toEmployeeEntityList( dto.getEmployees(), entity.getEmployees() );
         }
@@ -42,7 +42,7 @@ public class DepartmentMapperImpl implements DepartmentMapper {
         }
         if ( dto.getSecretaryToEmployee() != null ) {
             if ( entity.getSecretaryToEmployee() == null ) {
-                entity.setSecretaryToEmployee( new LinkedHashMap<SecretaryEntity, EmployeeEntity>() );
+                entity.setSecretaryToEmployee( new LinkedHashMap<>() );
             }
             externalHandWrittenMapper.toSecretaryEmployeeEntityMap( dto.getSecretaryToEmployee(), entity.getSecretaryToEmployee() );
         }


### PR DESCRIPTION
Adds a `NewInstanceCreation` ModelElement that renders `new T<>` and contributes only the raw class to imports, so type parameters used solely in the new-expression are no longer orphaned (Issue #955). Also fixes #3994's follow-up wildcard cases where explicit type arguments produced uncompilable Java.

Fixes #1018.

@hduelme I went down a rabbit hole with Claude Code while reviewing your PR #4026, so I finally have #1018. Let me know what you think