### PR TITLE
#4060 Report compilation error for SET_TO_DEFAULT without accessible no-args constructor

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -549,7 +549,7 @@ public class PropertyMapping extends ModelElement {
                 ctx.getMessager().printMessage(
                     method.getExecutable(),
                     positionHint,
-                    Message.GENERAL_NO_SUITABLE_CONSTRUCTOR,
+                    Message.PROPERTYMAPPING_NO_ACCESSIBLE_PARAMETERLESS_CONSTRUCTOR,
                     typeToConstruct.describe()
                 );
             }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -485,6 +485,7 @@ public class PropertyMapping extends ModelElement {
                         includeSourceNullCheck = false;
                     }
                 }
+                reportErrorWhenSetToDefaultCannotConstructTarget( targetType, factory );
                 return new UpdateWrapper(
                     rhs,
                     method.getThrownTypes(),
@@ -505,6 +506,7 @@ public class PropertyMapping extends ModelElement {
                     // however, a local var is not needed if there's no need to check for null.
                     rhs.setSourceLocalVarName( null );
                 }
+                reportErrorWhenSetToDefaultCannotConstructTarget( targetType, null );
                 return new SetterWrapper(
                     rhs,
                     method.getThrownTypes(),
@@ -514,6 +516,41 @@ public class PropertyMapping extends ModelElement {
                     nvpms == SET_TO_DEFAULT,
                     hasTwoOrMoreSettersWithName(),
                     targetType
+                );
+            }
+        }
+
+        /**
+         * For {@code NullValuePropertyMappingStrategy.SET_TO_DEFAULT} the target property is reset to a new
+         * default instance when the source is {@code null}. When that default instance is constructed via a
+         * parameterless constructor ({@code new Target()}) and the target type does not provide one, MapStruct
+         * would generate uncompilable code such as {@code target.setLocalDate( new LocalDate() )}. Report a
+         * compilation error in that case instead.
+         *
+         * @param targetType the type of the target property
+         * @param factory the factory used to construct the default instance, or {@code null} if none is used
+         */
+        private void reportErrorWhenSetToDefaultCannotConstructTarget(Type targetType, Assignment factory) {
+            if ( nvpms != SET_TO_DEFAULT || factory != null ) {
+                // the default instance is either not created or created through a factory / builder method
+                return;
+            }
+
+            Type typeToConstruct = targetType.isOptionalType() ? targetType.getOptionalBaseType() : targetType;
+            if ( typeToConstruct.getImplementationType() != null
+                || typeToConstruct.isArrayType()
+                || typeToConstruct.isOptionalType()
+                || typeToConstruct.getSensibleDefault() != null ) {
+                // these are initialized without invoking a parameterless constructor on the target type
+                return;
+            }
+
+            if ( !typeToConstruct.hasAccessibleParameterlessConstructor() ) {
+                ctx.getMessager().printMessage(
+                    method.getExecutable(),
+                    positionHint,
+                    Message.GENERAL_NO_SUITABLE_CONSTRUCTOR,
+                    typeToConstruct.describe()
                 );
             }
         }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Type.java
@@ -1560,6 +1560,30 @@ public class Type extends ModelElement implements Comparable<Type> {
         return hasAccessibleConstructor;
     }
 
