### PR TITLE
Fix #4030 remove double getters in null checks

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
@@ -37,7 +37,7 @@ import static org.mapstruct.ap.internal.gem.NullValuePropertyMappingStrategyGem.
 
 /**
  * A builder that is used for creating an assignment to a collection.
- *
+ * <p>
  * The created assignments to the following null checks:
  * <ul>
  *     <li>source-null-check - For this the {@link SetterWrapperForCollectionsAndMapsWithNullCheck} is used when a
@@ -49,7 +49,7 @@ import static org.mapstruct.ap.internal.gem.NullValuePropertyMappingStrategyGem.
  *     <li>local-var-null-check - Done in {@link ExistingInstanceSetterWrapperForCollectionsAndMaps}, and
  *     {@link SetterWrapperForCollectionsAndMapsWithNullCheck}</li>
  * </ul>
- *
+ * <p>
  * A local-var-null-check is needed in the following cases:
  *
  * <ul>
@@ -106,7 +106,6 @@ public class CollectionAssignmentBuilder {
 
     /**
      * @param assignment the assignment that needs to be invoked
-     *
      * @return this builder for chaining
      */
     public CollectionAssignmentBuilder assignment(Assignment assignment) {
@@ -116,7 +115,6 @@ public class CollectionAssignmentBuilder {
 
     /**
      * @param sourceRHS the source right hand side for getting the property for mapping
-     *
      * @return this builder for chaining
      */
     public CollectionAssignmentBuilder rightHandSide(SourceRHS sourceRHS) {
@@ -124,12 +122,12 @@ public class CollectionAssignmentBuilder {
         return this;
     }
 
-    public CollectionAssignmentBuilder nullValueCheckStrategy( NullValueCheckStrategyGem nvcs ) {
+    public CollectionAssignmentBuilder nullValueCheckStrategy(NullValueCheckStrategyGem nvcs) {
         this.nvcs = nvcs;
         return this;
     }
 
-    public CollectionAssignmentBuilder nullValuePropertyMappingStrategy( NullValuePropertyMappingStrategyGem nvpms ) {
+    public CollectionAssignmentBuilder nullValuePropertyMappingStrategy(NullValuePropertyMappingStrategyGem nvpms) {
         this.nvpms = nvpms;
         return this;
     }
@@ -178,8 +176,12 @@ public class CollectionAssignmentBuilder {
                     ctx.getTypeFactory(),
                     targetAccessorType.isFieldAssignment()
                 );
+                if ( result.getSourceType().isPrimitive() ) {
+                    result.setSourceLocalVarName( null );
+                }
             }
-            else if ( method.isUpdateMethod() && nvpms == IGNORE ) {
+            else if ( method.isUpdateMethod() && nvpms == IGNORE
+                || setterWrapperNeedsSourceNullCheck( result ) && canBeMappedOrDirectlyAssigned( result ) ) {
 
                 result = new SetterWrapperForCollectionsAndMapsWithNullCheck(
                     result,
@@ -188,17 +190,7 @@ public class CollectionAssignmentBuilder {
                     ctx.getTypeFactory(),
                     targetAccessorType.isFieldAssignment()
                 );
-            }
-            else if ( setterWrapperNeedsSourceNullCheck( result )
-                && canBeMappedOrDirectlyAssigned( result ) ) {
-
-                result = new SetterWrapperForCollectionsAndMapsWithNullCheck(
-                    result,
-                    method.getThrownTypes(),
-                    targetType,
-                    ctx.getTypeFactory(),
-                    targetAccessorType.isFieldAssignment()
-                );
+                result.setSourceLocalVarName( null );
             }
             else if ( canBeMappedOrDirectlyAssigned( result ) ) {
                 //TODO init default value
@@ -210,6 +202,7 @@ public class CollectionAssignmentBuilder {
                     targetType,
                     targetAccessorType.isFieldAssignment()
                 );
+                result.setSourceLocalVarName( null );
             }
             else if ( hasNoArgsConstructor() ) {
                 result = new NewInstanceSetterWrapperForCollectionsAndMaps(
@@ -217,7 +210,9 @@ public class CollectionAssignmentBuilder {
                     method.getThrownTypes(),
                     targetType,
                     ctx.getTypeFactory(),
-                    targetAccessorType.isFieldAssignment() );
+                    targetAccessorType.isFieldAssignment()
+                );
+                result.setSourceLocalVarName( null );
             }
             else {
                 ctx.getMessager().printMessage(
@@ -244,6 +239,7 @@ public class CollectionAssignmentBuilder {
                 nvpms,
                 targetAccessorType.isFieldAssignment()
             );
+            result.setSourceLocalVarName( null );
         }
 
         return result;
@@ -251,8 +247,8 @@ public class CollectionAssignmentBuilder {
 
     private boolean canBeMappedOrDirectlyAssigned(Assignment result) {
         return result.getType() != AssignmentType.DIRECT
-                  || hasCopyConstructor()
-                  || targetType.isEnumSet();
+            || hasCopyConstructor()
+            || targetType.isEnumSet();
     }
 
     /**
@@ -294,8 +290,8 @@ public class CollectionAssignmentBuilder {
             }
             else {
                 Element sourceElement = targetType.getImplementationType() != null
-                                      ? targetType.getImplementationType().getTypeElement()
-                                      : targetType.getTypeElement();
+                    ? targetType.getImplementationType().getTypeElement()
+                    : targetType.getTypeElement();
                 if ( sourceElement != null ) {
                     for ( Element element : sourceElement.getEnclosedElements() ) {
                         if ( element.getKind() == ElementKind.CONSTRUCTOR

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -35,6 +35,7 @@ import org.mapstruct.ap.internal.model.common.BuilderType;
 import org.mapstruct.ap.internal.model.common.FormattingParameters;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Parameter;
+import org.mapstruct.ap.internal.model.common.ParameterBinding;
 import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.SourceRHS;
 import org.mapstruct.ap.internal.model.common.Type;
@@ -660,6 +661,11 @@ public class PropertyMapping extends ModelElement {
         private Assignment assignToPlainViaAdder( Assignment rightHandSide) {
 
             Assignment result = rightHandSide;
+            if ( sourceReference == null || !sourceReference.isNested() ) {
+                // For non-nested properties, reset the local var name: the adder wrapper handles
+                // the source reference inline without needing a local variable.
+                result.setSourceLocalVarName( null );
+            }
 
             String adderIteratorName = sourcePropertyName == null ? targetPropertyName : sourcePropertyName;
             if ( result.getSourceType().isIterableType() ) {
@@ -767,6 +773,9 @@ public class PropertyMapping extends ModelElement {
                     sourceReference,
                     sourceRHS
                 ) );
+                if ( presenceCheckAllowsLocalVar( sourceRHS.getSourcePresenceCheckerReference() ) ) {
+                    sourceRHS.setSourceLocalVarName( sourceRHS.createUniqueVarName( propertyEntry.getName() ) );
+                }
                 return sourceRHS;
             }
             // nested property given as dot path
@@ -819,6 +828,14 @@ public class PropertyMapping extends ModelElement {
                 return sourceRhs;
 
             }
+        }
+
+        private boolean presenceCheckAllowsLocalVar(PresenceCheck presenceCheck) {
+            if ( presenceCheck instanceof MethodReferencePresenceCheck ) {
+                return ((MethodReferencePresenceCheck) presenceCheck).getMethodReference().getParameterBindings()
+                    .stream().anyMatch( ParameterBinding::isForSourceRhs );
+            }
+            return true;
         }
 
         private PresenceCheck getSourcePresenceCheckerRef(SourceReference sourceReference,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/TypeConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/TypeConversion.java
@@ -49,6 +49,14 @@ public class TypeConversion extends ModelElement implements Assignment {
 
     @Override
     public Set<Type> getImportTypes() {
+        if ( assignment != null ) {
+            Set<Type> assignmentImports = assignment.getImportTypes();
+            if ( !assignmentImports.isEmpty() ) {
+                Set<Type> combined = new HashSet<>( importTypes );
+                combined.addAll( assignmentImports );
+                return combined;
+            }
+        }
         return importTypes;
     }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ArrayCopyWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/ArrayCopyWrapper.java
@@ -33,7 +33,9 @@ public class ArrayCopyWrapper extends AssignmentWrapper {
         super( rhs, fieldAssignment );
         this.arraysType = arraysType;
         this.targetType = targetType;
-        rhs.setSourceLocalVarName( rhs.createUniqueVarName( targetPropertyName ) );
+        if ( rhs.getSourceLocalVarName() == null ) {
+            rhs.setSourceLocalVarName( rhs.createUniqueVarName( targetPropertyName ) );
+        }
         this.setExplicitlyToDefault = setExplicitlyToDefault;
         this.setExplicitlyToNull = setExplicitlyToNull;
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/SourceRHS.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/SourceRHS.java
@@ -7,6 +7,7 @@ package org.mapstruct.ap.internal.model.common;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
@@ -17,7 +18,7 @@ import static org.mapstruct.ap.internal.util.Collections.first;
 
 /**
  * SourceRHS Assignment. Right Hand Side (RHS), source part of the assignment.
- *
+ * <p>
  * This class contains all information on the source side of an assignment needed for common use in the mapping.
  *
  * @author Sjaak Derksen
@@ -35,12 +36,12 @@ public class SourceRHS extends ModelElement implements Assignment {
     private final String sourceParameterName;
 
     public SourceRHS(String sourceReference, Type sourceType, Set<String> existingVariableNames,
-        String sourceErrorMessagePart ) {
+                     String sourceErrorMessagePart) {
         this( sourceReference, sourceReference, null, sourceType, existingVariableNames, sourceErrorMessagePart );
     }
 
     public SourceRHS(String sourceParameterName, String sourceReference, PresenceCheck sourcePresenceCheckerReference,
-        Type sourceType, Set<String> existingVariableNames,  String sourceErrorMessagePart ) {
+                     Type sourceType, Set<String> existingVariableNames, String sourceErrorMessagePart) {
         this.sourceReference = sourceReference;
         this.sourceType = sourceType;
         this.existingVariableNames = existingVariableNames;
@@ -100,6 +101,14 @@ public class SourceRHS extends ModelElement implements Assignment {
 
     @Override
     public Set<Type> getImportTypes() {
+        if ( sourceLocalVarName != null ) {
+            Set<Type> imports = new HashSet<>();
+            imports.add( sourceType );
+            if ( sourcePresenceCheckerReference != null ) {
+                imports.addAll( sourcePresenceCheckerReference.getImportTypes() );
+            }
+            return imports;
+        }
         if ( sourcePresenceCheckerReference != null ) {
             return sourcePresenceCheckerReference.getImportTypes();
         }
@@ -113,7 +122,7 @@ public class SourceRHS extends ModelElement implements Assignment {
     }
 
     @Override
-    public void setAssignment( Assignment assignment ) {
+    public void setAssignment(Assignment assignment) {
         throw new UnsupportedOperationException( "Not supported." );
     }
 

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_3591/ContainerBeanMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_3591/ContainerBeanMapperImpl.java
@@ -23,8 +23,9 @@ public class ContainerBeanMapperImpl implements ContainerBeanMapper {
             return containerBeanDto;
         }
 
+        Map<String, ContainerBean> beanMap = containerBean.getBeanMap();
         if ( containerBeanDto.getBeanMap() != null ) {
-            Map<String, ContainerBeanDto> map = stringContainerBeanMapToStringContainerBeanDtoMap( containerBean.getBeanMap() );
+            Map<String, ContainerBeanDto> map = stringContainerBeanMapToStringContainerBeanDtoMap( beanMap );
             if ( map != null ) {
                 containerBeanDto.getBeanMap().clear();
                 containerBeanDto.getBeanMap().putAll( map );
@@ -34,7 +35,7 @@ public class ContainerBeanMapperImpl implements ContainerBeanMapper {
             }
         }
         else {
-            Map<String, ContainerBeanDto> map = stringContainerBeanMapToStringContainerBeanDtoMap( containerBean.getBeanMap() );
+            Map<String, ContainerBeanDto> map = stringContainerBeanMapToStringContainerBeanDtoMap( beanMap );
             if ( map != null ) {
                 containerBeanDto.setBeanMap( map );
             }

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
@@ -59,56 +59,61 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
             return;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
                 target.getStrings().clear();
-                target.getStrings().addAll( source.getStrings() );
+                target.getStrings().addAll( strings );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
                 target.getLongs().clear();
-                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
+                target.getLongs().addAll( stringListToLongSet( strings1 ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                target.setLongs( stringListToLongSet( source.getStrings() ) );
+                target.setLongs( stringListToLongSet( strings1 ) );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( source.getStringsInitialized() );
+                target.getStringsInitialized().addAll( stringsInitialized );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
+                target.getLongsInitialized().addAll( stringListToLongSet( stringsInitialized1 ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+                target.setLongsInitialized( stringListToLongSet( stringsInitialized1 ) );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
+                target.getStringsWithDefault().addAll( stringsWithDefault );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -116,7 +121,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         else {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
@@ -131,56 +136,61 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
             return target;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
                 target.getStrings().clear();
-                target.getStrings().addAll( source.getStrings() );
+                target.getStrings().addAll( strings );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
                 target.getLongs().clear();
-                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
+                target.getLongs().addAll( stringListToLongSet( strings1 ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                target.setLongs( stringListToLongSet( source.getStrings() ) );
+                target.setLongs( stringListToLongSet( strings1 ) );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( source.getStringsInitialized() );
+                target.getStringsInitialized().addAll( stringsInitialized );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
+                target.getLongsInitialized().addAll( stringListToLongSet( stringsInitialized1 ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+                target.setLongsInitialized( stringListToLongSet( stringsInitialized1 ) );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
+                target.getStringsWithDefault().addAll( stringsWithDefault );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -188,7 +198,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         else {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
@@ -52,8 +52,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
     public void update(Dto source, Domain target) {
 
         if ( source != null ) {
+            List<String> strings = source.getStrings();
             if ( target.getStrings() != null ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 if ( list != null ) {
                     target.getStrings().clear();
                     target.getStrings().addAll( list );
@@ -63,7 +64,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 if ( list != null ) {
                     target.setStrings( new LinkedHashSet<>( list ) );
                 }
@@ -71,8 +72,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setStrings( new LinkedHashSet<>() );
                 }
             }
+            List<String> strings1 = source.getStrings();
             if ( target.getLongs() != null ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
+                Set<Long> set = stringListToLongSet( strings1 );
                 if ( set != null ) {
                     target.getLongs().clear();
                     target.getLongs().addAll( set );
@@ -82,7 +84,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
+                Set<Long> set = stringListToLongSet( strings1 );
                 if ( set != null ) {
                     target.setLongs( set );
                 }
@@ -90,8 +92,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongs( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsInitialized = source.getStringsInitialized();
             if ( target.getStringsInitialized() != null ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 if ( list1 != null ) {
                     target.getStringsInitialized().clear();
                     target.getStringsInitialized().addAll( list1 );
@@ -101,7 +104,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 if ( list1 != null ) {
                     target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
                 }
@@ -109,8 +112,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsInitialized1 = source.getStringsInitialized();
             if ( target.getLongsInitialized() != null ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+                Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
                 if ( set1 != null ) {
                     target.getLongsInitialized().clear();
                     target.getLongsInitialized().addAll( set1 );
@@ -120,7 +124,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+                Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
                 if ( set1 != null ) {
                     target.setLongsInitialized( set1 );
                 }
@@ -128,8 +132,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsWithDefault = source.getStringsWithDefault();
             if ( target.getStringsWithDefault() != null ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 if ( list2 != null ) {
                     target.getStringsWithDefault().clear();
                     target.getStringsWithDefault().addAll( list2 );
@@ -139,7 +144,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 if ( list2 != null ) {
                     target.setStringsWithDefault( new ArrayList<>( list2 ) );
                 }
@@ -154,8 +159,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
     public Domain updateWithReturn(Dto source, Domain target) {
 
         if ( source != null ) {
+            List<String> strings = source.getStrings();
             if ( target.getStrings() != null ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 if ( list != null ) {
                     target.getStrings().clear();
                     target.getStrings().addAll( list );
@@ -165,7 +171,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 if ( list != null ) {
                     target.setStrings( new LinkedHashSet<>( list ) );
                 }
@@ -173,8 +179,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setStrings( new LinkedHashSet<>() );
                 }
             }
+            List<String> strings1 = source.getStrings();
             if ( target.getLongs() != null ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
+                Set<Long> set = stringListToLongSet( strings1 );
                 if ( set != null ) {
                     target.getLongs().clear();
                     target.getLongs().addAll( set );
@@ -184,7 +191,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
+                Set<Long> set = stringListToLongSet( strings1 );
                 if ( set != null ) {
                     target.setLongs( set );
                 }
@@ -192,8 +199,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongs( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsInitialized = source.getStringsInitialized();
             if ( target.getStringsInitialized() != null ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 if ( list1 != null ) {
                     target.getStringsInitialized().clear();
                     target.getStringsInitialized().addAll( list1 );
@@ -203,7 +211,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 if ( list1 != null ) {
                     target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
                 }
@@ -211,8 +219,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsInitialized1 = source.getStringsInitialized();
             if ( target.getLongsInitialized() != null ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+                Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
                 if ( set1 != null ) {
                     target.getLongsInitialized().clear();
                     target.getLongsInitialized().addAll( set1 );
@@ -222,7 +231,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+                Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
                 if ( set1 != null ) {
                     target.setLongsInitialized( set1 );
                 }
@@ -230,8 +239,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsWithDefault = source.getStringsWithDefault();
             if ( target.getStringsWithDefault() != null ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 if ( list2 != null ) {
                     target.getStringsWithDefault().clear();
                     target.getStringsWithDefault().addAll( list2 );
@@ -241,7 +251,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 if ( list2 != null ) {
                     target.setStringsWithDefault( new ArrayList<>( list2 ) );
                 }

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
@@ -55,8 +55,9 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             return;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
-            List<String> list = source.getStrings();
+            List<String> list = strings;
             if ( list != null ) {
                 target.getStrings().clear();
                 target.getStrings().addAll( list );
@@ -66,13 +67,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list = source.getStrings();
+            List<String> list = strings;
             if ( list != null ) {
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
-            Set<Long> set = stringListToLongSet( source.getStrings() );
+            Set<Long> set = stringListToLongSet( strings1 );
             if ( set != null ) {
                 target.getLongs().clear();
                 target.getLongs().addAll( set );
@@ -82,13 +84,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            Set<Long> set = stringListToLongSet( source.getStrings() );
+            Set<Long> set = stringListToLongSet( strings1 );
             if ( set != null ) {
                 target.setLongs( set );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
-            List<String> list1 = source.getStringsInitialized();
+            List<String> list1 = stringsInitialized;
             if ( list1 != null ) {
                 target.getStringsInitialized().clear();
                 target.getStringsInitialized().addAll( list1 );
@@ -98,13 +101,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list1 = source.getStringsInitialized();
+            List<String> list1 = stringsInitialized;
             if ( list1 != null ) {
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
-            Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+            Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
             if ( set1 != null ) {
                 target.getLongsInitialized().clear();
                 target.getLongsInitialized().addAll( set1 );
@@ -114,13 +118,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+            Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
             if ( set1 != null ) {
                 target.setLongsInitialized( set1 );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
-            List<String> list2 = source.getStringsWithDefault();
+            List<String> list2 = stringsWithDefault;
             if ( list2 != null ) {
                 target.getStringsWithDefault().clear();
                 target.getStringsWithDefault().addAll( list2 );
@@ -130,7 +135,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list2 = source.getStringsWithDefault();
+            List<String> list2 = stringsWithDefault;
             if ( list2 != null ) {
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
@@ -146,8 +151,9 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             return target;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
-            List<String> list = source.getStrings();
+            List<String> list = strings;
             if ( list != null ) {
                 target.getStrings().clear();
                 target.getStrings().addAll( list );
@@ -157,13 +163,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list = source.getStrings();
+            List<String> list = strings;
             if ( list != null ) {
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
-            Set<Long> set = stringListToLongSet( source.getStrings() );
+            Set<Long> set = stringListToLongSet( strings1 );
             if ( set != null ) {
                 target.getLongs().clear();
                 target.getLongs().addAll( set );
@@ -173,13 +180,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            Set<Long> set = stringListToLongSet( source.getStrings() );
+            Set<Long> set = stringListToLongSet( strings1 );
             if ( set != null ) {
                 target.setLongs( set );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
-            List<String> list1 = source.getStringsInitialized();
+            List<String> list1 = stringsInitialized;
             if ( list1 != null ) {
                 target.getStringsInitialized().clear();
                 target.getStringsInitialized().addAll( list1 );
@@ -189,13 +197,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list1 = source.getStringsInitialized();
+            List<String> list1 = stringsInitialized;
             if ( list1 != null ) {
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
-            Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+            Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
             if ( set1 != null ) {
                 target.getLongsInitialized().clear();
                 target.getLongsInitialized().addAll( set1 );
@@ -205,13 +214,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+            Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
             if ( set1 != null ) {
                 target.setLongsInitialized( set1 );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
-            List<String> list2 = source.getStringsWithDefault();
+            List<String> list2 = stringsWithDefault;
             if ( list2 != null ) {
                 target.getStringsWithDefault().clear();
                 target.getStringsWithDefault().addAll( list2 );
@@ -221,7 +231,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list2 = source.getStringsWithDefault();
+            List<String> list2 = stringsWithDefault;
             if ( list2 != null ) {
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
@@ -59,56 +59,61 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
             return;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
                 target.getStrings().clear();
-                target.getStrings().addAll( source.getStrings() );
+                target.getStrings().addAll( strings );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
                 target.getLongs().clear();
-                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
+                target.getLongs().addAll( stringListToLongSet( strings1 ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                target.setLongs( stringListToLongSet( source.getStrings() ) );
+                target.setLongs( stringListToLongSet( strings1 ) );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( source.getStringsInitialized() );
+                target.getStringsInitialized().addAll( stringsInitialized );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
+                target.getLongsInitialized().addAll( stringListToLongSet( stringsInitialized1 ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+                target.setLongsInitialized( stringListToLongSet( stringsInitialized1 ) );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
+                target.getStringsWithDefault().addAll( stringsWithDefault );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -116,7 +121,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         else {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
@@ -131,56 +136,61 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
             return target;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
                 target.getStrings().clear();
-                target.getStrings().addAll( source.getStrings() );
+                target.getStrings().addAll( strings );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
                 target.getLongs().clear();
-                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
+                target.getLongs().addAll( stringListToLongSet( strings1 ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                target.setLongs( stringListToLongSet( source.getStrings() ) );
+                target.setLongs( stringListToLongSet( strings1 ) );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( source.getStringsInitialized() );
+                target.getStringsInitialized().addAll( stringsInitialized );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
+                target.getLongsInitialized().addAll( stringListToLongSet( stringsInitialized1 ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+                target.setLongsInitialized( stringListToLongSet( stringsInitialized1 ) );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
+                target.getStringsWithDefault().addAll( stringsWithDefault );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -188,7 +198,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         else {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/conversion/numbers/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/conversion/numbers/SourceTargetMapperImpl.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.test.conversion.numbers;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
@@ -18,8 +19,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-09-14T11:37:30+0300",
-    comments = "version: , compiler: javac, environment: Java 21.0.2 (Amazon.com Inc.)"
+    date = "2026-06-05T15:54:34+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.2 (Oracle Corporation)"
 )
 public class SourceTargetMapperImpl implements SourceTargetMapper {
 
@@ -32,32 +33,39 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
         Target target = new Target();
 
         target.setI( new DecimalFormat( "##.00" ).format( source.getI() ) );
-        if ( source.getIi() != null ) {
-            target.setIi( new DecimalFormat( "##.00" ).format( source.getIi() ) );
+        Integer ii = source.getIi();
+        if ( ii != null ) {
+            target.setIi( new DecimalFormat( "##.00" ).format( ii ) );
         }
         target.setD( new DecimalFormat( "##.00" ).format( source.getD() ) );
-        if ( source.getDd() != null ) {
-            target.setDd( new DecimalFormat( "##.00" ).format( source.getDd() ) );
+        Double dd = source.getDd();
+        if ( dd != null ) {
+            target.setDd( new DecimalFormat( "##.00" ).format( dd ) );
         }
         target.setF( new DecimalFormat( "##.00" ).format( source.getF() ) );
-        if ( source.getFf() != null ) {
-            target.setFf( new DecimalFormat( "##.00" ).format( source.getFf() ) );
+        Float ff = source.getFf();
+        if ( ff != null ) {
+            target.setFf( new DecimalFormat( "##.00" ).format( ff ) );
         }
         target.setL( new DecimalFormat( "##.00" ).format( source.getL() ) );
-        if ( source.getLl() != null ) {
-            target.setLl( new DecimalFormat( "##.00" ).format( source.getLl() ) );
+        Long ll = source.getLl();
+        if ( ll != null ) {
+            target.setLl( new DecimalFormat( "##.00" ).format( ll ) );
         }
         target.setB( new DecimalFormat( "##.00" ).format( source.getB() ) );
-        if ( source.getBb() != null ) {
-            target.setBb( new DecimalFormat( "##.00" ).format( source.getBb() ) );
+        Byte bb = source.getBb();
+        if ( bb != null ) {
+            target.setBb( new DecimalFormat( "##.00" ).format( bb ) );
         }
         target.setComplex1( new DecimalFormat( "##0.##E0" ).format( source.getComplex1() ) );
         target.setComplex2( new DecimalFormat( "$#.00" ).format( source.getComplex2() ) );
-        if ( source.getBigDecimal1() != null ) {
-            target.setBigDecimal1( createDecimalFormat( "#0.#E0" ).format( source.getBigDecimal1() ) );
+        BigDecimal bigDecimal1 = source.getBigDecimal1();
+        if ( bigDecimal1 != null ) {
+            target.setBigDecimal1( createDecimalFormat( "#0.#E0" ).format( bigDecimal1 ) );
         }
-        if ( source.getBigInteger1() != null ) {
-            target.setBigInteger1( createDecimalFormat( "0.#############E0" ).format( source.getBigInteger1() ) );
+        BigInteger bigInteger1 = source.getBigInteger1();
+        if ( bigInteger1 != null ) {
+            target.setBigInteger1( createDecimalFormat( "0.#############E0" ).format( bigInteger1 ) );
         }
 
         return target;
@@ -72,32 +80,39 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
         Target target = new Target();
 
         target.setI( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getI() ) );
-        if ( source.getIi() != null ) {
-            target.setIi( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getIi() ) );
+        Integer ii = source.getIi();
+        if ( ii != null ) {
+            target.setIi( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( ii ) );
         }
         target.setD( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getD() ) );
-        if ( source.getDd() != null ) {
-            target.setDd( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getDd() ) );
+        Double dd = source.getDd();
+        if ( dd != null ) {
+            target.setDd( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( dd ) );
         }
         target.setF( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getF() ) );
-        if ( source.getFf() != null ) {
-            target.setFf( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getFf() ) );
+        Float ff = source.getFf();
+        if ( ff != null ) {
+            target.setFf( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( ff ) );
         }
         target.setL( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getL() ) );
-        if ( source.getLl() != null ) {
-            target.setLl( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getLl() ) );
+        Long ll = source.getLl();
+        if ( ll != null ) {
+            target.setLl( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( ll ) );
         }
         target.setB( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getB() ) );
-        if ( source.getBb() != null ) {
-            target.setBb( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getBb() ) );
+        Byte bb = source.getBb();
+        if ( bb != null ) {
+            target.setBb( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( bb ) );
         }
         target.setComplex1( new DecimalFormat( "##0.##E0", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getComplex1() ) );
         target.setComplex2( new DecimalFormat( "$#.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getComplex2() ) );
-        if ( source.getBigDecimal1() != null ) {
-            target.setBigDecimal1( createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "ru" ) ).format( source.getBigDecimal1() ) );
+        BigDecimal bigDecimal1 = source.getBigDecimal1();
+        if ( bigDecimal1 != null ) {
+            target.setBigDecimal1( createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "ru" ) ).format( bigDecimal1 ) );
         }
-        if ( source.getBigInteger1() != null ) {
-            target.setBigInteger1( createDecimalFormatWithLocale( "0.#############E0", Locale.forLanguageTag( "ru" ) ).format( source.getBigInteger1() ) );
+        BigInteger bigInteger1 = source.getBigInteger1();
+        if ( bigInteger1 != null ) {
+            target.setBigInteger1( createDecimalFormatWithLocale( "0.#############E0", Locale.forLanguageTag( "ru" ) ).format( bigInteger1 ) );
         }
 
         return target;
@@ -112,112 +127,126 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
         Source source = new Source();
 
         try {
-            if ( target.getI() != null ) {
-                source.setI( new DecimalFormat( "##.00" ).parse( target.getI() ).intValue() );
+            String i = target.getI();
+            if ( i != null ) {
+                source.setI( new DecimalFormat( "##.00" ).parse( i ).intValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getIi() != null ) {
-                source.setIi( new DecimalFormat( "##.00" ).parse( target.getIi() ).intValue() );
+            String ii = target.getIi();
+            if ( ii != null ) {
+                source.setIi( new DecimalFormat( "##.00" ).parse( ii ).intValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getD() != null ) {
-                source.setD( new DecimalFormat( "##.00" ).parse( target.getD() ).doubleValue() );
+            String d = target.getD();
+            if ( d != null ) {
+                source.setD( new DecimalFormat( "##.00" ).parse( d ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getDd() != null ) {
-                source.setDd( new DecimalFormat( "##.00" ).parse( target.getDd() ).doubleValue() );
+            String dd = target.getDd();
+            if ( dd != null ) {
+                source.setDd( new DecimalFormat( "##.00" ).parse( dd ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getF() != null ) {
-                source.setF( new DecimalFormat( "##.00" ).parse( target.getF() ).floatValue() );
+            String f = target.getF();
+            if ( f != null ) {
+                source.setF( new DecimalFormat( "##.00" ).parse( f ).floatValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getFf() != null ) {
-                source.setFf( new DecimalFormat( "##.00" ).parse( target.getFf() ).floatValue() );
+            String ff = target.getFf();
+            if ( ff != null ) {
+                source.setFf( new DecimalFormat( "##.00" ).parse( ff ).floatValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getL() != null ) {
-                source.setL( new DecimalFormat( "##.00" ).parse( target.getL() ).longValue() );
+            String l = target.getL();
+            if ( l != null ) {
+                source.setL( new DecimalFormat( "##.00" ).parse( l ).longValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getLl() != null ) {
-                source.setLl( new DecimalFormat( "##.00" ).parse( target.getLl() ).longValue() );
+            String ll = target.getLl();
+            if ( ll != null ) {
+                source.setLl( new DecimalFormat( "##.00" ).parse( ll ).longValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getB() != null ) {
-                source.setB( new DecimalFormat( "##.00" ).parse( target.getB() ).byteValue() );
+            String b = target.getB();
+            if ( b != null ) {
+                source.setB( new DecimalFormat( "##.00" ).parse( b ).byteValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBb() != null ) {
-                source.setBb( new DecimalFormat( "##.00" ).parse( target.getBb() ).byteValue() );
+            String bb = target.getBb();
+            if ( bb != null ) {
+                source.setBb( new DecimalFormat( "##.00" ).parse( bb ).byteValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getComplex1() != null ) {
-                source.setComplex1( new DecimalFormat( "##0.##E0" ).parse( target.getComplex1() ).doubleValue() );
+            String complex1 = target.getComplex1();
+            if ( complex1 != null ) {
+                source.setComplex1( new DecimalFormat( "##0.##E0" ).parse( complex1 ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getComplex2() != null ) {
-                source.setComplex2( new DecimalFormat( "$#.00" ).parse( target.getComplex2() ).doubleValue() );
+            String complex2 = target.getComplex2();
+            if ( complex2 != null ) {
+                source.setComplex2( new DecimalFormat( "$#.00" ).parse( complex2 ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBigDecimal1() != null ) {
-                source.setBigDecimal1( (BigDecimal) createDecimalFormat( "#0.#E0" ).parse( target.getBigDecimal1() ) );
+            String bigDecimal1 = target.getBigDecimal1();
+            if ( bigDecimal1 != null ) {
+                source.setBigDecimal1( (BigDecimal) createDecimalFormat( "#0.#E0" ).parse( bigDecimal1 ) );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBigInteger1() != null ) {
-                source.setBigInteger1( ( (BigDecimal) createDecimalFormat( "0.#############E0" ).parse( target.getBigInteger1() ) ).toBigInteger() );
+            String bigInteger1 = target.getBigInteger1();
+            if ( bigInteger1 != null ) {
+                source.setBigInteger1( ( (BigDecimal) createDecimalFormat( "0.#############E0" ).parse( bigInteger1 ) ).toBigInteger() );
             }
         }
         catch ( ParseException e ) {
@@ -236,112 +265,126 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
         Source source = new Source();
 
         try {
-            if ( target.getI() != null ) {
-                source.setI( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getI() ).intValue() );
+            String i = target.getI();
+            if ( i != null ) {
+                source.setI( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( i ).intValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getIi() != null ) {
-                source.setIi( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getIi() ).intValue() );
+            String ii = target.getIi();
+            if ( ii != null ) {
+                source.setIi( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( ii ).intValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getD() != null ) {
-                source.setD( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getD() ).doubleValue() );
+            String d = target.getD();
+            if ( d != null ) {
+                source.setD( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( d ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getDd() != null ) {
-                source.setDd( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getDd() ).doubleValue() );
+            String dd = target.getDd();
+            if ( dd != null ) {
+                source.setDd( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( dd ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getF() != null ) {
-                source.setF( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getF() ).floatValue() );
+            String f = target.getF();
+            if ( f != null ) {
+                source.setF( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( f ).floatValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getFf() != null ) {
-                source.setFf( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getFf() ).floatValue() );
+            String ff = target.getFf();
+            if ( ff != null ) {
+                source.setFf( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( ff ).floatValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getL() != null ) {
-                source.setL( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getL() ).longValue() );
+            String l = target.getL();
+            if ( l != null ) {
+                source.setL( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( l ).longValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getLl() != null ) {
-                source.setLl( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getLl() ).longValue() );
+            String ll = target.getLl();
+            if ( ll != null ) {
+                source.setLl( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( ll ).longValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getB() != null ) {
-                source.setB( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getB() ).byteValue() );
+            String b = target.getB();
+            if ( b != null ) {
+                source.setB( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( b ).byteValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBb() != null ) {
-                source.setBb( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getBb() ).byteValue() );
+            String bb = target.getBb();
+            if ( bb != null ) {
+                source.setBb( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( bb ).byteValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getComplex1() != null ) {
-                source.setComplex1( new DecimalFormat( "##0.##E0", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getComplex1() ).doubleValue() );
+            String complex1 = target.getComplex1();
+            if ( complex1 != null ) {
+                source.setComplex1( new DecimalFormat( "##0.##E0", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( complex1 ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getComplex2() != null ) {
-                source.setComplex2( new DecimalFormat( "$#.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getComplex2() ).doubleValue() );
+            String complex2 = target.getComplex2();
+            if ( complex2 != null ) {
+                source.setComplex2( new DecimalFormat( "$#.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( complex2 ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBigDecimal1() != null ) {
-                source.setBigDecimal1( (BigDecimal) createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "ru" ) ).parse( target.getBigDecimal1() ) );
+            String bigDecimal1 = target.getBigDecimal1();
+            if ( bigDecimal1 != null ) {
+                source.setBigDecimal1( (BigDecimal) createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "ru" ) ).parse( bigDecimal1 ) );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBigInteger1() != null ) {
-                source.setBigInteger1( ( (BigDecimal) createDecimalFormatWithLocale( "0.#############E0", Locale.forLanguageTag( "ru" ) ).parse( target.getBigInteger1() ) ).toBigInteger() );
+            String bigInteger1 = target.getBigInteger1();
+            if ( bigInteger1 != null ) {
+                source.setBigInteger1( ( (BigDecimal) createDecimalFormatWithLocale( "0.#############E0", Locale.forLanguageTag( "ru" ) ).parse( bigInteger1 ) ).toBigInteger() );
             }
         }
         catch ( ParseException e ) {

--- a/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/updatemethods/CompanyMapper1Impl.java
+++ b/processor/src/test/resources/fixtures/21/org/mapstruct/ap/test/updatemethods/CompanyMapper1Impl.java
@@ -25,11 +25,12 @@ public class CompanyMapper1Impl implements CompanyMapper1 {
         }
 
         entity.setName( dto.getName() );
-        if ( dto.getDepartment() != null ) {
+        UnmappableDepartmentDto department = dto.getDepartment();
+        if ( department != null ) {
             if ( entity.getDepartment() == null ) {
                 entity.setDepartment( departmentEntityFactory.createDepartmentEntity() );
             }
-            unmappableDepartmentDtoToDepartmentEntity( dto.getDepartment(), entity.getDepartment() );
+            unmappableDepartmentDtoToDepartmentEntity( department, entity.getDepartment() );
         }
         else {
             entity.setDepartment( null );
@@ -100,8 +101,9 @@ public class CompanyMapper1Impl implements CompanyMapper1 {
         }
 
         mappingTarget.setName( unmappableDepartmentDto.getName() );
+        Map<SecretaryDto, EmployeeDto> secretaryToEmployee = unmappableDepartmentDto.getSecretaryToEmployee();
         if ( mappingTarget.getSecretaryToEmployee() != null ) {
-            Map<SecretaryEntity, EmployeeEntity> map = secretaryDtoEmployeeDtoMapToSecretaryEntityEmployeeEntityMap( unmappableDepartmentDto.getSecretaryToEmployee() );
+            Map<SecretaryEntity, EmployeeEntity> map = secretaryDtoEmployeeDtoMapToSecretaryEntityEmployeeEntityMap( secretaryToEmployee );
             if ( map != null ) {
                 mappingTarget.getSecretaryToEmployee().clear();
                 mappingTarget.getSecretaryToEmployee().putAll( map );
@@ -111,7 +113,7 @@ public class CompanyMapper1Impl implements CompanyMapper1 {
             }
         }
         else {
-            Map<SecretaryEntity, EmployeeEntity> map = secretaryDtoEmployeeDtoMapToSecretaryEntityEmployeeEntityMap( unmappableDepartmentDto.getSecretaryToEmployee() );
+            Map<SecretaryEntity, EmployeeEntity> map = secretaryDtoEmployeeDtoMapToSecretaryEntityEmployeeEntityMap( secretaryToEmployee );
             if ( map != null ) {
                 mappingTarget.setSecretaryToEmployee( map );
             }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1576/java8/Issue1576MapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1576/java8/Issue1576MapperImpl.java
@@ -10,12 +10,13 @@ import java.time.LocalTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import javax.annotation.Generated;
+import java.util.Date;
+import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2018-11-05T21:40:12+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_181 (Oracle Corporation)"
+    date = "2026-06-05T15:53:43+0200",
+    comments = "version: , compiler: Eclipse JDT (Batch) 3.20.0.v20191203-2131, environment: Java 21.0.2 (Oracle Corporation)"
 )
 public class Issue1576MapperImpl implements Issue1576Mapper {
 
@@ -27,20 +28,25 @@ public class Issue1576MapperImpl implements Issue1576Mapper {
 
         Target target = new Target();
 
-        if ( source.getLocalDateTime() != null ) {
-            target.setLocalDateTime( LocalDateTime.ofInstant( source.getLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) );
+        Date localDateTime = source.getLocalDateTime();
+        if ( localDateTime != null ) {
+            target.setLocalDateTime( LocalDateTime.ofInstant( localDateTime.toInstant(), ZoneId.of( "UTC" ) ) );
         }
-        if ( source.getLocalDate() != null ) {
-            target.setLocalDate( LocalDateTime.ofInstant( source.getLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() );
+        Date localDate = source.getLocalDate();
+        if ( localDate != null ) {
+            target.setLocalDate( LocalDateTime.ofInstant( localDate.toInstant(), ZoneOffset.UTC ).toLocalDate() );
         }
-        if ( source.getLocalTime() != null ) {
-            target.setLocalTime( LocalTime.parse( source.getLocalTime() ) );
+        String localTime = source.getLocalTime();
+        if ( localTime != null ) {
+            target.setLocalTime( LocalTime.parse( localTime ) );
         }
-        if ( source.getZonedDateTime() != null ) {
-            target.setZonedDateTime( ZonedDateTime.ofInstant( source.getZonedDateTime().toInstant(), ZoneId.systemDefault() ) );
+        Date zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            target.setZonedDateTime( ZonedDateTime.ofInstant( zonedDateTime.toInstant(), ZoneId.systemDefault() ) );
         }
-        if ( source.getInstant() != null ) {
-            target.setInstant( source.getInstant().toInstant() );
+        Date instant = source.getInstant();
+        if ( instant != null ) {
+            target.setInstant( instant.toInstant() );
         }
 
         return target;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1685/UserMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_1685/UserMapperImpl.java
@@ -8,12 +8,12 @@ package org.mapstruct.ap.test.bugs._1685;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2019-01-27T12:40:32+0100",
-    comments = "version: , compiler: Eclipse JDT (Batch) 1.2.100.v20160418-1457, environment: Java 1.8.0_181 (Oracle Corporation)"
+    date = "2026-06-05T14:55:19+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class UserMapperImpl implements UserMapper {
 
@@ -52,9 +52,9 @@ public class UserMapperImpl implements UserMapper {
                 user.addPreference( contactDataDTOPreference );
             }
         }
-        String[] settings1 = userDTOContactDataDTOSettings( userDTO );
-        if ( settings1 != null ) {
-            user.setSettings( Arrays.copyOf( settings1, settings1.length ) );
+        String[] settings = userDTOContactDataDTOSettings( userDTO );
+        if ( settings != null ) {
+            user.setSettings( Arrays.copyOf( settings, settings.length ) );
         }
         else {
             user.setSettings( null );
@@ -86,12 +86,13 @@ public class UserMapperImpl implements UserMapper {
                 user.addPreference( contactDataDTOPreference );
             }
         }
-        String[] settings1 = userDTOContactDataDTOSettings( userDTO );
-        if ( settings1 != null ) {
-            user.setSettings( Arrays.copyOf( settings1, settings1.length ) );
+        String[] settings = userDTOContactDataDTOSettings( userDTO );
+        if ( settings != null ) {
+            user.setSettings( Arrays.copyOf( settings, settings.length ) );
         }
-        if ( userDTO.getName() != null ) {
-            user.setName( userDTO.getName() );
+        String name = userDTO.getName();
+        if ( name != null ) {
+            user.setName( name );
         }
     }
 
@@ -128,15 +129,16 @@ public class UserMapperImpl implements UserMapper {
                 user.addPreference( contactDataDTOPreference );
             }
         }
-        String[] settings1 = userDTOContactDataDTOSettings( userDTO );
-        if ( settings1 != null ) {
-            user.setSettings( Arrays.copyOf( settings1, settings1.length ) );
+        String[] settings = userDTOContactDataDTOSettings( userDTO );
+        if ( settings != null ) {
+            user.setSettings( Arrays.copyOf( settings, settings.length ) );
         }
         else {
             user.setSettings( new String[0] );
         }
-        if ( userDTO.getName() != null ) {
-            user.setName( userDTO.getName() );
+        String name = userDTO.getName();
+        if ( name != null ) {
+            user.setName( name );
         }
         else {
             user.setName( "" );
@@ -151,8 +153,9 @@ public class UserMapperImpl implements UserMapper {
         ContactDataDTO contactDataDTO = new ContactDataDTO();
 
         contactDataDTO.setEmail( user.getEmail() );
-        if ( user.getPhone() != null ) {
-            contactDataDTO.setPhone( String.valueOf( user.getPhone() ) );
+        Integer phone = user.getPhone();
+        if ( phone != null ) {
+            contactDataDTO.setPhone( String.valueOf( phone ) );
         }
         contactDataDTO.setAddress( user.getAddress() );
         List<String> list = user.getPreferences();

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_3591/ContainerBeanMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_3591/ContainerBeanMapperImpl.java
@@ -23,8 +23,9 @@ public class ContainerBeanMapperImpl implements ContainerBeanMapper {
             return containerBeanDto;
         }
 
+        Map<String, ContainerBean> beanMap = containerBean.getBeanMap();
         if ( containerBeanDto.getBeanMap() != null ) {
-            Map<String, ContainerBeanDto> map = stringContainerBeanMapToStringContainerBeanDtoMap( containerBean.getBeanMap() );
+            Map<String, ContainerBeanDto> map = stringContainerBeanMapToStringContainerBeanDtoMap( beanMap );
             if ( map != null ) {
                 containerBeanDto.getBeanMap().clear();
                 containerBeanDto.getBeanMap().putAll( map );
@@ -34,7 +35,7 @@ public class ContainerBeanMapperImpl implements ContainerBeanMapper {
             }
         }
         else {
-            Map<String, ContainerBeanDto> map = stringContainerBeanMapToStringContainerBeanDtoMap( containerBean.getBeanMap() );
+            Map<String, ContainerBeanDto> map = stringContainerBeanMapToStringContainerBeanDtoMap( beanMap );
             if ( map != null ) {
                 containerBeanDto.setBeanMap( map );
             }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNcvsAlwaysMapperImpl.java
@@ -59,56 +59,61 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
             return;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
                 target.getStrings().clear();
-                target.getStrings().addAll( source.getStrings() );
+                target.getStrings().addAll( strings );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
                 target.getLongs().clear();
-                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
+                target.getLongs().addAll( stringListToLongSet( strings1 ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                target.setLongs( stringListToLongSet( source.getStrings() ) );
+                target.setLongs( stringListToLongSet( strings1 ) );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( source.getStringsInitialized() );
+                target.getStringsInitialized().addAll( stringsInitialized );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
+                target.getLongsInitialized().addAll( stringListToLongSet( stringsInitialized1 ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+                target.setLongsInitialized( stringListToLongSet( stringsInitialized1 ) );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
+                target.getStringsWithDefault().addAll( stringsWithDefault );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -116,7 +121,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         else {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
@@ -131,56 +136,61 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
             return target;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
                 target.getStrings().clear();
-                target.getStrings().addAll( source.getStrings() );
+                target.getStrings().addAll( strings );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
                 target.getLongs().clear();
-                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
+                target.getLongs().addAll( stringListToLongSet( strings1 ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                target.setLongs( stringListToLongSet( source.getStrings() ) );
+                target.setLongs( stringListToLongSet( strings1 ) );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( source.getStringsInitialized() );
+                target.getStringsInitialized().addAll( stringsInitialized );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
+                target.getLongsInitialized().addAll( stringListToLongSet( stringsInitialized1 ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+                target.setLongsInitialized( stringListToLongSet( stringsInitialized1 ) );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
+                target.getStringsWithDefault().addAll( stringsWithDefault );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -188,7 +198,7 @@ public class DomainDtoWithNcvsAlwaysMapperImpl implements DomainDtoWithNcvsAlway
         }
         else {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsDefaultMapperImpl.java
@@ -52,8 +52,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
     public void update(Dto source, Domain target) {
 
         if ( source != null ) {
+            List<String> strings = source.getStrings();
             if ( target.getStrings() != null ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 if ( list != null ) {
                     target.getStrings().clear();
                     target.getStrings().addAll( list );
@@ -63,7 +64,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 if ( list != null ) {
                     target.setStrings( new LinkedHashSet<>( list ) );
                 }
@@ -71,8 +72,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setStrings( new LinkedHashSet<>() );
                 }
             }
+            List<String> strings1 = source.getStrings();
             if ( target.getLongs() != null ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
+                Set<Long> set = stringListToLongSet( strings1 );
                 if ( set != null ) {
                     target.getLongs().clear();
                     target.getLongs().addAll( set );
@@ -82,7 +84,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
+                Set<Long> set = stringListToLongSet( strings1 );
                 if ( set != null ) {
                     target.setLongs( set );
                 }
@@ -90,8 +92,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongs( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsInitialized = source.getStringsInitialized();
             if ( target.getStringsInitialized() != null ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 if ( list1 != null ) {
                     target.getStringsInitialized().clear();
                     target.getStringsInitialized().addAll( list1 );
@@ -101,7 +104,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 if ( list1 != null ) {
                     target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
                 }
@@ -109,8 +112,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsInitialized1 = source.getStringsInitialized();
             if ( target.getLongsInitialized() != null ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+                Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
                 if ( set1 != null ) {
                     target.getLongsInitialized().clear();
                     target.getLongsInitialized().addAll( set1 );
@@ -120,7 +124,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+                Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
                 if ( set1 != null ) {
                     target.setLongsInitialized( set1 );
                 }
@@ -128,8 +132,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsWithDefault = source.getStringsWithDefault();
             if ( target.getStringsWithDefault() != null ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 if ( list2 != null ) {
                     target.getStringsWithDefault().clear();
                     target.getStringsWithDefault().addAll( list2 );
@@ -139,7 +144,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 if ( list2 != null ) {
                     target.setStringsWithDefault( new ArrayList<>( list2 ) );
                 }
@@ -154,8 +159,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
     public Domain updateWithReturn(Dto source, Domain target) {
 
         if ( source != null ) {
+            List<String> strings = source.getStrings();
             if ( target.getStrings() != null ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 if ( list != null ) {
                     target.getStrings().clear();
                     target.getStrings().addAll( list );
@@ -165,7 +171,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 if ( list != null ) {
                     target.setStrings( new LinkedHashSet<>( list ) );
                 }
@@ -173,8 +179,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setStrings( new LinkedHashSet<>() );
                 }
             }
+            List<String> strings1 = source.getStrings();
             if ( target.getLongs() != null ) {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
+                Set<Long> set = stringListToLongSet( strings1 );
                 if ( set != null ) {
                     target.getLongs().clear();
                     target.getLongs().addAll( set );
@@ -184,7 +191,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                Set<Long> set = stringListToLongSet( source.getStrings() );
+                Set<Long> set = stringListToLongSet( strings1 );
                 if ( set != null ) {
                     target.setLongs( set );
                 }
@@ -192,8 +199,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongs( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsInitialized = source.getStringsInitialized();
             if ( target.getStringsInitialized() != null ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 if ( list1 != null ) {
                     target.getStringsInitialized().clear();
                     target.getStringsInitialized().addAll( list1 );
@@ -203,7 +211,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 if ( list1 != null ) {
                     target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
                 }
@@ -211,8 +219,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setStringsInitialized( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsInitialized1 = source.getStringsInitialized();
             if ( target.getLongsInitialized() != null ) {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+                Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
                 if ( set1 != null ) {
                     target.getLongsInitialized().clear();
                     target.getLongsInitialized().addAll( set1 );
@@ -222,7 +231,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+                Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
                 if ( set1 != null ) {
                     target.setLongsInitialized( set1 );
                 }
@@ -230,8 +239,9 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                     target.setLongsInitialized( new LinkedHashSet<>() );
                 }
             }
+            List<String> stringsWithDefault = source.getStringsWithDefault();
             if ( target.getStringsWithDefault() != null ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 if ( list2 != null ) {
                     target.getStringsWithDefault().clear();
                     target.getStringsWithDefault().addAll( list2 );
@@ -241,7 +251,7 @@ public class DomainDtoWithNvmsDefaultMapperImpl implements DomainDtoWithNvmsDefa
                 }
             }
             else {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 if ( list2 != null ) {
                     target.setStringsWithDefault( new ArrayList<>( list2 ) );
                 }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithNvmsNullMapperImpl.java
@@ -55,8 +55,9 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             return;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
-            List<String> list = source.getStrings();
+            List<String> list = strings;
             if ( list != null ) {
                 target.getStrings().clear();
                 target.getStrings().addAll( list );
@@ -66,13 +67,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list = source.getStrings();
+            List<String> list = strings;
             if ( list != null ) {
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
-            Set<Long> set = stringListToLongSet( source.getStrings() );
+            Set<Long> set = stringListToLongSet( strings1 );
             if ( set != null ) {
                 target.getLongs().clear();
                 target.getLongs().addAll( set );
@@ -82,13 +84,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            Set<Long> set = stringListToLongSet( source.getStrings() );
+            Set<Long> set = stringListToLongSet( strings1 );
             if ( set != null ) {
                 target.setLongs( set );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
-            List<String> list1 = source.getStringsInitialized();
+            List<String> list1 = stringsInitialized;
             if ( list1 != null ) {
                 target.getStringsInitialized().clear();
                 target.getStringsInitialized().addAll( list1 );
@@ -98,13 +101,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list1 = source.getStringsInitialized();
+            List<String> list1 = stringsInitialized;
             if ( list1 != null ) {
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
-            Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+            Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
             if ( set1 != null ) {
                 target.getLongsInitialized().clear();
                 target.getLongsInitialized().addAll( set1 );
@@ -114,13 +118,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+            Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
             if ( set1 != null ) {
                 target.setLongsInitialized( set1 );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
-            List<String> list2 = source.getStringsWithDefault();
+            List<String> list2 = stringsWithDefault;
             if ( list2 != null ) {
                 target.getStringsWithDefault().clear();
                 target.getStringsWithDefault().addAll( list2 );
@@ -130,7 +135,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list2 = source.getStringsWithDefault();
+            List<String> list2 = stringsWithDefault;
             if ( list2 != null ) {
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
@@ -146,8 +151,9 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             return target;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
-            List<String> list = source.getStrings();
+            List<String> list = strings;
             if ( list != null ) {
                 target.getStrings().clear();
                 target.getStrings().addAll( list );
@@ -157,13 +163,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list = source.getStrings();
+            List<String> list = strings;
             if ( list != null ) {
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
-            Set<Long> set = stringListToLongSet( source.getStrings() );
+            Set<Long> set = stringListToLongSet( strings1 );
             if ( set != null ) {
                 target.getLongs().clear();
                 target.getLongs().addAll( set );
@@ -173,13 +180,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            Set<Long> set = stringListToLongSet( source.getStrings() );
+            Set<Long> set = stringListToLongSet( strings1 );
             if ( set != null ) {
                 target.setLongs( set );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
-            List<String> list1 = source.getStringsInitialized();
+            List<String> list1 = stringsInitialized;
             if ( list1 != null ) {
                 target.getStringsInitialized().clear();
                 target.getStringsInitialized().addAll( list1 );
@@ -189,13 +197,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list1 = source.getStringsInitialized();
+            List<String> list1 = stringsInitialized;
             if ( list1 != null ) {
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
-            Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+            Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
             if ( set1 != null ) {
                 target.getLongsInitialized().clear();
                 target.getLongsInitialized().addAll( set1 );
@@ -205,13 +214,14 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            Set<Long> set1 = stringListToLongSet( source.getStringsInitialized() );
+            Set<Long> set1 = stringListToLongSet( stringsInitialized1 );
             if ( set1 != null ) {
                 target.setLongsInitialized( set1 );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
-            List<String> list2 = source.getStringsWithDefault();
+            List<String> list2 = stringsWithDefault;
             if ( list2 != null ) {
                 target.getStringsWithDefault().clear();
                 target.getStringsWithDefault().addAll( list2 );
@@ -221,7 +231,7 @@ public class DomainDtoWithNvmsNullMapperImpl implements DomainDtoWithNvmsNullMap
             }
         }
         else {
-            List<String> list2 = source.getStringsWithDefault();
+            List<String> list2 = stringsWithDefault;
             if ( list2 != null ) {
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_913/DomainDtoWithPresenceCheckMapperImpl.java
@@ -59,56 +59,61 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
             return;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
                 target.getStrings().clear();
-                target.getStrings().addAll( source.getStrings() );
+                target.getStrings().addAll( strings );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
                 target.getLongs().clear();
-                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
+                target.getLongs().addAll( stringListToLongSet( strings1 ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                target.setLongs( stringListToLongSet( source.getStrings() ) );
+                target.setLongs( stringListToLongSet( strings1 ) );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( source.getStringsInitialized() );
+                target.getStringsInitialized().addAll( stringsInitialized );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
+                target.getLongsInitialized().addAll( stringListToLongSet( stringsInitialized1 ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+                target.setLongsInitialized( stringListToLongSet( stringsInitialized1 ) );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
+                target.getStringsWithDefault().addAll( stringsWithDefault );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -116,7 +121,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         else {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {
@@ -131,56 +136,61 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
             return target;
         }
 
+        List<String> strings = source.getStrings();
         if ( target.getStrings() != null ) {
             if ( source.hasStrings() ) {
                 target.getStrings().clear();
-                target.getStrings().addAll( source.getStrings() );
+                target.getStrings().addAll( strings );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                List<String> list = source.getStrings();
+                List<String> list = strings;
                 target.setStrings( new LinkedHashSet<>( list ) );
             }
         }
+        List<String> strings1 = source.getStrings();
         if ( target.getLongs() != null ) {
             if ( source.hasStrings() ) {
                 target.getLongs().clear();
-                target.getLongs().addAll( stringListToLongSet( source.getStrings() ) );
+                target.getLongs().addAll( stringListToLongSet( strings1 ) );
             }
         }
         else {
             if ( source.hasStrings() ) {
-                target.setLongs( stringListToLongSet( source.getStrings() ) );
+                target.setLongs( stringListToLongSet( strings1 ) );
             }
         }
+        List<String> stringsInitialized = source.getStringsInitialized();
         if ( target.getStringsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getStringsInitialized().clear();
-                target.getStringsInitialized().addAll( source.getStringsInitialized() );
+                target.getStringsInitialized().addAll( stringsInitialized );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                List<String> list1 = source.getStringsInitialized();
+                List<String> list1 = stringsInitialized;
                 target.setStringsInitialized( new LinkedHashSet<>( list1 ) );
             }
         }
+        List<String> stringsInitialized1 = source.getStringsInitialized();
         if ( target.getLongsInitialized() != null ) {
             if ( source.hasStringsInitialized() ) {
                 target.getLongsInitialized().clear();
-                target.getLongsInitialized().addAll( stringListToLongSet( source.getStringsInitialized() ) );
+                target.getLongsInitialized().addAll( stringListToLongSet( stringsInitialized1 ) );
             }
         }
         else {
             if ( source.hasStringsInitialized() ) {
-                target.setLongsInitialized( stringListToLongSet( source.getStringsInitialized() ) );
+                target.setLongsInitialized( stringListToLongSet( stringsInitialized1 ) );
             }
         }
+        List<String> stringsWithDefault = source.getStringsWithDefault();
         if ( target.getStringsWithDefault() != null ) {
             if ( source.hasStringsWithDefault() ) {
                 target.getStringsWithDefault().clear();
-                target.getStringsWithDefault().addAll( source.getStringsWithDefault() );
+                target.getStringsWithDefault().addAll( stringsWithDefault );
             }
             else {
                 target.setStringsWithDefault( helper.toList( "3" ) );
@@ -188,7 +198,7 @@ public class DomainDtoWithPresenceCheckMapperImpl implements DomainDtoWithPresen
         }
         else {
             if ( source.hasStringsWithDefault() ) {
-                List<String> list2 = source.getStringsWithDefault();
+                List<String> list2 = stringsWithDefault;
                 target.setStringsWithDefault( new ArrayList<>( list2 ) );
             }
             else {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conditional/basic/ConditionalMethodInMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conditional/basic/ConditionalMethodInMapperImpl.java
@@ -9,8 +9,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2021-04-19T21:10:40+0200",
-    comments = "version: , compiler: javac, environment: Java 11.0.9.1 (AdoptOpenJDK)"
+    date = "2026-06-05T14:55:58+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class ConditionalMethodInMapperImpl implements ConditionalMethodInMapper {
 
@@ -22,8 +22,9 @@ public class ConditionalMethodInMapperImpl implements ConditionalMethodInMapper 
 
         BasicEmployee basicEmployee = new BasicEmployee();
 
-        if ( isNotBlank( employee.getName() ) ) {
-            basicEmployee.setName( employee.getName() );
+        String name = employee.getName();
+        if ( isNotBlank( name ) ) {
+            basicEmployee.setName( name );
         }
 
         return basicEmployee;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conditional/basic/ConditionalMethodWithSourceParameterAndValueMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conditional/basic/ConditionalMethodWithSourceParameterAndValueMapperImpl.java
@@ -9,8 +9,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2021-04-19T21:10:38+0200",
-    comments = "version: , compiler: javac, environment: Java 11.0.9.1 (AdoptOpenJDK)"
+    date = "2026-06-05T14:55:45+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class ConditionalMethodWithSourceParameterAndValueMapperImpl implements ConditionalMethodWithSourceParameterAndValueMapper {
 
@@ -22,8 +22,9 @@ public class ConditionalMethodWithSourceParameterAndValueMapperImpl implements C
 
         BasicEmployee basicEmployee = new BasicEmployee();
 
-        if ( isPresent( employee, employee.getName() ) ) {
-            basicEmployee.setName( employee.getName() );
+        String name = employee.getName();
+        if ( isPresent( employee, name ) ) {
+            basicEmployee.setName( name );
         }
 
         return basicEmployee;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/java8time/OptionalSourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/java8time/OptionalSourceTargetMapperImpl.java
@@ -23,8 +23,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2026-01-24T16:06:24+0100",
-    comments = "version: , compiler: javac, environment: Java 21.0.3 (Eclipse Adoptium)"
+    date = "2026-06-05T14:56:13+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMapper {
 
@@ -41,46 +41,60 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         Target target = new Target();
 
-        if ( source.getZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime.isPresent() ) {
             target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime().get() ) );
         }
-        if ( source.getLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> localDateTime = source.getLocalDateTime();
+        if ( localDateTime.isPresent() ) {
             target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime().get() ) );
         }
-        if ( source.getLocalDate().isPresent() ) {
+        Optional<LocalDate> localDate = source.getLocalDate();
+        if ( localDate.isPresent() ) {
             target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate().get() ) );
         }
-        if ( source.getLocalTime().isPresent() ) {
+        Optional<LocalTime> localTime = source.getLocalTime();
+        if ( localTime.isPresent() ) {
             target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime().get() ) );
         }
-        if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+        Optional<ZonedDateTime> forCalendarConversion = source.getForCalendarConversion();
+        if ( forCalendarConversion.isPresent() ) {
+            target.setForCalendarConversion( zonedDateTimeToCalendar( forCalendarConversion.get() ) );
         }
-        if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime.isPresent() ) {
             target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime.isPresent() ) {
             target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate.isPresent() ) {
             target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate.isPresent() ) {
             target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant().isPresent() ) {
+        Optional<Instant> forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant.isPresent() ) {
             target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate.isPresent() ) {
             target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString().isPresent() ) {
+        Optional<Instant> forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString.isPresent() ) {
             target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
         }
-        if ( source.getForPeriodConversionWithString().isPresent() ) {
+        Optional<Period> forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString.isPresent() ) {
             target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
         }
-        if ( source.getForDurationConversionWithString().isPresent() ) {
+        Optional<Duration> forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString.isPresent() ) {
             target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
         }
 
@@ -95,46 +109,60 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         Target target = new Target();
 
-        if ( source.getZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime.isPresent() ) {
             target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime().get() ) );
         }
-        if ( source.getLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> localDateTime = source.getLocalDateTime();
+        if ( localDateTime.isPresent() ) {
             target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime().get() ) );
         }
-        if ( source.getLocalDate().isPresent() ) {
+        Optional<LocalDate> localDate = source.getLocalDate();
+        if ( localDate.isPresent() ) {
             target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate().get() ) );
         }
-        if ( source.getLocalTime().isPresent() ) {
+        Optional<LocalTime> localTime = source.getLocalTime();
+        if ( localTime.isPresent() ) {
             target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime().get() ) );
         }
-        if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+        Optional<ZonedDateTime> forCalendarConversion = source.getForCalendarConversion();
+        if ( forCalendarConversion.isPresent() ) {
+            target.setForCalendarConversion( zonedDateTimeToCalendar( forCalendarConversion.get() ) );
         }
-        if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime.isPresent() ) {
             target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime.isPresent() ) {
             target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate.isPresent() ) {
             target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate.isPresent() ) {
             target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant().isPresent() ) {
+        Optional<Instant> forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant.isPresent() ) {
             target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate.isPresent() ) {
             target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString().isPresent() ) {
+        Optional<Instant> forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString.isPresent() ) {
             target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
         }
-        if ( source.getForPeriodConversionWithString().isPresent() ) {
+        Optional<Period> forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString.isPresent() ) {
             target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
         }
-        if ( source.getForDurationConversionWithString().isPresent() ) {
+        Optional<Duration> forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString.isPresent() ) {
             target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
         }
 
@@ -149,46 +177,60 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         Target target = new Target();
 
-        if ( source.getZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime.isPresent() ) {
             target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime().get() ) );
         }
-        if ( source.getLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> localDateTime = source.getLocalDateTime();
+        if ( localDateTime.isPresent() ) {
             target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime().get() ) );
         }
-        if ( source.getLocalDate().isPresent() ) {
+        Optional<LocalDate> localDate = source.getLocalDate();
+        if ( localDate.isPresent() ) {
             target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate().get() ) );
         }
-        if ( source.getLocalTime().isPresent() ) {
+        Optional<LocalTime> localTime = source.getLocalTime();
+        if ( localTime.isPresent() ) {
             target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime().get() ) );
         }
-        if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+        Optional<ZonedDateTime> forCalendarConversion = source.getForCalendarConversion();
+        if ( forCalendarConversion.isPresent() ) {
+            target.setForCalendarConversion( zonedDateTimeToCalendar( forCalendarConversion.get() ) );
         }
-        if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime.isPresent() ) {
             target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime.isPresent() ) {
             target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate.isPresent() ) {
             target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate.isPresent() ) {
             target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant().isPresent() ) {
+        Optional<Instant> forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant.isPresent() ) {
             target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate.isPresent() ) {
             target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString().isPresent() ) {
+        Optional<Instant> forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString.isPresent() ) {
             target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
         }
-        if ( source.getForPeriodConversionWithString().isPresent() ) {
+        Optional<Period> forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString.isPresent() ) {
             target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
         }
-        if ( source.getForDurationConversionWithString().isPresent() ) {
+        Optional<Duration> forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString.isPresent() ) {
             target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
         }
 
@@ -203,46 +245,60 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         Target target = new Target();
 
-        if ( source.getLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> localDateTime = source.getLocalDateTime();
+        if ( localDateTime.isPresent() ) {
             target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime().get() ) );
         }
-        if ( source.getZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime.isPresent() ) {
             target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime().get() ) );
         }
-        if ( source.getLocalDate().isPresent() ) {
+        Optional<LocalDate> localDate = source.getLocalDate();
+        if ( localDate.isPresent() ) {
             target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate().get() ) );
         }
-        if ( source.getLocalTime().isPresent() ) {
+        Optional<LocalTime> localTime = source.getLocalTime();
+        if ( localTime.isPresent() ) {
             target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime().get() ) );
         }
-        if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+        Optional<ZonedDateTime> forCalendarConversion = source.getForCalendarConversion();
+        if ( forCalendarConversion.isPresent() ) {
+            target.setForCalendarConversion( zonedDateTimeToCalendar( forCalendarConversion.get() ) );
         }
-        if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime.isPresent() ) {
             target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime.isPresent() ) {
             target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate.isPresent() ) {
             target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate.isPresent() ) {
             target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant().isPresent() ) {
+        Optional<Instant> forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant.isPresent() ) {
             target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate.isPresent() ) {
             target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString().isPresent() ) {
+        Optional<Instant> forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString.isPresent() ) {
             target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
         }
-        if ( source.getForPeriodConversionWithString().isPresent() ) {
+        Optional<Period> forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString.isPresent() ) {
             target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
         }
-        if ( source.getForDurationConversionWithString().isPresent() ) {
+        Optional<Duration> forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString.isPresent() ) {
             target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
         }
 
@@ -257,46 +313,60 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         Target target = new Target();
 
-        if ( source.getLocalDate().isPresent() ) {
+        Optional<LocalDate> localDate = source.getLocalDate();
+        if ( localDate.isPresent() ) {
             target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate().get() ) );
         }
-        if ( source.getZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime.isPresent() ) {
             target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime().get() ) );
         }
-        if ( source.getLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> localDateTime = source.getLocalDateTime();
+        if ( localDateTime.isPresent() ) {
             target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime().get() ) );
         }
-        if ( source.getLocalTime().isPresent() ) {
+        Optional<LocalTime> localTime = source.getLocalTime();
+        if ( localTime.isPresent() ) {
             target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime().get() ) );
         }
-        if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+        Optional<ZonedDateTime> forCalendarConversion = source.getForCalendarConversion();
+        if ( forCalendarConversion.isPresent() ) {
+            target.setForCalendarConversion( zonedDateTimeToCalendar( forCalendarConversion.get() ) );
         }
-        if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime.isPresent() ) {
             target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime.isPresent() ) {
             target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate.isPresent() ) {
             target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate.isPresent() ) {
             target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant().isPresent() ) {
+        Optional<Instant> forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant.isPresent() ) {
             target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate.isPresent() ) {
             target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString().isPresent() ) {
+        Optional<Instant> forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString.isPresent() ) {
             target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
         }
-        if ( source.getForPeriodConversionWithString().isPresent() ) {
+        Optional<Period> forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString.isPresent() ) {
             target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
         }
-        if ( source.getForDurationConversionWithString().isPresent() ) {
+        Optional<Duration> forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString.isPresent() ) {
             target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
         }
 
@@ -311,46 +381,60 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         Target target = new Target();
 
-        if ( source.getLocalTime().isPresent() ) {
+        Optional<LocalTime> localTime = source.getLocalTime();
+        if ( localTime.isPresent() ) {
             target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime().get() ) );
         }
-        if ( source.getZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime.isPresent() ) {
             target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime().get() ) );
         }
-        if ( source.getLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> localDateTime = source.getLocalDateTime();
+        if ( localDateTime.isPresent() ) {
             target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime().get() ) );
         }
-        if ( source.getLocalDate().isPresent() ) {
+        Optional<LocalDate> localDate = source.getLocalDate();
+        if ( localDate.isPresent() ) {
             target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate().get() ) );
         }
-        if ( source.getForCalendarConversion().isPresent() ) {
-            target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion().get() ) );
+        Optional<ZonedDateTime> forCalendarConversion = source.getForCalendarConversion();
+        if ( forCalendarConversion.isPresent() ) {
+            target.setForCalendarConversion( zonedDateTimeToCalendar( forCalendarConversion.get() ) );
         }
-        if ( source.getForDateConversionWithZonedDateTime().isPresent() ) {
+        Optional<ZonedDateTime> forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime.isPresent() ) {
             target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().get().toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime().isPresent() ) {
+        Optional<LocalDateTime> forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime.isPresent() ) {
             target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().get().toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate.isPresent() ) {
             target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate.isPresent() ) {
             target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().get().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant().isPresent() ) {
+        Optional<Instant> forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant.isPresent() ) {
             target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant().get() ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate().isPresent() ) {
+        Optional<LocalDate> forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate.isPresent() ) {
             target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().get().atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString().isPresent() ) {
+        Optional<Instant> forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString.isPresent() ) {
             target.setForInstantConversionWithString( source.getForInstantConversionWithString().get().toString() );
         }
-        if ( source.getForPeriodConversionWithString().isPresent() ) {
+        Optional<Period> forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString.isPresent() ) {
             target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().get().toString() );
         }
-        if ( source.getForDurationConversionWithString().isPresent() ) {
+        Optional<Duration> forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString.isPresent() ) {
             target.setForDurationConversionWithString( source.getForDurationConversionWithString().get().toString() );
         }
 
@@ -365,47 +449,61 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         OptionalSource optionalSource = new OptionalSource();
 
-        if ( target.getZonedDateTime() != null ) {
-            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( target.getZonedDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( zonedDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) ) );
         }
-        if ( target.getLocalDateTime() != null ) {
-            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( target.getLocalDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( localDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) ) );
         }
-        if ( target.getLocalDate() != null ) {
-            optionalSource.setLocalDate( Optional.of( LocalDate.parse( target.getLocalDate(), dateTimeFormatter_dd_MM_yyyy_11900521056 ) ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            optionalSource.setLocalDate( Optional.of( LocalDate.parse( localDate, dateTimeFormatter_dd_MM_yyyy_11900521056 ) ) );
         }
-        if ( target.getLocalTime() != null ) {
-            optionalSource.setLocalTime( Optional.of( LocalTime.parse( target.getLocalTime(), dateTimeFormatter_HH_mm_168697690 ) ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            optionalSource.setLocalTime( Optional.of( LocalTime.parse( localTime, dateTimeFormatter_HH_mm_168697690 ) ) );
         }
-        if ( target.getForCalendarConversion() != null ) {
-            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( target.getForCalendarConversion() ) ) );
+        Calendar forCalendarConversion = target.getForCalendarConversion();
+        if ( forCalendarConversion != null ) {
+            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( forCalendarConversion ) ) );
         }
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( target.getForSqlDateConversionWithLocalDate().toLocalDate() ) );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( forSqlDateConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            optionalSource.setForDateConversionWithInstant( Optional.of( target.getForDateConversionWithInstant().toInstant() ) );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            optionalSource.setForDateConversionWithInstant( Optional.of( forDateConversionWithInstant.toInstant() ) );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() ) );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( forLocalDateTimeConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( target.getForInstantConversionWithString() ) ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( forInstantConversionWithString ) ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( target.getForPeriodConversionWithString() ) ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( forPeriodConversionWithString ) ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( target.getForDurationConversionWithString() ) ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( forDurationConversionWithString ) ) );
         }
 
         return optionalSource;
@@ -419,47 +517,61 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         OptionalSource optionalSource = new OptionalSource();
 
-        if ( target.getZonedDateTime() != null ) {
-            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( target.getZonedDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( zonedDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) ) );
         }
-        if ( target.getLocalDateTime() != null ) {
-            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( target.getLocalDateTime() ) ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( localDateTime ) ) );
         }
-        if ( target.getLocalDate() != null ) {
-            optionalSource.setLocalDate( Optional.of( LocalDate.parse( target.getLocalDate() ) ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            optionalSource.setLocalDate( Optional.of( LocalDate.parse( localDate ) ) );
         }
-        if ( target.getLocalTime() != null ) {
-            optionalSource.setLocalTime( Optional.of( LocalTime.parse( target.getLocalTime() ) ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            optionalSource.setLocalTime( Optional.of( LocalTime.parse( localTime ) ) );
         }
-        if ( target.getForCalendarConversion() != null ) {
-            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( target.getForCalendarConversion() ) ) );
+        Calendar forCalendarConversion = target.getForCalendarConversion();
+        if ( forCalendarConversion != null ) {
+            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( forCalendarConversion ) ) );
         }
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( target.getForSqlDateConversionWithLocalDate().toLocalDate() ) );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( forSqlDateConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            optionalSource.setForDateConversionWithInstant( Optional.of( target.getForDateConversionWithInstant().toInstant() ) );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            optionalSource.setForDateConversionWithInstant( Optional.of( forDateConversionWithInstant.toInstant() ) );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() ) );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( forLocalDateTimeConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( target.getForInstantConversionWithString() ) ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( forInstantConversionWithString ) ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( target.getForPeriodConversionWithString() ) ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( forPeriodConversionWithString ) ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( target.getForDurationConversionWithString() ) ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( forDurationConversionWithString ) ) );
         }
 
         return optionalSource;
@@ -473,47 +585,61 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         OptionalSource optionalSource = new OptionalSource();
 
-        if ( target.getLocalDateTime() != null ) {
-            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( target.getLocalDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( localDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) ) );
         }
-        if ( target.getZonedDateTime() != null ) {
-            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( target.getZonedDateTime() ) ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( zonedDateTime ) ) );
         }
-        if ( target.getLocalDate() != null ) {
-            optionalSource.setLocalDate( Optional.of( LocalDate.parse( target.getLocalDate() ) ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            optionalSource.setLocalDate( Optional.of( LocalDate.parse( localDate ) ) );
         }
-        if ( target.getLocalTime() != null ) {
-            optionalSource.setLocalTime( Optional.of( LocalTime.parse( target.getLocalTime() ) ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            optionalSource.setLocalTime( Optional.of( LocalTime.parse( localTime ) ) );
         }
-        if ( target.getForCalendarConversion() != null ) {
-            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( target.getForCalendarConversion() ) ) );
+        Calendar forCalendarConversion = target.getForCalendarConversion();
+        if ( forCalendarConversion != null ) {
+            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( forCalendarConversion ) ) );
         }
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( target.getForSqlDateConversionWithLocalDate().toLocalDate() ) );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( forSqlDateConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            optionalSource.setForDateConversionWithInstant( Optional.of( target.getForDateConversionWithInstant().toInstant() ) );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            optionalSource.setForDateConversionWithInstant( Optional.of( forDateConversionWithInstant.toInstant() ) );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() ) );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( forLocalDateTimeConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( target.getForInstantConversionWithString() ) ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( forInstantConversionWithString ) ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( target.getForPeriodConversionWithString() ) ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( forPeriodConversionWithString ) ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( target.getForDurationConversionWithString() ) ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( forDurationConversionWithString ) ) );
         }
 
         return optionalSource;
@@ -527,47 +653,61 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         OptionalSource optionalSource = new OptionalSource();
 
-        if ( target.getLocalDate() != null ) {
-            optionalSource.setLocalDate( Optional.of( LocalDate.parse( target.getLocalDate(), dateTimeFormatter_dd_MM_yyyy_11900521056 ) ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            optionalSource.setLocalDate( Optional.of( LocalDate.parse( localDate, dateTimeFormatter_dd_MM_yyyy_11900521056 ) ) );
         }
-        if ( target.getZonedDateTime() != null ) {
-            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( target.getZonedDateTime() ) ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( zonedDateTime ) ) );
         }
-        if ( target.getLocalDateTime() != null ) {
-            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( target.getLocalDateTime() ) ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( localDateTime ) ) );
         }
-        if ( target.getLocalTime() != null ) {
-            optionalSource.setLocalTime( Optional.of( LocalTime.parse( target.getLocalTime() ) ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            optionalSource.setLocalTime( Optional.of( LocalTime.parse( localTime ) ) );
         }
-        if ( target.getForCalendarConversion() != null ) {
-            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( target.getForCalendarConversion() ) ) );
+        Calendar forCalendarConversion = target.getForCalendarConversion();
+        if ( forCalendarConversion != null ) {
+            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( forCalendarConversion ) ) );
         }
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( target.getForSqlDateConversionWithLocalDate().toLocalDate() ) );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( forSqlDateConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            optionalSource.setForDateConversionWithInstant( Optional.of( target.getForDateConversionWithInstant().toInstant() ) );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            optionalSource.setForDateConversionWithInstant( Optional.of( forDateConversionWithInstant.toInstant() ) );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() ) );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( forLocalDateTimeConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( target.getForInstantConversionWithString() ) ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( forInstantConversionWithString ) ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( target.getForPeriodConversionWithString() ) ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( forPeriodConversionWithString ) ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( target.getForDurationConversionWithString() ) ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( forDurationConversionWithString ) ) );
         }
 
         return optionalSource;
@@ -581,47 +721,61 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         OptionalSource optionalSource = new OptionalSource();
 
-        if ( target.getLocalTime() != null ) {
-            optionalSource.setLocalTime( Optional.of( LocalTime.parse( target.getLocalTime(), dateTimeFormatter_HH_mm_168697690 ) ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            optionalSource.setLocalTime( Optional.of( LocalTime.parse( localTime, dateTimeFormatter_HH_mm_168697690 ) ) );
         }
-        if ( target.getZonedDateTime() != null ) {
-            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( target.getZonedDateTime() ) ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( zonedDateTime ) ) );
         }
-        if ( target.getLocalDateTime() != null ) {
-            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( target.getLocalDateTime() ) ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( localDateTime ) ) );
         }
-        if ( target.getLocalDate() != null ) {
-            optionalSource.setLocalDate( Optional.of( LocalDate.parse( target.getLocalDate() ) ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            optionalSource.setLocalDate( Optional.of( LocalDate.parse( localDate ) ) );
         }
-        if ( target.getForCalendarConversion() != null ) {
-            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( target.getForCalendarConversion() ) ) );
+        Calendar forCalendarConversion = target.getForCalendarConversion();
+        if ( forCalendarConversion != null ) {
+            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( forCalendarConversion ) ) );
         }
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( target.getForSqlDateConversionWithLocalDate().toLocalDate() ) );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( forSqlDateConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            optionalSource.setForDateConversionWithInstant( Optional.of( target.getForDateConversionWithInstant().toInstant() ) );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            optionalSource.setForDateConversionWithInstant( Optional.of( forDateConversionWithInstant.toInstant() ) );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() ) );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( forLocalDateTimeConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( target.getForInstantConversionWithString() ) ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( forInstantConversionWithString ) ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( target.getForPeriodConversionWithString() ) ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( forPeriodConversionWithString ) ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( target.getForDurationConversionWithString() ) ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( forDurationConversionWithString ) ) );
         }
 
         return optionalSource;
@@ -635,47 +789,61 @@ public class OptionalSourceTargetMapperImpl implements OptionalSourceTargetMappe
 
         OptionalSource optionalSource = new OptionalSource();
 
-        if ( target.getZonedDateTime() != null ) {
-            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( target.getZonedDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            optionalSource.setZonedDateTime( Optional.of( ZonedDateTime.parse( zonedDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) ) );
         }
-        if ( target.getLocalDateTime() != null ) {
-            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( target.getLocalDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            optionalSource.setLocalDateTime( Optional.of( LocalDateTime.parse( localDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) ) );
         }
-        if ( target.getLocalDate() != null ) {
-            optionalSource.setLocalDate( Optional.of( LocalDate.parse( target.getLocalDate(), dateTimeFormatter_dd_MM_yyyy_11900521056 ) ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            optionalSource.setLocalDate( Optional.of( LocalDate.parse( localDate, dateTimeFormatter_dd_MM_yyyy_11900521056 ) ) );
         }
-        if ( target.getLocalTime() != null ) {
-            optionalSource.setLocalTime( Optional.of( LocalTime.parse( target.getLocalTime(), dateTimeFormatter_HH_mm_168697690 ) ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            optionalSource.setLocalTime( Optional.of( LocalTime.parse( localTime, dateTimeFormatter_HH_mm_168697690 ) ) );
         }
-        if ( target.getForCalendarConversion() != null ) {
-            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( target.getForCalendarConversion() ) ) );
+        Calendar forCalendarConversion = target.getForCalendarConversion();
+        if ( forCalendarConversion != null ) {
+            optionalSource.setForCalendarConversion( Optional.of( calendarToZonedDateTime( forCalendarConversion ) ) );
         }
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            optionalSource.setForDateConversionWithZonedDateTime( Optional.of( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            optionalSource.setForDateConversionWithLocalDateTime( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            optionalSource.setForDateConversionWithLocalDate( Optional.of( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() ) );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( target.getForSqlDateConversionWithLocalDate().toLocalDate() ) );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            optionalSource.setForSqlDateConversionWithLocalDate( Optional.of( forSqlDateConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            optionalSource.setForDateConversionWithInstant( Optional.of( target.getForDateConversionWithInstant().toInstant() ) );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            optionalSource.setForDateConversionWithInstant( Optional.of( forDateConversionWithInstant.toInstant() ) );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() ) );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            optionalSource.setForLocalDateTimeConversionWithLocalDate( Optional.of( forLocalDateTimeConversionWithLocalDate.toLocalDate() ) );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( target.getForInstantConversionWithString() ) ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            optionalSource.setForInstantConversionWithString( Optional.of( Instant.parse( forInstantConversionWithString ) ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( target.getForPeriodConversionWithString() ) ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            optionalSource.setForPeriodConversionWithString( Optional.of( Period.parse( forPeriodConversionWithString ) ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( target.getForDurationConversionWithString() ) ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            optionalSource.setForDurationConversionWithString( Optional.of( Duration.parse( forDurationConversionWithString ) ) );
         }
 
         return optionalSource;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/java8time/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/java8time/SourceTargetMapperImpl.java
@@ -18,12 +18,12 @@ import java.time.format.DateTimeFormatter;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2021-05-15T18:24:04+0200",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_275 (AdoptOpenJDK)"
+    date = "2026-06-05T14:56:18+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class SourceTargetMapperImpl implements SourceTargetMapper {
 
@@ -40,45 +40,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Target target = new Target();
 
-        if ( source.getZonedDateTime() != null ) {
-            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime() ) );
+        ZonedDateTime zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( zonedDateTime ) );
         }
-        if ( source.getLocalDateTime() != null ) {
-            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime() ) );
+        LocalDateTime localDateTime = source.getLocalDateTime();
+        if ( localDateTime != null ) {
+            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( localDateTime ) );
         }
-        if ( source.getLocalDate() != null ) {
-            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate() ) );
+        LocalDate localDate = source.getLocalDate();
+        if ( localDate != null ) {
+            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( localDate ) );
         }
-        if ( source.getLocalTime() != null ) {
-            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime() ) );
+        LocalTime localTime = source.getLocalTime();
+        if ( localTime != null ) {
+            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( localTime ) );
         }
         target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion() ) );
-        if ( source.getForDateConversionWithZonedDateTime() != null ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().toInstant() ) );
+        ZonedDateTime forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            target.setForDateConversionWithZonedDateTime( Date.from( forDateConversionWithZonedDateTime.toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime() != null ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().toInstant( ZoneOffset.UTC ) ) );
+        LocalDateTime forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            target.setForDateConversionWithLocalDateTime( Date.from( forDateConversionWithLocalDateTime.toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate() != null ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+        LocalDate forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            target.setForDateConversionWithLocalDate( Date.from( forDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate() != null ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+        LocalDate forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( forSqlDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant() != null ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant() ) );
+        Instant forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            target.setForDateConversionWithInstant( Date.from( forDateConversionWithInstant ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().atStartOfDay() );
+        LocalDate forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            target.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString() != null ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().toString() );
+        Instant forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            target.setForInstantConversionWithString( forInstantConversionWithString.toString() );
         }
-        if ( source.getForPeriodConversionWithString() != null ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().toString() );
+        Period forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            target.setForPeriodConversionWithString( forPeriodConversionWithString.toString() );
         }
-        if ( source.getForDurationConversionWithString() != null ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().toString() );
+        Duration forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            target.setForDurationConversionWithString( forDurationConversionWithString.toString() );
         }
 
         return target;
@@ -92,45 +105,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Target target = new Target();
 
-        if ( source.getZonedDateTime() != null ) {
-            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime() ) );
+        ZonedDateTime zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( zonedDateTime ) );
         }
-        if ( source.getLocalDateTime() != null ) {
-            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime() ) );
+        LocalDateTime localDateTime = source.getLocalDateTime();
+        if ( localDateTime != null ) {
+            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( localDateTime ) );
         }
-        if ( source.getLocalDate() != null ) {
-            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate() ) );
+        LocalDate localDate = source.getLocalDate();
+        if ( localDate != null ) {
+            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( localDate ) );
         }
-        if ( source.getLocalTime() != null ) {
-            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime() ) );
+        LocalTime localTime = source.getLocalTime();
+        if ( localTime != null ) {
+            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( localTime ) );
         }
         target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion() ) );
-        if ( source.getForDateConversionWithZonedDateTime() != null ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().toInstant() ) );
+        ZonedDateTime forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            target.setForDateConversionWithZonedDateTime( Date.from( forDateConversionWithZonedDateTime.toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime() != null ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().toInstant( ZoneOffset.UTC ) ) );
+        LocalDateTime forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            target.setForDateConversionWithLocalDateTime( Date.from( forDateConversionWithLocalDateTime.toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate() != null ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+        LocalDate forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            target.setForDateConversionWithLocalDate( Date.from( forDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate() != null ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+        LocalDate forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( forSqlDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant() != null ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant() ) );
+        Instant forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            target.setForDateConversionWithInstant( Date.from( forDateConversionWithInstant ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().atStartOfDay() );
+        LocalDate forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            target.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString() != null ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().toString() );
+        Instant forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            target.setForInstantConversionWithString( forInstantConversionWithString.toString() );
         }
-        if ( source.getForPeriodConversionWithString() != null ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().toString() );
+        Period forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            target.setForPeriodConversionWithString( forPeriodConversionWithString.toString() );
         }
-        if ( source.getForDurationConversionWithString() != null ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().toString() );
+        Duration forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            target.setForDurationConversionWithString( forDurationConversionWithString.toString() );
         }
 
         return target;
@@ -144,45 +170,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Target target = new Target();
 
-        if ( source.getZonedDateTime() != null ) {
-            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( source.getZonedDateTime() ) );
+        ZonedDateTime zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            target.setZonedDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668.format( zonedDateTime ) );
         }
-        if ( source.getLocalDateTime() != null ) {
-            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime() ) );
+        LocalDateTime localDateTime = source.getLocalDateTime();
+        if ( localDateTime != null ) {
+            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( localDateTime ) );
         }
-        if ( source.getLocalDate() != null ) {
-            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate() ) );
+        LocalDate localDate = source.getLocalDate();
+        if ( localDate != null ) {
+            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( localDate ) );
         }
-        if ( source.getLocalTime() != null ) {
-            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime() ) );
+        LocalTime localTime = source.getLocalTime();
+        if ( localTime != null ) {
+            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( localTime ) );
         }
         target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion() ) );
-        if ( source.getForDateConversionWithZonedDateTime() != null ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().toInstant() ) );
+        ZonedDateTime forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            target.setForDateConversionWithZonedDateTime( Date.from( forDateConversionWithZonedDateTime.toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime() != null ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().toInstant( ZoneOffset.UTC ) ) );
+        LocalDateTime forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            target.setForDateConversionWithLocalDateTime( Date.from( forDateConversionWithLocalDateTime.toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate() != null ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+        LocalDate forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            target.setForDateConversionWithLocalDate( Date.from( forDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate() != null ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+        LocalDate forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( forSqlDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant() != null ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant() ) );
+        Instant forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            target.setForDateConversionWithInstant( Date.from( forDateConversionWithInstant ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().atStartOfDay() );
+        LocalDate forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            target.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString() != null ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().toString() );
+        Instant forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            target.setForInstantConversionWithString( forInstantConversionWithString.toString() );
         }
-        if ( source.getForPeriodConversionWithString() != null ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().toString() );
+        Period forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            target.setForPeriodConversionWithString( forPeriodConversionWithString.toString() );
         }
-        if ( source.getForDurationConversionWithString() != null ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().toString() );
+        Duration forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            target.setForDurationConversionWithString( forDurationConversionWithString.toString() );
         }
 
         return target;
@@ -196,45 +235,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Target target = new Target();
 
-        if ( source.getLocalDateTime() != null ) {
-            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime() ) );
+        LocalDateTime localDateTime = source.getLocalDateTime();
+        if ( localDateTime != null ) {
+            target.setLocalDateTime( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( localDateTime ) );
         }
-        if ( source.getZonedDateTime() != null ) {
-            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime() ) );
+        ZonedDateTime zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( zonedDateTime ) );
         }
-        if ( source.getLocalDate() != null ) {
-            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate() ) );
+        LocalDate localDate = source.getLocalDate();
+        if ( localDate != null ) {
+            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( localDate ) );
         }
-        if ( source.getLocalTime() != null ) {
-            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime() ) );
+        LocalTime localTime = source.getLocalTime();
+        if ( localTime != null ) {
+            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( localTime ) );
         }
         target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion() ) );
-        if ( source.getForDateConversionWithZonedDateTime() != null ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().toInstant() ) );
+        ZonedDateTime forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            target.setForDateConversionWithZonedDateTime( Date.from( forDateConversionWithZonedDateTime.toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime() != null ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().toInstant( ZoneOffset.UTC ) ) );
+        LocalDateTime forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            target.setForDateConversionWithLocalDateTime( Date.from( forDateConversionWithLocalDateTime.toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate() != null ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+        LocalDate forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            target.setForDateConversionWithLocalDate( Date.from( forDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate() != null ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+        LocalDate forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( forSqlDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant() != null ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant() ) );
+        Instant forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            target.setForDateConversionWithInstant( Date.from( forDateConversionWithInstant ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().atStartOfDay() );
+        LocalDate forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            target.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString() != null ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().toString() );
+        Instant forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            target.setForInstantConversionWithString( forInstantConversionWithString.toString() );
         }
-        if ( source.getForPeriodConversionWithString() != null ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().toString() );
+        Period forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            target.setForPeriodConversionWithString( forPeriodConversionWithString.toString() );
         }
-        if ( source.getForDurationConversionWithString() != null ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().toString() );
+        Duration forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            target.setForDurationConversionWithString( forDurationConversionWithString.toString() );
         }
 
         return target;
@@ -248,45 +300,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Target target = new Target();
 
-        if ( source.getLocalDate() != null ) {
-            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( source.getLocalDate() ) );
+        LocalDate localDate = source.getLocalDate();
+        if ( localDate != null ) {
+            target.setLocalDate( dateTimeFormatter_dd_MM_yyyy_11900521056.format( localDate ) );
         }
-        if ( source.getZonedDateTime() != null ) {
-            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime() ) );
+        ZonedDateTime zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( zonedDateTime ) );
         }
-        if ( source.getLocalDateTime() != null ) {
-            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime() ) );
+        LocalDateTime localDateTime = source.getLocalDateTime();
+        if ( localDateTime != null ) {
+            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( localDateTime ) );
         }
-        if ( source.getLocalTime() != null ) {
-            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( source.getLocalTime() ) );
+        LocalTime localTime = source.getLocalTime();
+        if ( localTime != null ) {
+            target.setLocalTime( DateTimeFormatter.ISO_LOCAL_TIME.format( localTime ) );
         }
         target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion() ) );
-        if ( source.getForDateConversionWithZonedDateTime() != null ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().toInstant() ) );
+        ZonedDateTime forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            target.setForDateConversionWithZonedDateTime( Date.from( forDateConversionWithZonedDateTime.toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime() != null ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().toInstant( ZoneOffset.UTC ) ) );
+        LocalDateTime forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            target.setForDateConversionWithLocalDateTime( Date.from( forDateConversionWithLocalDateTime.toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate() != null ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+        LocalDate forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            target.setForDateConversionWithLocalDate( Date.from( forDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate() != null ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+        LocalDate forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( forSqlDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant() != null ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant() ) );
+        Instant forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            target.setForDateConversionWithInstant( Date.from( forDateConversionWithInstant ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().atStartOfDay() );
+        LocalDate forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            target.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString() != null ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().toString() );
+        Instant forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            target.setForInstantConversionWithString( forInstantConversionWithString.toString() );
         }
-        if ( source.getForPeriodConversionWithString() != null ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().toString() );
+        Period forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            target.setForPeriodConversionWithString( forPeriodConversionWithString.toString() );
         }
-        if ( source.getForDurationConversionWithString() != null ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().toString() );
+        Duration forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            target.setForDurationConversionWithString( forDurationConversionWithString.toString() );
         }
 
         return target;
@@ -300,45 +365,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Target target = new Target();
 
-        if ( source.getLocalTime() != null ) {
-            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( source.getLocalTime() ) );
+        LocalTime localTime = source.getLocalTime();
+        if ( localTime != null ) {
+            target.setLocalTime( dateTimeFormatter_HH_mm_168697690.format( localTime ) );
         }
-        if ( source.getZonedDateTime() != null ) {
-            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( source.getZonedDateTime() ) );
+        ZonedDateTime zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            target.setZonedDateTime( DateTimeFormatter.ISO_DATE_TIME.format( zonedDateTime ) );
         }
-        if ( source.getLocalDateTime() != null ) {
-            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( source.getLocalDateTime() ) );
+        LocalDateTime localDateTime = source.getLocalDateTime();
+        if ( localDateTime != null ) {
+            target.setLocalDateTime( DateTimeFormatter.ISO_LOCAL_DATE_TIME.format( localDateTime ) );
         }
-        if ( source.getLocalDate() != null ) {
-            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( source.getLocalDate() ) );
+        LocalDate localDate = source.getLocalDate();
+        if ( localDate != null ) {
+            target.setLocalDate( DateTimeFormatter.ISO_LOCAL_DATE.format( localDate ) );
         }
         target.setForCalendarConversion( zonedDateTimeToCalendar( source.getForCalendarConversion() ) );
-        if ( source.getForDateConversionWithZonedDateTime() != null ) {
-            target.setForDateConversionWithZonedDateTime( Date.from( source.getForDateConversionWithZonedDateTime().toInstant() ) );
+        ZonedDateTime forDateConversionWithZonedDateTime = source.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            target.setForDateConversionWithZonedDateTime( Date.from( forDateConversionWithZonedDateTime.toInstant() ) );
         }
-        if ( source.getForDateConversionWithLocalDateTime() != null ) {
-            target.setForDateConversionWithLocalDateTime( Date.from( source.getForDateConversionWithLocalDateTime().toInstant( ZoneOffset.UTC ) ) );
+        LocalDateTime forDateConversionWithLocalDateTime = source.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            target.setForDateConversionWithLocalDateTime( Date.from( forDateConversionWithLocalDateTime.toInstant( ZoneOffset.UTC ) ) );
         }
-        if ( source.getForDateConversionWithLocalDate() != null ) {
-            target.setForDateConversionWithLocalDate( Date.from( source.getForDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
+        LocalDate forDateConversionWithLocalDate = source.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            target.setForDateConversionWithLocalDate( Date.from( forDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant() ) );
         }
-        if ( source.getForSqlDateConversionWithLocalDate() != null ) {
-            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( source.getForSqlDateConversionWithLocalDate().atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
+        LocalDate forSqlDateConversionWithLocalDate = source.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            target.setForSqlDateConversionWithLocalDate( new java.sql.Date( forSqlDateConversionWithLocalDate.atStartOfDay( ZoneOffset.UTC ).toInstant().toEpochMilli() ) );
         }
-        if ( source.getForDateConversionWithInstant() != null ) {
-            target.setForDateConversionWithInstant( Date.from( source.getForDateConversionWithInstant() ) );
+        Instant forDateConversionWithInstant = source.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            target.setForDateConversionWithInstant( Date.from( forDateConversionWithInstant ) );
         }
-        if ( source.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            target.setForLocalDateTimeConversionWithLocalDate( source.getForLocalDateTimeConversionWithLocalDate().atStartOfDay() );
+        LocalDate forLocalDateTimeConversionWithLocalDate = source.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            target.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.atStartOfDay() );
         }
-        if ( source.getForInstantConversionWithString() != null ) {
-            target.setForInstantConversionWithString( source.getForInstantConversionWithString().toString() );
+        Instant forInstantConversionWithString = source.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            target.setForInstantConversionWithString( forInstantConversionWithString.toString() );
         }
-        if ( source.getForPeriodConversionWithString() != null ) {
-            target.setForPeriodConversionWithString( source.getForPeriodConversionWithString().toString() );
+        Period forPeriodConversionWithString = source.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            target.setForPeriodConversionWithString( forPeriodConversionWithString.toString() );
         }
-        if ( source.getForDurationConversionWithString() != null ) {
-            target.setForDurationConversionWithString( source.getForDurationConversionWithString().toString() );
+        Duration forDurationConversionWithString = source.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            target.setForDurationConversionWithString( forDurationConversionWithString.toString() );
         }
 
         return target;
@@ -352,45 +430,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Source source = new Source();
 
-        if ( target.getZonedDateTime() != null ) {
-            source.setZonedDateTime( ZonedDateTime.parse( target.getZonedDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            source.setZonedDateTime( ZonedDateTime.parse( zonedDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) );
         }
-        if ( target.getLocalDateTime() != null ) {
-            source.setLocalDateTime( LocalDateTime.parse( target.getLocalDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            source.setLocalDateTime( LocalDateTime.parse( localDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) );
         }
-        if ( target.getLocalDate() != null ) {
-            source.setLocalDate( LocalDate.parse( target.getLocalDate(), dateTimeFormatter_dd_MM_yyyy_11900521056 ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            source.setLocalDate( LocalDate.parse( localDate, dateTimeFormatter_dd_MM_yyyy_11900521056 ) );
         }
-        if ( target.getLocalTime() != null ) {
-            source.setLocalTime( LocalTime.parse( target.getLocalTime(), dateTimeFormatter_HH_mm_168697690 ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            source.setLocalTime( LocalTime.parse( localTime, dateTimeFormatter_HH_mm_168697690 ) );
         }
         source.setForCalendarConversion( calendarToZonedDateTime( target.getForCalendarConversion() ) );
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            source.setForSqlDateConversionWithLocalDate( target.getForSqlDateConversionWithLocalDate().toLocalDate() );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            source.setForSqlDateConversionWithLocalDate( forSqlDateConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            source.setForDateConversionWithInstant( target.getForDateConversionWithInstant().toInstant() );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            source.setForDateConversionWithInstant( forDateConversionWithInstant.toInstant() );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            source.setForLocalDateTimeConversionWithLocalDate( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            source.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            source.setForInstantConversionWithString( Instant.parse( target.getForInstantConversionWithString() ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            source.setForInstantConversionWithString( Instant.parse( forInstantConversionWithString ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            source.setForPeriodConversionWithString( Period.parse( target.getForPeriodConversionWithString() ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            source.setForPeriodConversionWithString( Period.parse( forPeriodConversionWithString ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            source.setForDurationConversionWithString( Duration.parse( target.getForDurationConversionWithString() ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            source.setForDurationConversionWithString( Duration.parse( forDurationConversionWithString ) );
         }
 
         return source;
@@ -404,45 +495,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Source source = new Source();
 
-        if ( target.getZonedDateTime() != null ) {
-            source.setZonedDateTime( ZonedDateTime.parse( target.getZonedDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            source.setZonedDateTime( ZonedDateTime.parse( zonedDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) );
         }
-        if ( target.getLocalDateTime() != null ) {
-            source.setLocalDateTime( LocalDateTime.parse( target.getLocalDateTime() ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            source.setLocalDateTime( LocalDateTime.parse( localDateTime ) );
         }
-        if ( target.getLocalDate() != null ) {
-            source.setLocalDate( LocalDate.parse( target.getLocalDate() ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            source.setLocalDate( LocalDate.parse( localDate ) );
         }
-        if ( target.getLocalTime() != null ) {
-            source.setLocalTime( LocalTime.parse( target.getLocalTime() ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            source.setLocalTime( LocalTime.parse( localTime ) );
         }
         source.setForCalendarConversion( calendarToZonedDateTime( target.getForCalendarConversion() ) );
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            source.setForSqlDateConversionWithLocalDate( target.getForSqlDateConversionWithLocalDate().toLocalDate() );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            source.setForSqlDateConversionWithLocalDate( forSqlDateConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            source.setForDateConversionWithInstant( target.getForDateConversionWithInstant().toInstant() );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            source.setForDateConversionWithInstant( forDateConversionWithInstant.toInstant() );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            source.setForLocalDateTimeConversionWithLocalDate( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            source.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            source.setForInstantConversionWithString( Instant.parse( target.getForInstantConversionWithString() ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            source.setForInstantConversionWithString( Instant.parse( forInstantConversionWithString ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            source.setForPeriodConversionWithString( Period.parse( target.getForPeriodConversionWithString() ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            source.setForPeriodConversionWithString( Period.parse( forPeriodConversionWithString ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            source.setForDurationConversionWithString( Duration.parse( target.getForDurationConversionWithString() ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            source.setForDurationConversionWithString( Duration.parse( forDurationConversionWithString ) );
         }
 
         return source;
@@ -456,45 +560,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Source source = new Source();
 
-        if ( target.getLocalDateTime() != null ) {
-            source.setLocalDateTime( LocalDateTime.parse( target.getLocalDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            source.setLocalDateTime( LocalDateTime.parse( localDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) );
         }
-        if ( target.getZonedDateTime() != null ) {
-            source.setZonedDateTime( ZonedDateTime.parse( target.getZonedDateTime() ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            source.setZonedDateTime( ZonedDateTime.parse( zonedDateTime ) );
         }
-        if ( target.getLocalDate() != null ) {
-            source.setLocalDate( LocalDate.parse( target.getLocalDate() ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            source.setLocalDate( LocalDate.parse( localDate ) );
         }
-        if ( target.getLocalTime() != null ) {
-            source.setLocalTime( LocalTime.parse( target.getLocalTime() ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            source.setLocalTime( LocalTime.parse( localTime ) );
         }
         source.setForCalendarConversion( calendarToZonedDateTime( target.getForCalendarConversion() ) );
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            source.setForSqlDateConversionWithLocalDate( target.getForSqlDateConversionWithLocalDate().toLocalDate() );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            source.setForSqlDateConversionWithLocalDate( forSqlDateConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            source.setForDateConversionWithInstant( target.getForDateConversionWithInstant().toInstant() );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            source.setForDateConversionWithInstant( forDateConversionWithInstant.toInstant() );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            source.setForLocalDateTimeConversionWithLocalDate( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            source.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            source.setForInstantConversionWithString( Instant.parse( target.getForInstantConversionWithString() ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            source.setForInstantConversionWithString( Instant.parse( forInstantConversionWithString ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            source.setForPeriodConversionWithString( Period.parse( target.getForPeriodConversionWithString() ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            source.setForPeriodConversionWithString( Period.parse( forPeriodConversionWithString ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            source.setForDurationConversionWithString( Duration.parse( target.getForDurationConversionWithString() ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            source.setForDurationConversionWithString( Duration.parse( forDurationConversionWithString ) );
         }
 
         return source;
@@ -508,45 +625,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Source source = new Source();
 
-        if ( target.getLocalDate() != null ) {
-            source.setLocalDate( LocalDate.parse( target.getLocalDate(), dateTimeFormatter_dd_MM_yyyy_11900521056 ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            source.setLocalDate( LocalDate.parse( localDate, dateTimeFormatter_dd_MM_yyyy_11900521056 ) );
         }
-        if ( target.getZonedDateTime() != null ) {
-            source.setZonedDateTime( ZonedDateTime.parse( target.getZonedDateTime() ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            source.setZonedDateTime( ZonedDateTime.parse( zonedDateTime ) );
         }
-        if ( target.getLocalDateTime() != null ) {
-            source.setLocalDateTime( LocalDateTime.parse( target.getLocalDateTime() ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            source.setLocalDateTime( LocalDateTime.parse( localDateTime ) );
         }
-        if ( target.getLocalTime() != null ) {
-            source.setLocalTime( LocalTime.parse( target.getLocalTime() ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            source.setLocalTime( LocalTime.parse( localTime ) );
         }
         source.setForCalendarConversion( calendarToZonedDateTime( target.getForCalendarConversion() ) );
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            source.setForSqlDateConversionWithLocalDate( target.getForSqlDateConversionWithLocalDate().toLocalDate() );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            source.setForSqlDateConversionWithLocalDate( forSqlDateConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            source.setForDateConversionWithInstant( target.getForDateConversionWithInstant().toInstant() );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            source.setForDateConversionWithInstant( forDateConversionWithInstant.toInstant() );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            source.setForLocalDateTimeConversionWithLocalDate( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            source.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            source.setForInstantConversionWithString( Instant.parse( target.getForInstantConversionWithString() ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            source.setForInstantConversionWithString( Instant.parse( forInstantConversionWithString ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            source.setForPeriodConversionWithString( Period.parse( target.getForPeriodConversionWithString() ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            source.setForPeriodConversionWithString( Period.parse( forPeriodConversionWithString ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            source.setForDurationConversionWithString( Duration.parse( target.getForDurationConversionWithString() ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            source.setForDurationConversionWithString( Duration.parse( forDurationConversionWithString ) );
         }
 
         return source;
@@ -560,45 +690,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Source source = new Source();
 
-        if ( target.getLocalTime() != null ) {
-            source.setLocalTime( LocalTime.parse( target.getLocalTime(), dateTimeFormatter_HH_mm_168697690 ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            source.setLocalTime( LocalTime.parse( localTime, dateTimeFormatter_HH_mm_168697690 ) );
         }
-        if ( target.getZonedDateTime() != null ) {
-            source.setZonedDateTime( ZonedDateTime.parse( target.getZonedDateTime() ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            source.setZonedDateTime( ZonedDateTime.parse( zonedDateTime ) );
         }
-        if ( target.getLocalDateTime() != null ) {
-            source.setLocalDateTime( LocalDateTime.parse( target.getLocalDateTime() ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            source.setLocalDateTime( LocalDateTime.parse( localDateTime ) );
         }
-        if ( target.getLocalDate() != null ) {
-            source.setLocalDate( LocalDate.parse( target.getLocalDate() ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            source.setLocalDate( LocalDate.parse( localDate ) );
         }
         source.setForCalendarConversion( calendarToZonedDateTime( target.getForCalendarConversion() ) );
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            source.setForSqlDateConversionWithLocalDate( target.getForSqlDateConversionWithLocalDate().toLocalDate() );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            source.setForSqlDateConversionWithLocalDate( forSqlDateConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            source.setForDateConversionWithInstant( target.getForDateConversionWithInstant().toInstant() );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            source.setForDateConversionWithInstant( forDateConversionWithInstant.toInstant() );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            source.setForLocalDateTimeConversionWithLocalDate( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            source.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            source.setForInstantConversionWithString( Instant.parse( target.getForInstantConversionWithString() ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            source.setForInstantConversionWithString( Instant.parse( forInstantConversionWithString ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            source.setForPeriodConversionWithString( Period.parse( target.getForPeriodConversionWithString() ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            source.setForPeriodConversionWithString( Period.parse( forPeriodConversionWithString ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            source.setForDurationConversionWithString( Duration.parse( target.getForDurationConversionWithString() ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            source.setForDurationConversionWithString( Duration.parse( forDurationConversionWithString ) );
         }
 
         return source;
@@ -612,45 +755,58 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Source source = new Source();
 
-        if ( target.getZonedDateTime() != null ) {
-            source.setZonedDateTime( ZonedDateTime.parse( target.getZonedDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) );
+        String zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            source.setZonedDateTime( ZonedDateTime.parse( zonedDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_z_01894582668 ) );
         }
-        if ( target.getLocalDateTime() != null ) {
-            source.setLocalDateTime( LocalDateTime.parse( target.getLocalDateTime(), dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) );
+        String localDateTime = target.getLocalDateTime();
+        if ( localDateTime != null ) {
+            source.setLocalDateTime( LocalDateTime.parse( localDateTime, dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) );
         }
-        if ( target.getLocalDate() != null ) {
-            source.setLocalDate( LocalDate.parse( target.getLocalDate(), dateTimeFormatter_dd_MM_yyyy_11900521056 ) );
+        String localDate = target.getLocalDate();
+        if ( localDate != null ) {
+            source.setLocalDate( LocalDate.parse( localDate, dateTimeFormatter_dd_MM_yyyy_11900521056 ) );
         }
-        if ( target.getLocalTime() != null ) {
-            source.setLocalTime( LocalTime.parse( target.getLocalTime(), dateTimeFormatter_HH_mm_168697690 ) );
+        String localTime = target.getLocalTime();
+        if ( localTime != null ) {
+            source.setLocalTime( LocalTime.parse( localTime, dateTimeFormatter_HH_mm_168697690 ) );
         }
         source.setForCalendarConversion( calendarToZonedDateTime( target.getForCalendarConversion() ) );
-        if ( target.getForDateConversionWithZonedDateTime() != null ) {
-            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( target.getForDateConversionWithZonedDateTime().toInstant(), ZoneId.systemDefault() ) );
+        Date forDateConversionWithZonedDateTime = target.getForDateConversionWithZonedDateTime();
+        if ( forDateConversionWithZonedDateTime != null ) {
+            source.setForDateConversionWithZonedDateTime( ZonedDateTime.ofInstant( forDateConversionWithZonedDateTime.toInstant(), ZoneId.systemDefault() ) );
         }
-        if ( target.getForDateConversionWithLocalDateTime() != null ) {
-            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDateTime().toInstant(), ZoneId.of( "UTC" ) ) );
+        Date forDateConversionWithLocalDateTime = target.getForDateConversionWithLocalDateTime();
+        if ( forDateConversionWithLocalDateTime != null ) {
+            source.setForDateConversionWithLocalDateTime( LocalDateTime.ofInstant( forDateConversionWithLocalDateTime.toInstant(), ZoneId.of( "UTC" ) ) );
         }
-        if ( target.getForDateConversionWithLocalDate() != null ) {
-            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( target.getForDateConversionWithLocalDate().toInstant(), ZoneOffset.UTC ).toLocalDate() );
+        Date forDateConversionWithLocalDate = target.getForDateConversionWithLocalDate();
+        if ( forDateConversionWithLocalDate != null ) {
+            source.setForDateConversionWithLocalDate( LocalDateTime.ofInstant( forDateConversionWithLocalDate.toInstant(), ZoneOffset.UTC ).toLocalDate() );
         }
-        if ( target.getForSqlDateConversionWithLocalDate() != null ) {
-            source.setForSqlDateConversionWithLocalDate( target.getForSqlDateConversionWithLocalDate().toLocalDate() );
+        java.sql.Date forSqlDateConversionWithLocalDate = target.getForSqlDateConversionWithLocalDate();
+        if ( forSqlDateConversionWithLocalDate != null ) {
+            source.setForSqlDateConversionWithLocalDate( forSqlDateConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForDateConversionWithInstant() != null ) {
-            source.setForDateConversionWithInstant( target.getForDateConversionWithInstant().toInstant() );
+        Date forDateConversionWithInstant = target.getForDateConversionWithInstant();
+        if ( forDateConversionWithInstant != null ) {
+            source.setForDateConversionWithInstant( forDateConversionWithInstant.toInstant() );
         }
-        if ( target.getForLocalDateTimeConversionWithLocalDate() != null ) {
-            source.setForLocalDateTimeConversionWithLocalDate( target.getForLocalDateTimeConversionWithLocalDate().toLocalDate() );
+        LocalDateTime forLocalDateTimeConversionWithLocalDate = target.getForLocalDateTimeConversionWithLocalDate();
+        if ( forLocalDateTimeConversionWithLocalDate != null ) {
+            source.setForLocalDateTimeConversionWithLocalDate( forLocalDateTimeConversionWithLocalDate.toLocalDate() );
         }
-        if ( target.getForInstantConversionWithString() != null ) {
-            source.setForInstantConversionWithString( Instant.parse( target.getForInstantConversionWithString() ) );
+        String forInstantConversionWithString = target.getForInstantConversionWithString();
+        if ( forInstantConversionWithString != null ) {
+            source.setForInstantConversionWithString( Instant.parse( forInstantConversionWithString ) );
         }
-        if ( target.getForPeriodConversionWithString() != null ) {
-            source.setForPeriodConversionWithString( Period.parse( target.getForPeriodConversionWithString() ) );
+        String forPeriodConversionWithString = target.getForPeriodConversionWithString();
+        if ( forPeriodConversionWithString != null ) {
+            source.setForPeriodConversionWithString( Period.parse( forPeriodConversionWithString ) );
         }
-        if ( target.getForDurationConversionWithString() != null ) {
-            source.setForDurationConversionWithString( Duration.parse( target.getForDurationConversionWithString() ) );
+        String forDurationConversionWithString = target.getForDurationConversionWithString();
+        if ( forDurationConversionWithString != null ) {
+            source.setForDurationConversionWithString( Duration.parse( forDurationConversionWithString ) );
         }
 
         return source;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/java8time/custompatterndatetimeformattergenerated/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/java8time/custompatterndatetimeformattergenerated/SourceTargetMapperImpl.java
@@ -7,12 +7,12 @@ package org.mapstruct.ap.test.conversion.java8time.custompatterndatetimeformatte
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2021-05-16T13:11:04+0200",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_275 (AdoptOpenJDK)"
+    date = "2026-06-05T14:55:51+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class SourceTargetMapperImpl implements SourceTargetMapper {
 
@@ -27,14 +27,17 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Target target = new Target();
 
-        if ( source.getLocalDateTime1() != null ) {
-            target.setLocalDateTime1( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime1() ) );
+        LocalDateTime localDateTime1 = source.getLocalDateTime1();
+        if ( localDateTime1 != null ) {
+            target.setLocalDateTime1( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( localDateTime1 ) );
         }
-        if ( source.getLocalDateTime2() != null ) {
-            target.setLocalDateTime2( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( source.getLocalDateTime2() ) );
+        LocalDateTime localDateTime2 = source.getLocalDateTime2();
+        if ( localDateTime2 != null ) {
+            target.setLocalDateTime2( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242.format( localDateTime2 ) );
         }
-        if ( source.getLocalDateTime3() != null ) {
-            target.setLocalDateTime3( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071757710.format( source.getLocalDateTime3() ) );
+        LocalDateTime localDateTime3 = source.getLocalDateTime3();
+        if ( localDateTime3 != null ) {
+            target.setLocalDateTime3( dateTimeFormatter_dd_MM_yyyy_HH_mm_12071757710.format( localDateTime3 ) );
         }
 
         return target;
@@ -48,14 +51,17 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Source source = new Source();
 
-        if ( target.getLocalDateTime1() != null ) {
-            source.setLocalDateTime1( LocalDateTime.parse( target.getLocalDateTime1(), dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) );
+        String localDateTime1 = target.getLocalDateTime1();
+        if ( localDateTime1 != null ) {
+            source.setLocalDateTime1( LocalDateTime.parse( localDateTime1, dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) );
         }
-        if ( target.getLocalDateTime2() != null ) {
-            source.setLocalDateTime2( LocalDateTime.parse( target.getLocalDateTime2(), dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) );
+        String localDateTime2 = target.getLocalDateTime2();
+        if ( localDateTime2 != null ) {
+            source.setLocalDateTime2( LocalDateTime.parse( localDateTime2, dateTimeFormatter_dd_MM_yyyy_HH_mm_12071769242 ) );
         }
-        if ( target.getLocalDateTime3() != null ) {
-            source.setLocalDateTime3( LocalDateTime.parse( target.getLocalDateTime3(), dateTimeFormatter_dd_MM_yyyy_HH_mm_12071757710 ) );
+        String localDateTime3 = target.getLocalDateTime3();
+        if ( localDateTime3 != null ) {
+            source.setLocalDateTime3( LocalDateTime.parse( localDateTime3, dateTimeFormatter_dd_MM_yyyy_HH_mm_12071757710 ) );
         }
 
         return source;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/java8time/zonedoffsetdatetimetolocaldatetimeconversion/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/java8time/zonedoffsetdatetimetolocaldatetimeconversion/SourceTargetMapperImpl.java
@@ -5,13 +5,17 @@
  */
 package org.mapstruct.ap.test.conversion.java8time.zonedoffsetdatetimetolocaldatetimeconversion;
 
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2026-05-23T21:55:42+0900",
-    comments = "version: , compiler: javac, environment: Java 25.0.2 (Homebrew)"
+    date = "2026-06-05T15:54:14+0200",
+    comments = "version: , compiler: Eclipse JDT (Batch) 3.20.0.v20191203-2131, environment: Java 21.0.2 (Oracle Corporation)"
 )
 public class SourceTargetMapperImpl implements SourceTargetMapper {
 
@@ -23,17 +27,21 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Target target = new Target();
 
-        if ( source.getOffsetDateTime() != null ) {
-            target.setOffsetDateTime( source.getOffsetDateTime().toLocalDateTime() );
+        OffsetDateTime offsetDateTime = source.getOffsetDateTime();
+        if ( offsetDateTime != null ) {
+            target.setOffsetDateTime( offsetDateTime.toLocalDateTime() );
         }
-        if ( source.getZonedDateTime() != null ) {
-            target.setZonedDateTime( source.getZonedDateTime().toLocalDateTime() );
+        ZonedDateTime zonedDateTime = source.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            target.setZonedDateTime( zonedDateTime.toLocalDateTime() );
         }
-        if ( source.getZonedDateTimeAsInstant() != null ) {
-            target.setZonedDateTimeAsInstant( source.getZonedDateTimeAsInstant().toInstant() );
+        ZonedDateTime zonedDateTimeAsInstant = source.getZonedDateTimeAsInstant();
+        if ( zonedDateTimeAsInstant != null ) {
+            target.setZonedDateTimeAsInstant( zonedDateTimeAsInstant.toInstant() );
         }
-        if ( source.getOffsetDateTimeAsInstant() != null ) {
-            target.setOffsetDateTimeAsInstant( source.getOffsetDateTimeAsInstant().toInstant() );
+        OffsetDateTime offsetDateTimeAsInstant = source.getOffsetDateTimeAsInstant();
+        if ( offsetDateTimeAsInstant != null ) {
+            target.setOffsetDateTimeAsInstant( offsetDateTimeAsInstant.toInstant() );
         }
 
         return target;
@@ -47,17 +55,21 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Source source = new Source();
 
-        if ( target.getZonedDateTime() != null ) {
-            source.setZonedDateTime( target.getZonedDateTime().atZone( ZoneOffset.UTC ) );
+        LocalDateTime zonedDateTime = target.getZonedDateTime();
+        if ( zonedDateTime != null ) {
+            source.setZonedDateTime( zonedDateTime.atZone( ZoneOffset.UTC ) );
         }
-        if ( target.getOffsetDateTime() != null ) {
-            source.setOffsetDateTime( target.getOffsetDateTime().atOffset( ZoneOffset.UTC ) );
+        LocalDateTime offsetDateTime = target.getOffsetDateTime();
+        if ( offsetDateTime != null ) {
+            source.setOffsetDateTime( offsetDateTime.atOffset( ZoneOffset.UTC ) );
         }
-        if ( target.getZonedDateTimeAsInstant() != null ) {
-            source.setZonedDateTimeAsInstant( target.getZonedDateTimeAsInstant().atZone( ZoneOffset.UTC ) );
+        Instant zonedDateTimeAsInstant = target.getZonedDateTimeAsInstant();
+        if ( zonedDateTimeAsInstant != null ) {
+            source.setZonedDateTimeAsInstant( zonedDateTimeAsInstant.atZone( ZoneOffset.UTC ) );
         }
-        if ( target.getOffsetDateTimeAsInstant() != null ) {
-            source.setOffsetDateTimeAsInstant( target.getOffsetDateTimeAsInstant().atOffset( ZoneOffset.UTC ) );
+        Instant offsetDateTimeAsInstant = target.getOffsetDateTimeAsInstant();
+        if ( offsetDateTimeAsInstant != null ) {
+            source.setOffsetDateTimeAsInstant( offsetDateTimeAsInstant.atOffset( ZoneOffset.UTC ) );
         }
 
         return source;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/numbers/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/numbers/SourceTargetMapperImpl.java
@@ -6,6 +6,7 @@
 package org.mapstruct.ap.test.conversion.numbers;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
@@ -18,8 +19,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2024-09-14T11:36:20+0300",
-    comments = "version: , compiler: javac, environment: Java 17.0.10 (Private Build)"
+    date = "2026-06-05T15:54:36+0200",
+    comments = "version: , compiler: Eclipse JDT (Batch) 3.20.0.v20191203-2131, environment: Java 21.0.2 (Oracle Corporation)"
 )
 public class SourceTargetMapperImpl implements SourceTargetMapper {
 
@@ -32,32 +33,39 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
         Target target = new Target();
 
         target.setI( new DecimalFormat( "##.00" ).format( source.getI() ) );
-        if ( source.getIi() != null ) {
-            target.setIi( new DecimalFormat( "##.00" ).format( source.getIi() ) );
+        Integer ii = source.getIi();
+        if ( ii != null ) {
+            target.setIi( new DecimalFormat( "##.00" ).format( ii ) );
         }
         target.setD( new DecimalFormat( "##.00" ).format( source.getD() ) );
-        if ( source.getDd() != null ) {
-            target.setDd( new DecimalFormat( "##.00" ).format( source.getDd() ) );
+        Double dd = source.getDd();
+        if ( dd != null ) {
+            target.setDd( new DecimalFormat( "##.00" ).format( dd ) );
         }
         target.setF( new DecimalFormat( "##.00" ).format( source.getF() ) );
-        if ( source.getFf() != null ) {
-            target.setFf( new DecimalFormat( "##.00" ).format( source.getFf() ) );
+        Float ff = source.getFf();
+        if ( ff != null ) {
+            target.setFf( new DecimalFormat( "##.00" ).format( ff ) );
         }
         target.setL( new DecimalFormat( "##.00" ).format( source.getL() ) );
-        if ( source.getLl() != null ) {
-            target.setLl( new DecimalFormat( "##.00" ).format( source.getLl() ) );
+        Long ll = source.getLl();
+        if ( ll != null ) {
+            target.setLl( new DecimalFormat( "##.00" ).format( ll ) );
         }
         target.setB( new DecimalFormat( "##.00" ).format( source.getB() ) );
-        if ( source.getBb() != null ) {
-            target.setBb( new DecimalFormat( "##.00" ).format( source.getBb() ) );
+        Byte bb = source.getBb();
+        if ( bb != null ) {
+            target.setBb( new DecimalFormat( "##.00" ).format( bb ) );
         }
         target.setComplex1( new DecimalFormat( "##0.##E0" ).format( source.getComplex1() ) );
         target.setComplex2( new DecimalFormat( "$#.00" ).format( source.getComplex2() ) );
-        if ( source.getBigDecimal1() != null ) {
-            target.setBigDecimal1( createDecimalFormat( "#0.#E0" ).format( source.getBigDecimal1() ) );
+        BigDecimal bigDecimal1 = source.getBigDecimal1();
+        if ( bigDecimal1 != null ) {
+            target.setBigDecimal1( createDecimalFormat( "#0.#E0" ).format( bigDecimal1 ) );
         }
-        if ( source.getBigInteger1() != null ) {
-            target.setBigInteger1( createDecimalFormat( "0.#############E0" ).format( source.getBigInteger1() ) );
+        BigInteger bigInteger1 = source.getBigInteger1();
+        if ( bigInteger1 != null ) {
+            target.setBigInteger1( createDecimalFormat( "0.#############E0" ).format( bigInteger1 ) );
         }
 
         return target;
@@ -72,32 +80,39 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
         Target target = new Target();
 
         target.setI( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getI() ) );
-        if ( source.getIi() != null ) {
-            target.setIi( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getIi() ) );
+        Integer ii = source.getIi();
+        if ( ii != null ) {
+            target.setIi( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( ii ) );
         }
         target.setD( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getD() ) );
-        if ( source.getDd() != null ) {
-            target.setDd( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getDd() ) );
+        Double dd = source.getDd();
+        if ( dd != null ) {
+            target.setDd( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( dd ) );
         }
         target.setF( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getF() ) );
-        if ( source.getFf() != null ) {
-            target.setFf( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getFf() ) );
+        Float ff = source.getFf();
+        if ( ff != null ) {
+            target.setFf( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( ff ) );
         }
         target.setL( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getL() ) );
-        if ( source.getLl() != null ) {
-            target.setLl( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getLl() ) );
+        Long ll = source.getLl();
+        if ( ll != null ) {
+            target.setLl( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( ll ) );
         }
         target.setB( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getB() ) );
-        if ( source.getBb() != null ) {
-            target.setBb( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getBb() ) );
+        Byte bb = source.getBb();
+        if ( bb != null ) {
+            target.setBb( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( bb ) );
         }
         target.setComplex1( new DecimalFormat( "##0.##E0", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getComplex1() ) );
         target.setComplex2( new DecimalFormat( "$#.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).format( source.getComplex2() ) );
-        if ( source.getBigDecimal1() != null ) {
-            target.setBigDecimal1( createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "ru" ) ).format( source.getBigDecimal1() ) );
+        BigDecimal bigDecimal1 = source.getBigDecimal1();
+        if ( bigDecimal1 != null ) {
+            target.setBigDecimal1( createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "ru" ) ).format( bigDecimal1 ) );
         }
-        if ( source.getBigInteger1() != null ) {
-            target.setBigInteger1( createDecimalFormatWithLocale( "0.#############E0", Locale.forLanguageTag( "ru" ) ).format( source.getBigInteger1() ) );
+        BigInteger bigInteger1 = source.getBigInteger1();
+        if ( bigInteger1 != null ) {
+            target.setBigInteger1( createDecimalFormatWithLocale( "0.#############E0", Locale.forLanguageTag( "ru" ) ).format( bigInteger1 ) );
         }
 
         return target;
@@ -112,112 +127,126 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
         Source source = new Source();
 
         try {
-            if ( target.getI() != null ) {
-                source.setI( new DecimalFormat( "##.00" ).parse( target.getI() ).intValue() );
+            String i = target.getI();
+            if ( i != null ) {
+                source.setI( new DecimalFormat( "##.00" ).parse( i ).intValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getIi() != null ) {
-                source.setIi( new DecimalFormat( "##.00" ).parse( target.getIi() ).intValue() );
+            String ii = target.getIi();
+            if ( ii != null ) {
+                source.setIi( new DecimalFormat( "##.00" ).parse( ii ).intValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getD() != null ) {
-                source.setD( new DecimalFormat( "##.00" ).parse( target.getD() ).doubleValue() );
+            String d = target.getD();
+            if ( d != null ) {
+                source.setD( new DecimalFormat( "##.00" ).parse( d ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getDd() != null ) {
-                source.setDd( new DecimalFormat( "##.00" ).parse( target.getDd() ).doubleValue() );
+            String dd = target.getDd();
+            if ( dd != null ) {
+                source.setDd( new DecimalFormat( "##.00" ).parse( dd ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getF() != null ) {
-                source.setF( new DecimalFormat( "##.00" ).parse( target.getF() ).floatValue() );
+            String f = target.getF();
+            if ( f != null ) {
+                source.setF( new DecimalFormat( "##.00" ).parse( f ).floatValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getFf() != null ) {
-                source.setFf( new DecimalFormat( "##.00" ).parse( target.getFf() ).floatValue() );
+            String ff = target.getFf();
+            if ( ff != null ) {
+                source.setFf( new DecimalFormat( "##.00" ).parse( ff ).floatValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getL() != null ) {
-                source.setL( new DecimalFormat( "##.00" ).parse( target.getL() ).longValue() );
+            String l = target.getL();
+            if ( l != null ) {
+                source.setL( new DecimalFormat( "##.00" ).parse( l ).longValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getLl() != null ) {
-                source.setLl( new DecimalFormat( "##.00" ).parse( target.getLl() ).longValue() );
+            String ll = target.getLl();
+            if ( ll != null ) {
+                source.setLl( new DecimalFormat( "##.00" ).parse( ll ).longValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getB() != null ) {
-                source.setB( new DecimalFormat( "##.00" ).parse( target.getB() ).byteValue() );
+            String b = target.getB();
+            if ( b != null ) {
+                source.setB( new DecimalFormat( "##.00" ).parse( b ).byteValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBb() != null ) {
-                source.setBb( new DecimalFormat( "##.00" ).parse( target.getBb() ).byteValue() );
+            String bb = target.getBb();
+            if ( bb != null ) {
+                source.setBb( new DecimalFormat( "##.00" ).parse( bb ).byteValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getComplex1() != null ) {
-                source.setComplex1( new DecimalFormat( "##0.##E0" ).parse( target.getComplex1() ).doubleValue() );
+            String complex1 = target.getComplex1();
+            if ( complex1 != null ) {
+                source.setComplex1( new DecimalFormat( "##0.##E0" ).parse( complex1 ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getComplex2() != null ) {
-                source.setComplex2( new DecimalFormat( "$#.00" ).parse( target.getComplex2() ).doubleValue() );
+            String complex2 = target.getComplex2();
+            if ( complex2 != null ) {
+                source.setComplex2( new DecimalFormat( "$#.00" ).parse( complex2 ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBigDecimal1() != null ) {
-                source.setBigDecimal1( (BigDecimal) createDecimalFormat( "#0.#E0" ).parse( target.getBigDecimal1() ) );
+            String bigDecimal1 = target.getBigDecimal1();
+            if ( bigDecimal1 != null ) {
+                source.setBigDecimal1( (BigDecimal) createDecimalFormat( "#0.#E0" ).parse( bigDecimal1 ) );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBigInteger1() != null ) {
-                source.setBigInteger1( ( (BigDecimal) createDecimalFormat( "0.#############E0" ).parse( target.getBigInteger1() ) ).toBigInteger() );
+            String bigInteger1 = target.getBigInteger1();
+            if ( bigInteger1 != null ) {
+                source.setBigInteger1( ( (BigDecimal) createDecimalFormat( "0.#############E0" ).parse( bigInteger1 ) ).toBigInteger() );
             }
         }
         catch ( ParseException e ) {
@@ -236,112 +265,126 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
         Source source = new Source();
 
         try {
-            if ( target.getI() != null ) {
-                source.setI( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getI() ).intValue() );
+            String i = target.getI();
+            if ( i != null ) {
+                source.setI( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( i ).intValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getIi() != null ) {
-                source.setIi( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getIi() ).intValue() );
+            String ii = target.getIi();
+            if ( ii != null ) {
+                source.setIi( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( ii ).intValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getD() != null ) {
-                source.setD( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getD() ).doubleValue() );
+            String d = target.getD();
+            if ( d != null ) {
+                source.setD( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( d ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getDd() != null ) {
-                source.setDd( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getDd() ).doubleValue() );
+            String dd = target.getDd();
+            if ( dd != null ) {
+                source.setDd( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( dd ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getF() != null ) {
-                source.setF( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getF() ).floatValue() );
+            String f = target.getF();
+            if ( f != null ) {
+                source.setF( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( f ).floatValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getFf() != null ) {
-                source.setFf( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getFf() ).floatValue() );
+            String ff = target.getFf();
+            if ( ff != null ) {
+                source.setFf( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( ff ).floatValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getL() != null ) {
-                source.setL( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getL() ).longValue() );
+            String l = target.getL();
+            if ( l != null ) {
+                source.setL( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( l ).longValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getLl() != null ) {
-                source.setLl( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getLl() ).longValue() );
+            String ll = target.getLl();
+            if ( ll != null ) {
+                source.setLl( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( ll ).longValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getB() != null ) {
-                source.setB( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getB() ).byteValue() );
+            String b = target.getB();
+            if ( b != null ) {
+                source.setB( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( b ).byteValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBb() != null ) {
-                source.setBb( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getBb() ).byteValue() );
+            String bb = target.getBb();
+            if ( bb != null ) {
+                source.setBb( new DecimalFormat( "##.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( bb ).byteValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getComplex1() != null ) {
-                source.setComplex1( new DecimalFormat( "##0.##E0", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getComplex1() ).doubleValue() );
+            String complex1 = target.getComplex1();
+            if ( complex1 != null ) {
+                source.setComplex1( new DecimalFormat( "##0.##E0", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( complex1 ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getComplex2() != null ) {
-                source.setComplex2( new DecimalFormat( "$#.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( target.getComplex2() ).doubleValue() );
+            String complex2 = target.getComplex2();
+            if ( complex2 != null ) {
+                source.setComplex2( new DecimalFormat( "$#.00", DecimalFormatSymbols.getInstance( Locale.forLanguageTag( "ru " ) ) ).parse( complex2 ).doubleValue() );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBigDecimal1() != null ) {
-                source.setBigDecimal1( (BigDecimal) createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "ru" ) ).parse( target.getBigDecimal1() ) );
+            String bigDecimal1 = target.getBigDecimal1();
+            if ( bigDecimal1 != null ) {
+                source.setBigDecimal1( (BigDecimal) createDecimalFormatWithLocale( "#0.#E0", Locale.forLanguageTag( "ru" ) ).parse( bigDecimal1 ) );
             }
         }
         catch ( ParseException e ) {
             throw new RuntimeException( e );
         }
         try {
-            if ( target.getBigInteger1() != null ) {
-                source.setBigInteger1( ( (BigDecimal) createDecimalFormatWithLocale( "0.#############E0", Locale.forLanguageTag( "ru" ) ).parse( target.getBigInteger1() ) ).toBigInteger() );
+            String bigInteger1 = target.getBigInteger1();
+            if ( bigInteger1 != null ) {
+                source.setBigInteger1( ( (BigDecimal) createDecimalFormatWithLocale( "0.#############E0", Locale.forLanguageTag( "ru" ) ).parse( bigInteger1 ) ).toBigInteger() );
             }
         }
         catch ( ParseException e ) {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/string/SourceTargetMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/conversion/string/SourceTargetMapperImpl.java
@@ -5,12 +5,12 @@
  */
 package org.mapstruct.ap.test.conversion.string;
 
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2020-10-24T17:41:29+0300",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_265 (AdoptOpenJDK)"
+    date = "2026-06-05T14:55:53+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class SourceTargetMapperImpl implements SourceTargetMapper {
 
@@ -23,39 +23,48 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
         Target target = new Target();
 
         target.setB( String.valueOf( source.getB() ) );
-        if ( source.getBb() != null ) {
-            target.setBb( String.valueOf( source.getBb() ) );
+        Byte bb = source.getBb();
+        if ( bb != null ) {
+            target.setBb( String.valueOf( bb ) );
         }
         target.setS( String.valueOf( source.getS() ) );
-        if ( source.getSs() != null ) {
-            target.setSs( String.valueOf( source.getSs() ) );
+        Short ss = source.getSs();
+        if ( ss != null ) {
+            target.setSs( String.valueOf( ss ) );
         }
         target.setI( String.valueOf( source.getI() ) );
-        if ( source.getIi() != null ) {
-            target.setIi( String.valueOf( source.getIi() ) );
+        Integer ii = source.getIi();
+        if ( ii != null ) {
+            target.setIi( String.valueOf( ii ) );
         }
         target.setL( String.valueOf( source.getL() ) );
-        if ( source.getLl() != null ) {
-            target.setLl( String.valueOf( source.getLl() ) );
+        Long ll = source.getLl();
+        if ( ll != null ) {
+            target.setLl( String.valueOf( ll ) );
         }
         target.setF( String.valueOf( source.getF() ) );
-        if ( source.getFf() != null ) {
-            target.setFf( String.valueOf( source.getFf() ) );
+        Float ff = source.getFf();
+        if ( ff != null ) {
+            target.setFf( String.valueOf( ff ) );
         }
         target.setD( String.valueOf( source.getD() ) );
-        if ( source.getDd() != null ) {
-            target.setDd( String.valueOf( source.getDd() ) );
+        Double dd = source.getDd();
+        if ( dd != null ) {
+            target.setDd( String.valueOf( dd ) );
         }
         target.setBool( String.valueOf( source.getBool() ) );
-        if ( source.getBoolBool() != null ) {
-            target.setBoolBool( String.valueOf( source.getBoolBool() ) );
+        Boolean boolBool = source.getBoolBool();
+        if ( boolBool != null ) {
+            target.setBoolBool( String.valueOf( boolBool ) );
         }
         target.setC( String.valueOf( source.getC() ) );
-        if ( source.getCc() != null ) {
-            target.setCc( source.getCc().toString() );
+        Character cc = source.getCc();
+        if ( cc != null ) {
+            target.setCc( cc.toString() );
         }
-        if ( source.getSb() != null ) {
-            target.setSb( source.getSb().toString() );
+        StringBuilder sb = source.getSb();
+        if ( sb != null ) {
+            target.setSb( sb.toString() );
         }
 
         return target;
@@ -69,57 +78,74 @@ public class SourceTargetMapperImpl implements SourceTargetMapper {
 
         Source source = new Source();
 
-        if ( target.getB() != null ) {
-            source.setB( Byte.parseByte( target.getB() ) );
+        String b = target.getB();
+        if ( b != null ) {
+            source.setB( Byte.parseByte( b ) );
         }
-        if ( target.getBb() != null ) {
-            source.setBb( Byte.parseByte( target.getBb() ) );
+        String bb = target.getBb();
+        if ( bb != null ) {
+            source.setBb( Byte.parseByte( bb ) );
         }
-        if ( target.getS() != null ) {
-            source.setS( Short.parseShort( target.getS() ) );
+        String s = target.getS();
+        if ( s != null ) {
+            source.setS( Short.parseShort( s ) );
         }
-        if ( target.getSs() != null ) {
-            source.setSs( Short.parseShort( target.getSs() ) );
+        String ss = target.getSs();
+        if ( ss != null ) {
+            source.setSs( Short.parseShort( ss ) );
         }
-        if ( target.getI() != null ) {
-            source.setI( Integer.parseInt( target.getI() ) );
+        String i = target.getI();
+        if ( i != null ) {
+            source.setI( Integer.parseInt( i ) );
         }
-        if ( target.getIi() != null ) {
-            source.setIi( Integer.parseInt( target.getIi() ) );
+        String ii = target.getIi();
+        if ( ii != null ) {
+            source.setIi( Integer.parseInt( ii ) );
         }
-        if ( target.getL() != null ) {
-            source.setL( Long.parseLong( target.getL() ) );
+        String l = target.getL();
+        if ( l != null ) {
+            source.setL( Long.parseLong( l ) );
         }
-        if ( target.getLl() != null ) {
-            source.setLl( Long.parseLong( target.getLl() ) );
+        String ll = target.getLl();
+        if ( ll != null ) {
+            source.setLl( Long.parseLong( ll ) );
         }
-        if ( target.getF() != null ) {
-            source.setF( Float.parseFloat( target.getF() ) );
+        String f = target.getF();
+        if ( f != null ) {
+            source.setF( Float.parseFloat( f ) );
         }
-        if ( target.getFf() != null ) {
-            source.setFf( Float.parseFloat( target.getFf() ) );
+        String ff = target.getFf();
+        if ( ff != null ) {
+            source.setFf( Float.parseFloat( ff ) );
         }
-        if ( target.getD() != null ) {
-            source.setD( Double.parseDouble( target.getD() ) );
+        String d = target.getD();
+        if ( d != null ) {
+            source.setD( Double.parseDouble( d ) );
         }
-        if ( target.getDd() != null ) {
-            source.setDd( Double.parseDouble( target.getDd() ) );
+        String dd = target.getDd();
+        if ( dd != null ) {
+            source.setDd( Double.parseDouble( dd ) );
         }
-        if ( target.getBool() != null ) {
-            source.setBool( Boolean.parseBoolean( target.getBool() ) );
+        String bool = target.getBool();
+        if ( bool != null ) {
+            source.setBool( Boolean.parseBoolean( bool ) );
         }
-        if ( target.getBoolBool() != null ) {
-            source.setBoolBool( Boolean.parseBoolean( target.getBoolBool() ) );
+        String boolBool = target.getBoolBool();
+        if ( boolBool != null ) {
+            source.setBoolBool( Boolean.parseBoolean( boolBool ) );
         }
-        if ( target.getC() != null ) {
-            source.setC( target.getC().charAt( 0 ) );
+        String c = target.getC();
+        if ( c != null ) {
+            source.setC( c.charAt( 0 ) );
         }
-        if ( target.getCc() != null ) {
-            source.setCc( target.getCc().charAt( 0 ) );
+        String cc = target.getCc();
+        if ( cc != null ) {
+            source.setCc( cc.charAt( 0 ) );
         }
         source.setObject( target.getObject() );
-        if ( target.getSb() != null ) {
-            source.setSb( new StringBuilder( target.getSb() ) );
+        String sb = target.getSb();
+        if ( sb != null ) {
+            source.setSb( new StringBuilder( sb ) );
         }
 
         return source;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/imports/innerclasses/BeanWithInnerEnumMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/imports/innerclasses/BeanWithInnerEnumMapperImpl.java
@@ -9,8 +9,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2021-10-16T21:06:53+0200",
-    comments = "version: , compiler: javac, environment: Java 17 (Oracle Corporation)"
+    date = "2026-06-05T14:56:03+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class BeanWithInnerEnumMapperImpl implements BeanWithInnerEnumMapper {
 
@@ -23,8 +23,9 @@ public class BeanWithInnerEnumMapperImpl implements BeanWithInnerEnumMapper {
         BeanWithInnerEnum beanWithInnerEnum = new BeanWithInnerEnum();
 
         beanWithInnerEnum.setTest( beanFacade.getTest() );
-        if ( beanFacade.getInnerEnum() != null ) {
-            beanWithInnerEnum.setInnerEnum( Enum.valueOf( BeanWithInnerEnum.InnerEnum.class, beanFacade.getInnerEnum() ) );
+        String innerEnum = beanFacade.getInnerEnum();
+        if ( innerEnum != null ) {
+            beanWithInnerEnum.setInnerEnum( Enum.valueOf( BeanWithInnerEnum.InnerEnum.class, innerEnum ) );
         }
 
         return beanWithInnerEnum;
@@ -39,8 +40,9 @@ public class BeanWithInnerEnumMapperImpl implements BeanWithInnerEnumMapper {
         BeanFacade beanFacade = new BeanFacade();
 
         beanFacade.setTest( beanWithInnerEnum.getTest() );
-        if ( beanWithInnerEnum.getInnerEnum() != null ) {
-            beanFacade.setInnerEnum( beanWithInnerEnum.getInnerEnum().name() );
+        BeanWithInnerEnum.InnerEnum innerEnum = beanWithInnerEnum.getInnerEnum();
+        if ( innerEnum != null ) {
+            beanFacade.setInnerEnum( innerEnum.name() );
         }
 
         return beanFacade;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoUpdateMapperSmartImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedbeans/UserDtoUpdateMapperSmartImpl.java
@@ -22,35 +22,39 @@ public class UserDtoUpdateMapperSmartImpl implements UserDtoUpdateMapperSmart {
             return;
         }
 
-        if ( user.getName() != null ) {
-            userDto.setName( user.getName() );
+        String name = user.getName();
+        if ( name != null ) {
+            userDto.setName( name );
         }
         else {
             userDto.setName( null );
         }
-        if ( user.getCar() != null ) {
+        Car car = user.getCar();
+        if ( car != null ) {
             if ( userDto.getCar() == null ) {
                 userDto.setCar( new CarDto() );
             }
-            carToCarDto( user.getCar(), userDto.getCar() );
+            carToCarDto( car, userDto.getCar() );
         }
         else {
             userDto.setCar( null );
         }
-        if ( user.getSecondCar() != null ) {
+        Car secondCar = user.getSecondCar();
+        if ( secondCar != null ) {
             if ( userDto.getSecondCar() == null ) {
                 userDto.setSecondCar( new CarDto() );
             }
-            carToCarDto( user.getSecondCar(), userDto.getSecondCar() );
+            carToCarDto( secondCar, userDto.getSecondCar() );
         }
         else {
             userDto.setSecondCar( null );
         }
-        if ( user.getHouse() != null ) {
+        House house = user.getHouse();
+        if ( house != null ) {
             if ( userDto.getHouse() == null ) {
                 userDto.setHouse( new HouseDto() );
             }
-            houseToHouseDto( user.getHouse(), userDto.getHouse() );
+            houseToHouseDto( house, userDto.getHouse() );
         }
         else {
             userDto.setHouse( null );
@@ -88,22 +92,24 @@ public class UserDtoUpdateMapperSmartImpl implements UserDtoUpdateMapperSmart {
             return;
         }
 
-        if ( car.getName() != null ) {
-            mappingTarget.setName( car.getName() );
+        String name = car.getName();
+        if ( name != null ) {
+            mappingTarget.setName( name );
         }
         else {
             mappingTarget.setName( null );
         }
         mappingTarget.setYear( car.getYear() );
+        List<Wheel> wheels = car.getWheels();
         if ( mappingTarget.getWheels() != null ) {
-            List<WheelDto> list = wheelListToWheelDtoList( car.getWheels() );
+            List<WheelDto> list = wheelListToWheelDtoList( wheels );
             if ( list != null ) {
                 mappingTarget.getWheels().clear();
                 mappingTarget.getWheels().addAll( list );
             }
         }
         else {
-            List<WheelDto> list = wheelListToWheelDtoList( car.getWheels() );
+            List<WheelDto> list = wheelListToWheelDtoList( wheels );
             if ( list != null ) {
                 mappingTarget.setWheels( list );
             }
@@ -136,8 +142,9 @@ public class UserDtoUpdateMapperSmartImpl implements UserDtoUpdateMapperSmart {
         }
 
         mappingTarget.setColor( String.valueOf( roof.getColor() ) );
-        if ( roof.getType() != null ) {
-            mappingTarget.setType( roofTypeToExternalRoofType( roof.getType() ) );
+        RoofType type = roof.getType();
+        if ( type != null ) {
+            mappingTarget.setType( roofTypeToExternalRoofType( type ) );
         }
         else {
             mappingTarget.setType( null );
@@ -149,18 +156,20 @@ public class UserDtoUpdateMapperSmartImpl implements UserDtoUpdateMapperSmart {
             return;
         }
 
-        if ( house.getName() != null ) {
-            mappingTarget.setName( house.getName() );
+        String name = house.getName();
+        if ( name != null ) {
+            mappingTarget.setName( name );
         }
         else {
             mappingTarget.setName( null );
         }
         mappingTarget.setYear( house.getYear() );
-        if ( house.getRoof() != null ) {
+        Roof roof = house.getRoof();
+        if ( roof != null ) {
             if ( mappingTarget.getRoof() == null ) {
                 mappingTarget.setRoof( new RoofDto() );
             }
-            roofToRoofDto( house.getRoof(), mappingTarget.getRoof() );
+            roofToRoofDto( roof, mappingTarget.getRoof() );
         }
         else {
             mappingTarget.setRoof( null );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedtargetproperties/ChartEntryToArtistUpdateImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nestedtargetproperties/ChartEntryToArtistUpdateImpl.java
@@ -6,7 +6,7 @@
 package org.mapstruct.ap.test.nestedtargetproperties;
 
 import java.util.List;
-import javax.annotation.Generated;
+import javax.annotation.processing.Generated;
 import org.mapstruct.ap.test.nestedsourceproperties._target.ChartEntry;
 import org.mapstruct.ap.test.nestedsourceproperties.source.Artist;
 import org.mapstruct.ap.test.nestedsourceproperties.source.Chart;
@@ -16,8 +16,8 @@ import org.mapstruct.ap.test.nestedsourceproperties.source.Studio;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2017-02-07T21:05:06+0100",
-    comments = "version: , compiler: javac, environment: Java 1.8.0_112 (Oracle Corporation)"
+    date = "2026-06-05T14:56:17+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class ChartEntryToArtistUpdateImpl extends ChartEntryToArtistUpdate {
 
@@ -31,8 +31,9 @@ public class ChartEntryToArtistUpdateImpl extends ChartEntryToArtistUpdate {
             chart.setSong( new Song() );
         }
         chartEntryToSong( chartEntry, chart.getSong() );
-        if ( chartEntry.getChartName() != null ) {
-            chart.setName( chartEntry.getChartName() );
+        String chartName = chartEntry.getChartName();
+        if ( chartName != null ) {
+            chart.setName( chartName );
         }
     }
 
@@ -41,11 +42,13 @@ public class ChartEntryToArtistUpdateImpl extends ChartEntryToArtistUpdate {
             return;
         }
 
-        if ( chartEntry.getRecordedAt() != null ) {
-            mappingTarget.setName( chartEntry.getRecordedAt() );
+        String recordedAt = chartEntry.getRecordedAt();
+        if ( recordedAt != null ) {
+            mappingTarget.setName( recordedAt );
         }
-        if ( chartEntry.getCity() != null ) {
-            mappingTarget.setCity( chartEntry.getCity() );
+        String city = chartEntry.getCity();
+        if ( city != null ) {
+            mappingTarget.setCity( city );
         }
     }
 
@@ -69,8 +72,9 @@ public class ChartEntryToArtistUpdateImpl extends ChartEntryToArtistUpdate {
             mappingTarget.setLabel( new Label() );
         }
         chartEntryToLabel( chartEntry, mappingTarget.getLabel() );
-        if ( chartEntry.getArtistName() != null ) {
-            mappingTarget.setName( chartEntry.getArtistName() );
+        String artistName = chartEntry.getArtistName();
+        if ( artistName != null ) {
+            mappingTarget.setName( artistName );
         }
     }
 
@@ -83,8 +87,9 @@ public class ChartEntryToArtistUpdateImpl extends ChartEntryToArtistUpdate {
             mappingTarget.setArtist( new Artist() );
         }
         chartEntryToArtist( chartEntry, mappingTarget.getArtist() );
-        if ( chartEntry.getSongTitle() != null ) {
-            mappingTarget.setTitle( chartEntry.getSongTitle() );
+        String songTitle = chartEntry.getSongTitle();
+        if ( songTitle != null ) {
+            mappingTarget.setTitle( songTitle );
         }
         if ( mappingTarget.getPositions() != null ) {
             List<Integer> list = mapPosition( chartEntry.getPosition() );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullParamMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNonNullParamMapperImpl.java
@@ -9,8 +9,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2026-03-15T07:45:45+0100",
-    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+    date = "2026-06-05T14:55:02+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class JSpecifyNonNullParamMapperImpl implements JSpecifyNonNullParamMapper {
 
@@ -22,8 +22,9 @@ public class JSpecifyNonNullParamMapperImpl implements JSpecifyNonNullParamMappe
         targetBean.setNonNullTarget( source.getNonNullValue() );
         targetBean.setNullableTarget( source.getNullableValue() );
         targetBean.setUnannotatedTarget( source.getUnannotatedValue() );
-        if ( source.getNullableValue() != null ) {
-            targetBean.setNonNullTargetFromNullable( source.getNullableValue() );
+        String nullableValue1 = source.getNullableValue();
+        if ( nullableValue1 != null ) {
+            targetBean.setNonNullTargetFromNullable( nullableValue1 );
         }
 
         return targetBean;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullCheckMapperImpl.java
@@ -9,8 +9,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2026-03-14T18:40:10+0100",
-    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+    date = "2026-06-05T14:54:55+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class JSpecifyNullCheckMapperImpl implements JSpecifyNullCheckMapper {
 
@@ -25,8 +25,9 @@ public class JSpecifyNullCheckMapperImpl implements JSpecifyNullCheckMapper {
         targetBean.setNonNullTarget( source.getNonNullValue() );
         targetBean.setNullableTarget( source.getNullableValue() );
         targetBean.setUnannotatedTarget( source.getUnannotatedValue() );
-        if ( source.getNullableValue() != null ) {
-            targetBean.setNonNullTargetFromNullable( source.getNullableValue() );
+        String nullableValue1 = source.getNullableValue();
+        if ( nullableValue1 != null ) {
+            targetBean.setNonNullTargetFromNullable( nullableValue1 );
         }
 
         return targetBean;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyOverridesStrategyMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyOverridesStrategyMapperImpl.java
@@ -9,8 +9,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2026-03-15T07:45:45+0100",
-    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+    date = "2026-06-05T14:55:04+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class JSpecifyOverridesStrategyMapperImpl implements JSpecifyOverridesStrategyMapper {
 
@@ -23,14 +23,17 @@ public class JSpecifyOverridesStrategyMapperImpl implements JSpecifyOverridesStr
         TargetBean targetBean = new TargetBean();
 
         targetBean.setNonNullTarget( source.getNonNullValue() );
-        if ( source.getNullableValue() != null ) {
-            targetBean.setNullableTarget( source.getNullableValue() );
+        String nullableValue = source.getNullableValue();
+        if ( nullableValue != null ) {
+            targetBean.setNullableTarget( nullableValue );
         }
-        if ( source.getUnannotatedValue() != null ) {
-            targetBean.setUnannotatedTarget( source.getUnannotatedValue() );
+        String unannotatedValue = source.getUnannotatedValue();
+        if ( unannotatedValue != null ) {
+            targetBean.setUnannotatedTarget( unannotatedValue );
         }
-        if ( source.getNullableValue() != null ) {
-            targetBean.setNonNullTargetFromNullable( source.getNullableValue() );
+        String nullableValue1 = source.getNullableValue();
+        if ( nullableValue1 != null ) {
+            targetBean.setNonNullTargetFromNullable( nullableValue1 );
         }
 
         return targetBean;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyUpdateMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyUpdateMapperImpl.java
@@ -9,8 +9,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2026-03-15T15:17:03+0100",
-    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+    date = "2026-06-05T14:54:55+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class JSpecifyUpdateMapperImpl implements JSpecifyUpdateMapper {
 
@@ -21,14 +21,17 @@ public class JSpecifyUpdateMapperImpl implements JSpecifyUpdateMapper {
         }
 
         target.setNonNullTarget( source.getNonNullValue() );
-        if ( source.getNullableValue() != null ) {
-            target.setNullableTarget( source.getNullableValue() );
+        String nullableValue = source.getNullableValue();
+        if ( nullableValue != null ) {
+            target.setNullableTarget( nullableValue );
         }
-        if ( source.getUnannotatedValue() != null ) {
-            target.setUnannotatedTarget( source.getUnannotatedValue() );
+        String unannotatedValue = source.getUnannotatedValue();
+        if ( unannotatedValue != null ) {
+            target.setUnannotatedTarget( unannotatedValue );
         }
-        if ( source.getNullableValue() != null ) {
-            target.setNonNullTargetFromNullable( source.getNullableValue() );
+        String nullableValue1 = source.getNullableValue();
+        if ( nullableValue1 != null ) {
+            target.setNonNullTargetFromNullable( nullableValue1 );
         }
     }
 }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedMapperImpl_withoutPackageInfo.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/nullmarkedpackage/PackageNullMarkedMapperImpl_withoutPackageInfo.java
@@ -9,8 +9,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2026-04-12T20:03:08+0200",
-    comments = "version: , compiler: javac, environment: Java 25 (Eclipse Adoptium)"
+    date = "2026-06-05T14:55:05+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class PackageNullMarkedMapperImpl implements PackageNullMarkedMapper {
 
@@ -22,8 +22,9 @@ public class PackageNullMarkedMapperImpl implements PackageNullMarkedMapper {
 
         PackageNullMarkedTargetBean packageNullMarkedTargetBean = new PackageNullMarkedTargetBean();
 
-        if ( source.getValue() != null ) {
-            packageNullMarkedTargetBean.setValue( source.getValue() );
+        String value = source.getValue();
+        if ( value != null ) {
+            packageNullMarkedTargetBean.setValue( value );
         }
 
         return packageNullMarkedTargetBean;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/beforeafter/OptionalBeforeAfterMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/beforeafter/OptionalBeforeAfterMapperImpl.java
@@ -10,8 +10,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2023-11-20T22:01:31-0500",
-    comments = "version: , compiler: javac, environment: Java 11.0.19 (Homebrew)"
+    date = "2026-06-05T14:56:19+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class OptionalBeforeAfterMapperImpl implements OptionalBeforeAfterMapper {
 
@@ -32,11 +32,13 @@ public class OptionalBeforeAfterMapperImpl implements OptionalBeforeAfterMapper 
         deepOptionalToNonOptional = subTypeOptionalToSubType( source.getDeepOptionalToNonOptional() );
         deepNonOptionalToOptional = subTypeToSubTypeOptional( source.getDeepNonOptionalToOptional() );
         shallowOptionalToOptional = source.getShallowOptionalToOptional();
-        if ( source.getShallowOptionalToNonOptional().isPresent() ) {
-            shallowOptionalToNonOptional = source.getShallowOptionalToNonOptional().get();
+        Optional<String> shallowOptionalToNonOptional1 = source.getShallowOptionalToNonOptional();
+        if ( shallowOptionalToNonOptional1.isPresent() ) {
+            shallowOptionalToNonOptional = shallowOptionalToNonOptional1.get();
         }
-        if ( source.getShallowNonOptionalToOptional() != null ) {
-            shallowNonOptionalToOptional = Optional.of( source.getShallowNonOptionalToOptional() );
+        String shallowNonOptionalToOptional1 = source.getShallowNonOptionalToOptional();
+        if ( shallowNonOptionalToOptional1 != null ) {
+            shallowNonOptionalToOptional = Optional.of( shallowNonOptionalToOptional1 );
         }
 
         Target target = new Target( deepOptionalToOptional, deepOptionalToNonOptional, deepNonOptionalToOptional, shallowOptionalToOptional, shallowOptionalToNonOptional, shallowNonOptionalToOptional );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nested/OptionalNestedPresenceCheckFirstMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nested/OptionalNestedPresenceCheckFirstMapperImpl.java
@@ -10,8 +10,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2026-01-23T09:56:12+0100",
-    comments = "version: , compiler: javac, environment: Java 21.0.3 (Eclipse Adoptium)"
+    date = "2026-06-05T14:56:21+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class OptionalNestedPresenceCheckFirstMapperImpl implements OptionalNestedPresenceCheckFirstMapper {
 
@@ -23,8 +23,9 @@ public class OptionalNestedPresenceCheckFirstMapperImpl implements OptionalNeste
 
         TargetAggregate targetAggregate = new TargetAggregate();
 
+        Optional<String> title = song.getTitle();
         if ( song.hasTitle() ) {
-            targetAggregate.setSongTitle( song.getTitle().get() );
+            targetAggregate.setSongTitle( title.get() );
         }
         String name = songArtistName( song );
         if ( song.hasArtist() && song.getArtist().isPresent() && song.getArtist().get().hasName() ) {

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nullcheckalways/OptionalNullCheckAlwaysMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/nullcheckalways/OptionalNullCheckAlwaysMapperImpl.java
@@ -10,8 +10,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2026-01-23T10:02:54+0100",
-    comments = "version: , compiler: javac, environment: Java 21.0.3 (Eclipse Adoptium)"
+    date = "2026-06-05T14:56:21+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class OptionalNullCheckAlwaysMapperImpl implements OptionalNullCheckAlwaysMapper {
 
@@ -23,14 +23,17 @@ public class OptionalNullCheckAlwaysMapperImpl implements OptionalNullCheckAlway
 
         Target target = new Target();
 
-        if ( source.getOptionalToOptional().isPresent() ) {
-            target.setOptionalToOptional( source.getOptionalToOptional() );
+        Optional<String> optionalToOptional = source.getOptionalToOptional();
+        if ( optionalToOptional.isPresent() ) {
+            target.setOptionalToOptional( optionalToOptional );
         }
-        if ( source.getOptionalToNonOptional().isPresent() ) {
-            target.setOptionalToNonOptional( source.getOptionalToNonOptional().get() );
+        Optional<String> optionalToNonOptional = source.getOptionalToNonOptional();
+        if ( optionalToNonOptional.isPresent() ) {
+            target.setOptionalToNonOptional( optionalToNonOptional.get() );
         }
-        if ( source.getNonOptionalToOptional() != null ) {
-            target.setNonOptionalToOptional( Optional.of( source.getNonOptionalToOptional() ) );
+        String nonOptionalToOptional = source.getNonOptionalToOptional();
+        if ( nonOptionalToOptional != null ) {
+            target.setNonOptionalToOptional( Optional.of( nonOptionalToOptional ) );
         }
 
         return target;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/sametype/OptionalSameTypeMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/optional/sametype/OptionalSameTypeMapperImpl.java
@@ -10,8 +10,8 @@ import javax.annotation.processing.Generated;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
-    date = "2026-01-23T10:02:54+0100",
-    comments = "version: , compiler: javac, environment: Java 21.0.3 (Eclipse Adoptium)"
+    date = "2026-06-05T14:56:21+0200",
+    comments = "version: , compiler: javac, environment: Java 21.0.11 (IBM Corporation)"
 )
 public class OptionalSameTypeMapperImpl implements OptionalSameTypeMapper {
 
@@ -26,28 +26,34 @@ public class OptionalSameTypeMapperImpl implements OptionalSameTypeMapper {
         Optional<String> constructorNonOptionalToOptional = Optional.empty();
 
         constructorOptionalToOptional = source.getConstructorOptionalToOptional();
-        if ( source.getConstructorOptionalToNonOptional().isPresent() ) {
-            constructorOptionalToNonOptional = source.getConstructorOptionalToNonOptional().get();
+        Optional<String> constructorOptionalToNonOptional1 = source.getConstructorOptionalToNonOptional();
+        if ( constructorOptionalToNonOptional1.isPresent() ) {
+            constructorOptionalToNonOptional = constructorOptionalToNonOptional1.get();
         }
-        if ( source.getConstructorNonOptionalToOptional() != null ) {
-            constructorNonOptionalToOptional = Optional.of( source.getConstructorNonOptionalToOptional() );
+        String constructorNonOptionalToOptional1 = source.getConstructorNonOptionalToOptional();
+        if ( constructorNonOptionalToOptional1 != null ) {
+            constructorNonOptionalToOptional = Optional.of( constructorNonOptionalToOptional1 );
         }
 
         Target target = new Target( constructorOptionalToOptional, constructorOptionalToNonOptional, constructorNonOptionalToOptional );
 
         target.setOptionalToOptional( source.getOptionalToOptional() );
-        if ( source.getOptionalToNonOptional().isPresent() ) {
-            target.setOptionalToNonOptional( source.getOptionalToNonOptional().get() );
+        Optional<String> optionalToNonOptional = source.getOptionalToNonOptional();
+        if ( optionalToNonOptional.isPresent() ) {
+            target.setOptionalToNonOptional( optionalToNonOptional.get() );
         }
-        if ( source.getNonOptionalToOptional() != null ) {
-            target.setNonOptionalToOptional( Optional.of( source.getNonOptionalToOptional() ) );
+        String nonOptionalToOptional = source.getNonOptionalToOptional();
+        if ( nonOptionalToOptional != null ) {
+            target.setNonOptionalToOptional( Optional.of( nonOptionalToOptional ) );
         }
         target.publicOptionalToOptional = source.publicOptionalToOptional;
-        if ( source.publicOptionalToNonOptional.isPresent() ) {
-            target.publicOptionalToNonOptional = source.publicOptionalToNonOptional.get();
+        Optional<String> publicOptionalToNonOptional = source.publicOptionalToNonOptional;
+        if ( publicOptionalToNonOptional.isPresent() ) {
+            target.publicOptionalToNonOptional = publicOptionalToNonOptional.get();
         }
-        if ( source.publicNonOptionalToOptional != null ) {
-            target.publicNonOptionalToOptional = Optional.of( source.publicNonOptionalToOptional );
+        String publicNonOptionalToOptional = source.publicNonOptionalToOptional;
+        if ( publicNonOptionalToOptional != null ) {
+            target.publicNonOptionalToOptional = Optional.of( publicNonOptionalToOptional );
         }
 
         return target;

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/CompanyMapper1Impl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/CompanyMapper1Impl.java
@@ -25,11 +25,12 @@ public class CompanyMapper1Impl implements CompanyMapper1 {
         }
 
         entity.setName( dto.getName() );
-        if ( dto.getDepartment() != null ) {
+        UnmappableDepartmentDto department = dto.getDepartment();
+        if ( department != null ) {
             if ( entity.getDepartment() == null ) {
                 entity.setDepartment( departmentEntityFactory.createDepartmentEntity() );
             }
-            unmappableDepartmentDtoToDepartmentEntity( dto.getDepartment(), entity.getDepartment() );
+            unmappableDepartmentDtoToDepartmentEntity( department, entity.getDepartment() );
         }
         else {
             entity.setDepartment( null );
@@ -100,8 +101,9 @@ public class CompanyMapper1Impl implements CompanyMapper1 {
         }
 
         mappingTarget.setName( unmappableDepartmentDto.getName() );
+        Map<SecretaryDto, EmployeeDto> secretaryToEmployee = unmappableDepartmentDto.getSecretaryToEmployee();
         if ( mappingTarget.getSecretaryToEmployee() != null ) {
-            Map<SecretaryEntity, EmployeeEntity> map = secretaryDtoEmployeeDtoMapToSecretaryEntityEmployeeEntityMap( unmappableDepartmentDto.getSecretaryToEmployee() );
+            Map<SecretaryEntity, EmployeeEntity> map = secretaryDtoEmployeeDtoMapToSecretaryEntityEmployeeEntityMap( secretaryToEmployee );
             if ( map != null ) {
                 mappingTarget.getSecretaryToEmployee().clear();
                 mappingTarget.getSecretaryToEmployee().putAll( map );
@@ -111,7 +113,7 @@ public class CompanyMapper1Impl implements CompanyMapper1 {
             }
         }
         else {
-            Map<SecretaryEntity, EmployeeEntity> map = secretaryDtoEmployeeDtoMapToSecretaryEntityEmployeeEntityMap( unmappableDepartmentDto.getSecretaryToEmployee() );
+            Map<SecretaryEntity, EmployeeEntity> map = secretaryDtoEmployeeDtoMapToSecretaryEntityEmployeeEntityMap( secretaryToEmployee );
             if ( map != null ) {
                 mappingTarget.setSecretaryToEmployee( map );
             }

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/CompanyMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/CompanyMapperImpl.java
@@ -23,11 +23,12 @@ public class CompanyMapperImpl implements CompanyMapper {
         }
 
         entity.setName( dto.getName() );
-        if ( dto.getDepartment() != null ) {
+        DepartmentDto department = dto.getDepartment();
+        if ( department != null ) {
             if ( entity.getDepartment() == null ) {
                 entity.setDepartment( departmentEntityFactory.createDepartmentEntity() );
             }
-            toDepartmentEntity( toInBetween( dto.getDepartment() ), entity.getDepartment() );
+            toDepartmentEntity( toInBetween( department ), entity.getDepartment() );
         }
         else {
             entity.setDepartment( null );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/OrganizationMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/OrganizationMapperImpl.java
@@ -22,11 +22,12 @@ public class OrganizationMapperImpl implements OrganizationMapper {
             return;
         }
 
-        if ( dto.getCompany() != null ) {
+        CompanyDto company = dto.getCompany();
+        if ( company != null ) {
             if ( entity.getCompany() == null ) {
                 entity.setCompany( new CompanyEntity() );
             }
-            toCompanyEntity( dto.getCompany(), entity.getCompany() );
+            toCompanyEntity( company, entity.getCompany() );
         }
         else {
             entity.setCompany( null );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/DepartmentMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/DepartmentMapperImpl.java
@@ -7,6 +7,8 @@ package org.mapstruct.ap.test.updatemethods.selection;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import javax.annotation.Generated;
 import org.mapstruct.ap.test.updatemethods.DepartmentDto;
 import org.mapstruct.ap.test.updatemethods.DepartmentEntity;
@@ -31,20 +33,22 @@ public class DepartmentMapperImpl implements DepartmentMapper {
         }
 
         entity.setName( dto.getName() );
-        if ( dto.getEmployees() != null ) {
+        List<EmployeeDto> employees = dto.getEmployees();
+        if ( employees != null ) {
             if ( entity.getEmployees() == null ) {
                 entity.setEmployees( new ArrayList<>() );
             }
-            externalHandWrittenMapper.toEmployeeEntityList( dto.getEmployees(), entity.getEmployees() );
+            externalHandWrittenMapper.toEmployeeEntityList( employees, entity.getEmployees() );
         }
         else {
             entity.setEmployees( null );
         }
-        if ( dto.getSecretaryToEmployee() != null ) {
+        Map<SecretaryDto, EmployeeDto> secretaryToEmployee = dto.getSecretaryToEmployee();
+        if ( secretaryToEmployee != null ) {
             if ( entity.getSecretaryToEmployee() == null ) {
                 entity.setSecretaryToEmployee( new LinkedHashMap<>() );
             }
-            externalHandWrittenMapper.toSecretaryEmployeeEntityMap( dto.getSecretaryToEmployee(), entity.getSecretaryToEmployee() );
+            externalHandWrittenMapper.toSecretaryEmployeeEntityMap( secretaryToEmployee, entity.getSecretaryToEmployee() );
         }
         else {
             entity.setSecretaryToEmployee( null );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/OrganizationMapper1Impl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/OrganizationMapper1Impl.java
@@ -8,6 +8,7 @@ package org.mapstruct.ap.test.updatemethods.selection;
 import javax.annotation.Generated;
 import org.mapstruct.ap.test.updatemethods.CompanyDto;
 import org.mapstruct.ap.test.updatemethods.CompanyEntity;
+import org.mapstruct.ap.test.updatemethods.DepartmentDto;
 import org.mapstruct.ap.test.updatemethods.DepartmentEntityFactory;
 
 @Generated(
@@ -27,11 +28,12 @@ public class OrganizationMapper1Impl implements OrganizationMapper1 {
         }
 
         entity.setName( dto.getName() );
-        if ( dto.getDepartment() != null ) {
+        DepartmentDto department = dto.getDepartment();
+        if ( department != null ) {
             if ( entity.getDepartment() == null ) {
                 entity.setDepartment( departmentEntityFactory.createDepartmentEntity() );
             }
-            externalMapper.toDepartmentEntity( dto.getDepartment(), entity.getDepartment() );
+            externalMapper.toDepartmentEntity( department, entity.getDepartment() );
         }
         else {
             entity.setDepartment( null );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/OrganizationMapper2Impl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/OrganizationMapper2Impl.java
@@ -8,6 +8,7 @@ package org.mapstruct.ap.test.updatemethods.selection;
 import javax.annotation.Generated;
 import org.mapstruct.ap.test.updatemethods.CompanyDto;
 import org.mapstruct.ap.test.updatemethods.CompanyEntity;
+import org.mapstruct.ap.test.updatemethods.DepartmentDto;
 import org.mapstruct.ap.test.updatemethods.DepartmentEntityFactory;
 
 @Generated(
@@ -27,11 +28,12 @@ public class OrganizationMapper2Impl implements OrganizationMapper2 {
         }
 
         entity.setName( dto.getName() );
-        if ( dto.getDepartment() != null ) {
+        DepartmentDto department = dto.getDepartment();
+        if ( department != null ) {
             if ( entity.getDepartment() == null ) {
                 entity.setDepartment( departmentEntityFactory.createDepartmentEntity() );
             }
-            externalHandWrittenMapper.toDepartmentEntity( dto.getDepartment(), entity.getDepartment() );
+            externalHandWrittenMapper.toDepartmentEntity( department, entity.getDepartment() );
         }
         else {
             entity.setDepartment( null );

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/OrganizationMapper3Impl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/updatemethods/selection/OrganizationMapper3Impl.java
@@ -9,6 +9,7 @@ import javax.annotation.Generated;
 import org.mapstruct.ap.test.updatemethods.BossDto;
 import org.mapstruct.ap.test.updatemethods.BossEntity;
 import org.mapstruct.ap.test.updatemethods.ConstructableDepartmentEntity;
+import org.mapstruct.ap.test.updatemethods.DepartmentDto;
 
 @Generated(
     value = "org.mapstruct.ap.MappingProcessor",
@@ -26,11 +27,12 @@ public class OrganizationMapper3Impl implements OrganizationMapper3 {
         }
 
         entity.setName( dto.getName() );
-        if ( dto.getDepartment() != null ) {
+        DepartmentDto department = dto.getDepartment();
+        if ( department != null ) {
             if ( entity.getDepartment() == null ) {
                 entity.setDepartment( new ConstructableDepartmentEntity() );
             }
-            externalMapper.toDepartmentEntity( dto.getDepartment(), entity.getDepartment() );
+            externalMapper.toDepartmentEntity( department, entity.getDepartment() );
         }
         else {
             entity.setDepartment( null );


### PR DESCRIPTION
fixes #4030 

Note: There is an edge-case considered out of scope for this PR, where source is used multiple times for different mappings. Then the generated code has multiple blocks with a different extracted variable, with incremental names. For example in `DomainDtoWithNcvsAlwaysMapperImpl`:

   ```java
   List<String> strings = source.getStrings();
   if ( target.getStrings() != null ) {
       if ( source.hasStrings() ) {
           target.getStrings().clear();
           target.getStrings().addAll( strings );
       }
   }
   else {
       if ( source.hasStrings() ) {
           List<String> list = strings;
           target.setStrings( new LinkedHashSet<>( list ) );
       }
   }
   List<String> strings1 = source.getStrings();
   if ( target.getLongs() != null ) {
       if ( source.hasStrings() ) {
           target.getLongs().clear();
           target.getLongs().addAll( stringListToLongSet( strings1 ) );
       }
   }
   else {
       if ( source.hasStrings() ) {
           target.setLongs( stringListToLongSet( strings1 ) );
       }
   }
   ```