### PR TITLE
#4056 Extend JSpecify support for container mapping and @NonNull return types

### DIFF
--- a/NEXT_RELEASE_CHANGELOG.md
+++ b/NEXT_RELEASE_CHANGELOG.md
@@ -3,6 +3,9 @@
 * Add support for JSpecify nullness annotations (#1243) - MapStruct now detects `@NonNull`, `@Nullable`, `@NullMarked` and `@NullUnmarked` from `org.jspecify.annotations` to control null check generation:
   - Source `@NonNull` skips null checks; target `@NonNull` always adds them
   - `@NonNull` source parameters skip the method-level null guard
+  - `@NonNull` source on collection-typed property mappings skips the wrapping null guard
+  - Container mapping methods (`Iterable`, `Map`, `Stream`, arrays) honor JSpecify on their source parameter
+  - `@NonNull` mapping-method return type implies `NullValueMappingStrategy.RETURN_DEFAULT` semantics across bean, iterable, map and stream mapping methods
   - `@NullMarked` / `@NullUnmarked` scope is resolved by walking method &rarr; class &rarr; outer class &rarr; package
   - Compile error when mapping a potentially nullable source to a `@NonNull` constructor parameter without a `defaultValue`
   - Can be disabled with the `mapstruct.disableJSpecify` compiler option

--- a/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
@@ -328,6 +328,11 @@ The existing safety guards (`defaultValue` / `defaultExpression`, primitive unbo
 ==== Method-level source parameter
 
 When the source parameter of a mapping method is annotated `@NonNull` (directly or via a `@NullMarked` scope), MapStruct skips the method-level null guard, since the caller is contractually obliged to pass a non-null value.
+This rule applies uniformly to bean, iterable, map, and stream mapping methods.
+
+==== Method-level return type
+
+When the return type of a mapping method is `@NonNull` (directly or via a `@NullMarked` scope), MapStruct forces `NullValueMappingStrategy.RETURN_DEFAULT` semantics. The generated method returns a default-constructed target (bean methods), an empty collection (`Iterable` / array mappings), an empty map (`Map` mappings), or `Stream.empty()` (stream mappings) rather than `null`, so the return contract is never violated. This rule applies regardless of the explicit `NullValueMappingStrategy` setting.
 
 ==== Constructor parameter constraint
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -64,7 +64,6 @@ import org.mapstruct.ap.internal.model.source.SubclassMappingOptions;
 import org.mapstruct.ap.internal.model.source.selector.SelectedMethod;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Message;
-import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.AccessorType;
@@ -508,22 +507,20 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 }
             }
 
-            // JSpecify: @NonNull return forces RETURN_DEFAULT to avoid generating `return null`.
-            // Only applies when there are nullable source parameters (presence checks exist), since without them
-            // the template never generates a `return null` block in the first place.
+            // JSpecify: a @NonNull return forces RETURN_DEFAULT to avoid generating `return null`.
+            // The extra presence-check guard is bean-specific and required for correctness, not just an
+            // optimization: the bean template only emits a `return null` (and the presence-check wrapping that
+            // forcing mapNullToDefault would alter) when there are nullable source parameters. With none,
+            // getPresenceCheckByParameter would resolve to null in the single-source template branches.
+            // Container/Map/Stream methods instead gate this in their templates via `sourceParameterPresenceCheck??`,
+            // so they force unconditionally.
             if ( !mapNullToDefault
-                    && !method.isUpdateMethod()
-                    && !method.getReturnType().isVoid()
-                    && !presenceChecksByParameter.isEmpty() ) {
-                NullabilityResolver.Nullability returnNullability = ctx.getNullabilityResolver().getNullability(
-                    method.getExecutable(),
-                    () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked() );
-                if ( returnNullability == NullabilityResolver.Nullability.NON_NULL ) {
-                    ctx.getMessager().note( 2,
-                        Message.MAPPING_METHOD_JSPECIFY_FORCE_RETURN_DEFAULT,
-                        method.getName() );
-                    mapNullToDefault = true;
-                }
+                    && !presenceChecksByParameter.isEmpty()
+                    && ctx.isJSpecifyNonNullReturn( method ) ) {
+                ctx.getMessager().note( 2,
+                    Message.MAPPING_METHOD_JSPECIFY_FORCE_RETURN_DEFAULT,
+                    method.getName() );
+                mapNullToDefault = true;
             }
 
             return new BeanMappingMethod(

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -64,6 +64,7 @@ import org.mapstruct.ap.internal.model.source.SubclassMappingOptions;
 import org.mapstruct.ap.internal.model.source.selector.SelectedMethod;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Message;
+import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.AccessorType;
@@ -371,7 +372,7 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             reportErrorForUnusedSourceParameters();
             reportErrorForRedundantIgnoredSourceProperties();
 
-            // mapNullToDefault
+            // mapNullToDefault — JSpecify @NonNull return forces RETURN_DEFAULT to avoid generating `return null`.
             boolean mapNullToDefault = method.getOptions()
                 .getBeanMapping()
                 .getNullValueMappingStrategy()
@@ -507,6 +508,23 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
                 }
             }
 
