### PR TITLE
enforce ParenPad for ENUM_CONSTANT_DEF

### DIFF
--- a/build-config/src/main/resources/build-config/checkstyle.xml
+++ b/build-config/src/main/resources/build-config/checkstyle.xml
@@ -149,7 +149,7 @@
         <module name="NoWhitespaceBefore"/>
         <!-- <module name="OperatorWrap"/> -->
         <module name="ParenPad">
-            <property name="tokens" value="CTOR_CALL, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL, SUPER_CTOR_CALL"/>
+            <property name="tokens" value="CTOR_CALL, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL, SUPER_CTOR_CALL, ENUM_CONSTANT_DEF"/>
             <property name="option" value="space"/>
         </module>
         <module name="TypecastParenPad"/>

--- a/processor/src/test/java/org/mapstruct/ap/test/source/nullvaluecheckstrategy/Stage.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/source/nullvaluecheckstrategy/Stage.java
@@ -14,9 +14,9 @@ import java.util.List;
  */
 public enum Stage {
 
-    MAIN("Paul McCartney", "Ellie Goulding", "Disclosure", "Kaiser Chiefs", "Rammstein"),
-    KLUB_C("James Blake", "Lost Frequencies"),
-    THE_BARN("New Order", "Year and Years");
+    MAIN( "Paul McCartney", "Ellie Goulding", "Disclosure", "Kaiser Chiefs", "Rammstein" ),
+    KLUB_C( "James Blake", "Lost Frequencies" ),
+    THE_BARN( "New Order", "Year and Years" );
 
     private final List<String> artists;
 


### PR DESCRIPTION
Currently we don't enforce consistent spaces for enum constants. 

Found in #4071 