### PR TITLE
#4000 Fix property name resolution for fluent setters whose second character is upper case

### DIFF
--- a/NEXT_RELEASE_CHANGELOG.md
+++ b/NEXT_RELEASE_CHANGELOG.md
@@ -24,6 +24,7 @@
 
 * Prevent mapper generation from a type with a generic super bound to a type with a generic extends bound (#3994)
 * Fix location for Javadoc when generating the distribution zip
+* Fix property name resolution for fluent setters whose second character is upper case (#4000)
 
 ### Documentation
 

--- a/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
+++ b/processor/src/main/java/org/mapstruct/ap/spi/DefaultAccessorNamingStrategy.java
@@ -242,7 +242,14 @@ public class DefaultAccessorNamingStrategy implements AccessorNamingStrategy {
                 return IntrospectorUtils.decapitalize( methodName.substring( 3 ) );
             }
             else {
-                return methodName;
+                // [#4000] Apply the same JavaBean-style decapitalization as for `getXyz` /
+                // `setXyz` accessors so that a fluent setter `xNameField(...)` resolves to
+                // the same property name as a JavaBean accessor `getXNameField()` /
+                // `setXNameField(...)`. Without this, the two are recognised as different
+                // properties when the second character is upper case (see Introspector spec).
+                return IntrospectorUtils.decapitalize(
+                    Character.toUpperCase( methodName.charAt( 0 ) ) + methodName.substring( 1 )
+                );
             }
         }
         return IntrospectorUtils.decapitalize( methodName.substring( methodName.startsWith( "is" ) ? 2 : 3 ) );

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4000/Issue4000Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4000/Issue4000Mapper.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4000;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue4000Mapper {
+
+    Issue4000Mapper INSTANCE = Mappers.getMapper( Issue4000Mapper.class );
+
+    Target map(Source source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4000/Issue4000Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4000/Issue4000Test.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4000;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@WithClasses({
+    Issue4000Mapper.class,
+    Source.class,
+    Target.class,
+})
+@IssueKey("4000")
+public class Issue4000Test {
+
+    @ProcessorTest
+    public void fluentSetterWithSecondCharUpperCaseShouldMatchJavaBeanAccessor() {
+        Target target = Issue4000Mapper.INSTANCE.map( new Source( "value" ) );
+
+        assertThat( target.getXNameField() ).isEqualTo( "value" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4000/Source.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4000/Source.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4000;
+
+public class Source {
+
+    private final String xNameField;
+
+    public Source(String xNameField) {
+        this.xNameField = xNameField;
+    }
+
+    public String getXNameField() {
+        return xNameField;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4000/Target.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4000/Target.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4000;
+
+public class Target {
+
+    private final String xNameField;
+
+    public Target(Builder builder) {
+        this.xNameField = builder.xNameField;
+    }
+
+    public String getXNameField() {
+        return xNameField;
+    }
+
+    public static Target.Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String xNameField;
+
+        public Builder xNameField(String xNameField) {
+            this.xNameField = xNameField;
+            return this;
+        }
+
+        public Target build() {
+            return new Target( this );
+        }
+    }
+}


### PR DESCRIPTION
Fixes #4000.

`DefaultAccessorNamingStrategy.getPropertyName(...)` returns the raw method name as the property name for fluent setters that do **not** start with `set` (e.g. Lombok `@Builder` style). For methods whose second character is upper case, this conflicts with how the JavaBean accessor side resolves the same property:

| Side | Method | Existing property name |
|------|----------------|------------------------|
| Source (JavaBean) | `getXNameField()` | `XNameField` (via Introspector decapitalize, both first chars upper case → kept) |
| Target (fluent setter) | `xNameField(...)` (Lombok `@Builder`) | `xNameField` (raw method name) |

The two property names differ, so the target field is silently skipped and a user-supplied `@Mapping(target = "xNameField", source = "XNameField")` with a capitalized source is required to work around it.

This PR applies the same JavaBean-style decapitalization to fluent setters: `xNameField` → capitalize first char → `XNameField` → `decapitalize` → `XNameField`. Ordinary fluent setters whose second character is lower case (`settlementDate(...)`) are unaffected (`SettlementDate` → `settlementDate`).

### Test
Added `Issue4000Test` modelled after `Issue1799Test`, with a source class exposing `getXNameField()` and a target class with a Lombok-style `Builder.xNameField(...)` fluent setter.

### Regression
Ran the `builder` / `superbuilder` / `_1799` test suites locally (82 tests) - all passing. Full processor suite was not run locally; CI will exercise it.