+            // JSpecify: @NonNull return forces RETURN_DEFAULT to avoid generating `return null`.
+            // Only applies when there are nullable source parameters (presence checks exist), since without them
+            // the template never generates a `return null` block in the first place.
+            if ( !mapNullToDefault
+                    && !method.isUpdateMethod()
+                    && !method.getReturnType().isVoid()
+                    && !presenceChecksByParameter.isEmpty() ) {
+                NullabilityResolver.Nullability returnNullability = ctx.getNullabilityResolver().getNullability(
+                    method.getExecutable(),
+                    () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked() );
+                if ( returnNullability == NullabilityResolver.Nullability.NON_NULL ) {
+                    ctx.getMessager().note( 2,
+                        Message.MAPPING_METHOD_JSPECIFY_FORCE_RETURN_DEFAULT,
+                        method.getName() );
+                    mapNullToDefault = true;
+                }
+            }
 
             return new BeanMappingMethod(
                 method,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
@@ -27,6 +27,7 @@ import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.util.Message;
+import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.accessor.Accessor;
 import org.mapstruct.ap.internal.util.accessor.AccessorType;
 
@@ -73,6 +74,7 @@ public class CollectionAssignmentBuilder {
     private SourceRHS sourceRHS;
     private NullValueCheckStrategyGem nvcs;
     private NullValuePropertyMappingStrategyGem nvpms;
+    private NullabilityResolver.Nullability sourceJSpecifyNullability = NullabilityResolver.Nullability.UNKNOWN;
 
     public CollectionAssignmentBuilder mappingBuilderContext(MappingBuilderContext ctx) {
         this.ctx = ctx;
@@ -131,6 +133,15 @@ public class CollectionAssignmentBuilder {
 
     public CollectionAssignmentBuilder nullValuePropertyMappingStrategy( NullValuePropertyMappingStrategyGem nvpms ) {
         this.nvpms = nvpms;
+        return this;
+    }
+
+    public CollectionAssignmentBuilder sourceJSpecifyNullability(
+        NullabilityResolver.Nullability sourceJSpecifyNullability
+    ) {
+        this.sourceJSpecifyNullability = sourceJSpecifyNullability != null
+            ? sourceJSpecifyNullability
+            : NullabilityResolver.Nullability.UNKNOWN;
         return this;
     }
 
@@ -262,6 +273,14 @@ public class CollectionAssignmentBuilder {
      * @return whether to include a null / presence check or not
      */
     private boolean setterWrapperNeedsSourceNullCheck(Assignment rhs) {
+        // JSpecify: source @NonNull means the value is guaranteed non-null, skip the wrapper
+        if ( sourceJSpecifyNullability == NullabilityResolver.Nullability.NON_NULL ) {
+            ctx.getMessager().note( 2,
+                Message.PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK_NON_NULL_SOURCE,
+                targetPropertyName );
+            return false;
+        }
+
         if ( rhs.getSourcePresenceCheckerReference() != null ) {
             // If there is a source presence check then we should do a null check
             return true;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethod.java
@@ -14,7 +14,6 @@ import org.mapstruct.ap.internal.model.common.Assignment;
 import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.Type;
-import org.mapstruct.ap.internal.model.presence.NullPresenceCheck;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.util.Strings;
@@ -36,12 +35,14 @@ public abstract class ContainerMappingMethod extends NormalTypeMappingMethod {
     private final PresenceCheck sourceParameterPresenceCheck;
     private IterableCreation iterableCreation;
 
+    //CHECKSTYLE:OFF
     ContainerMappingMethod(Method method, List<Annotation> annotations,
                            Collection<String> existingVariables, Assignment parameterAssignment,
         MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
         List<LifecycleCallbackMethodReference> beforeMappingReferences,
         List<LifecycleCallbackMethodReference> afterMappingReferences,
-        SelectionParameters selectionParameters) {
+        SelectionParameters selectionParameters, PresenceCheck sourceParameterPresenceCheck) {
+        //CHECKSTYLE:ON
         super( method, annotations, existingVariables, factoryMethod, mapNullToDefault, beforeMappingReferences,
             afterMappingReferences );
         this.elementAssignment = parameterAssignment;
@@ -64,7 +65,7 @@ public abstract class ContainerMappingMethod extends NormalTypeMappingMethod {
         }
 
         this.sourceParameter = sourceParameter;
-        this.sourceParameterPresenceCheck = new NullPresenceCheck( this.sourceParameter.getName() );
+        this.sourceParameterPresenceCheck = sourceParameterPresenceCheck;
 
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
@@ -21,7 +21,6 @@ import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Message;
-import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.Strings;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
@@ -127,23 +126,18 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
         }
         assignment = getWrapper( assignment, method );
 
-        // mapNullToDefault — JSpecify @NonNull return forces RETURN_DEFAULT to avoid generating `return null`.
+        // mapNullToDefault — a JSpecify @NonNull return forces RETURN_DEFAULT to avoid generating `return null`.
+        // Forcing is unconditional here (unlike BeanMappingMethod): when the source is @NonNull the template skips
+        // the whole guard block via `sourceParameterPresenceCheck??`, so the forced value is simply unused there.
         boolean mapNullToDefault = method.getOptions()
             .getIterableMapping()
             .getNullValueMappingStrategy()
             .isReturnDefault();
-        if ( !mapNullToDefault
-                && !method.isUpdateMethod()
-                && !method.getReturnType().isVoid() ) {
-            NullabilityResolver.Nullability returnNullability = ctx.getNullabilityResolver().getNullability(
-                method.getExecutable(),
-                () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked() );
-            if ( returnNullability == NullabilityResolver.Nullability.NON_NULL ) {
-                ctx.getMessager().note( 2,
-                    Message.MAPPING_METHOD_JSPECIFY_FORCE_RETURN_DEFAULT,
-                    method.getName() );
-                mapNullToDefault = true;
-            }
+        if ( !mapNullToDefault && ctx.isJSpecifyNonNullReturn( method ) ) {
+            ctx.getMessager().note( 2,
+                Message.MAPPING_METHOD_JSPECIFY_FORCE_RETURN_DEFAULT,
+                method.getName() );
+            mapNullToDefault = true;
         }
 
         MethodReference factoryMethod = null;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ContainerMappingMethodBuilder.java
@@ -13,12 +13,15 @@ import javax.lang.model.element.AnnotationMirror;
 
 import org.mapstruct.ap.internal.model.common.Assignment;
 import org.mapstruct.ap.internal.model.common.FormattingParameters;
+import org.mapstruct.ap.internal.model.common.Parameter;
+import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.SourceRHS;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Message;
+import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.Strings;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
@@ -124,11 +127,24 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
         }
         assignment = getWrapper( assignment, method );
 
-        // mapNullToDefault
+        // mapNullToDefault — JSpecify @NonNull return forces RETURN_DEFAULT to avoid generating `return null`.
         boolean mapNullToDefault = method.getOptions()
             .getIterableMapping()
             .getNullValueMappingStrategy()
             .isReturnDefault();
+        if ( !mapNullToDefault
+                && !method.isUpdateMethod()
+                && !method.getReturnType().isVoid() ) {
+            NullabilityResolver.Nullability returnNullability = ctx.getNullabilityResolver().getNullability(
+                method.getExecutable(),
+                () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked() );
+            if ( returnNullability == NullabilityResolver.Nullability.NON_NULL ) {
+                ctx.getMessager().note( 2,
+                    Message.MAPPING_METHOD_JSPECIFY_FORCE_RETURN_DEFAULT,
+                    method.getName() );
+                mapNullToDefault = true;
+            }
+        }
 
         MethodReference factoryMethod = null;
         if ( !method.isUpdateMethod() ) {
@@ -151,6 +167,11 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
             existingVariables
         );
 
+        // Resolve presence check via JSpecify-aware resolver — returns null when source is @NonNull.
+        Parameter sourceParam = first( method.getSourceParameters() );
+        PresenceCheck sourceParameterPresenceCheck =
+            PresenceCheckMethodResolver.getPresenceCheckForSourceParameter( method, null, sourceParam, ctx );
+
         return instantiateMappingMethod(
             method,
             existingVariables,
@@ -160,7 +181,8 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
             loopVariableName,
             beforeMappingMethods,
             afterMappingMethods,
-            selectionParameters
+            selectionParameters,
+            sourceParameterPresenceCheck
         );
     }
 
@@ -177,7 +199,7 @@ public abstract class ContainerMappingMethodBuilder<B extends ContainerMappingMe
                                                   boolean mapNullToDefault, String loopVariableName,
                                                   List<LifecycleCallbackMethodReference> beforeMappingMethods,
                                                   List<LifecycleCallbackMethodReference> afterMappingMethods,
-        SelectionParameters selectionParameters);
+        SelectionParameters selectionParameters, PresenceCheck sourceParameterPresenceCheck);
 
     protected abstract Type getElementType(Type parameterType);
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/IterableMappingMethod.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import org.mapstruct.ap.internal.model.assignment.LocalVarWrapper;
 import org.mapstruct.ap.internal.model.assignment.SetterWrapper;
 import org.mapstruct.ap.internal.model.common.Assignment;
+import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
@@ -54,7 +55,8 @@ public class IterableMappingMethod extends ContainerMappingMethod {
         protected IterableMappingMethod instantiateMappingMethod(Method method, Collection<String> existingVariables,
             Assignment assignment, MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
             List<LifecycleCallbackMethodReference> beforeMappingMethods,
-            List<LifecycleCallbackMethodReference> afterMappingMethods, SelectionParameters selectionParameters) {
+            List<LifecycleCallbackMethodReference> afterMappingMethods, SelectionParameters selectionParameters,
+            PresenceCheck sourceParameterPresenceCheck) {
             return new IterableMappingMethod(
                 method,
                 getMethodAnnotations(),
@@ -65,17 +67,20 @@ public class IterableMappingMethod extends ContainerMappingMethod {
                 loopVariableName,
                 beforeMappingMethods,
                 afterMappingMethods,
-                selectionParameters
+                selectionParameters,
+                sourceParameterPresenceCheck
             );
         }
     }
 
+    //CHECKSTYLE:OFF
     private IterableMappingMethod(Method method, List<Annotation> annotations,
                                   Collection<String> existingVariables, Assignment parameterAssignment,
                                   MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
                                   List<LifecycleCallbackMethodReference> beforeMappingReferences,
                                   List<LifecycleCallbackMethodReference> afterMappingReferences,
-        SelectionParameters selectionParameters) {
+        SelectionParameters selectionParameters, PresenceCheck sourceParameterPresenceCheck) {
+        //CHECKSTYLE:ON
         super(
             method,
             annotations,
@@ -86,7 +91,8 @@ public class IterableMappingMethod extends ContainerMappingMethod {
             loopVariableName,
             beforeMappingReferences,
             afterMappingReferences,
-            selectionParameters
+            selectionParameters,
+            sourceParameterPresenceCheck
         );
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -18,11 +18,11 @@ import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.SourceRHS;
 import org.mapstruct.ap.internal.model.common.Type;
-import org.mapstruct.ap.internal.model.presence.NullPresenceCheck;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Message;
+import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.Strings;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
@@ -182,9 +182,22 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
                 ctx.getMessager().note( 2, Message.MAPMAPPING_SELECT_VALUE_NOTE, valueAssignment );
             }
 
-            // mapNullToDefault
+            // mapNullToDefault — JSpecify @NonNull return forces RETURN_DEFAULT to avoid generating `return null`.
             boolean mapNullToDefault =
                 method.getOptions().getMapMapping().getNullValueMappingStrategy().isReturnDefault();
+            if ( !mapNullToDefault
+                    && !method.isUpdateMethod()
+                    && !method.getReturnType().isVoid() ) {
+                NullabilityResolver.Nullability returnNullability = ctx.getNullabilityResolver().getNullability(
+                    method.getExecutable(),
+                    () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked() );
+                if ( returnNullability == NullabilityResolver.Nullability.NON_NULL ) {
+                    ctx.getMessager().note( 2,
+                        Message.MAPPING_METHOD_JSPECIFY_FORCE_RETURN_DEFAULT,
+                        method.getName() );
+                    mapNullToDefault = true;
+                }
+            }
 
             MethodReference factoryMethod = null;
             if ( !method.isUpdateMethod() ) {
@@ -201,6 +214,10 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
             List<LifecycleCallbackMethodReference> afterMappingMethods =
                 LifecycleMethodResolver.afterMappingMethods( method, null, ctx, existingVariables );
 
+            Parameter sourceParam = first( method.getSourceParameters() );
+            PresenceCheck sourceParameterPresenceCheck =
+                PresenceCheckMethodResolver.getPresenceCheckForSourceParameter( method, null, sourceParam, ctx );
+
             return new MapMappingMethod(
                 method,
                 getMethodAnnotations(),
@@ -210,7 +227,8 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
                 factoryMethod,
                 mapNullToDefault,
                 beforeMappingMethods,
-                afterMappingMethods
+                afterMappingMethods,
+                sourceParameterPresenceCheck
             );
         }
 
@@ -229,11 +247,14 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
 
     }
 
+    //CHECKSTYLE:OFF
     private MapMappingMethod(Method method, List<Annotation> annotations,
                              Collection<String> existingVariableNames, Assignment keyAssignment,
                              Assignment valueAssignment, MethodReference factoryMethod, boolean mapNullToDefault,
                              List<LifecycleCallbackMethodReference> beforeMappingReferences,
-                             List<LifecycleCallbackMethodReference> afterMappingReferences) {
+                             List<LifecycleCallbackMethodReference> afterMappingReferences,
+                             PresenceCheck sourceParameterPresenceCheck) {
+        //CHECKSTYLE:ON
         super( method, annotations, existingVariableNames, factoryMethod, mapNullToDefault, beforeMappingReferences,
             afterMappingReferences );
 
@@ -252,7 +273,7 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
         }
 
         this.sourceParameter = sourceParameter;
-        this.sourceParameterPresenceCheck = new NullPresenceCheck( this.sourceParameter.getName() );
+        this.sourceParameterPresenceCheck = sourceParameterPresenceCheck;
     }
 
     public Parameter getSourceParameter() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MapMappingMethod.java
@@ -22,7 +22,6 @@ import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
 import org.mapstruct.ap.internal.model.source.selector.SelectionCriteria;
 import org.mapstruct.ap.internal.util.Message;
-import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.Strings;
 
 import static org.mapstruct.ap.internal.util.Collections.first;
@@ -182,21 +181,16 @@ public class MapMappingMethod extends NormalTypeMappingMethod {
                 ctx.getMessager().note( 2, Message.MAPMAPPING_SELECT_VALUE_NOTE, valueAssignment );
             }
 
-            // mapNullToDefault — JSpecify @NonNull return forces RETURN_DEFAULT to avoid generating `return null`.
+            // mapNullToDefault — a JSpecify @NonNull return forces RETURN_DEFAULT to avoid generating `return null`.
+            // Forcing is unconditional here (unlike BeanMappingMethod): when the source is @NonNull the template skips
+            // the whole guard block via `sourceParameterPresenceCheck??`, so the forced value is simply unused there.
             boolean mapNullToDefault =
                 method.getOptions().getMapMapping().getNullValueMappingStrategy().isReturnDefault();
-            if ( !mapNullToDefault
-                    && !method.isUpdateMethod()
-                    && !method.getReturnType().isVoid() ) {
-                NullabilityResolver.Nullability returnNullability = ctx.getNullabilityResolver().getNullability(
-                    method.getExecutable(),
-                    () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked() );
-                if ( returnNullability == NullabilityResolver.Nullability.NON_NULL ) {
-                    ctx.getMessager().note( 2,
-                        Message.MAPPING_METHOD_JSPECIFY_FORCE_RETURN_DEFAULT,
-                        method.getName() );
-                    mapNullToDefault = true;
-                }
+            if ( !mapNullToDefault && ctx.isJSpecifyNonNullReturn( method ) ) {
+                ctx.getMessager().note( 2,
+                    Message.MAPPING_METHOD_JSPECIFY_FORCE_RETURN_DEFAULT,
+                    method.getName() );
+                mapNullToDefault = true;
             }
 
             MethodReference factoryMethod = null;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
@@ -209,6 +209,28 @@ public class MappingBuilderContext {
         return nullabilityResolver;
     }
 
+    /**
+     * Whether the return type of the given mapping method is JSpecify {@code @NonNull} (directly or via a
+     * {@code @NullMarked} scope). When it is, a mapping method must not generate {@code return null}, so callers
+     * force {@link org.mapstruct.ap.internal.gem.NullValueMappingStrategyGem#RETURN_DEFAULT} semantics.
+     * <p>
+     * Update methods and {@code void}-returning methods never generate a {@code return null} and are excluded.
+     *
+     * @param method the mapping method to inspect
+     *
+     * @return {@code true} if the return type is {@code @NonNull}, {@code false} otherwise
+     */
+    public boolean isJSpecifyNonNullReturn(Method method) {
+        if ( method.isUpdateMethod() || method.getReturnType().isVoid() ) {
+            return false;
+        }
+
+        NullabilityResolver.Nullability returnNullability = nullabilityResolver.getNullability(
+            method.getExecutable(),
+            () -> typeFactory.getType( mapperTypeElement.asType() ).isNullMarked() );
+        return returnNullability == NullabilityResolver.Nullability.NON_NULL;
+    }
+
     public EnumMappingStrategy getEnumMappingStrategy() {
         return enumMappingStrategy;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MappingBuilderContext.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import javax.lang.model.element.AnnotationMirror;
+import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 
 import org.mapstruct.ap.internal.model.common.Assignment;
@@ -210,6 +211,21 @@ public class MappingBuilderContext {
     }
 
     /**
+     * Resolves the JSpecify nullability of an element declared directly on the mapper (e.g. a mapping method's
+     * return type or one of its source parameters), using the mapper type's {@code @NullMarked} scope as the
+     * enclosing scope for unannotated elements.
+     *
+     * @param element the element declared on the mapper to inspect
+     *
+     * @return the resolved nullability ({@link NullabilityResolver.Nullability#UNKNOWN} when JSpecify is disabled)
+     */
+    public NullabilityResolver.Nullability getNullabilityInMapperScope(Element element) {
+        return nullabilityResolver.getNullability(
+            element,
+            () -> typeFactory.getType( mapperTypeElement.asType() ).isNullMarked() );
+    }
+
+    /**
      * Whether the return type of the given mapping method is JSpecify {@code @NonNull} (directly or via a
      * {@code @NullMarked} scope). When it is, a mapping method must not generate {@code return null}, so callers
      * force {@link org.mapstruct.ap.internal.gem.NullValueMappingStrategyGem#RETURN_DEFAULT} semantics.
@@ -225,10 +241,7 @@ public class MappingBuilderContext {
             return false;
         }
 
-        NullabilityResolver.Nullability returnNullability = nullabilityResolver.getNullability(
-            method.getExecutable(),
-            () -> typeFactory.getType( mapperTypeElement.asType() ).isNullMarked() );
-        return returnNullability == NullabilityResolver.Nullability.NON_NULL;
+        return getNullabilityInMapperScope( method.getExecutable() ) == NullabilityResolver.Nullability.NON_NULL;
     }
 
     public EnumMappingStrategy getEnumMappingStrategy() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PresenceCheckMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PresenceCheckMethodResolver.java
@@ -96,11 +96,8 @@ public final class PresenceCheckMethodResolver {
             }
             else if ( !sourceParameter.getType().isPrimitive() ) {
                 // If the source parameter is @NonNull (JSpecify), skip the null guard entirely.
-                // Use the mapper type for @NullMarked scope resolution since the parameter
-                // is declared in the mapper interface.
-                if ( ctx.getNullabilityResolver().getNullability(
-                    sourceParameter.getElement(),
-                    () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked() )
+                // Resolved in the mapper's @NullMarked scope since the parameter is declared in the mapper interface.
+                if ( ctx.getNullabilityInMapperScope( sourceParameter.getElement() )
                     == NullabilityResolver.Nullability.NON_NULL ) {
                     ctx.getMessager().note( 2,
                         Message.PROPERTYMAPPING_JSPECIFY_SKIP_METHOD_GUARD_NON_NULL_PARAM,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -717,6 +717,7 @@ public class PropertyMapping extends ModelElement {
                 .assignment( rhs )
                 .nullValueCheckStrategy( hasDefaultValueOrDefaultExpression() ? ALWAYS : nvcs )
                 .nullValuePropertyMappingStrategy( nvpms )
+                .sourceJSpecifyNullability( getSourceJSpecifyNullability() )
                 .build();
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -626,10 +626,7 @@ public class PropertyMapping extends ModelElement {
             // Use the mapper type for @NullMarked scope resolution since the parameter is declared there.
             Parameter parameter = sourceReference.getParameter();
             if ( parameter != null && parameter.getElement() != null ) {
-                return ctx.getNullabilityResolver().getNullability(
-                    parameter.getElement(),
-                    () -> ctx.getTypeFactory().getType( ctx.getMapperTypeElement().asType() ).isNullMarked()
-                );
+                return ctx.getNullabilityInMapperScope( parameter.getElement() );
             }
             return NullabilityResolver.Nullability.UNKNOWN;
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/StreamMappingMethod.java
@@ -15,6 +15,7 @@ import java.util.stream.StreamSupport;
 
 import org.mapstruct.ap.internal.model.assignment.Java8FunctionWrapper;
 import org.mapstruct.ap.internal.model.common.Assignment;
+import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.SelectionParameters;
@@ -51,7 +52,8 @@ public class StreamMappingMethod extends ContainerMappingMethod {
         protected StreamMappingMethod instantiateMappingMethod(Method method, Collection<String> existingVariables,
             Assignment assignment, MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
             List<LifecycleCallbackMethodReference> beforeMappingMethods,
-            List<LifecycleCallbackMethodReference> afterMappingMethods, SelectionParameters selectionParameters) {
+            List<LifecycleCallbackMethodReference> afterMappingMethods, SelectionParameters selectionParameters,
+            PresenceCheck sourceParameterPresenceCheck) {
 
             Set<Type> helperImports = new HashSet<>();
             if ( method.getResultType().isIterableType() ) {
@@ -74,7 +76,8 @@ public class StreamMappingMethod extends ContainerMappingMethod {
                 beforeMappingMethods,
                 afterMappingMethods,
                 selectionParameters,
-                helperImports
+                helperImports,
+                sourceParameterPresenceCheck
             );
         }
     }
@@ -84,7 +87,7 @@ public class StreamMappingMethod extends ContainerMappingMethod {
                                 MethodReference factoryMethod, boolean mapNullToDefault, String loopVariableName,
                                 List<LifecycleCallbackMethodReference> beforeMappingReferences,
                                 List<LifecycleCallbackMethodReference> afterMappingReferences,
-        SelectionParameters selectionParameters, Set<Type> helperImports) {
+        SelectionParameters selectionParameters, Set<Type> helperImports, PresenceCheck sourceParameterPresenceCheck) {
         super(
             method,
             annotations,
@@ -95,7 +98,8 @@ public class StreamMappingMethod extends ContainerMappingMethod {
             loopVariableName,
             beforeMappingReferences,
             afterMappingReferences,
-            selectionParameters
+            selectionParameters,
+            sourceParameterPresenceCheck
         );
         //CHECKSTYLE:ON
         this.helperImports = helperImports;

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -101,6 +101,7 @@ public enum Message {
     PROPERTYMAPPING_JSPECIFY_ADD_NULL_CHECK( "JSpecify adding null check for property \"%s\": source=%s, target=%s.", Diagnostic.Kind.NOTE ),
     PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK( "JSpecify skipping null check for property \"%s\": source=%s, target=%s.", Diagnostic.Kind.NOTE ),
     PROPERTYMAPPING_JSPECIFY_SKIP_METHOD_GUARD_NON_NULL_PARAM( "JSpecify skipping method-level null guard for property \"%s\": parameter is @NonNull.", Diagnostic.Kind.NOTE ),
+    MAPPING_METHOD_JSPECIFY_FORCE_RETURN_DEFAULT( "JSpecify forcing NullValueMappingStrategy.RETURN_DEFAULT for method \"%s\": return type is @NonNull.", Diagnostic.Kind.NOTE ),
 
     CONVERSION_LOSSY_WARNING( "%s has a possibly lossy conversion from %s to %s.", Diagnostic.Kind.WARNING ),
     CONVERSION_LOSSY_ERROR( "Can't map %s. It has a possibly lossy conversion from %s to %s." ),

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/IterableMappingMethod.ftl
@@ -17,6 +17,7 @@
 
     	</#if>
     </#list>
+    <#if sourceParameterPresenceCheck??>
     if ( <@includeModel object=sourceParameterPresenceCheck.negate() /> ) {
         <#if !mapNullToDefault>
             return<#if returnType.name != "void"> <#if existingInstanceMapping>${resultName}<#else>null</#if></#if>;
@@ -41,6 +42,7 @@
             </#if>
         </#if>
     }
+    </#if>
 
     <#if resultType.arrayType>
         <#if !existingInstanceMapping>

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/MapMappingMethod.ftl
@@ -16,6 +16,7 @@
 
     	</#if>
     </#list>
+    <#if sourceParameterPresenceCheck??>
     if ( <@includeModel object=sourceParameterPresenceCheck.negate() /> ) {
         <#if !mapNullToDefault>
             return<#if returnType.name != "void"> <#if existingInstanceMapping>${resultName}<#else>null</#if></#if>;
@@ -28,6 +29,7 @@
             </#if>
         </#if>
     }
+    </#if>
 
     <#if existingInstanceMapping>
         ${resultName}.clear();

--- a/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
+++ b/processor/src/main/resources/org/mapstruct/ap/internal/model/StreamMappingMethod.ftl
@@ -18,6 +18,7 @@
 
     	</#if>
     </#list>
+    <#if sourceParameterPresenceCheck??>
     if ( <@includeModel object=sourceParameterPresenceCheck.negate() /> ) {
         <#if !mapNullToDefault>
             return<#if returnType.name != "void"> <#if existingInstanceMapping>${resultName}<#else>null</#if></#if>;
@@ -49,6 +50,7 @@
             </#if>
         </#if>
     }
+    </#if>
 
     <#-- A variable needs to be defined if there are before or after mappings and this is not exisitingInstanceMapping -->
     <#assign needVarDefine = (beforeMappingReferencesWithMappingTarget?has_content || afterMappingReferences?has_content) && !existingInstanceMapping />

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyCollectionPropertyMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyCollectionPropertyMapper.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@NullMarked
+@Mapper
+public interface JSpecifyCollectionPropertyMapper {
+
+    JSpecifyCollectionPropertyMapper INSTANCE = Mappers.getMapper( JSpecifyCollectionPropertyMapper.class );
+
+    NullMarkedCollectionTargetBean map(NullMarkedCollectionSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyCollectionPropertyTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyCollectionPropertyTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("1243")
+@WithJSpecify
+class JSpecifyCollectionPropertyTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedCollectionSourceBean.class,
+        NullMarkedCollectionTargetBean.class,
+        JSpecifyCollectionPropertyMapper.class
+    })
+    void collectionPropertyWithNonNullSourceSkipsNullCheck() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyCollectionPropertyMapper.class );
+
+        NullMarkedCollectionSourceBean source = new NullMarkedCollectionSourceBean();
+        source.setValues( Arrays.asList( "a", "b", "c" ) );
+
+        NullMarkedCollectionTargetBean target = JSpecifyCollectionPropertyMapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getValues() ).containsExactly( "a", "b", "c" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledContainerSourceMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledContainerSourceMapper.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+
+import org.jspecify.annotations.NullMarked;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Dedicated to {@link JSpecifyDisabledTest} so its generated implementation is not shared (and pre-loaded) by an
+ * enabled test in the same JVM. With JSpecify enabled the {@code @NonNull} source would skip the method-level guard.
+ */
+@NullMarked
+@Mapper
+public interface JSpecifyDisabledContainerSourceMapper {
+
+    JSpecifyDisabledContainerSourceMapper INSTANCE =
+        Mappers.getMapper( JSpecifyDisabledContainerSourceMapper.class );
+
+    List<NullMarkedTargetBean> mapAll(List<NullMarkedSourceBean> sources);
+
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledNonNullReturnMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledNonNullReturnMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Dedicated to {@link JSpecifyDisabledTest} so its generated implementation is not shared (and pre-loaded) by an
+ * enabled test in the same JVM. With JSpecify enabled the {@code @NonNull} return would force RETURN_DEFAULT.
+ */
+@NullMarked
+@Mapper
+public interface JSpecifyDisabledNonNullReturnMapper {
+
+    JSpecifyDisabledNonNullReturnMapper INSTANCE =
+        Mappers.getMapper( JSpecifyDisabledNonNullReturnMapper.class );
+
+    List<NullMarkedTargetBean> mapAll(@Nullable List<NullMarkedSourceBean> sources);
+
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledTest.java
@@ -54,4 +54,30 @@ class JSpecifyDisabledTest {
         // The JSpecify-driven hard error for a @Nullable source mapped to a @NonNull constructor
         // parameter is purely a JSpecify signal; with the flag disabled it must not be raised.
     }
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyDisabledContainerSourceMapper.class
+    })
+    public void disabledFlagKeepsContainerMethodSourceGuard() {
+        // With JSpecify enabled the @NonNull source parameter skips the method-level null guard. When disabled,
+        // the resolver reports UNKNOWN, so the unconditional "if (sources == null) return null;" guard is kept and
+        // mapping a null source returns null rather than throwing an NPE.
+        assertThat( JSpecifyDisabledContainerSourceMapper.INSTANCE.mapAll( null ) ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyDisabledNonNullReturnMapper.class
+    })
+    public void disabledFlagSkipsNonNullReturnForcing() {
+        // With JSpecify enabled the @NonNull return forces RETURN_DEFAULT (empty list for a null source). When
+        // disabled, that forcing is suppressed and the default RETURN_NULL strategy applies, so a null source
+        // maps to null.
+        assertThat( JSpecifyDisabledNonNullReturnMapper.INSTANCE.mapAll( null ) ).isNull();
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyIterableMethodMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyIterableMethodMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+
+import org.jspecify.annotations.NullMarked;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@NullMarked
+@Mapper
+public interface JSpecifyIterableMethodMapper {
+
+    JSpecifyIterableMethodMapper INSTANCE = Mappers.getMapper( JSpecifyIterableMethodMapper.class );
+
+    List<NullMarkedTargetBean> mapAll(List<NullMarkedSourceBean> sources);
+
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyIterableMethodTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyIterableMethodTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("1243")
+@WithJSpecify
+class JSpecifyIterableMethodTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyIterableMethodMapper.class
+    })
+    void iterableMethodWithNonNullSourceSkipsMethodGuard() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyIterableMethodMapper.class );
+
+        NullMarkedSourceBean source = new NullMarkedSourceBean();
+        source.setNonNullByDefault( "value" );
+
+        List<NullMarkedTargetBean> targets = JSpecifyIterableMethodMapper.INSTANCE.mapAll( Arrays.asList( source ) );
+
+        assertThat( targets ).hasSize( 1 );
+        assertThat( targets.get( 0 ).getNonNullByDefault() ).isEqualTo( "value" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyMapMethodMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyMapMethodMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.Map;
+
+import org.jspecify.annotations.NullMarked;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@NullMarked
+@Mapper
+public interface JSpecifyMapMethodMapper {
+
+    JSpecifyMapMethodMapper INSTANCE = Mappers.getMapper( JSpecifyMapMethodMapper.class );
+
+    Map<String, NullMarkedTargetBean> mapAll(Map<String, NullMarkedSourceBean> sources);
+
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyMapMethodTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyMapMethodTest.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("1243")
+@WithJSpecify
+class JSpecifyMapMethodTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyMapMethodMapper.class
+    })
+    void mapMethodWithNonNullSourceSkipsMethodGuard() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyMapMethodMapper.class );
+
+        NullMarkedSourceBean source = new NullMarkedSourceBean();
+        source.setNonNullByDefault( "value" );
+
+        Map<String, NullMarkedTargetBean> targets =
+            JSpecifyMapMethodMapper.INSTANCE.mapAll( Collections.singletonMap( "k", source ) );
+
+        assertThat( targets ).hasSize( 1 );
+        assertThat( targets.get( "k" ).getNonNullByDefault() ).isEqualTo( "value" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnBeanMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnBeanMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@NullMarked
+@Mapper
+public interface JSpecifyNonNullReturnBeanMapper {
+
+    JSpecifyNonNullReturnBeanMapper INSTANCE = Mappers.getMapper( JSpecifyNonNullReturnBeanMapper.class );
+
+    @BeanMapping(ignoreByDefault = true)
+    @Mapping(target = "nonNullByDefault", source = "value")
+    NullMarkedTargetBean map(@Nullable JSpecifyNonNullReturnBeanSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnBeanSourceBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnBeanSourceBean.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class JSpecifyNonNullReturnBeanSourceBean {
+
+    private String value;
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnBeanTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnBeanTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("1243")
+@WithJSpecify
+class JSpecifyNonNullReturnBeanTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({
+        JSpecifyNonNullReturnBeanSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyNonNullReturnBeanMapper.class
+    })
+    void nonNullReturnForcesMapNullToDefault() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyNonNullReturnBeanMapper.class );
+
+        NullMarkedTargetBean fromNull = JSpecifyNonNullReturnBeanMapper.INSTANCE.map( null );
+
+        assertThat( fromNull ).isNotNull();
+        assertThat( fromNull.getNonNullByDefault() ).isNull();
+
+        JSpecifyNonNullReturnBeanSourceBean source = new JSpecifyNonNullReturnBeanSourceBean();
+        source.setValue( "value" );
+
+        NullMarkedTargetBean fromSource = JSpecifyNonNullReturnBeanMapper.INSTANCE.map( source );
+
+        assertThat( fromSource ).isNotNull();
+        assertThat( fromSource.getNonNullByDefault() ).isEqualTo( "value" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnIterableMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnIterableMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@NullMarked
+@Mapper
+public interface JSpecifyNonNullReturnIterableMapper {
+
+    JSpecifyNonNullReturnIterableMapper INSTANCE = Mappers.getMapper( JSpecifyNonNullReturnIterableMapper.class );
+
+    List<NullMarkedTargetBean> mapAll(@Nullable List<NullMarkedSourceBean> sources);
+
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnIterableTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnIterableTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("1243")
+@WithJSpecify
+class JSpecifyNonNullReturnIterableTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyNonNullReturnIterableMapper.class
+    })
+    void nonNullReturnIterableForcesEmptyDefault() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyNonNullReturnIterableMapper.class );
+
+        List<NullMarkedTargetBean> fromNull = JSpecifyNonNullReturnIterableMapper.INSTANCE.mapAll( null );
+
+        assertThat( fromNull ).isEmpty();
+
+        NullMarkedSourceBean source = new NullMarkedSourceBean();
+        source.setNonNullByDefault( "value" );
+
+        List<NullMarkedTargetBean> fromSource =
+            JSpecifyNonNullReturnIterableMapper.INSTANCE.mapAll( Arrays.asList( source ) );
+
+        assertThat( fromSource ).hasSize( 1 );
+        assertThat( fromSource.get( 0 ).getNonNullByDefault() ).isEqualTo( "value" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnMapMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnMapMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.Map;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@NullMarked
+@Mapper
+public interface JSpecifyNonNullReturnMapMapper {
+
+    JSpecifyNonNullReturnMapMapper INSTANCE = Mappers.getMapper( JSpecifyNonNullReturnMapMapper.class );
+
+    Map<String, NullMarkedTargetBean> mapAll(@Nullable Map<String, NullMarkedSourceBean> sources);
+
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnMapTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnMapTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.Collections;
+import java.util.Map;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("1243")
+@WithJSpecify
+class JSpecifyNonNullReturnMapTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyNonNullReturnMapMapper.class
+    })
+    void nonNullReturnMapForcesEmptyDefault() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyNonNullReturnMapMapper.class );
+
+        Map<String, NullMarkedTargetBean> fromNull = JSpecifyNonNullReturnMapMapper.INSTANCE.mapAll( null );
+
+        assertThat( fromNull ).isEmpty();
+
+        NullMarkedSourceBean source = new NullMarkedSourceBean();
+        source.setNonNullByDefault( "value" );
+
+        Map<String, NullMarkedTargetBean> fromSource =
+            JSpecifyNonNullReturnMapMapper.INSTANCE.mapAll( Collections.singletonMap( "k", source ) );
+
+        assertThat( fromSource ).hasSize( 1 );
+        assertThat( fromSource.get( "k" ).getNonNullByDefault() ).isEqualTo( "value" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnStreamMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnStreamMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.stream.Stream;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@NullMarked
+@Mapper
+public interface JSpecifyNonNullReturnStreamMapper {
+
+    JSpecifyNonNullReturnStreamMapper INSTANCE = Mappers.getMapper( JSpecifyNonNullReturnStreamMapper.class );
+
+    Stream<NullMarkedTargetBean> mapAll(@Nullable Stream<NullMarkedSourceBean> sources);
+
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnStreamTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnStreamTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("1243")
+@WithJSpecify
+class JSpecifyNonNullReturnStreamTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyNonNullReturnStreamMapper.class
+    })
+    void nonNullReturnStreamForcesEmptyDefault() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyNonNullReturnStreamMapper.class );
+
+        Stream<NullMarkedTargetBean> fromNull = JSpecifyNonNullReturnStreamMapper.INSTANCE.mapAll( null );
+
+        assertThat( fromNull ).isNotNull();
+        assertThat( fromNull.collect( Collectors.toList() ) ).isEmpty();
+
+        NullMarkedSourceBean source = new NullMarkedSourceBean();
+        source.setNonNullByDefault( "value" );
+
+        List<NullMarkedTargetBean> fromSource = JSpecifyNonNullReturnStreamMapper.INSTANCE
+            .mapAll( Stream.of( source ) )
+            .collect( Collectors.toList() );
+
+        assertThat( fromSource ).hasSize( 1 );
+        assertThat( fromSource.get( 0 ).getNonNullByDefault() ).isEqualTo( "value" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnUpdateIterableMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnUpdateIterableMapper.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.factory.Mappers;
+
+@NullMarked
+@Mapper
+public interface JSpecifyNonNullReturnUpdateIterableMapper {
+
+    JSpecifyNonNullReturnUpdateIterableMapper INSTANCE =
+        Mappers.getMapper( JSpecifyNonNullReturnUpdateIterableMapper.class );
+
+    List<NullMarkedTargetBean> mapAll(@Nullable List<NullMarkedSourceBean> sources,
+                                      @MappingTarget List<NullMarkedTargetBean> target);
+
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnUpdateIterableTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnUpdateIterableTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The @NonNull-return forcing is gated on {@code !isUpdateMethod()}. An update (existing-instance) method must not
+ * be forced to RETURN_DEFAULT: a null source returns the supplied target instance, not a fresh empty collection.
+ */
+@IssueKey("1243")
+@WithJSpecify
+class JSpecifyNonNullReturnUpdateIterableTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyNonNullReturnUpdateIterableMapper.class
+    })
+    void updateMethodWithNonNullReturnIsNotForced() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyNonNullReturnUpdateIterableMapper.class );
+
+        List<NullMarkedTargetBean> target = new ArrayList<>();
+
+        List<NullMarkedTargetBean> result = JSpecifyNonNullReturnUpdateIterableMapper.INSTANCE.mapAll( null, target );
+
+        assertThat( result ).isSameAs( target );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableSourceIterableMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableSourceIterableMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@NullMarked
+@Mapper
+public interface JSpecifyNullableSourceIterableMapper {
+
+    JSpecifyNullableSourceIterableMapper INSTANCE = Mappers.getMapper( JSpecifyNullableSourceIterableMapper.class );
+
+    @Nullable
+    List<NullMarkedTargetBean> mapAll(@Nullable List<NullMarkedSourceBean> sources);
+
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableSourceIterableTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableSourceIterableTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Negative counterpart to {@link JSpecifyIterableMethodTest}: a {@code @Nullable} source parameter (and a
+ * {@code @Nullable} return, so the @NonNull-return forcing does not kick in) must keep the method-level
+ * {@code if ( sources == null ) return null;} guard.
+ */
+@IssueKey("1243")
+@WithJSpecify
+class JSpecifyNullableSourceIterableTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyNullableSourceIterableMapper.class
+    })
+    void nullableSourceKeepsMethodGuard() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyNullableSourceIterableMapper.class );
+
+        assertThat( JSpecifyNullableSourceIterableMapper.INSTANCE.mapAll( null ) ).isNull();
+
+        NullMarkedSourceBean source = new NullMarkedSourceBean();
+        source.setNonNullByDefault( "value" );
+
+        List<NullMarkedTargetBean> targets =
+            JSpecifyNullableSourceIterableMapper.INSTANCE.mapAll( Arrays.asList( source ) );
+
+        assertThat( targets ).hasSize( 1 );
+        assertThat( targets.get( 0 ).getNonNullByDefault() ).isEqualTo( "value" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReturnNullOverrideIterableMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReturnNullOverrideIterableMapper.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.IterableMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.NullValueMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@NullMarked
+@Mapper
+public interface JSpecifyReturnNullOverrideIterableMapper {
+
+    JSpecifyReturnNullOverrideIterableMapper INSTANCE =
+        Mappers.getMapper( JSpecifyReturnNullOverrideIterableMapper.class );
+
+    // Explicit RETURN_NULL, but the @NonNull return type (NullMarked scope) wins and forces RETURN_DEFAULT.
+    @IterableMapping(nullValueMappingStrategy = NullValueMappingStrategy.RETURN_NULL)
+    List<NullMarkedTargetBean> mapAll(@Nullable List<NullMarkedSourceBean> sources);
+
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReturnNullOverrideIterableTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReturnNullOverrideIterableTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that a JSpecify {@code @NonNull} return type wins over an explicitly configured
+ * {@code NullValueMappingStrategy.RETURN_NULL}: the generated method returns an empty collection rather
+ * than {@code null}.
+ */
+@IssueKey("1243")
+@WithJSpecify
+class JSpecifyReturnNullOverrideIterableTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyReturnNullOverrideIterableMapper.class
+    })
+    void nonNullReturnOverridesExplicitReturnNull() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyReturnNullOverrideIterableMapper.class );
+
+        assertThat( JSpecifyReturnNullOverrideIterableMapper.INSTANCE.mapAll( null ) ).isEmpty();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyStreamMethodMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyStreamMethodMapper.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.stream.Stream;
+
+import org.jspecify.annotations.NullMarked;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@NullMarked
+@Mapper
+public interface JSpecifyStreamMethodMapper {
+
+    JSpecifyStreamMethodMapper INSTANCE = Mappers.getMapper( JSpecifyStreamMethodMapper.class );
+
+    Stream<NullMarkedTargetBean> mapAll(Stream<NullMarkedSourceBean> sources);
+
+    NullMarkedTargetBean map(NullMarkedSourceBean source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyStreamMethodTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyStreamMethodTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("1243")
+@WithJSpecify
+class JSpecifyStreamMethodTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    @WithClasses({
+        NullMarkedSourceBean.class,
+        NullMarkedTargetBean.class,
+        JSpecifyStreamMethodMapper.class
+    })
+    void streamMethodWithNonNullSourceSkipsMethodGuard() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyStreamMethodMapper.class );
+
+        NullMarkedSourceBean source = new NullMarkedSourceBean();
+        source.setNonNullByDefault( "value" );
+
+        List<NullMarkedTargetBean> targets = JSpecifyStreamMethodMapper.INSTANCE
+            .mapAll( Stream.of( source ) )
+            .collect( Collectors.toList() );
+
+        assertThat( targets ).hasSize( 1 );
+        assertThat( targets.get( 0 ).getNonNullByDefault() ).isEqualTo( "value" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedCollectionSourceBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedCollectionSourceBean.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+
+import org.jspecify.annotations.NullMarked;
+
+/**
+ * Source bean with a {@code @NonNull} collection getter (via @NullMarked scope).
+ */
+@NullMarked
+public class NullMarkedCollectionSourceBean {
+
+    private List<String> values;
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedCollectionTargetBean.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/NullMarkedCollectionTargetBean.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class NullMarkedCollectionTargetBean {
+
+    private List<String> values;
+
+    public List<String> getValues() {
+        return values;
+    }
+
+    public void setValues(List<String> values) {
+        this.values = values;
+    }
+}

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyMapMethodMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyMapMethodMapperImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-05-14T23:31:18+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyMapMethodMapperImpl implements JSpecifyMapMethodMapper {
+
+    @Override
+    public Map<String, NullMarkedTargetBean> mapAll(Map<String, NullMarkedSourceBean> sources) {
+
+        Map<String, NullMarkedTargetBean> map = LinkedHashMap.newLinkedHashMap( sources.size() );
+
+        for ( java.util.Map.Entry<String, NullMarkedSourceBean> entry : sources.entrySet() ) {
+            String key = entry.getKey();
+            NullMarkedTargetBean value = map( entry.getValue() );
+            map.put( key, value );
+        }
+
+        return map;
+    }
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnMapMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnMapMapperImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-05-15T00:03:32+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyNonNullReturnMapMapperImpl implements JSpecifyNonNullReturnMapMapper {
+
+    @Override
+    public Map<String, NullMarkedTargetBean> mapAll(Map<String, NullMarkedSourceBean> sources) {
+        if ( sources == null ) {
+            return new LinkedHashMap<>();
+        }
+
+        Map<String, NullMarkedTargetBean> map = LinkedHashMap.newLinkedHashMap( sources.size() );
+
+        for ( java.util.Map.Entry<String, NullMarkedSourceBean> entry : sources.entrySet() ) {
+            String key = entry.getKey();
+            NullMarkedTargetBean value = map( entry.getValue() );
+            map.put( key, value );
+        }
+
+        return map;
+    }
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyCollectionPropertyMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyCollectionPropertyMapperImpl.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-05-14T23:05:10+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyCollectionPropertyMapperImpl implements JSpecifyCollectionPropertyMapper {
+
+    @Override
+    public NullMarkedCollectionTargetBean map(NullMarkedCollectionSourceBean source) {
+
+        NullMarkedCollectionTargetBean nullMarkedCollectionTargetBean = new NullMarkedCollectionTargetBean();
+
+        nullMarkedCollectionTargetBean.setValues( source.getValues() );
+
+        return nullMarkedCollectionTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyIterableMethodMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyIterableMethodMapperImpl.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-05-14T23:18:22+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyIterableMethodMapperImpl implements JSpecifyIterableMethodMapper {
+
+    @Override
+    public List<NullMarkedTargetBean> mapAll(List<NullMarkedSourceBean> sources) {
+
+        List<NullMarkedTargetBean> list = new ArrayList<>( sources.size() );
+        for ( NullMarkedSourceBean nullMarkedSourceBean : sources ) {
+            list.add( map( nullMarkedSourceBean ) );
+        }
+
+        return list;
+    }
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyMapMethodMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyMapMethodMapperImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-05-14T23:30:08+0200",
+    comments = "version: , compiler: Eclipse JDT (Batch) 3.20.0.v20191203-2131, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyMapMethodMapperImpl implements JSpecifyMapMethodMapper {
+
+    @Override
+    public Map<String, NullMarkedTargetBean> mapAll(Map<String, NullMarkedSourceBean> sources) {
+
+        Map<String, NullMarkedTargetBean> map = new LinkedHashMap<>( Math.max( (int) ( sources.size() / .75f ) + 1, 16 ) );
+
+        for ( java.util.Map.Entry<String, NullMarkedSourceBean> entry : sources.entrySet() ) {
+            String key = entry.getKey();
+            NullMarkedTargetBean value = map( entry.getValue() );
+            map.put( key, value );
+        }
+
+        return map;
+    }
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnBeanMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnBeanMapperImpl.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-05-14T23:41:40+0200",
+    comments = "version: , compiler: Eclipse JDT (Batch) 3.20.0.v20191203-2131, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyNonNullReturnBeanMapperImpl implements JSpecifyNonNullReturnBeanMapper {
+
+    @Override
+    public NullMarkedTargetBean map(JSpecifyNonNullReturnBeanSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        if ( source != null ) {
+            nullMarkedTargetBean.setNonNullByDefault( source.getValue() );
+        }
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnIterableMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnIterableMapperImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-05-14T23:55:43+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyNonNullReturnIterableMapperImpl implements JSpecifyNonNullReturnIterableMapper {
+
+    @Override
+    public List<NullMarkedTargetBean> mapAll(List<NullMarkedSourceBean> sources) {
+        if ( sources == null ) {
+            return new ArrayList<>();
+        }
+
+        List<NullMarkedTargetBean> list = new ArrayList<>( sources.size() );
+        for ( NullMarkedSourceBean nullMarkedSourceBean : sources ) {
+            list.add( map( nullMarkedSourceBean ) );
+        }
+
+        return list;
+    }
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnMapMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnMapMapperImpl.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-05-15T00:03:33+0200",
+    comments = "version: , compiler: Eclipse JDT (Batch) 3.20.0.v20191203-2131, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyNonNullReturnMapMapperImpl implements JSpecifyNonNullReturnMapMapper {
+
+    @Override
+    public Map<String, NullMarkedTargetBean> mapAll(Map<String, NullMarkedSourceBean> sources) {
+        if ( sources == null ) {
+            return new LinkedHashMap<>();
+        }
+
+        Map<String, NullMarkedTargetBean> map = new LinkedHashMap<>( Math.max( (int) ( sources.size() / .75f ) + 1, 16 ) );
+
+        for ( java.util.Map.Entry<String, NullMarkedSourceBean> entry : sources.entrySet() ) {
+            String key = entry.getKey();
+            NullMarkedTargetBean value = map( entry.getValue() );
+            map.put( key, value );
+        }
+
+        return map;
+    }
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnStreamMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnStreamMapperImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.stream.Stream;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-06-05T14:55:49+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyNonNullReturnStreamMapperImpl implements JSpecifyNonNullReturnStreamMapper {
+
+    @Override
+    public Stream<NullMarkedTargetBean> mapAll(Stream<NullMarkedSourceBean> sources) {
+        if ( sources == null ) {
+            return Stream.empty();
+        }
+
+        return sources.map( nullMarkedSourceBean -> map( nullMarkedSourceBean ) );
+    }
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnUpdateIterableMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullReturnUpdateIterableMapperImpl.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-06-05T15:01:46+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyNonNullReturnUpdateIterableMapperImpl implements JSpecifyNonNullReturnUpdateIterableMapper {
+
+    @Override
+    public List<NullMarkedTargetBean> mapAll(List<NullMarkedSourceBean> sources, List<NullMarkedTargetBean> target) {
+        if ( sources == null ) {
+            return target;
+        }
+
+        target.clear();
+        for ( NullMarkedSourceBean nullMarkedSourceBean : sources ) {
+            target.add( map( nullMarkedSourceBean ) );
+        }
+
+        return target;
+    }
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableSourceIterableMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableSourceIterableMapperImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-06-05T14:55:49+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyNullableSourceIterableMapperImpl implements JSpecifyNullableSourceIterableMapper {
+
+    @Override
+    public List<NullMarkedTargetBean> mapAll(List<NullMarkedSourceBean> sources) {
+        if ( sources == null ) {
+            return null;
+        }
+
+        List<NullMarkedTargetBean> list = new ArrayList<>( sources.size() );
+        for ( NullMarkedSourceBean nullMarkedSourceBean : sources ) {
+            list.add( map( nullMarkedSourceBean ) );
+        }
+
+        return list;
+    }
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReturnNullOverrideIterableMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReturnNullOverrideIterableMapperImpl.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-06-05T14:55:49+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyReturnNullOverrideIterableMapperImpl implements JSpecifyReturnNullOverrideIterableMapper {
+
+    @Override
+    public List<NullMarkedTargetBean> mapAll(List<NullMarkedSourceBean> sources) {
+        if ( sources == null ) {
+            return new ArrayList<>();
+        }
+
+        List<NullMarkedTargetBean> list = new ArrayList<>( sources.size() );
+        for ( NullMarkedSourceBean nullMarkedSourceBean : sources ) {
+            list.add( map( nullMarkedSourceBean ) );
+        }
+
+        return list;
+    }
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyStreamMethodMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyStreamMethodMapperImpl.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.stream.Stream;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-06-05T14:54:43+0200",
+    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+)
+public class JSpecifyStreamMethodMapperImpl implements JSpecifyStreamMethodMapper {
+
+    @Override
+    public Stream<NullMarkedTargetBean> mapAll(Stream<NullMarkedSourceBean> sources) {
+
+        return sources.map( nullMarkedSourceBean -> map( nullMarkedSourceBean ) );
+    }
+
+    @Override
+    public NullMarkedTargetBean map(NullMarkedSourceBean source) {
+
+        NullMarkedTargetBean nullMarkedTargetBean = new NullMarkedTargetBean();
+
+        nullMarkedTargetBean.setNonNullByDefault( source.getNonNullByDefault() );
+        nullMarkedTargetBean.setExplicitlyNullable( source.getExplicitlyNullable() );
+
+        return nullMarkedTargetBean;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #4056.

Extends the JSpecify support added in #4033:
- `@NonNull` source on collection-typed property mappings skips the wrapping null guard
- Container mapping methods (`Iterable`, `Map`, `Stream`) honor JSpecify on their source parameter
- `@NonNull` mapping-method return type implies `NullValueMappingStrategy.RETURN_DEFAULT` semantics across bean, iterable, map and stream mapping methods

All new behaviour is gated on JSpecify annotations and remains fully suppressed by `mapstruct.disableJSpecify`.