### PR TITLE
Add nullValueIterablePropertyMappingStrategy and nullValueMapProperty…

### DIFF
--- a/core/src/main/java/org/mapstruct/Mapper.java
+++ b/core/src/main/java/org/mapstruct/Mapper.java
@@ -249,6 +249,36 @@ public @interface Mapper {
         NullValuePropertyMappingStrategy.SET_TO_NULL;
 
     /**
+     * The strategy to be applied when a source bean property of an {@link Iterable} type is {@code null} or not
+     * present. If no strategy is configured, the strategy given via
+     * {@link MapperConfig#nullValueIterablePropertyMappingStrategy()} will be applied. If neither strategy is
+     * configured, the strategy given via {@link #nullValuePropertyMappingStrategy()} will be applied,
+     * {@link NullValuePropertyMappingStrategy#SET_TO_NULL} will be used by default.
+     *
+     * @since 1.7
+     *
+     * @return The strategy to be applied when {@code null} is passed as an {@link Iterable} source property value or
+     * the source property is not present.
+     */
+    NullValuePropertyMappingStrategy nullValueIterablePropertyMappingStrategy() default
+        NullValuePropertyMappingStrategy.SET_TO_NULL;
+
+    /**
+     * The strategy to be applied when a source bean property of a {@link java.util.Map} type is {@code null} or not
+     * present. If no strategy is configured, the strategy given via
+     * {@link MapperConfig#nullValueMapPropertyMappingStrategy()} will be applied. If neither strategy is configured,
+     * the strategy given via {@link #nullValuePropertyMappingStrategy()} will be applied,
+     * {@link NullValuePropertyMappingStrategy#SET_TO_NULL} will be used by default.
+     *
+     * @since 1.7
+     *
+     * @return The strategy to be applied when {@code null} is passed as a {@link java.util.Map} source property value
+     * or the source property is not present.
+     */
+    NullValuePropertyMappingStrategy nullValueMapPropertyMappingStrategy() default
+        NullValuePropertyMappingStrategy.SET_TO_NULL;
+
+    /**
      * The strategy to use for applying method-level configuration annotations of prototype methods in the interface
      * specified with {@link #config()}. Annotations that can be inherited are for example {@link Mapping},
      * {@link IterableMapping}, {@link MapMapping}, or {@link BeanMapping}.

--- a/core/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core/src/main/java/org/mapstruct/MapperConfig.java
@@ -217,6 +217,32 @@ public @interface MapperConfig {
         NullValuePropertyMappingStrategy.SET_TO_NULL;
 
     /**
+     * The strategy to be applied when a source bean property of an {@link Iterable} type is {@code null} or not
+     * present. If no strategy is configured, the strategy given via {@link #nullValuePropertyMappingStrategy()} will
+     * be applied, {@link NullValuePropertyMappingStrategy#SET_TO_NULL} will be used by default.
+     *
+     * @since 1.7
+     *
+     * @return The strategy to be applied when {@code null} is passed as an {@link Iterable} source property value or
+     * the source property is not present.
+     */
+    NullValuePropertyMappingStrategy nullValueIterablePropertyMappingStrategy() default
+        NullValuePropertyMappingStrategy.SET_TO_NULL;
+
+    /**
+     * The strategy to be applied when a source bean property of a {@link java.util.Map} type is {@code null} or not
+     * present. If no strategy is configured, the strategy given via {@link #nullValuePropertyMappingStrategy()} will
+     * be applied, {@link NullValuePropertyMappingStrategy#SET_TO_NULL} will be used by default.
+     *
+     * @since 1.7
+     *
+     * @return The strategy to be applied when {@code null} is passed as a {@link java.util.Map} source property value
+     * or the source property is not present.
+     */
+    NullValuePropertyMappingStrategy nullValueMapPropertyMappingStrategy() default
+        NullValuePropertyMappingStrategy.SET_TO_NULL;
+
+    /**
      * The strategy to use for applying method-level configuration annotations of prototype methods in the interface
      * annotated with this annotation. Annotations that can be inherited are for example {@link Mapping},
      * {@link IterableMapping}, {@link MapMapping}, or {@link BeanMapping}.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -161,6 +161,8 @@ public class PropertyMapping extends ModelElement {
         private boolean forgedNamedBased = true;
         private NullValueCheckStrategyGem nvcs;
         private NullValuePropertyMappingStrategyGem nvpms;
+        private NullValuePropertyMappingStrategyGem nvpmsIterable;
+        private NullValuePropertyMappingStrategyGem nvpmsMap;
 
         PropertyMappingBuilder() {
             super( PropertyMappingBuilder.class );
@@ -227,6 +229,8 @@ public class PropertyMapping extends ModelElement {
             this.nvcs = options.getNullValueCheckStrategy();
             if ( method.isUpdateMethod() ) {
                 this.nvpms = options.getNullValuePropertyMappingStrategy();
+                this.nvpmsIterable = options.getNullValueIterablePropertyMappingStrategy();
+                this.nvpmsMap = options.getNullValueMapPropertyMappingStrategy();
             }
             return this;
         }
@@ -235,6 +239,17 @@ public class PropertyMapping extends ModelElement {
 
             // handle source
             this.rightHandSide = getSourceRHS( sourceReference );
+
+            // resolve the most specific null value property mapping strategy based on source type
+            if ( nvpms != null ) {
+                Type sourceType = rightHandSide.getSourceType();
+                if ( sourceType.isIterableType() && nvpmsIterable != null ) {
+                    nvpms = nvpmsIterable;
+                }
+                else if ( sourceType.isMapType() && nvpmsMap != null ) {
+                    nvpms = nvpmsMap;
+                }
+            }
 
             ctx.getMessager().note( 2, Message.PROPERTYMAPPING_MAPPING_NOTE, rightHandSide, targetWriteAccessor );
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/DefaultOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/DefaultOptions.java
@@ -127,6 +127,14 @@ public class DefaultOptions extends DelegatingOptions {
             mapper.nullValuePropertyMappingStrategy().getDefaultValue() );
     }
 
+    public NullValuePropertyMappingStrategyGem getNullValueIterablePropertyMappingStrategy() {
+        return null;
+    }
+
+    public NullValuePropertyMappingStrategyGem getNullValueMapPropertyMappingStrategy() {
+        return null;
+    }
+
     public NullValueMappingStrategyGem getNullValueMappingStrategy() {
         return NullValueMappingStrategyGem.valueOf( mapper.nullValueMappingStrategy().getDefaultValue() );
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/DelegatingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/DelegatingOptions.java
@@ -98,6 +98,14 @@ public abstract class DelegatingOptions {
         return next.getNullValuePropertyMappingStrategy();
     }
 
+    public NullValuePropertyMappingStrategyGem getNullValueIterablePropertyMappingStrategy() {
+        return next.getNullValueIterablePropertyMappingStrategy();
+    }
+
+    public NullValuePropertyMappingStrategyGem getNullValueMapPropertyMappingStrategy() {
+        return next.getNullValueMapPropertyMappingStrategy();
+    }
+
     public NullValueMappingStrategyGem getNullValueMappingStrategy() {
         return next.getNullValueMappingStrategy();
     }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperConfigOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperConfigOptions.java
@@ -128,6 +128,24 @@ public class MapperConfigOptions extends DelegatingOptions {
     }
 
     @Override
+    public NullValuePropertyMappingStrategyGem getNullValueIterablePropertyMappingStrategy() {
+        if ( mapperConfig.nullValueIterablePropertyMappingStrategy().hasValue() ) {
+            return NullValuePropertyMappingStrategyGem.valueOf(
+                mapperConfig.nullValueIterablePropertyMappingStrategy().get() );
+        }
+        return next().getNullValueIterablePropertyMappingStrategy();
+    }
+
+    @Override
+    public NullValuePropertyMappingStrategyGem getNullValueMapPropertyMappingStrategy() {
+        if ( mapperConfig.nullValueMapPropertyMappingStrategy().hasValue() ) {
+            return NullValuePropertyMappingStrategyGem.valueOf(
+                mapperConfig.nullValueMapPropertyMappingStrategy().get() );
+        }
+        return next().getNullValueMapPropertyMappingStrategy();
+    }
+
+    @Override
     public NullValueMappingStrategyGem getNullValueMappingStrategy() {
         return mapperConfig.nullValueMappingStrategy().hasValue() ?
             NullValueMappingStrategyGem.valueOf( mapperConfig.nullValueMappingStrategy().get() ) :

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperOptions.java
@@ -157,6 +157,24 @@ public class MapperOptions extends DelegatingOptions {
     }
 
     @Override
+    public NullValuePropertyMappingStrategyGem getNullValueIterablePropertyMappingStrategy() {
+        if ( mapper.nullValueIterablePropertyMappingStrategy().hasValue() ) {
+            return NullValuePropertyMappingStrategyGem.valueOf(
+                mapper.nullValueIterablePropertyMappingStrategy().get() );
+        }
+        return next().getNullValueIterablePropertyMappingStrategy();
+    }
+
+    @Override
+    public NullValuePropertyMappingStrategyGem getNullValueMapPropertyMappingStrategy() {
+        if ( mapper.nullValueMapPropertyMappingStrategy().hasValue() ) {
+            return NullValuePropertyMappingStrategyGem.valueOf(
+                mapper.nullValueMapPropertyMappingStrategy().get() );
+        }
+        return next().getNullValueMapPropertyMappingStrategy();
+    }
+
+    @Override
     public NullValueMappingStrategyGem getNullValueMappingStrategy() {
         return mapper.nullValueMappingStrategy().hasValue() ?
             NullValueMappingStrategyGem.valueOf( mapper.nullValueMappingStrategy().get() ) :

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluepropertymapping/CustomerNvpmsIterableOnMapperMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluepropertymapping/CustomerNvpmsIterableOnMapperMapper.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullvaluepropertymapping;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingTarget;
+import org.mapstruct.NullValuePropertyMappingStrategy;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(nullValueIterablePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE)
+public interface CustomerNvpmsIterableOnMapperMapper {
+
+    CustomerNvpmsIterableOnMapperMapper INSTANCE = Mappers.getMapper( CustomerNvpmsIterableOnMapperMapper.class );
+
+    void map(Customer customer, @MappingTarget CustomerDTO mappingTarget);
+
+    @Mapping(target = "houseNo", source = "houseNumber")
+    void mapAddress(Address address, @MappingTarget AddressDTO addressDTO);
+
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullvaluepropertymapping/NullValuePropertyMappingTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullvaluepropertymapping/NullValuePropertyMappingTest.java
@@ -179,6 +179,29 @@ public class NullValuePropertyMappingTest {
     public void testBothIgnoreAndNvpmsDefined() {
     }
 
+    @ProcessorTest
+    @IssueKey("3387")
+    @WithClasses(CustomerNvpmsIterableOnMapperMapper.class)
+    public void testIterablePropertyIgnoredWhenNullWithIterableStrategy() {
+
+        Customer customer = new Customer();
+        customer.setAddress( null );
+        customer.setDetails( null );
+
+        CustomerDTO customerDto = new CustomerDTO();
+        customerDto.setAddress( new AddressDTO() );
+        customerDto.getAddress().setHouseNo( 5 );
+        customerDto.setDetails( Arrays.asList( "green hair" ) );
+
+        CustomerNvpmsIterableOnMapperMapper.INSTANCE.map( customer, customerDto );
+
+        // address is null in source and strategy is SET_TO_NULL (default for non-iterable)
+        assertThat( customerDto.getAddress() ).isNull();
+        // details is null in source but strategy is IGNORE for Iterable, so existing value preserved
+        assertThat( customerDto.getDetails() ).isNotNull();
+        assertThat( customerDto.getDetails() ).containsExactly( "green hair" );
+    }
+
     private void testConfig(BiConsumer<Customer, CustomerDTO> customerMapper) {
 
         Customer customer = new Customer();


### PR DESCRIPTION
## Changes

- Added `nullValueIterablePropertyMappingStrategy` to `@Mapper` and `@MapperConfig`
- Added `nullValueMapPropertyMappingStrategy` to `@Mapper` and `@MapperConfig`
- Resolution follows the same chain as existing strategies: specific strategy
  takes precedence over `nullValuePropertyMappingStrategy`, which falls back
  to `SET_TO_NULL` by default
- Added test covering `IGNORE` behavior for `Iterable` source properties

## Example

```java
@Mapper(
    nullValuePropertyMappingStrategy = NullValuePropertyMappingStrategy.SET_TO_NULL,
    nullValueIterablePropertyMappingStrategy = NullValuePropertyMappingStrategy.IGNORE
)
public interface CustomerMapper {
    void update(Customer source, @MappingTarget CustomerDTO target);
}

When source.getItems() is null, the target's items field is left unchanged.
When source.getAddress() is null, the target's address is set to null.

Closes #3387
```