### PR TITLE
remove Java 9 code from integration tests

### DIFF
--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationExclusionCliEnhancer.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/FullFeatureCompilationExclusionCliEnhancer.java
@@ -42,13 +42,6 @@ public final class FullFeatureCompilationExclusionCliEnhancer implements Process
                         "org/mapstruct/ap/test/selection/methodgenerics/wildcards/LifecycleIntersectionMapper.java" );
                 }
                 break;
-            case JAVA_9:
-                // TODO find out why this fails:
-                additionalExcludes.add( "org/mapstruct/ap/test/collection/wildcard/BeanMapper.java" );
-                additionalExcludes.add( "org/mapstruct/ap/test/**/jdk17/*.java" );
-                additionalExcludes.add( "org/mapstruct/ap/test/**/jdk17/**/*.java" );
-                additionalExcludes.add( "org/mapstruct/ap/test/**/jdk21/*.java" );
-                break;
             case JAVA_11:
                 additionalExcludes.add( "org/mapstruct/ap/test/**/spring/**/*.java" );
                 additionalExcludes.add( "org/mapstruct/ap/test/**/jdk17/*.java" );


### PR DESCRIPTION
Java 9 support ended in 2018 and we are no longer testing against it.