### PR TITLE
Fix Optional target not using static builder factory method

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ObjectFactoryMethodResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ObjectFactoryMethodResolver.java
@@ -135,7 +135,11 @@ public class ObjectFactoryMethodResolver {
     }
 
     public static MethodReference getBuilderFactoryMethod(Method method, BuilderType builder ) {
-        return getBuilderFactoryMethod( method.getReturnType(), builder );
+        Type returnType = method.getReturnType();
+        if ( returnType.isOptionalType() ) {
+            returnType = returnType.getOptionalBaseType();
+        }
+        return getBuilderFactoryMethod( returnType, builder );
     }
 
     public static MethodReference getBuilderFactoryMethod(Type typeToBuild, BuilderType builder ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/optional/builder/crosspackage/CrossPackageOptionalBuilderMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/optional/builder/crosspackage/CrossPackageOptionalBuilderMapper.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.optional.builder.crosspackage;
+
+import java.util.Optional;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.ap.test.optional.builder.crosspackage.dto.PersonTarget;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface CrossPackageOptionalBuilderMapper {
+
+    CrossPackageOptionalBuilderMapper INSTANCE = Mappers.getMapper( CrossPackageOptionalBuilderMapper.class );
+
+    Optional<PersonTarget> toTarget(PersonSource source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/optional/builder/crosspackage/CrossPackageOptionalBuilderTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/optional/builder/crosspackage/CrossPackageOptionalBuilderTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.optional.builder.crosspackage;
+
+import java.util.Optional;
+
+import org.mapstruct.ap.test.optional.builder.crosspackage.dto.PersonTarget;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey( "4046" )
+@WithClasses({ CrossPackageOptionalBuilderMapper.class, PersonSource.class, PersonTarget.class })
+class CrossPackageOptionalBuilderTest {
+
+    @ProcessorTest
+    void shouldUseStaticBuilderMethodForOptionalTargetAcrossPackages() {
+        PersonSource source = new PersonSource( "John" );
+        Optional<PersonTarget> result = CrossPackageOptionalBuilderMapper.INSTANCE.toTarget( source );
+
+        assertThat( result ).isPresent();
+        assertThat( result.get().getName() ).isEqualTo( "John" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/optional/builder/crosspackage/PersonSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/optional/builder/crosspackage/PersonSource.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.optional.builder.crosspackage;
+
+public class PersonSource {
+    private final String name;
+
+    public PersonSource(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/optional/builder/crosspackage/dto/PersonTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/optional/builder/crosspackage/dto/PersonTarget.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.optional.builder.crosspackage.dto;
+
+public class PersonTarget {
+
+    private final String name;
+
+    private PersonTarget(PersonTargetBuilder builder) {
+        this.name = builder.name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public static PersonTargetBuilder builder() {
+        return new PersonTargetBuilder();
+    }
+
+    public static class PersonTargetBuilder {
+
+        private String name;
+
+        PersonTargetBuilder() { }
+
+        public PersonTargetBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public PersonTarget build() {
+            return new PersonTarget( this );
+        }
+    }
+}


### PR DESCRIPTION
When the return type of a mapping method is Optional<T> and T uses a 
Lombok @Builder, MapStruct was generating new T.TBuilder() instead of 
T.builder(). This caused a compilation error when the mapper and T are 
in different packages, because the generated builder constructor is 
package-private.

Root cause: ObjectFactoryMethodResolver.getBuilderFactoryMethod(Method, BuilderType) 
was passing method.getReturnType() (i.e. Optional<T>) to the overload 
that checks assignability. Since T is not assignable to Optional<T>, 
the check failed and returned null, causing the fallback to use the 
constructor directly.

Fix: Unwrap the Optional type before passing to the overload.

Fixes #4046