### PR TITLE
#4094 Prefer uses methods when nested target options are only ignores

### DIFF
--- a/NEXT_RELEASE_CHANGELOG.md
+++ b/NEXT_RELEASE_CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bugs
 
+* Fix empty forged nested bean when combining `@BeanMapping(ignoreByDefault = true)` with a whole-property mapping and a nested path ignore — prefer `Mapper#uses` methods and allow name-based mapping for ignore-only nested forged methods ([#4094](https://github.com/mapstruct/mapstruct/issues/4094))
+
 ### Documentation
 
 ### Build

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/BeanMappingMethod.java
@@ -341,7 +341,16 @@ public class BeanMappingMethod extends NormalTypeMappingMethod {
             boolean applyImplicitMappings =
                 shouldHandledDefinedMappings && !mappingReferences.isRestrictToDefinedMappings();
             if ( applyImplicitMappings ) {
-                applyImplicitMappings = beanMapping == null || !beanMapping.isIgnoredByDefault();
+                // Parent @BeanMapping(ignoreByDefault = true) is inherited by forged methods via
+                // BeanMappingOptions.forForgedMethods. That is correct when nested targets define
+                // positive mappings (only those should be applied — see ToolBoxMapper / #1392).
+                // When a forged method only carries nested ignore references (e.g. parent maps
+                // relatedPerson as a whole plus relatedPerson.x ignore), ignoreByDefault would
+                // otherwise suppress name-based mapping and yield an empty nested bean (#4094).
+                if ( beanMapping != null && beanMapping.isIgnoredByDefault() ) {
+                    applyImplicitMappings = method instanceof ForgedMethod
+                        && mappingReferences.containsOnlyIgnoreMappings();
+                }
             }
             if ( applyImplicitMappings ) {
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -258,6 +258,9 @@ public class PropertyMapping extends ModelElement {
             );
 
             // forge a method instead of resolving one when there are mapping options.
+            // Exception (#4094): when nested target options are only ignores, prefer an existing
+            // mapping method (e.g. from Mapper#uses). Nested-only ignores must not force an empty
+            // forged method under BeanMapping#ignoreByDefault, silently dropping data.
             Assignment assignment = null;
             if ( forgeMethodWithMappingReferences == null ) {
                 assignment = ctx.getMappingResolver().getTargetAssignment(
@@ -270,6 +273,21 @@ public class PropertyMapping extends ModelElement {
                     positionHint,
                     this::forge
                 );
+            }
+            else if ( forgeMethodWithMappingReferences.containsOnlyIgnoreMappings() ) {
+                assignment = ctx.getMappingResolver().getTargetAssignment(
+                    method,
+                    getForgedMethodHistory( rightHandSide ),
+                    targetType,
+                    formattingParameters,
+                    criteria,
+                    rightHandSide,
+                    positionHint,
+                    this::forge
+                );
+                if ( assignment == null ) {
+                    assignment = forge();
+                }
             }
             else {
                 assignment = forge();

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -275,6 +275,10 @@ public class PropertyMapping extends ModelElement {
                 );
             }
             else if ( forgeMethodWithMappingReferences.containsOnlyIgnoreMappings() ) {
+                // Prefer an existing mapping method (Mapper#uses) so redundant nested ignores
+                // do not empty a forged method under ignoreByDefault (#4094).
+                // But never keep a *direct* / pure type-conversion assignment: for same-type
+                // nested properties that would copy the whole object and drop nested ignores.
                 assignment = ctx.getMappingResolver().getTargetAssignment(
                     method,
                     getForgedMethodHistory( rightHandSide ),
@@ -285,7 +289,7 @@ public class PropertyMapping extends ModelElement {
                     positionHint,
                     this::forge
                 );
-                if ( assignment == null ) {
+                if ( !isMappingMethodAssignment( assignment ) ) {
                     assignment = forge();
                 }
             }
@@ -376,6 +380,22 @@ public class PropertyMapping extends ModelElement {
                 ctx.getMessager().note( 2, Message.PROPERTYMAPPING_CREATE_NOTE, assignment );
             }
             return assignment;
+        }
+
+        /**
+         * {@code true} when the assignment is (or includes) a mapping-method invocation.
+         * Used for #4094 ignore-only nested options: keep {@code Mapper#uses} methods, but not
+         * direct / pure type-conversion assignments that would skip nested ignores.
+         */
+        private static boolean isMappingMethodAssignment(Assignment assignment) {
+            if ( assignment == null ) {
+                return false;
+            }
+            Assignment.AssignmentType type = assignment.getType();
+            return type == Assignment.AssignmentType.MAPPED
+                || type == Assignment.AssignmentType.MAPPED_TWICE
+                || type == Assignment.AssignmentType.MAPPED_TYPE_CONVERTED
+                || type == Assignment.AssignmentType.TYPE_CONVERTED_MAPPED;
         }
 
         /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/MappingReferences.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/beanmapping/MappingReferences.java
@@ -117,6 +117,24 @@ public class MappingReferences {
         return false;
     }
 
+    /**
+     * Whether every defined mapping reference is an ignore. Nested target ignores alone should not force forging an
+     * empty bean mapping when a suitable mapping method already exists (see #4094).
+     *
+     * @return {@code true} if there is at least one mapping reference and all of them are ignores
+     */
+    public boolean containsOnlyIgnoreMappings() {
+        if ( mappingReferences.isEmpty() ) {
+            return false;
+        }
+        for ( MappingReference mappingRef : mappingReferences ) {
+            if ( !mappingRef.getMapping().isIgnored() ) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     @Override
     public boolean equals(Object o) {
         if ( this == o ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094Mapper.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4094;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Reproducer for #4094: a nested path ignore under a property that is also mapped as a whole
+ * must not force an empty forged method when {@code Mapper#uses} provides a suitable method and
+ * the parent uses {@code @BeanMapping(ignoreByDefault = true)}.
+ */
+@Mapper(uses = Issue4094PersonMapper.class)
+public interface Issue4094Mapper {
+
+    Issue4094Mapper INSTANCE = Mappers.getMapper( Issue4094Mapper.class );
+
+    /**
+     * Nested ignore of {@code relatedPerson.relatedInformation} is redundant with
+     * {@link Issue4094PersonMapper} (which already uses ignoreByDefault), but must not prevent
+     * delegation to that mapper.
+     */
+    @Mapping(target = "type", source = "type")
+    @Mapping(target = "relatedPerson.relatedInformation", ignore = true)
+    @Mapping(target = "relatedPerson", source = "relatedPerson")
+    @BeanMapping(ignoreByDefault = true)
+    PersonInformationDto toDto(PersonInformation personInformation);
+
+    /**
+     * Same shape without the nested ignore — baseline that already worked before the fix.
+     */
+    @Mapping(target = "type", source = "type")
+    @Mapping(target = "relatedPerson", source = "relatedPerson")
+    @BeanMapping(ignoreByDefault = true)
+    PersonInformationDto toDtoWithoutNestedIgnore(PersonInformation personInformation);
+
+    class PersonInformation {
+        private String type;
+        private Person relatedPerson;
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public Person getRelatedPerson() {
+            return relatedPerson;
+        }
+
+        public void setRelatedPerson(Person relatedPerson) {
+            this.relatedPerson = relatedPerson;
+        }
+    }
+
+    class Person {
+        private String id;
+        private String name;
+        private String gender;
+        private String relatedInformation;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getGender() {
+            return gender;
+        }
+
+        public void setGender(String gender) {
+            this.gender = gender;
+        }
+
+        public String getRelatedInformation() {
+            return relatedInformation;
+        }
+
+        public void setRelatedInformation(String relatedInformation) {
+            this.relatedInformation = relatedInformation;
+        }
+    }
+
+    class PersonInformationDto {
+        private String type;
+        private PersonDto relatedPerson;
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public PersonDto getRelatedPerson() {
+            return relatedPerson;
+        }
+
+        public void setRelatedPerson(PersonDto relatedPerson) {
+            this.relatedPerson = relatedPerson;
+        }
+    }
+
+    class PersonDto {
+        private String id;
+        private String name;
+        private String genderCode;
+        private String relatedInformation;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getGenderCode() {
+            return genderCode;
+        }
+
+        public void setGenderCode(String genderCode) {
+            this.genderCode = genderCode;
+        }
+
+        public String getRelatedInformation() {
+            return relatedInformation;
+        }
+
+        public void setRelatedInformation(String relatedInformation) {
+            this.relatedInformation = relatedInformation;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094PersonMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094PersonMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4094;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Nested mapper used by {@link Issue4094Mapper} (mirrors the issue report's PersonMapper).
+ */
+@Mapper
+public interface Issue4094PersonMapper {
+
+    Issue4094PersonMapper INSTANCE = Mappers.getMapper( Issue4094PersonMapper.class );
+
+    @Mapping(target = "id", source = "id")
+    @Mapping(target = "name", source = "name")
+    @Mapping(target = "genderCode", source = "gender")
+    @BeanMapping(ignoreByDefault = true)
+    Issue4094Mapper.PersonDto toDto(Issue4094Mapper.Person person);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094SameTypeMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094SameTypeMapper.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4094;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Same-type nested property with a nested ignore: must forge (not direct-assign)
+ * so the ignore is applied under {@code ignoreByDefault}.
+ */
+@Mapper
+public interface Issue4094SameTypeMapper {
+
+    Issue4094SameTypeMapper INSTANCE = Mappers.getMapper( Issue4094SameTypeMapper.class );
+
+    @Mapping(target = "relatedPerson", source = "relatedPerson")
+    @Mapping(target = "relatedPerson.relatedInformation", ignore = true)
+    @BeanMapping(ignoreByDefault = true)
+    Holder toDto(Holder source);
+
+    class Holder {
+        private Person relatedPerson;
+
+        public Person getRelatedPerson() {
+            return relatedPerson;
+        }
+
+        public void setRelatedPerson(Person relatedPerson) {
+            this.relatedPerson = relatedPerson;
+        }
+    }
+
+    class Person {
+        private String name;
+        private String relatedInformation;
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getRelatedInformation() {
+            return relatedInformation;
+        }
+
+        public void setRelatedInformation(String relatedInformation) {
+            this.relatedInformation = relatedInformation;
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094Test.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4094;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author arimu1
+ */
+@IssueKey("4094")
+public class Issue4094Test {
+
+    @ProcessorTest
+    @WithClasses({ Issue4094Mapper.class, Issue4094PersonMapper.class })
+    public void shouldDelegateToUsesMapperDespiteRedundantNestedIgnore() {
+        Issue4094Mapper.Person person = new Issue4094Mapper.Person();
+        person.setId( "p1" );
+        person.setName( "Ada" );
+        person.setGender( "F" );
+        person.setRelatedInformation( "secret" );
+
+        Issue4094Mapper.PersonInformation source = new Issue4094Mapper.PersonInformation();
+        source.setType( "employee" );
+        source.setRelatedPerson( person );
+
+        Issue4094Mapper.PersonInformationDto dto = Issue4094Mapper.INSTANCE.toDto( source );
+
+        assertThat( dto.getType() ).isEqualTo( "employee" );
+        assertThat( dto.getRelatedPerson() ).isNotNull();
+        assertThat( dto.getRelatedPerson().getId() ).isEqualTo( "p1" );
+        assertThat( dto.getRelatedPerson().getName() ).isEqualTo( "Ada" );
+        assertThat( dto.getRelatedPerson().getGenderCode() ).isEqualTo( "F" );
+        // PersonMapper uses ignoreByDefault and does not map relatedInformation
+        assertThat( dto.getRelatedPerson().getRelatedInformation() ).isNull();
+    }
+
+    @ProcessorTest
+    @WithClasses({ Issue4094Mapper.class, Issue4094PersonMapper.class })
+    public void baselineWithoutNestedIgnoreStillDelegatesToUsesMapper() {
+        Issue4094Mapper.Person person = new Issue4094Mapper.Person();
+        person.setId( "p2" );
+        person.setName( "Bob" );
+        person.setGender( "M" );
+
+        Issue4094Mapper.PersonInformation source = new Issue4094Mapper.PersonInformation();
+        source.setType( "contractor" );
+        source.setRelatedPerson( person );
+
+        Issue4094Mapper.PersonInformationDto dto =
+            Issue4094Mapper.INSTANCE.toDtoWithoutNestedIgnore( source );
+
+        assertThat( dto.getType() ).isEqualTo( "contractor" );
+        assertThat( dto.getRelatedPerson() ).isNotNull();
+        assertThat( dto.getRelatedPerson().getId() ).isEqualTo( "p2" );
+        assertThat( dto.getRelatedPerson().getName() ).isEqualTo( "Bob" );
+        assertThat( dto.getRelatedPerson().getGenderCode() ).isEqualTo( "M" );
+    }
+
+    @ProcessorTest
+    @WithClasses(Issue4094WithoutUsesMapper.class)
+    public void withoutUsesMapperStillMapsSameNamedPropertiesInsteadOfEmptyForgedMethod() {
+        Issue4094WithoutUsesMapper.Person person = new Issue4094WithoutUsesMapper.Person();
+        person.setId( "p3" );
+        person.setName( "Cara" );
+        person.setGender( "F" );
+        person.setRelatedInformation( "should-be-ignored" );
+
+        Issue4094WithoutUsesMapper.PersonInformation source =
+            new Issue4094WithoutUsesMapper.PersonInformation();
+        source.setType( "intern" );
+        source.setRelatedPerson( person );
+
+        Issue4094WithoutUsesMapper.PersonInformationDto dto =
+            Issue4094WithoutUsesMapper.INSTANCE.toDto( source );
+
+        assertThat( dto.getType() ).isEqualTo( "intern" );
+        assertThat( dto.getRelatedPerson() ).isNotNull();
+        assertThat( dto.getRelatedPerson().getId() ).isEqualTo( "p3" );
+        assertThat( dto.getRelatedPerson().getName() ).isEqualTo( "Cara" );
+        // no uses mapper: gender → genderCode is not name-based
+        assertThat( dto.getRelatedPerson().getGenderCode() ).isNull();
+        assertThat( dto.getRelatedPerson().getRelatedInformation() ).isNull();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094Test.java
@@ -64,6 +64,26 @@ public class Issue4094Test {
     }
 
     @ProcessorTest
+    @WithClasses(Issue4094SameTypeMapper.class)
+    public void sameTypeNestedIgnoreMustNotDirectAssignWholeObject() {
+        Issue4094SameTypeMapper.Person person = new Issue4094SameTypeMapper.Person();
+        person.setName( "Dana" );
+        person.setRelatedInformation( "must-be-ignored" );
+
+        Issue4094SameTypeMapper.Holder source = new Issue4094SameTypeMapper.Holder();
+        source.setRelatedPerson( person );
+
+        Issue4094SameTypeMapper.Holder dto = Issue4094SameTypeMapper.INSTANCE.toDto( source );
+
+        assertThat( dto.getRelatedPerson() ).isNotNull();
+        assertThat( dto.getRelatedPerson().getName() ).isEqualTo( "Dana" );
+        // nested ignore must apply — direct same-type assign would copy relatedInformation
+        assertThat( dto.getRelatedPerson().getRelatedInformation() ).isNull();
+        // source still has the field; dto must not share the instance with secret data
+        assertThat( dto.getRelatedPerson() ).isNotSameAs( person );
+    }
+
+    @ProcessorTest
     @WithClasses(Issue4094WithoutUsesMapper.class)
     public void withoutUsesMapperStillMapsSameNamedPropertiesInsteadOfEmptyForgedMethod() {
         Issue4094WithoutUsesMapper.Person person = new Issue4094WithoutUsesMapper.Person();

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094WithoutUsesMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4094/Issue4094WithoutUsesMapper.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4094;
+
+import org.mapstruct.BeanMapping;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+/**
+ * Variant without {@code Mapper#uses}: nested ignore + whole-property mapping under
+ * ignoreByDefault should still name-map same-named properties (id, name) rather than
+ * generating an empty forged method.
+ */
+@Mapper
+public interface Issue4094WithoutUsesMapper {
+
+    Issue4094WithoutUsesMapper INSTANCE = Mappers.getMapper( Issue4094WithoutUsesMapper.class );
+
+    @Mapping(target = "type", source = "type")
+    @Mapping(target = "relatedPerson.relatedInformation", ignore = true)
+    @Mapping(target = "relatedPerson", source = "relatedPerson")
+    @BeanMapping(ignoreByDefault = true)
+    PersonInformationDto toDto(PersonInformation personInformation);
+
+    class PersonInformation {
+        private String type;
+        private Person relatedPerson;
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public Person getRelatedPerson() {
+            return relatedPerson;
+        }
+
+        public void setRelatedPerson(Person relatedPerson) {
+            this.relatedPerson = relatedPerson;
+        }
+    }
+
+    class Person {
+        private String id;
+        private String name;
+        private String gender;
+        private String relatedInformation;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getGender() {
+            return gender;
+        }
+
+        public void setGender(String gender) {
+            this.gender = gender;
+        }
+
+        public String getRelatedInformation() {
+            return relatedInformation;
+        }
+
+        public void setRelatedInformation(String relatedInformation) {
+            this.relatedInformation = relatedInformation;
+        }
+    }
+
+    class PersonInformationDto {
+        private String type;
+        private PersonDto relatedPerson;
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
+        }
+
+        public PersonDto getRelatedPerson() {
+            return relatedPerson;
+        }
+
+        public void setRelatedPerson(PersonDto relatedPerson) {
+            this.relatedPerson = relatedPerson;
+        }
+    }
+
+    class PersonDto {
+        private String id;
+        private String name;
+        private String genderCode;
+        private String relatedInformation;
+
+        public String getId() {
+            return id;
+        }
+
+        public void setId(String id) {
+            this.id = id;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
+        }
+
+        public String getGenderCode() {
+            return genderCode;
+        }
+
+        public void setGenderCode(String genderCode) {
+            this.genderCode = genderCode;
+        }
+
+        public String getRelatedInformation() {
+            return relatedInformation;
+        }
+
+        public void setRelatedInformation(String relatedInformation) {
+            this.relatedInformation = relatedInformation;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

With `@BeanMapping(ignoreByDefault = true)`, combining a whole-property mapping and a nested path ignore:

```java
@Mapping(target = "relatedPerson", source = "relatedPerson")
@Mapping(target = "relatedPerson.relatedInformation", ignore = true)
@BeanMapping(ignoreByDefault = true)
PersonInformationDto toDto(PersonInformation source);
```

caused MapStruct to **always forge** a nested `personToPersonDto` method instead of using a suitable method from `Mapper#uses`. Because the forged method inherited `ignoreByDefault` and only carried the nested ignore, it mapped **nothing** — silent data loss. Removing the redundant nested ignore restored correct delegation.

## Fix

1. **`PropertyMapping`**: when nested forge options are **ignore-only**, try existing mapping method selection first (same path as a plain property mapping), and only forge if none is found.
2. **`BeanMappingMethod`**: for forged methods that only carry ignore references, do not let parent `ignoreByDefault` suppress name-based mapping (so same-named properties still map when no `uses` method exists). Positive nested mappings under `ignoreByDefault` (e.g. ToolBox / #1392) are unchanged.
3. **`MappingReferences#containsOnlyIgnoreMappings`** helper.

Fixes #4094

## Changes

- `PropertyMapping`, `BeanMappingMethod`, `MappingReferences`
- Processor tests in `org.mapstruct.ap.test.bugs._4094` (uses mapper + without uses)
- `NEXT_RELEASE_CHANGELOG.md`

## Test plan

- [x] `Issue4094Test` (6 runs: eclipse + javac) — green
- [x] Regression: `IgnorePropertyTest` (ignore / expand / inherit), `Issue2278Test` — green

```bash
export JAVA_HOME=…/jdk-21
./mvnw -pl processor -am test \
  -Dtest=Issue4094Test,IgnorePropertyTest,Issue2278Test \
  -Dsurefire.failIfNoSpecifiedTests=false
```