+    /**
+     * Whether this type can be instantiated through an accessible parameterless constructor, i.e. via
+     * {@code new Type()}. Unlike {@link #hasAccessibleConstructor()} this returns {@code false} for types that
+     * only expose constructors with parameters (e.g. {@code BigDecimal}).
+     *
+     * @return {@code true} if a {@code new Type()} call would compile, {@code false} otherwise
+     */
+    public boolean hasAccessibleParameterlessConstructor() {
+        if ( typeElement == null || isInterface() || isAbstract() || isEnumType() ) {
+            return false;
+        }
+        List<ExecutableElement> constructors = ElementFilter.constructorsIn( typeElement.getEnclosedElements() );
+        if ( constructors.isEmpty() ) {
+            // no declared constructors means the implicit, accessible default constructor is available
+            return true;
+        }
+        for ( ExecutableElement constructor : constructors ) {
+            if ( !constructor.getModifiers().contains( Modifier.PRIVATE ) && constructor.getParameters().isEmpty() ) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     public KotlinMetadata getKotlinMetadata() {
         if ( !kotlinMetadataInitialized ) {
             kotlinMetadataInitialized = true;

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -94,6 +94,7 @@ public enum Message {
     PROPERTYMAPPING_CANNOT_DETERMINE_SOURCE_PROPERTY_FROM_TARGET("The type of parameter \"%s\" has no property named \"%s\". Please define the source property explicitly."),
     PROPERTYMAPPING_CANNOT_DETERMINE_SOURCE_PARAMETER_FROM_TARGET("No property named \"%s\" exists in source parameter(s). Please define the source explicitly."),
     PROPERTYMAPPING_NO_SUITABLE_COLLECTION_OR_MAP_CONSTRUCTOR( "%s does not have an accessible copy or no-args constructor." ),
+    PROPERTYMAPPING_NO_ACCESSIBLE_PARAMETERLESS_CONSTRUCTOR( "%s does not have an accessible parameterless constructor. Either change the nullValuePropertyMappingStrategy or define a defaultValue or a defaultExpression." ),
     PROPERTYMAPPING_EXPRESSION_AND_CONDITION_QUALIFIED_BY_NAME_BOTH_DEFINED( "Expression and condition qualified by name are both defined in @Mapping, either define an expression or a condition qualified by name." ),
     PROPERTYMAPPING_TARGET_HAS_NO_TARGET_PROPERTIES( "No target property found for target \"%s\".", Diagnostic.Kind.WARNING ),
     PROPERTYMAPPING_NULLABLE_SOURCE_TO_NON_NULL_CONSTRUCTOR_PARAM( "Can't map potentially nullable source property \"%s\" to @NonNull constructor parameter \"%s\". Consider adding a defaultValue or defaultExpression." ),

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4060/ErroneousSetToDefaultMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4060/ErroneousSetToDefaultMapper.java
@@ -52,6 +52,37 @@ public interface ErroneousSetToDefaultMapper {
         }
     }
 
+    abstract class AbstractValue {
+    }
+
+    class WithAbstractValue {
+        private AbstractValue value;
+
+        public AbstractValue getValue() {
+            return value;
+        }
+
+        public void setValue(AbstractValue value) {
+            this.value = value;
+        }
+    }
+
+    enum EnumValue {
+        FIRST
+    }
+
+    class WithEnumValue {
+        private EnumValue value;
+
+        public EnumValue getValue() {
+            return value;
+        }
+
+        public void setValue(EnumValue value) {
+            this.value = value;
+        }
+    }
+
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_DEFAULT)
     void updateLocalDate(@MappingTarget WithLocalDate target, WithLocalDate source);
 
@@ -60,4 +91,10 @@ public interface ErroneousSetToDefaultMapper {
 
     @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_DEFAULT)
     void updateComparable(@MappingTarget WithComparable target, WithComparable source);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_DEFAULT)
+    void updateAbstractValue(@MappingTarget WithAbstractValue target, WithAbstractValue source);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_DEFAULT)
+    void updateEnumValue(@MappingTarget WithEnumValue target, WithEnumValue source);
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4060/ErroneousSetToDefaultMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4060/ErroneousSetToDefaultMapper.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4060;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+
+@Mapper
+public interface ErroneousSetToDefaultMapper {
+
+    class WithLocalDate {
+        private LocalDate value;
+
+        public LocalDate getValue() {
+            return value;
+        }
+
+        public void setValue(LocalDate value) {
+            this.value = value;
+        }
+    }
+
+    class WithBigDecimal {
+        private BigDecimal value;
+
+        public BigDecimal getValue() {
+            return value;
+        }
+
+        public void setValue(BigDecimal value) {
+            this.value = value;
+        }
+    }
+
+    class WithComparable {
+        private Comparable<String> value;
+
+        public Comparable<String> getValue() {
+            return value;
+        }
+
+        public void setValue(Comparable<String> value) {
+            this.value = value;
+        }
+    }
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_DEFAULT)
+    void updateLocalDate(@MappingTarget WithLocalDate target, WithLocalDate source);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_DEFAULT)
+    void updateBigDecimal(@MappingTarget WithBigDecimal target, WithBigDecimal source);
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_DEFAULT)
+    void updateComparable(@MappingTarget WithComparable target, WithComparable source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4060/Issue4060Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4060/Issue4060Test.java
@@ -23,16 +23,36 @@ public class Issue4060Test {
         diagnostics = {
             @Diagnostic(type = ErroneousSetToDefaultMapper.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
-                line = 56,
-                message = "LocalDate does not have an accessible constructor."),
+                line = 87,
+                message = "LocalDate does not have an accessible parameterless constructor. " +
+                    "Either change the nullValuePropertyMappingStrategy or define a defaultValue " +
+                    "or a defaultExpression."),
             @Diagnostic(type = ErroneousSetToDefaultMapper.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
-                line = 59,
-                message = "BigDecimal does not have an accessible constructor."),
+                line = 90,
+                message = "BigDecimal does not have an accessible parameterless constructor. " +
+                    "Either change the nullValuePropertyMappingStrategy or define a defaultValue " +
+                    "or a defaultExpression."),
             @Diagnostic(type = ErroneousSetToDefaultMapper.class,
                 kind = javax.tools.Diagnostic.Kind.ERROR,
-                line = 62,
-                message = "Comparable<String> does not have an accessible constructor.")
+                line = 93,
+                message = "Comparable<String> does not have an accessible parameterless constructor. " +
+                    "Either change the nullValuePropertyMappingStrategy or define a defaultValue " +
+                    "or a defaultExpression."),
+            @Diagnostic(type = ErroneousSetToDefaultMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 96,
+                message = "ErroneousSetToDefaultMapper.AbstractValue does not have an accessible " +
+                    "parameterless constructor. " +
+                    "Either change the nullValuePropertyMappingStrategy or define a defaultValue " +
+                    "or a defaultExpression."),
+            @Diagnostic(type = ErroneousSetToDefaultMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 99,
+                message = "ErroneousSetToDefaultMapper.EnumValue does not have an accessible " +
+                    "parameterless constructor. " +
+                    "Either change the nullValuePropertyMappingStrategy or define a defaultValue " +
+                    "or a defaultExpression.")
         })
     void setToDefaultWithoutParameterlessConstructorFails() {
     }

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4060/Issue4060Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4060/Issue4060Test.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4060;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("4060")
+public class Issue4060Test {
+
+    @ProcessorTest
+    @WithClasses(ErroneousSetToDefaultMapper.class)
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousSetToDefaultMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 56,
+                message = "LocalDate does not have an accessible constructor."),
+            @Diagnostic(type = ErroneousSetToDefaultMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 59,
+                message = "BigDecimal does not have an accessible constructor."),
+            @Diagnostic(type = ErroneousSetToDefaultMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                line = 62,
+                message = "Comparable<String> does not have an accessible constructor.")
+        })
+    void setToDefaultWithoutParameterlessConstructorFails() {
+    }
+
+    @ProcessorTest
+    @WithClasses(SetToDefaultMapper.class)
+    void setToDefaultWithParameterlessConstructorResetsToNewInstance() {
+        SetToDefaultMapper.Target target = new SetToDefaultMapper.Target();
+        SetToDefaultMapper.Nested existing = new SetToDefaultMapper.Nested();
+        existing.setName( "existing" );
+        target.setNested( existing );
+        target.setText( "existing" );
+
+        SetToDefaultMapper.INSTANCE.update( target, new SetToDefaultMapper.Source() );
+
+        // source properties are null, SET_TO_DEFAULT resets them to a fresh default
+        assertThat( target.getNested() ).isNotNull();
+        assertThat( target.getNested() ).isNotSameAs( existing );
+        assertThat( target.getNested().getName() ).isNull();
+        assertThat( target.getText() ).isEmpty();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4060/SetToDefaultMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4060/SetToDefaultMapper.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4060;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface SetToDefaultMapper {
+
+    SetToDefaultMapper INSTANCE = Mappers.getMapper( SetToDefaultMapper.class );
+
+    class Nested {
+        private String name;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+    }
+
+    class Target {
+        private Nested nested;
+        private String text;
+
+        public Nested getNested() {
+            return nested;
+        }
+
+        public void setNested(Nested nested) {
+            this.nested = nested;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
+    }
+
+    class Source {
+        private Nested nested;
+        private String text;
+
+        public Nested getNested() {
+            return nested;
+        }
+
+        public void setNested(Nested nested) {
+            this.nested = nested;
+        }
+
+        public String getText() {
+            return text;
+        }
+
+        public void setText(String text) {
+            this.text = text;
+        }
+    }
+
+    @BeanMapping(nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_DEFAULT)
+    void update(@MappingTarget Target target, Source source);
+}


### PR DESCRIPTION
Fixes #4060

### Problem

When updating an existing bean with `NullValuePropertyMappingStrategy.SET_TO_DEFAULT`, MapStruct resets a `null` source property by creating a fresh default instance via the parameterless constructor (`new Target()`). For target property types that do **not** expose an accessible no-args constructor (e.g. `LocalDate`, `LocalDateTime`, `Instant`, `BigDecimal`, `BigInteger`, `Comparable`), this generated uncompilable code such as:

```java
target.setLocalDate( new LocalDate() );
```

As requested in the issue, MapStruct should report a compilation error during annotation processing rather than emitting code that fails to compile.

### Change

- `Type#hasAccessibleParameterlessConstructor()` — new helper that returns `true` only when `new Type()` would actually compile (an implicit default constructor, or a declared non-private no-args constructor). Unlike the existing `hasAccessibleConstructor()`, it returns `false` for types that only expose parameterized constructors (e.g. `BigDecimal`).
- `PropertyMapping#assignToPlainViaSetter(...)` — for the `SET_TO_DEFAULT` case, when the default instance would be built through a parameterless constructor (no factory/builder) and the target type lacks an accessible one, report `GENERAL_NO_SUITABLE_CONSTRUCTOR` (the message referenced in the issue). Types that are initialized differently — those with an implementation type (collections/maps), arrays, `Optional`, or a sensible default — are intentionally excluded.

### Test evidence

Added `org.mapstruct.ap.test.bugs._4060.Issue4060Test`:
- `setToDefaultWithoutParameterlessConstructorFails` — asserts the expected compilation errors for `LocalDate`, `BigDecimal` and `Comparable<String>`.
- `setToDefaultWithParameterlessConstructorResetsToNewInstance` — verifies the existing reset-to-new-instance behaviour still works for constructible types.

Local run (JDK toolchain, `processor` module):
- `Issue4060Test` — 4 tests, 0 failures.
- Related regression tests pass: `Issue1790Test`, `Issue3884Test`, `JSpecifySafetyGuardTest`, `NullValuePropertyMappingTest`, `NullValuePropertyMappingClearTest`.
- `checkstyle:check` on the `processor` module passes.

### Verification done
1. No in-flight PR (`gh pr list --search` for 4060 / SET_TO_DEFAULT constructor) and no self-claim comments on the issue.
3. Fix touches `.java` files only.
4. Reproduced the bug against `main` (`453602e`): without the change the erroneous mapper compiles and emits `new LocalDate()`; with the change the documented compilation error is raised.
5. No parent epic — issue is standalone and labelled `bug`, `hack.commit.push`.