### PR TITLE
#3948 Generic types of declared type must match exactly

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -1842,6 +1842,13 @@ public class Type extends ModelElement implements Comparable<Type> {
                 for ( int i = 0; i < parameterized.getTypeArguments().size(); i++ ) {
                     TypeMirror parameterizedTypeArg = parameterized.getTypeArguments().get( i );
                     Type declaredTypeArg = declared.getTypeParameters().get( i );
+                    if ( parameterizedTypeArg.getKind() == TypeKind.DECLARED &&
+                            !types.isSameType( types.erasure( parameterizedTypeArg ),
+                                    types.erasure( declaredTypeArg.getTypeMirror() ) ) ) {
+                        // Comparable<Long> can never be assigned Comparable<Number>
+                        // Generics enforce exact matches for declared types
+                       return DEFAULT_VALUE;
+                    }
                     ResolvedPair result = visit( parameterizedTypeArg, declaredTypeArg );
                     if ( result != super.DEFAULT_VALUE ) {
                         results.add( result );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3948/Issue3948Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3948/Issue3948Mapper.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3948;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper
+public interface Issue3948Mapper {
+
+    class ComparableField implements Comparable<ComparableField> {
+
+        private final String code;
+
+        public ComparableField(String code) {
+            this.code = code;
+        }
+
+        @Override
+        public int compareTo(ComparableField o) {
+            return code.compareTo( o.code );
+        }
+    }
+
+    class Id<T> implements Comparable<Id<T>> {
+        private final long value;
+
+        public Id(long value) {
+            this.value = value;
+        }
+
+        @Override
+        public int compareTo(Id<T> o) {
+            return Long.compare( value, o.value );
+        }
+    }
+
+    class From {
+        private long id;
+        private String code;
+
+        public long getId() {
+            return id;
+        }
+
+        public void setId(long id) {
+            this.id = id;
+        }
+
+        public String getCode() {
+            return code;
+        }
+
+        public void setCode(String code) {
+            this.code = code;
+        }
+    }
+
+    class To {
+        private Id<To> id;
+        private ComparableField comparableField;
+
+        public Id<To> getId() {
+            return id;
+        }
+
+        public void setId(Id<To> id) {
+            this.id = id;
+        }
+
+        public ComparableField getComparableField() {
+            return comparableField;
+        }
+
+        public void setComparableField(ComparableField comparableField) {
+            this.comparableField = comparableField;
+        }
+    }
+
+    @Mapping(source = "code", target = "comparableField")
+    To convert(From from);
+
+    default <T> Id<T> longToId(Long id) {
+        return id == null ? null : new Id<>(id);
+    }
+
+    default ComparableField convert(String code) {
+        return code == null ? null : new ComparableField(code);
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_3948/Issue3948Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_3948/Issue3948Test.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._3948;
+
+import org.junitpioneer.jupiter.Issue;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+/**
+ * @author hduelme
+ */
+@Issue("3948")
+public class Issue3948Test {
+
+    @ProcessorTest
+    @WithClasses(Issue3948Mapper.class)
+    public void shouldRequireExactGenericMatchForDeclaredSameTypes() {
+
+    }
+}


### PR DESCRIPTION
Fixes #3948 and #3945.
The main issue was that MapStruct tries to match declared generic types even when they are not compatible. This results in an infinite loop when the type has a self-reference.

I used a modified version of the code provided in #3948 as a test case. I also manually tested the scenario using the repository linked in #3945 with local fixes applied.