### PR TITLE
#4029 Fall back from ADDER_PREFERRED to setter when adder path not applicable

### DIFF
--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -18,6 +19,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.TypeElement;
 
 import org.mapstruct.ap.internal.gem.BuilderGem;
+import org.mapstruct.ap.internal.gem.CollectionMappingStrategyGem;
 import org.mapstruct.ap.internal.gem.NullValueCheckStrategyGem;
 import org.mapstruct.ap.internal.gem.NullValuePropertyMappingStrategyGem;
 import org.mapstruct.ap.internal.model.assignment.AdderWrapper;
@@ -236,43 +238,35 @@ public class PropertyMapping extends ModelElement {
             // handle source
             this.rightHandSide = getSourceRHS( sourceReference );
 
+            // #4029 ADDER_PREFERRED is a preference, not a hard requirement. When the adder path is
+            // not applicable for this source (e.g. Map — not element-iterable for matching) and a
+            // setter exists, fall back to SETTER_PREFERRED so a direct collection mapping method
+            // can be selected instead of failing while trying to map into the adder parameter type.
+            if ( targetWriteAccessorType == AccessorType.ADDER
+                && !isSourceSuitableForAdderElementMatching( rightHandSide.getSourceType() ) ) {
+                Accessor setterFallback = findSetterFallbackWhenAdderNotApplicable();
+                if ( setterFallback != null ) {
+                    reconfigureTargetWriteAccessor( setterFallback );
+                }
+            }
+
             ctx.getMessager().note( 2, Message.PROPERTYMAPPING_MAPPING_NOTE, rightHandSide, targetWriteAccessor );
 
-            rightHandSide.setUseElementAsSourceTypeForMatching(
-                targetWriteAccessorType == AccessorType.ADDER );
+            Assignment assignment = resolveAssignment();
 
-            // all the tricky cases will be excluded for the time being.
-            boolean preferUpdateMethods;
-            if ( targetWriteAccessorType == AccessorType.ADDER ) {
-                preferUpdateMethods = false;
-            }
-            else {
-                preferUpdateMethods = method.getMappingTargetParameter() != null;
-            }
-
-            SelectionCriteria criteria = SelectionCriteria.forMappingMethods(
-                selectionParameters,
-                mappingControl,
-                targetPropertyName,
-                preferUpdateMethods
-            );
-
-            // forge a method instead of resolving one when there are mapping options.
-            Assignment assignment = null;
-            if ( forgeMethodWithMappingReferences == null ) {
-                assignment = ctx.getMappingResolver().getTargetAssignment(
-                    method,
-                    getForgedMethodHistory( rightHandSide ),
-                    targetType,
-                    formattingParameters,
-                    criteria,
-                    rightHandSide,
-                    positionHint,
-                    this::forge
-                );
-            }
-            else {
-                assignment = forge();
+            // #4029 If the adder path still could not produce an assignment, try the setter.
+            if ( assignment == null && targetWriteAccessorType == AccessorType.ADDER ) {
+                Accessor setterFallback = findSetterFallbackWhenAdderNotApplicable();
+                if ( setterFallback != null ) {
+                    reconfigureTargetWriteAccessor( setterFallback );
+                    ctx.getMessager().note(
+                        2,
+                        Message.PROPERTYMAPPING_MAPPING_NOTE,
+                        rightHandSide,
+                        targetWriteAccessor
+                    );
+                    assignment = resolveAssignment();
+                }
             }
 
             // JSpecify: raise a hard compile error when a source that is not guaranteed @NonNull
@@ -333,6 +327,103 @@ public class PropertyMapping extends ModelElement {
             );
         }
 
+        /**
+         * Resolves a mapping assignment for the current target write accessor.
+         * When the accessor is an adder, element type matching is used.
+         */
+        private Assignment resolveAssignment() {
+            rightHandSide.setUseElementAsSourceTypeForMatching(
+                targetWriteAccessorType == AccessorType.ADDER );
+
+            // all the tricky cases will be excluded for the time being.
+            boolean preferUpdateMethods;
+            if ( targetWriteAccessorType == AccessorType.ADDER ) {
+                preferUpdateMethods = false;
+            }
+            else {
+                preferUpdateMethods = method.getMappingTargetParameter() != null;
+            }
+
+            SelectionCriteria criteria = SelectionCriteria.forMappingMethods(
+                selectionParameters,
+                mappingControl,
+                targetPropertyName,
+                preferUpdateMethods
+            );
+
+            // forge a method instead of resolving one when there are mapping options.
+            if ( forgeMethodWithMappingReferences == null ) {
+                return ctx.getMappingResolver().getTargetAssignment(
+                    method,
+                    getForgedMethodHistory( rightHandSide ),
+                    targetType,
+                    formattingParameters,
+                    criteria,
+                    rightHandSide,
+                    positionHint,
+                    this::forge
+                );
+            }
+            return forge();
+        }
+
+        /**
+         * When {@link CollectionMappingStrategyGem#ADDER_PREFERRED} selected an adder but no
+         * assignment could be created for the adder path, look up the setter for the same property
+         * so the mapping can fall back to setter-preferred behavior.
+         *
+         * @return the setter (or field) write accessor for the property, or {@code null} if none
+         */
+        private Accessor findSetterFallbackWhenAdderNotApplicable() {
+            Element adderElement = targetWriteAccessor.getElement();
+            if ( adderElement == null ) {
+                return null;
+            }
+            Element enclosing = adderElement.getEnclosingElement();
+            while ( enclosing != null && !( enclosing instanceof TypeElement ) ) {
+                enclosing = enclosing.getEnclosingElement();
+            }
+            if ( enclosing == null ) {
+                return null;
+            }
+
+            Type beanType = ctx.getTypeFactory().getType( (TypeElement) enclosing );
+            Map<String, Accessor> writeAccessors =
+                beanType.getPropertyWriteAccessors( CollectionMappingStrategyGem.SETTER_PREFERRED );
+            Accessor candidate = writeAccessors.get( targetPropertyName );
+            if ( candidate != null
+                && ( candidate.getAccessorType() == AccessorType.SETTER
+                    || candidate.getAccessorType().isFieldAssignment() ) ) {
+                return candidate;
+            }
+            return null;
+        }
+
+        private void reconfigureTargetWriteAccessor(Accessor newAccessor) {
+            this.targetWriteAccessor = newAccessor;
+            this.targetWriteAccessorType = newAccessor.getAccessorType();
+            this.targetType = ctx.getTypeFactory().getType( newAccessor.getAccessedType() );
+            BuilderGem builder = method.getOptions().getBeanMapping().getBuilder();
+            this.targetBuilderType = ctx.getTypeFactory().builderTypeFor( this.targetType, builder );
+        }
+
+        /**
+         * Whether the source type can supply elements for an adder (collection / iterable / stream /
+         * array). Maps are not treated as element-iterable for matching (see
+         * {@link SourceRHS#getSourceTypeForMatching()}), so adder is not applicable for them.
+         * Non-collection sources (single element → adder) remain applicable.
+         */
+        private static boolean isSourceSuitableForAdderElementMatching(Type sourceType) {
+            if ( sourceType.isMapType() ) {
+                return false;
+            }
+            return sourceType.isCollectionType()
+                || sourceType.isIterableType()
+                || sourceType.isStreamType()
+                || sourceType.isArrayType()
+                || !sourceType.isCollectionOrMapType();
+        }
+
         private Assignment forge( ) {
             Assignment assignment;
             Type sourceType = rightHandSide.getSourceType();
@@ -344,7 +435,14 @@ public class PropertyMapping extends ModelElement {
                 assignment = forgeMapMapping( sourceType, targetType, rightHandSide );
             }
             else if ( sourceType.isMapType() && !targetType.isMapType() ) {
-                assignment = forgeMapping( sourceType, targetType.withoutBounds(), rightHandSide );
+                // #4029 Do not forge Map → adder-element (e.g. Map → String). That path is not
+                // meaningful for adders; return null so the caller can fall back to the setter.
+                if ( targetWriteAccessorType == AccessorType.ADDER ) {
+                    assignment = null;
+                }
+                else {
+                    assignment = forgeMapping( sourceType, targetType.withoutBounds(), rightHandSide );
+                }
             }
             else if ( ( sourceType.isIterableType() && targetType.isStreamType() )
                         || ( sourceType.isStreamType() && targetType.isStreamType() )

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4029/Issue4029Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4029/Issue4029Mapper.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4029;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.mapstruct.CollectionMappingStrategy;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Reproducer for #4029: with {@link CollectionMappingStrategy#ADDER_PREFERRED}, mapping a
+ * {@link Map} source property onto a collection target that has both an adder and a setter
+ * should fall back to the setter when a direct collection mapping method is available (adder
+ * path not applicable for the whole-map mapping).
+ */
+@Mapper(collectionMappingStrategy = CollectionMappingStrategy.ADDER_PREFERRED)
+public interface Issue4029Mapper {
+
+    Issue4029Mapper INSTANCE = Mappers.getMapper( Issue4029Mapper.class );
+
+    Target fromMapSource(MapSource source);
+
+    Target fromListSource(ListSource source);
+
+    /**
+     * Direct whole-collection mapping from Map to List. With ADDER_PREFERRED this must still
+     * be usable via the setter fallback when the adder path cannot apply.
+     */
+    default List<String> map(Map<String, String> map) {
+        if ( map == null ) {
+            return null;
+        }
+        List<String> result = new ArrayList<>( map.size() );
+        for ( Map.Entry<String, String> entry : map.entrySet() ) {
+            result.add( entry.getKey() + "=" + entry.getValue() );
+        }
+        return result;
+    }
+
+    class MapSource {
+        private Map<String, String> values = new LinkedHashMap<>();
+
+        public Map<String, String> getValues() {
+            return values;
+        }
+
+        public void setValues(Map<String, String> values) {
+            this.values = values;
+        }
+    }
+
+    class ListSource {
+        private List<String> values = new ArrayList<>();
+
+        public List<String> getValues() {
+            return values;
+        }
+
+        public void setValues(List<String> values) {
+            this.values = values;
+        }
+    }
+
+    class Target {
+        private List<String> values;
+        private boolean adderUsed;
+        private boolean setterUsed;
+
+        public List<String> getValues() {
+            return values;
+        }
+
+        public void setValues(List<String> values) {
+            this.setterUsed = true;
+            this.values = values;
+        }
+
+        public void addValue(String value) {
+            this.adderUsed = true;
+            if ( this.values == null ) {
+                this.values = new ArrayList<>();
+            }
+            this.values.add( value );
+        }
+
+        public boolean isAdderUsed() {
+            return adderUsed;
+        }
+
+        public boolean isSetterUsed() {
+            return setterUsed;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4029/Issue4029MapperTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4029/Issue4029MapperTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4029;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author arimu1
+ */
+@WithClasses(Issue4029Mapper.class)
+@IssueKey("4029")
+class Issue4029MapperTest {
+
+    @ProcessorTest
+    void adderPreferredFallsBackToSetterWhenDirectMapToListMappingIsGiven() {
+        Issue4029Mapper.MapSource source = new Issue4029Mapper.MapSource();
+        Map<String, String> values = new LinkedHashMap<>();
+        values.put( "a", "1" );
+        values.put( "b", "2" );
+        source.setValues( values );
+
+        Issue4029Mapper.Target target = Issue4029Mapper.INSTANCE.fromMapSource( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getValues() ).containsExactly( "a=1", "b=2" );
+        assertThat( target.isSetterUsed() )
+            .as( "Map→List with custom method should fall back to setter under ADDER_PREFERRED" )
+            .isTrue();
+        assertThat( target.isAdderUsed() ).isFalse();
+    }
+
+    @ProcessorTest
+    void adderPreferredStillUsesAdderWhenElementMappingIsApplicable() {
+        Issue4029Mapper.ListSource source = new Issue4029Mapper.ListSource();
+        source.setValues( Arrays.asList( "x", "y" ) );
+
+        Issue4029Mapper.Target target = Issue4029Mapper.INSTANCE.fromListSource( source );
+
+        assertThat( target ).isNotNull();
+        assertThat( target.getValues() ).containsExactly( "x", "y" );
+        assertThat( target.isAdderUsed() )
+            .as( "List→List with matching element type should still prefer adder" )
+            .isTrue();
+        assertThat( target.isSetterUsed() ).isFalse();
+    }
+}


### PR DESCRIPTION
## Summary

`CollectionMappingStrategy.ADDER_PREFERRED` is a preference, not a hard requirement. When the adder path is not applicable — for example mapping a `Map` source property onto a collection that has both an adder and a setter, with a direct whole-collection mapping method (`List map(Map)`) — MapStruct previously failed while trying to map into the adder parameter type (e.g. `Map → String`).

This change falls back to setter-preferred behavior when:

1. The source is not suitable for adder element matching (notably `Map`, which is not treated as element-iterable for matching), and a setter exists for the property; or
2. The adder path still cannot produce an assignment, and a setter is available.

List/iterable/array sources that can use the adder continue to prefer the adder.

Fixes #4029

## Changes

- `PropertyMapping`: fall back to the property setter when ADDER is selected but not applicable; do not forge doomed `Map → adder-element` mappings
- Processor tests in `org.mapstruct.ap.test.bugs._4029` covering Map→List (setter fallback) and List→List (adder still preferred)

## Test plan

- [x] `Issue4029MapperTest` (4 runs: eclipse + javac) — green
- [x] Regression: `AdderTest`, `Issue3165MapperTest`, `bugs._1170.AdderTest` — green

```bash
export JAVA_HOME=…/jdk-21
./mvnw -pl processor -am test -Dtest=Issue4029MapperTest,AdderTest,Issue3165MapperTest -Dsurefire.failIfNoSpecifiedTests=false
```