### PR TITLE
Improve JavaFileAssert#hasSameMapperContent to include File Information for the diff

### DIFF
--- a/processor/src/test/java/org/mapstruct/ap/testutil/assertions/JavaFileAssert.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/assertions/JavaFileAssert.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,6 +19,7 @@ import org.assertj.core.error.ShouldHaveSameContent;
 import org.assertj.core.internal.Diff;
 import org.assertj.core.internal.Failures;
 import org.assertj.core.util.diff.Delta;
+import org.opentest4j.FileInfo;
 
 import static java.lang.String.format;
 
@@ -81,8 +83,22 @@ public class JavaFileAssert extends FileAssert {
             ) );
             diffs.removeIf( this::ignoreDelta );
             if ( !diffs.isEmpty() ) {
+                FileInfo actualInfo;
+                FileInfo expectedInfo;
+                try {
+                    actualInfo = new FileInfo( actual.getAbsolutePath(), Files.readAllBytes( actual.toPath() ) );
+                    expectedInfo = new FileInfo( expected.getAbsolutePath(), Files.readAllBytes( expected.toPath() ) );
+                }
+                catch ( IOException e ) {
+                    throw new RuntimeException( e );
+                }
                 throw Failures.instance()
-                    .failure( info, ShouldHaveSameContent.shouldHaveSameContent( actual, expected, diffs ) );
+                    .failure(
+                        info,
+                        ShouldHaveSameContent.shouldHaveSameContent( actual, expected, diffs ),
+                        actualInfo,
+                        expectedInfo
+                    );
             }
         }
         catch ( IOException e ) {

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/CompilingExtension.java
@@ -674,7 +674,7 @@ abstract class CompilingExtension implements BeforeEachCallback {
         return !compilationRequest.equals( compilationCache.getLastRequest() );
     }
 
-    private static String getBasePath() {
+    static String getBasePath() {
         try {
             return new File( "." ).getCanonicalPath();
         }

--- a/processor/src/test/java/org/mapstruct/ap/testutil/runner/GeneratedSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/testutil/runner/GeneratedSource.java
@@ -6,9 +6,6 @@
 package org.mapstruct.ap.testutil.runner;
 
 import java.io.File;
-import java.net.URL;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -19,6 +16,7 @@ import org.mapstruct.ap.testutil.assertions.JavaFileAssert;
 
 import static org.assertj.core.api.Assertions.fail;
 import static org.mapstruct.ap.testutil.runner.CompilingExtension.NAMESPACE;
+import static org.mapstruct.ap.testutil.runner.CompilingExtension.getBasePath;
 
 /**
  * A {@link org.junit.jupiter.api.extension.RegisterExtension RegisterExtension} to perform assertions on generated
@@ -36,6 +34,7 @@ import static org.mapstruct.ap.testutil.runner.CompilingExtension.NAMESPACE;
 public class GeneratedSource implements BeforeTestExecutionCallback, AfterTestExecutionCallback {
 
     private static final String FIXTURES_ROOT = "fixtures/";
+    private static final String FIXTURES_DIR = getBasePath() + "/src/test/resources/fixtures/";
 
     /**
      * ThreadLocal, as the source dir must be injected for this extension to gain access
@@ -139,8 +138,8 @@ public class GeneratedSource implements BeforeTestExecutionCallback, AfterTestEx
     private void handleFixtureComparison() {
         for ( FixtureComparison fixture : fixturesFor ) {
             String fixtureName = getFixtureName( fixture.mapperClass, fixture.variant );
-            URL expectedFile = getExpectedResource( fixtureName );
-            if ( expectedFile == null ) {
+            File expectedFile = getExpectedResource( fixtureName );
+            if ( !expectedFile.exists() ) {
                 fail( String.format(
                     "No reference file could be found for Mapper %s. You should create a file %s",
                     fixture.mapperClass.getName(),
@@ -148,8 +147,7 @@ public class GeneratedSource implements BeforeTestExecutionCallback, AfterTestEx
                 ) );
             }
             else {
-                File expectedResource = new File( URLDecoder.decode( expectedFile.getFile(), StandardCharsets.UTF_8 ) );
-                forMapper( fixture.mapperClass ).hasSameMapperContent( expectedResource );
+                forMapper( fixture.mapperClass ).hasSameMapperContent( expectedFile );
             }
         }
     }
@@ -159,16 +157,15 @@ public class GeneratedSource implements BeforeTestExecutionCallback, AfterTestEx
         return mapperClass.getName().replace( '.', '/' ).concat( suffix );
     }
 
-    private URL getExpectedResource(String fixtureName) {
-        ClassLoader classLoader = getClass().getClassLoader();
+    private File getExpectedResource(String fixtureName) {
         for ( int version = Runtime.version().feature(); version >= 11 && compiler != Compiler.ECLIPSE; version-- ) {
-            URL resource = classLoader.getResource( FIXTURES_ROOT + "/" + version + "/" + fixtureName );
-            if ( resource != null ) {
-                return resource;
+            File fixtureFile = new File( FIXTURES_DIR + version + File.separator + fixtureName );
+            if ( fixtureFile.exists() ) {
+                return fixtureFile;
             }
         }
 
-        return classLoader.getResource( FIXTURES_ROOT + fixtureName );
+        return new File( FIXTURES_DIR + fixtureName );
     }
 
     private static final class FixtureComparison {


### PR DESCRIPTION
The `FileInfo` from Open Test Alliance for the JVM allows the IDE to display a diff between 2 files nicely in the UI. This makes it easier to compare failing fixtures and immediately copy what you want to the fixture. Also improve the loading of the expected fixture from the resource folder instead of the compilation folder

Before:

<img width="935" height="473" alt="image" src="https://github.com/user-attachments/assets/4336c012-feb9-4f86-aeeb-78d397076c75" />



After:

<img width="924" height="523" alt="image" src="https://github.com/user-attachments/assets/d6c3f248-002f-43c5-b475-98bd29692816" />

The new part is the "<Click to see difference>" which takes you to:

<img width="1504" height="955" alt="image" src="https://github.com/user-attachments/assets/cad70201-a501-41e0-983c-af48c0744430" />

