### PR TITLE
#2435 Do not import types from the unnamed package

### DIFF
--- a/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
+++ b/integrationtest/src/test/java/org/mapstruct/itest/tests/MavenIntegrationTest.java
@@ -170,7 +170,7 @@ public class MavenIntegrationTest {
     void simpleTest() {
     }
 
-    // for issue #2593
+    // for issues #2593 and #2435 (nested types in the unnamed package)
     @ProcessorTest(baseDir = "defaultPackage")
     void defaultPackageTest() {
     }

--- a/integrationtest/src/test/resources/defaultPackage/main/java/DefaultPackageObject.java
+++ b/integrationtest/src/test/resources/defaultPackage/main/java/DefaultPackageObject.java
@@ -9,6 +9,8 @@ import org.mapstruct.Mapping;
 import org.mapstruct.factory.Mappers;
 
 /**
+ * Nested types and mappers in the unnamed package (issues #2593, #2435).
+ *
  * @author Filip Hrisafov
  */
 public class DefaultPackageObject {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/GeneratedType.java
@@ -284,23 +284,29 @@ public abstract class GeneratedType extends ModelElement {
             return false;
         }
 
-        if ( typeToAdd.getPackageName() != null ) {
-            if ( typeToAdd.getPackageName().equals( JAVA_LANG_PACKAGE ) ) {
-                // only the types in the java.lang package are implicitly imported, the packages under java.lang
-                // like java.lang.management are not.
-                return false;
-            }
+        String typePackageName = typeToAdd.getPackageName();
 
-            if ( typeToAdd.getPackageName().equals( packageName ) ) {
-                if ( typeToAdd.getTypeElement() != null ) {
-                    if ( !typeToAdd.getTypeElement().getNestingKind().isNested() ) {
-                        return false;
-                    }
+        // Types in the unnamed package cannot be imported (JLS §7.5).
+        // Nested types there used to produce invalid imports like `import Outer.Nested`.
+        if ( typePackageName == null || typePackageName.isEmpty() ) {
+            return false;
+        }
+
+        if ( typePackageName.equals( JAVA_LANG_PACKAGE ) ) {
+            // only the types in the java.lang package are implicitly imported, the packages under java.lang
+            // like java.lang.management are not.
+            return false;
+        }
+
+        if ( typePackageName.equals( packageName ) ) {
+            if ( typeToAdd.getTypeElement() != null ) {
+                if ( !typeToAdd.getTypeElement().getNestingKind().isNested() ) {
+                    return false;
                 }
-                else if ( typeToAdd.getComponentType() != null ) {
-                    if ( !typeToAdd.getComponentType().getTypeElement().getNestingKind().isNested() ) {
-                        return false;
-                    }
+            }
+            else if ( typeToAdd.getComponentType() != null ) {
+                if ( !typeToAdd.getComponentType().getTypeElement().getNestingKind().isNested() ) {
+                    return false;
                 }
             }
         }

--- a/processor/src/test/java/Issue2435Test.java
+++ b/processor/src/test/java/Issue2435Test.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Nested types in the unnamed package must compile without invalid imports
+ * such as {@code import Outer.Nested}.
+ *
+ * Lives in the unnamed package so {@link WithClasses} can reference the mapper sources.
+ */
+@IssueKey("2435")
+@WithClasses(UnnamedPackageNestedMapperIssue.class)
+public class Issue2435Test {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest
+    public void shouldCompileAndMapNestedTypesInUnnamedPackage() {
+        UnnamedPackageNestedMapperIssue.Source source = new UnnamedPackageNestedMapperIssue.Source();
+        source.setProperty( "value" );
+
+        UnnamedPackageNestedMapperIssue.Target target =
+            UnnamedPackageNestedMapperIssue.NestedUnnamedPackageMapper.INSTANCE.map( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getProperty() ).isEqualTo( "value" );
+
+        // Types from the unnamed package must not be imported (JLS §7.5).
+        generatedSource.forMapper( UnnamedPackageNestedMapperIssue.NestedUnnamedPackageMapper.class )
+            .content()
+            .doesNotContain( "import UnnamedPackageNestedMapperIssue" );
+    }
+}

--- a/processor/src/test/java/UnnamedPackageNestedMapperIssue.java
+++ b/processor/src/test/java/UnnamedPackageNestedMapperIssue.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Reproduction of issue #2435: nested types in the unnamed package must not produce
+ * invalid imports such as {@code import UnnamedPackageNestedMapperIssue.Source}.
+ */
+public class UnnamedPackageNestedMapperIssue {
+
+    @Mapper
+    public interface NestedUnnamedPackageMapper {
+
+        NestedUnnamedPackageMapper INSTANCE = Mappers.getMapper( NestedUnnamedPackageMapper.class );
+
+        Target map(Source source);
+    }
+
+    public static class Source {
+
+        private String property;
+
+        public String getProperty() {
+            return property;
+        }
+
+        public void setProperty(String property) {
+            this.property = property;
+        }
+    }
+
+    public static class Target {
+
+        private String property;
+
+        public String getProperty() {
+            return property;
+        }
+
+        public void setProperty(String property) {
+            this.property = property;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes compilation failures when generating mappers for **nested types in the unnamed package**.

Previously MapStruct could emit invalid imports such as:

```java
import UnnamedPackageNestedMapperIssue.Source;
import UnnamedPackageNestedMapperIssue.Target;
```

Java does not allow importing types from the unnamed package ([JLS §7.5](https://docs.oracle.com/javase/specs/jls/se8/html/jls-7.html#jls-7.5)), so those statements fail with `package UnnamedPackageNestedMapperIssue does not exist`.

### Change

In `GeneratedType.needsImportDeclaration`, skip import generation when the type’s package name is `null` or empty. Nested (and top-level) types from the unnamed package are then referenced without import statements, e.g. `Outer.Nested`.

Top-level-only imports (#1386 / #2616) already mitigated much of this; this change makes the JLS rule explicit and guards the edge case.

### Tests

- New processor regression test matching the issue setup (`Issue2435Test` / `UnnamedPackageNestedMapperIssue` in the unnamed package)
- Asserts generated impl does not contain `import UnnamedPackageNestedMapperIssue…`
- Asserts mapping works at runtime
- Existing `defaultPackage` integration test documented as covering #2435 as well as #2593

Fixes #2435

## Checklist

- [x] Test cases
- [x] Code formatter (MapStruct style)
- [ ] Reference documentation (not required for this bugfix)