### PR TITLE
Define new enum ClassAccessibility

### DIFF
--- a/core/src/main/java/org/mapstruct/ClassAccessibility.java
+++ b/core/src/main/java/org/mapstruct/ClassAccessibility.java
@@ -6,7 +6,7 @@
 package org.mapstruct;
 
 /**
- * Indicates whether a generated Mapper implementation class should be declared {@code public} or not.
+ * Determines whether a generated Mapper implementation class will be declared {@code public} or not.
  *
  * @author Raimund Klein
  *
@@ -14,16 +14,15 @@ package org.mapstruct;
  */
 public enum ClassAccessibility {
     /**
-     * Indicates that the generated Mapper should have the same modifier ({@code public} or none) as the annotated
-     * class or interface.
+     * The generated Mapper will have the same modifier ({@code public} or none) as the annotated class or interface.
      */
     LIKE_ABSTRACTION,
     /**
-     * Indicates that the generated Mapoer should be declared {@code public}.
+     * The generated Mapper will be declared {@code public}.
      */
     PUBLIC,
     /**
-     * Indicates that the generated Mapper should have no visibility modifier ("package-private").
+     * The generated Mapper will have no visibility modifier ("package-private").
      */
     DEFAULT
 }

--- a/core/src/main/java/org/mapstruct/ClassAccessibility.java
+++ b/core/src/main/java/org/mapstruct/ClassAccessibility.java
@@ -16,7 +16,7 @@ public enum ClassAccessibility {
     /**
      * The generated Mapper will have the same modifier ({@code public} or none) as the annotated class or interface.
      */
-    LIKE_ABSTRACTION,
+    DEFAULT,
     /**
      * The generated Mapper will be declared {@code public}.
      */
@@ -24,5 +24,5 @@ public enum ClassAccessibility {
     /**
      * The generated Mapper will have no visibility modifier ("package-private").
      */
-    DEFAULT
+    PACKAGE_PRIVATE
 }

--- a/core/src/main/java/org/mapstruct/ClassAccessibility.java
+++ b/core/src/main/java/org/mapstruct/ClassAccessibility.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct;
+
+/**
+ * Indicates whether a generated Mapper implementation class should be declared {@code public} or not.
+ *
+ * @author Raimund Klein
+ *
+ * @since 1.7.0
+ */
+public enum ClassAccessibility {
+    /**
+     * Indicates that the generated Mapper should have the same modifier ({@code public} or none) as the annotated
+     * class or interface.
+     */
+    LIKE_ABSTRACTION,
+    /**
+     * Indicates that the generated Mapoer should be declared {@code public}.
+     */
+    PUBLIC,
+    /**
+     * Indicates that the generated Mapper should have no visibility modifier ("package-private").
+     */
+    DEFAULT
+}

--- a/core/src/main/java/org/mapstruct/Mapper.java
+++ b/core/src/main/java/org/mapstruct/Mapper.java
@@ -14,6 +14,7 @@ import java.lang.annotation.Target;
 import org.mapstruct.control.MappingControl;
 import org.mapstruct.factory.Mappers;
 
+import static org.mapstruct.ClassAccessibility.LIKE_ABSTRACTION;
 import static org.mapstruct.NullValueCheckStrategy.ON_IMPLICIT_CONVERSION;
 import static org.mapstruct.SubclassExhaustiveStrategy.COMPILE_ERROR;
 
@@ -388,4 +389,13 @@ public @interface Mapper {
      * @since 1.5
      */
     boolean suppressTimestampInGenerated() default false;
+
+    /**
+     * Determines the {@link ClassAccessibility} ({@code public} or package-private) for the generated Mapper
+     * implementation. Default is to mirror the interface or abstract class annotated by this {@code Mapper}.
+     *
+     * @return The {@link ClassAccessibility} ({@code public} or package-private) for the generated Mapper
+     *         implementation
+     */
+    ClassAccessibility accessibility() default LIKE_ABSTRACTION;
 }

--- a/core/src/main/java/org/mapstruct/Mapper.java
+++ b/core/src/main/java/org/mapstruct/Mapper.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
 import org.mapstruct.control.MappingControl;
 import org.mapstruct.factory.Mappers;
 
-import static org.mapstruct.ClassAccessibility.LIKE_ABSTRACTION;
+import static org.mapstruct.ClassAccessibility.DEFAULT;
 import static org.mapstruct.NullValueCheckStrategy.ON_IMPLICIT_CONVERSION;
 import static org.mapstruct.SubclassExhaustiveStrategy.COMPILE_ERROR;
 
@@ -397,5 +397,5 @@ public @interface Mapper {
      * @return The {@link ClassAccessibility} ({@code public} or package-private) for the generated Mapper
      *         implementation
      */
-    ClassAccessibility accessibility() default LIKE_ABSTRACTION;
+    ClassAccessibility accessibility() default DEFAULT;
 }

--- a/core/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core/src/main/java/org/mapstruct/MapperConfig.java
@@ -14,6 +14,7 @@ import java.lang.annotation.Target;
 import org.mapstruct.control.MappingControl;
 import org.mapstruct.factory.Mappers;
 
+import static org.mapstruct.ClassAccessibility.LIKE_ABSTRACTION;
 import static org.mapstruct.NullValueCheckStrategy.ON_IMPLICIT_CONVERSION;
 import static org.mapstruct.SubclassExhaustiveStrategy.COMPILE_ERROR;
 
@@ -357,5 +358,14 @@ public @interface MapperConfig {
      * @since 1.5
      */
     boolean suppressTimestampInGenerated() default false;
+
+    /**
+     * Determines the {@link ClassAccessibility} ({@code public} or package-private) for the generated Mapper
+     * implementation. Default is to mirror the interface or abstract class annotated by {@code Mapper}.
+     *
+     * @return The {@link ClassAccessibility} ({@code public} or package-private) for the generated Mapper
+     *         implementation
+     */
+    ClassAccessibility accessibility() default LIKE_ABSTRACTION;
 }
 

--- a/core/src/main/java/org/mapstruct/MapperConfig.java
+++ b/core/src/main/java/org/mapstruct/MapperConfig.java
@@ -14,7 +14,7 @@ import java.lang.annotation.Target;
 import org.mapstruct.control.MappingControl;
 import org.mapstruct.factory.Mappers;
 
-import static org.mapstruct.ClassAccessibility.LIKE_ABSTRACTION;
+import static org.mapstruct.ClassAccessibility.DEFAULT;
 import static org.mapstruct.NullValueCheckStrategy.ON_IMPLICIT_CONVERSION;
 import static org.mapstruct.SubclassExhaustiveStrategy.COMPILE_ERROR;
 
@@ -366,6 +366,6 @@ public @interface MapperConfig {
      * @return The {@link ClassAccessibility} ({@code public} or package-private) for the generated Mapper
      *         implementation
      */
-    ClassAccessibility accessibility() default LIKE_ABSTRACTION;
+    ClassAccessibility accessibility() default DEFAULT;
 }
 

--- a/documentation/src/main/asciidoc/chapter-4-retrieving-a-mapper.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-4-retrieving-a-mapper.asciidoc
@@ -141,7 +141,7 @@ By default, the generated Mapper implementation will have the same accessibility
 [source, java, linenums]
 [subs="verbatim,attributes"]
 ----
-@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, accessibility = ClassAccessibility.DEFAULT)
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, accessibility = ClassAccessibility.PACKAGE_PRIVATE)
 public interface CarMapper {
 
     CarDto carToCarDto(Car car);
@@ -150,4 +150,4 @@ public interface CarMapper {
 ----
 ====
 
-In this case, the generated Mapper will have no modifier. Possible values are `ClassAccessibility.LIKE_ABSTRACTION` (the default behavior described above), `ClassAccessibility.PUBLIC`, and `ClassAccessibility.DEFAULT` (no modifier, i.e. package-private).
+In this case, the generated Mapper will have no modifier. Possible values are `ClassAccessibility.DEFAULT` (the behavior described above), `ClassAccessibility.PUBLIC`, and `ClassAccessibility.PACKAGE_PRIVATE` (no modifier).

--- a/documentation/src/main/asciidoc/chapter-4-retrieving-a-mapper.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-4-retrieving-a-mapper.asciidoc
@@ -131,3 +131,23 @@ In that case utilize the `InjectionStrategy#SETTER` strategy.
 ====
 For abstract classes or decorators setter injection should be used.
 ====
+
+[[class-accessibility]]
+=== Class accessibility
+
+By default, the generated Mapper implementation will have the same accessibility (`public` or none) as the interface or abstract class carrying the `@Mapper` annotation. Especially in conjunction with a DI framework, this might not be desired. If you wish to reduce the visibility of the generated class, you can make use of the `accessibility` attribute like this:
+
+====
+[source, java, linenums]
+[subs="verbatim,attributes"]
+----
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING, accessibility = ClassAccessibility.DEFAULT)
+public interface CarMapper {
+
+    CarDto carToCarDto(Car car);
+}
+
+----
+====
+
+In this case, the generated Mapper will have no modifier. Possible values are `ClassAccessibility.LIKE_ABSTRACTION` (the default behavior described above), `ClassAccessibility.PUBLIC`, and `ClassAccessibility.DEFAULT` (no modifier, i.e. package-private).

--- a/processor/src/main/java/org/mapstruct/ap/internal/gem/ClassAccessibilityGem.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/gem/ClassAccessibilityGem.java
@@ -11,5 +11,5 @@ package org.mapstruct.ap.internal.gem;
  * @author Raimund Klein
  */
 public enum ClassAccessibilityGem {
-    LIKE_ABSTRACTION, PUBLIC, DEFAULT
+    DEFAULT, PUBLIC, PACKAGE_PRIVATE
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/gem/ClassAccessibilityGem.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/gem/ClassAccessibilityGem.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.internal.gem;
+
+/**
+ * Gem for the enum {@link org.mapstruct.ClassAccessibility}
+ *
+ * @author Raimund Klein
+ */
+public enum ClassAccessibilityGem {
+    LIKE_ABSTRACTION, PUBLIC, DEFAULT
+}

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -12,6 +12,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import javax.lang.model.type.TypeKind;
 
+import org.mapstruct.ap.internal.gem.ClassAccessibilityGem;
 import org.mapstruct.ap.internal.model.common.Accessibility;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.Type;
@@ -40,6 +41,7 @@ public abstract class GeneratedType extends ModelElement {
         protected SortedSet<Type> extraImportedTypes;
 
         protected List<MappingMethod> methods;
+        protected ClassAccessibilityGem classAccessibility;
 
         GeneratedTypeBuilder(Class<T> selfType) {
             myself = selfType.cast( this );
@@ -75,6 +77,10 @@ public abstract class GeneratedType extends ModelElement {
             return myself;
         }
 
+        public T classAccessibility(ClassAccessibilityGem classAccessibility) {
+            this.classAccessibility = classAccessibility;
+            return myself;
+        }
     }
 
     private final String packageName;

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
@@ -17,6 +17,8 @@ import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.option.Options;
 import org.mapstruct.ap.internal.version.VersionInformation;
 
+import static org.mapstruct.ap.internal.gem.ClassAccessibilityGem.LIKE_ABSTRACTION;
+
 /**
  * Represents a type implementing a mapper interface (annotated with {@code @Mapper}). This is the root object of the
  * mapper model.
@@ -109,6 +111,10 @@ public class Mapper extends GeneratedType {
 
             Type definitionType = typeFactory.getType( element );
 
+            Accessibility accessibility =
+                classAccessibility == LIKE_ABSTRACTION ? Accessibility.fromModifiers( element.getModifiers() ) :
+                    Accessibility.valueOf( classAccessibility.name() );
+
             return new Mapper(
                 typeFactory,
                 packageName,
@@ -121,7 +127,7 @@ public class Mapper extends GeneratedType {
                 options,
                 versionInformation,
                 suppressGeneratorTimestamp,
-                Accessibility.fromModifiers( element.getModifiers() ),
+                accessibility,
                 fields,
                 constructor,
                 decorator,

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/Mapper.java
@@ -17,7 +17,7 @@ import org.mapstruct.ap.internal.model.common.TypeFactory;
 import org.mapstruct.ap.internal.option.Options;
 import org.mapstruct.ap.internal.version.VersionInformation;
 
-import static org.mapstruct.ap.internal.gem.ClassAccessibilityGem.LIKE_ABSTRACTION;
+import static org.mapstruct.ap.internal.gem.ClassAccessibilityGem.DEFAULT;
 
 /**
  * Represents a type implementing a mapper interface (annotated with {@code @Mapper}). This is the root object of the
@@ -112,7 +112,7 @@ public class Mapper extends GeneratedType {
             Type definitionType = typeFactory.getType( element );
 
             Accessibility accessibility =
-                classAccessibility == LIKE_ABSTRACTION ? Accessibility.fromModifiers( element.getModifiers() ) :
+                classAccessibility == DEFAULT ? Accessibility.fromModifiers( element.getModifiers() ) :
                     Accessibility.valueOf( classAccessibility.name() );
 
             return new Mapper(

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Accessibility.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Accessibility.java
@@ -14,7 +14,7 @@ import javax.lang.model.element.Modifier;
  * @author Andreas Gudian
  */
 public enum Accessibility {
-    PRIVATE( "private" ), DEFAULT( "" ), PROTECTED( "protected" ), PUBLIC( "public" );
+    PRIVATE( "private" ), PACKAGE_PRIVATE("" ), PROTECTED("protected" ), PUBLIC("public" );
 
     private final String keyword;
 
@@ -37,6 +37,6 @@ public enum Accessibility {
             return PRIVATE;
         }
 
-        return DEFAULT;
+        return PACKAGE_PRIVATE;
     }
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Accessibility.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Accessibility.java
@@ -14,7 +14,7 @@ import javax.lang.model.element.Modifier;
  * @author Andreas Gudian
  */
 public enum Accessibility {
-    PRIVATE( "private" ), PACKAGE_PRIVATE("" ), PROTECTED("protected" ), PUBLIC("public" );
+    PRIVATE( "private" ), PACKAGE_PRIVATE( "" ), PROTECTED( "protected" ), PUBLIC( "public" );
 
     private final String keyword;
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/DefaultOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/DefaultOptions.java
@@ -11,6 +11,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
 import org.mapstruct.ap.internal.gem.BuilderGem;
+import org.mapstruct.ap.internal.gem.ClassAccessibilityGem;
 import org.mapstruct.ap.internal.gem.CollectionMappingStrategyGem;
 import org.mapstruct.ap.internal.gem.InjectionStrategyGem;
 import org.mapstruct.ap.internal.gem.MapperGem;
@@ -153,6 +154,11 @@ public class DefaultOptions extends DelegatingOptions {
             return nullValueMapMappingStrategy;
         }
         return NullValueMappingStrategyGem.valueOf( mapper.nullValueMapMappingStrategy().getDefaultValue() );
+    }
+
+    @Override
+    public ClassAccessibilityGem accessibility() {
+        return ClassAccessibilityGem.valueOf( mapper.accessibility().getDefaultValue() );
     }
 
     public BuilderGem getBuilder() {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/DelegatingOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/DelegatingOptions.java
@@ -12,6 +12,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
 import org.mapstruct.ap.internal.gem.BuilderGem;
+import org.mapstruct.ap.internal.gem.ClassAccessibilityGem;
 import org.mapstruct.ap.internal.gem.CollectionMappingStrategyGem;
 import org.mapstruct.ap.internal.gem.InjectionStrategyGem;
 import org.mapstruct.ap.internal.gem.MappingInheritanceStrategyGem;
@@ -82,6 +83,10 @@ public abstract class DelegatingOptions {
 
     public Boolean isDisableSubMappingMethodsGeneration() {
         return next.isDisableSubMappingMethodsGeneration();
+    }
+
+    public ClassAccessibilityGem accessibility() {
+        return next.accessibility();
     }
 
     // BeanMapping and Mapping

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperConfigOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperConfigOptions.java
@@ -10,6 +10,7 @@ import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
 import org.mapstruct.ap.internal.gem.BuilderGem;
+import org.mapstruct.ap.internal.gem.ClassAccessibilityGem;
 import org.mapstruct.ap.internal.gem.CollectionMappingStrategyGem;
 import org.mapstruct.ap.internal.gem.InjectionStrategyGem;
 import org.mapstruct.ap.internal.gem.MapperConfigGem;
@@ -167,6 +168,13 @@ public class MapperConfigOptions extends DelegatingOptions {
             return NullValueMappingStrategyGem.valueOf( mapperConfig.nullValueMappingStrategy().get() );
         }
         return next().getNullValueMapMappingStrategy();
+    }
+
+    @Override
+    public ClassAccessibilityGem accessibility() {
+        return mapperConfig.accessibility().hasValue() ?
+            ClassAccessibilityGem.valueOf( mapperConfig.accessibility().get() ) :
+            next().accessibility();
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperOptions.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/source/MapperOptions.java
@@ -14,6 +14,7 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import org.mapstruct.ap.internal.gem.BuilderGem;
+import org.mapstruct.ap.internal.gem.ClassAccessibilityGem;
 import org.mapstruct.ap.internal.gem.CollectionMappingStrategyGem;
 import org.mapstruct.ap.internal.gem.InjectionStrategyGem;
 import org.mapstruct.ap.internal.gem.MapperConfigGem;
@@ -168,6 +169,13 @@ public class MapperOptions extends DelegatingOptions {
         return mapper.subclassExhaustiveStrategy().hasValue() ?
             SubclassExhaustiveStrategyGem.valueOf( mapper.subclassExhaustiveStrategy().get() ) :
             next().getSubclassExhaustiveStrategy();
+    }
+
+    @Override
+    public ClassAccessibilityGem accessibility() {
+        return mapper.accessibility().hasValue() ?
+            ClassAccessibilityGem.valueOf( mapper.accessibility().get() ) :
+            next().accessibility();
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -217,6 +217,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
             .suppressGeneratorTimestamp( mapperOptions.suppressTimestampInGenerated() )
             .additionalAnnotations( additionalAnnotationsBuilder.getProcessedAnnotations( element ) )
             .javadoc( getJavadoc( element ) )
+            .classAccessibility( mapperOptions.accessibility() )
             .build();
 
         if ( !mappingContext.getForgedMethodsUnderCreation().isEmpty() ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/ClassAccessibilityTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/ClassAccessibilityTest.java
@@ -19,7 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
     PublicAbstractionMapper.class,
     PackageAbstractionMapper.class,
     ForcedPublicMapper.class,
-    ForcedDefaultMapper.class
+    ForcedPackagePrivateMapper.class
 })
 public class ClassAccessibilityTest {
 
@@ -34,7 +34,7 @@ public class ClassAccessibilityTest {
         Class<?> forcedPublic = loadForMapper( ForcedPublicMapper.class );
         assertThat( isPublic( forcedPublic.getModifiers() ) ).isTrue();
 
-        Class<?> forcedDefault = loadForMapper( ForcedDefaultMapper.class );
+        Class<?> forcedDefault = loadForMapper( ForcedPackagePrivateMapper.class );
         assertThat( isDefault( forcedDefault.getModifiers() ) ).isTrue();
     }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/ClassAccessibilityTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/ClassAccessibilityTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.classaccessibility;
+
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static java.lang.reflect.Modifier.isPrivate;
+import static java.lang.reflect.Modifier.isProtected;
+import static java.lang.reflect.Modifier.isPublic;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses({
+    Source.class,
+    Target.class,
+    PublicAbstractionMapper.class,
+    PackageAbstractionMapper.class,
+    ForcedPublicMapper.class,
+    ForcedDefaultMapper.class
+})
+public class ClassAccessibilityTest {
+
+    @ProcessorTest
+    public void shouldCreateModifierAccordingToAnnotation() throws Exception {
+        Class<?> publicLike = loadForMapper( PublicAbstractionMapper.class );
+        assertThat( isPublic( publicLike.getModifiers() ) ).isTrue();
+
+        Class<?> packageLike = loadForMapper( PackageAbstractionMapper.class );
+        assertThat( isDefault( packageLike.getModifiers() ) ).isTrue();
+
+        Class<?> forcedPublic = loadForMapper( ForcedPublicMapper.class );
+        assertThat( isPublic( forcedPublic.getModifiers() ) ).isTrue();
+
+        Class<?> forcedDefault = loadForMapper( ForcedDefaultMapper.class );
+        assertThat( isDefault( forcedDefault.getModifiers() ) ).isTrue();
+    }
+
+    private static Class<?> loadForMapper(Class<?> mapper) throws ClassNotFoundException {
+        return Thread.currentThread().getContextClassLoader().loadClass( mapper.getName() + "Impl" );
+    }
+
+    private static boolean isDefault(int modifiers) {
+        return !isPublic( modifiers ) && !isProtected( modifiers ) && !isPrivate( modifiers );
+    }
+}
+

--- a/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/ForcedDefaultMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/ForcedDefaultMapper.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.classaccessibility;
+
+import org.mapstruct.ClassAccessibility;
+import org.mapstruct.Mapper;
+
+@Mapper(accessibility = ClassAccessibility.DEFAULT)
+public interface ForcedDefaultMapper {
+    Target map(Source value);
+}
+

--- a/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/ForcedPackagePrivateMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/ForcedPackagePrivateMapper.java
@@ -8,8 +8,8 @@ package org.mapstruct.ap.test.classaccessibility;
 import org.mapstruct.ClassAccessibility;
 import org.mapstruct.Mapper;
 
-@Mapper(accessibility = ClassAccessibility.DEFAULT)
-public interface ForcedDefaultMapper {
+@Mapper(accessibility = ClassAccessibility.PACKAGE_PRIVATE)
+public interface ForcedPackagePrivateMapper {
     Target map(Source value);
 }
 

--- a/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/ForcedPublicMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/ForcedPublicMapper.java
@@ -1,0 +1,15 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.classaccessibility;
+
+import org.mapstruct.ClassAccessibility;
+import org.mapstruct.Mapper;
+
+@Mapper(accessibility = ClassAccessibility.PUBLIC)
+interface ForcedPublicMapper {
+    Target map(Source value);
+}
+

--- a/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/PackageAbstractionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/PackageAbstractionMapper.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.classaccessibility;
+
+import org.mapstruct.Mapper;
+
+@Mapper
+interface PackageAbstractionMapper {
+    Target map(Source value);
+}
+

--- a/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/PublicAbstractionMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/PublicAbstractionMapper.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.classaccessibility;
+
+import org.mapstruct.Mapper;
+
+@Mapper
+public interface PublicAbstractionMapper {
+    Target map(Source value);
+}
+

--- a/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/Source.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.classaccessibility;
+
+/**
+ * @author Raimund Klein
+ **/
+public class Source {
+    private String foo;
+
+    public String getFoo() {
+        return foo;
+    }
+
+    public void setFoo(String foo) {
+        this.foo = foo;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/classaccessibility/Target.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.classaccessibility;
+
+/**
+ * @author Raimund Klein
+ **/
+public class Target {
+    private String foo;
+
+    public String getFoo() {
+        return foo;
+    }
+
+    public void setFoo(String foo) {
+        this.foo = foo;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/gem/EnumGemsTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/gem/EnumGemsTest.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.mapstruct.ClassAccessibility;
 import org.mapstruct.CollectionMappingStrategy;
 import org.mapstruct.ConditionStrategy;
 import org.mapstruct.InjectionStrategy;
@@ -17,6 +18,7 @@ import org.mapstruct.MappingInheritanceStrategy;
 import org.mapstruct.NullValueCheckStrategy;
 import org.mapstruct.NullValueMappingStrategy;
 import org.mapstruct.ReportingPolicy;
+import org.mapstruct.ap.internal.gem.ClassAccessibilityGem;
 import org.mapstruct.ap.internal.gem.CollectionMappingStrategyGem;
 import org.mapstruct.ap.internal.gem.ConditionStrategyGem;
 import org.mapstruct.ap.internal.gem.InjectionStrategyGem;
@@ -73,6 +75,12 @@ public class EnumGemsTest {
     public void conditionStrategyGemIsCorrect() {
         assertThat( namesOf( ConditionStrategy.values() ) ).isEqualTo(
             namesOf( ConditionStrategyGem.values() ) );
+    }
+
+    @Test
+    public void classAccesibilityGemIsCorrect() {
+        assertThat( namesOf( ClassAccessibility.values() ) ).isEqualTo(
+            namesOf( ClassAccessibilityGem.values() ) );
     }
 
     private static List<String> namesOf(Enum<?>[] values) {

--- a/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/CentralConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/CentralConfig.java
@@ -15,7 +15,7 @@ import org.mapstruct.ReportingPolicy;
  */
 @MapperConfig(uses = {CustomMapperViaMapperConfig.class},
         unmappedTargetPolicy = ReportingPolicy.ERROR,
-        accessibility = ClassAccessibility.DEFAULT)
+        accessibility = ClassAccessibility.PACKAGE_PRIVATE)
 public class CentralConfig {
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/CentralConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/CentralConfig.java
@@ -13,7 +13,9 @@ import org.mapstruct.ReportingPolicy;
  *
  * @author Sjaak Derksen
  */
-@MapperConfig(uses = { CustomMapperViaMapperConfig.class }, unmappedTargetPolicy = ReportingPolicy.ERROR, accessibility = ClassAccessibility.DEFAULT)
+@MapperConfig(uses = {CustomMapperViaMapperConfig.class},
+        unmappedTargetPolicy = ReportingPolicy.ERROR,
+        accessibility = ClassAccessibility.DEFAULT)
 public class CentralConfig {
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/CentralConfig.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/CentralConfig.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct.ap.test.mapperconfig;
 
+import org.mapstruct.ClassAccessibility;
 import org.mapstruct.MapperConfig;
 import org.mapstruct.ReportingPolicy;
 
@@ -12,7 +13,7 @@ import org.mapstruct.ReportingPolicy;
  *
  * @author Sjaak Derksen
  */
-@MapperConfig(uses = { CustomMapperViaMapperConfig.class }, unmappedTargetPolicy = ReportingPolicy.ERROR )
+@MapperConfig(uses = { CustomMapperViaMapperConfig.class }, unmappedTargetPolicy = ReportingPolicy.ERROR, accessibility = ClassAccessibility.DEFAULT)
 public class CentralConfig {
 
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/ConfigTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/ConfigTest.java
@@ -12,6 +12,9 @@ import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 
+import static java.lang.reflect.Modifier.isPrivate;
+import static java.lang.reflect.Modifier.isProtected;
+import static java.lang.reflect.Modifier.isPublic;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -50,6 +53,13 @@ public class ConfigTest {
     }
 
     @ProcessorTest
+    @WithClasses( { Target.class, SourceTargetMapper.class } )
+    public void shouldDeclareMapperImplementationAsPackagePrivate() throws ClassNotFoundException {
+        Class<?> implementation = loadForMapper( SourceTargetMapper.class );
+        assertThat( isDefault( implementation.getModifiers() )).isTrue();
+    }
+
+    @ProcessorTest
     @WithClasses( { TargetNoFoo.class, SourceTargetMapperWarn.class } )
     @ExpectedCompilationOutcome(value = CompilationResult.SUCCEEDED,
         diagnostics = {
@@ -69,5 +79,13 @@ public class ConfigTest {
                 message = "Unmapped target property: \"noFoo\".")
         })
     public void shouldUseERRORViaMapperConfig() {
+    }
+
+    private static Class<?> loadForMapper(Class<?> mapper) throws ClassNotFoundException {
+        return Thread.currentThread().getContextClassLoader().loadClass( mapper.getName() + "Impl" );
+    }
+
+    private static boolean isDefault(int modifiers) {
+        return !isPublic( modifiers ) && !isProtected( modifiers ) && !isPrivate( modifiers );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/ConfigTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/mapperconfig/ConfigTest.java
@@ -56,7 +56,7 @@ public class ConfigTest {
     @WithClasses( { Target.class, SourceTargetMapper.class } )
     public void shouldDeclareMapperImplementationAsPackagePrivate() throws ClassNotFoundException {
         Class<?> implementation = loadForMapper( SourceTargetMapper.class );
-        assertThat( isDefault( implementation.getModifiers() )).isTrue();
+        assertThat( isDefault( implementation.getModifiers() ) ).isTrue();
     }
 
     @ProcessorTest


### PR DESCRIPTION
Define new enum `ClassAccessibility` for controlling generated Mappers' declared accessibility.

Fixes #2513.