### PR TITLE
Honor JSpecify nullability of reused mapping methods

### DIFF
--- a/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
+++ b/documentation/src/main/asciidoc/chapter-10-advanced-mapping-options.asciidoc
@@ -334,6 +334,12 @@ This rule applies uniformly to bean, iterable, map, and stream mapping methods.
 
 When the return type of a mapping method is `@NonNull` (directly or via a `@NullMarked` scope), MapStruct forces `NullValueMappingStrategy.RETURN_DEFAULT` semantics. The generated method returns a default-constructed target (bean methods), an empty collection (`Iterable` / array mappings), an empty map (`Map` mappings), or `Stream.empty()` (stream mappings) rather than `null`, so the return contract is never violated. This rule applies regardless of the explicit `NullValueMappingStrategy` setting.
 
+==== Reused mapping methods
+
+When a property assignment reuses a mapping method, MapStruct considers both sides of that method's JSpecify contract. A nullable source is guarded before calling a method whose first source parameter is `@NonNull`. A method whose first source parameter is `@Nullable` and whose return type is `@NonNull` is called directly, even when the source and target properties are nullable or non-null. For a chain of methods, the innermost input contract and outermost result contract are used.
+
+JSpecify annotations refine null-check generation only; they do not participate in mapping-method overload selection. If annotations make several methods otherwise applicable, use qualifiers to select the intended method.
+
 ==== Constructor parameter constraint
 
 If a property mapping would assign a potentially `null` source value to a `@NonNull` constructor parameter, MapStruct raises a *compilation error*. Neither inserting a null check (which would leave the variable at `null` and violate the contract) nor passing the value through is safe. Provide a `defaultValue` or `defaultExpression` on the `@Mapping` to satisfy the parameter when the source is absent.

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/CollectionAssignmentBuilder.java
@@ -75,6 +75,7 @@ public class CollectionAssignmentBuilder {
     private NullValueCheckStrategyGem nvcs;
     private NullValuePropertyMappingStrategyGem nvpms;
     private NullabilityResolver.Nullability sourceJSpecifyNullability = NullabilityResolver.Nullability.UNKNOWN;
+    private NullabilityResolver.Nullability targetJSpecifyNullability = NullabilityResolver.Nullability.UNKNOWN;
 
     public CollectionAssignmentBuilder mappingBuilderContext(MappingBuilderContext ctx) {
         this.ctx = ctx;
@@ -141,6 +142,15 @@ public class CollectionAssignmentBuilder {
     ) {
         this.sourceJSpecifyNullability = sourceJSpecifyNullability != null
             ? sourceJSpecifyNullability
+            : NullabilityResolver.Nullability.UNKNOWN;
+        return this;
+    }
+
+    public CollectionAssignmentBuilder targetJSpecifyNullability(
+        NullabilityResolver.Nullability targetJSpecifyNullability
+    ) {
+        this.targetJSpecifyNullability = targetJSpecifyNullability != null
+            ? targetJSpecifyNullability
             : NullabilityResolver.Nullability.UNKNOWN;
         return this;
     }
@@ -286,12 +296,45 @@ public class CollectionAssignmentBuilder {
             return true;
         }
 
-        if ( nvcs == ALWAYS ) {
-            // NullValueCheckStrategy is ALWAYS -> do a null check
+        if ( nvpms == SET_TO_DEFAULT || nvpms == IGNORE ) {
+            // NullValuePropertyMappingStrategy requires a source null check before applying its behavior.
+            return true;
+        }
+
+        if ( rhs.getType().isConverted() ) {
+            // A type conversion is applied, so a null check is required before invoking it.
             return true;
         }
 
         if ( rhs.getType().isDirect() ) {
+            // Direct collection assignment uses a copy constructor and must not receive null.
+            return true;
+        }
+
+        NullabilityResolver.Nullability parameterNullability = rhs.getSourceParameterNullability();
+        NullabilityResolver.Nullability resultNullability = rhs.getResultNullability();
+        Boolean jspecifyDecision = ctx.getNullabilityResolver().requiresNullCheck(
+            sourceJSpecifyNullability,
+            targetJSpecifyNullability,
+            parameterNullability,
+            resultNullability
+        );
+        if ( jspecifyDecision != null ) {
+            ctx.getMessager().note( 2,
+                jspecifyDecision && parameterNullability == NullabilityResolver.Nullability.NON_NULL
+                    ? Message.PROPERTYMAPPING_JSPECIFY_ADD_NULL_CHECK_NON_NULL_PARAM
+                    : jspecifyDecision
+                        ? Message.PROPERTYMAPPING_JSPECIFY_ADD_NULL_CHECK
+                        : Message.PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK,
+                targetPropertyName,
+                sourceJSpecifyNullability,
+                targetJSpecifyNullability
+            );
+            return jspecifyDecision;
+        }
+
+        if ( nvcs == ALWAYS ) {
+            // NullValueCheckStrategy is ALWAYS -> do a null check
             return true;
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/FromOptionalTypeConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/FromOptionalTypeConversion.java
@@ -13,6 +13,7 @@ import org.mapstruct.ap.internal.model.common.Assignment;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.util.NullabilityResolver.Nullability;
 
 /**
  * An inline conversion from an optional source to it's value.
@@ -61,6 +62,16 @@ public class FromOptionalTypeConversion extends ModelElement implements Assignme
     @Override
     public Type getSourceType() {
         return conversionAssignment.getSourceType();
+    }
+
+    @Override
+    public Nullability getSourceParameterNullability() {
+        return conversionAssignment.getSourceParameterNullability();
+    }
+
+    @Override
+    public Nullability getResultNullability() {
+        return conversionAssignment.getResultNullability();
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/MethodReference.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/MethodReference.java
@@ -24,6 +24,7 @@ import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.source.Method;
 import org.mapstruct.ap.internal.model.source.builtin.BuiltInMethod;
+import org.mapstruct.ap.internal.util.NullabilityResolver.Nullability;
 import org.mapstruct.ap.internal.util.Strings;
 
 /**
@@ -63,6 +64,8 @@ public class MethodReference extends ModelElement implements Assignment {
     private final boolean isStatic;
     private final boolean isConstructor;
     private final boolean isMethodChaining;
+    private final Nullability sourceParameterNullability;
+    private final Nullability resultNullability;
 
     /**
      * Creates a new reference to the given method.
@@ -75,6 +78,12 @@ public class MethodReference extends ModelElement implements Assignment {
      */
     protected MethodReference(Method method, MapperReference declaringMapper, Parameter providingParameter,
                               List<ParameterBinding> parameterBindings) {
+        this( method, declaringMapper, providingParameter, parameterBindings, null, null );
+    }
+
+    private MethodReference(Method method, MapperReference declaringMapper, Parameter providingParameter,
+                            List<ParameterBinding> parameterBindings, Nullability sourceParameterNullability,
+                            Nullability resultNullability) {
         this.declaringMapper = declaringMapper;
         this.sourceParameters = Parameter.getSourceParameters( method.getParameters() );
         this.returnType = method.getReturnType();
@@ -100,6 +109,8 @@ public class MethodReference extends ModelElement implements Assignment {
         this.isConstructor = false;
         this.methodsToChain = Collections.emptyList();
         this.isMethodChaining = false;
+        this.sourceParameterNullability = sourceParameterNullability;
+        this.resultNullability = resultNullability;
    }
 
     private MethodReference(BuiltInMethod method, ConversionContext contextParam) {
@@ -118,6 +129,8 @@ public class MethodReference extends ModelElement implements Assignment {
         this.isConstructor = false;
         this.methodsToChain = Collections.emptyList();
         this.isMethodChaining = false;
+        this.sourceParameterNullability = null;
+        this.resultNullability = null;
     }
 
     private MethodReference(String name, Type definingType, boolean isStatic) {
@@ -136,6 +149,8 @@ public class MethodReference extends ModelElement implements Assignment {
         this.isConstructor = false;
         this.methodsToChain = Collections.emptyList();
         this.isMethodChaining = false;
+        this.sourceParameterNullability = null;
+        this.resultNullability = null;
     }
 
     private MethodReference(Type definingType, List<ParameterBinding> parameterBindings) {
@@ -153,6 +168,8 @@ public class MethodReference extends ModelElement implements Assignment {
         this.isConstructor = true;
         this.methodsToChain = Collections.emptyList();
         this.isMethodChaining = false;
+        this.sourceParameterNullability = null;
+        this.resultNullability = null;
 
         if ( parameterBindings.isEmpty() ) {
             this.importTypes = Collections.emptySet();
@@ -186,6 +203,8 @@ public class MethodReference extends ModelElement implements Assignment {
         this.isConstructor = false;
         this.methodsToChain = Arrays.asList( references );
         this.isMethodChaining = true;
+        this.sourceParameterNullability = null;
+        this.resultNullability = null;
     }
 
     public MapperReference getDeclaringMapper() {
@@ -206,6 +225,22 @@ public class MethodReference extends ModelElement implements Assignment {
 
     public Assignment getAssignment() {
         return assignment;
+    }
+
+    @Override
+    public Nullability getSourceParameterNullability() {
+        if ( assignment != null ) {
+            Nullability nestedNullability = assignment.getSourceParameterNullability();
+            if ( nestedNullability != null ) {
+                return nestedNullability;
+            }
+        }
+        return sourceParameterNullability;
+    }
+
+    @Override
+    public Nullability getResultNullability() {
+        return resultNullability;
     }
 
     public String getName() {
@@ -420,6 +455,19 @@ public class MethodReference extends ModelElement implements Assignment {
     public static MethodReference forMapperReference(Method method, MapperReference declaringMapper,
             List<ParameterBinding> parameterBindings) {
         return new MethodReference( method, declaringMapper, null, parameterBindings );
+    }
+
+    public static MethodReference forMapperReference(Method method, MapperReference declaringMapper,
+            List<ParameterBinding> parameterBindings, Nullability sourceParameterNullability,
+            Nullability resultNullability) {
+        return new MethodReference(
+            method,
+            declaringMapper,
+            null,
+            parameterBindings,
+            sourceParameterNullability,
+            resultNullability
+        );
     }
 
     public static MethodReference forStaticBuilder(String builderCreationMethod, Type definingType) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -657,6 +657,13 @@ public class PropertyMapping extends ModelElement {
             if ( resultNullability == null ) {
                 return sourceNullability;
             }
+            if ( assignment.getSourceParameterNullability() == NullabilityResolver.Nullability.NULLABLE
+                && resultNullability == NullabilityResolver.Nullability.UNKNOWN ) {
+                // An unannotated reused-method result is not explicitly nullable. Preserve the
+                // pre-JSpecify assignment behavior when that helper accepts null; an explicit
+                // @Nullable result still remains potentially nullable.
+                return NullabilityResolver.Nullability.NON_NULL;
+            }
             if ( sourceNullability != NullabilityResolver.Nullability.NON_NULL
                 && assignment.getSourceParameterNullability() == NullabilityResolver.Nullability.NON_NULL
                 && resultNullability == NullabilityResolver.Nullability.NON_NULL ) {

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/PropertyMapping.java
@@ -290,7 +290,11 @@ public class PropertyMapping extends ModelElement {
                 NullabilityResolver.Nullability targetNullability = ctx.getNullabilityResolver().getSetterNullability(
                     targetWriteAccessor.getElement(), this::targetDeclaringTypeIsNullMarked
                 );
-                if ( sourceNullability != NullabilityResolver.Nullability.NON_NULL
+                NullabilityResolver.Nullability effectiveAssignmentNullability = getAssignmentResultNullability(
+                    assignment,
+                    sourceNullability
+                );
+                if ( effectiveAssignmentNullability != NullabilityResolver.Nullability.NON_NULL
                     && targetNullability == NullabilityResolver.Nullability.NON_NULL ) {
                     ctx.getMessager().printMessage(
                         method.getExecutable(),
@@ -615,12 +619,21 @@ public class PropertyMapping extends ModelElement {
             NullabilityResolver.Nullability targetNullability = resolver.getSetterNullability(
                 targetWriteAccessor.getElement(), this::targetDeclaringTypeIsNullMarked
             );
-            Boolean jspecifyDecision = resolver.requiresNullCheck( sourceNullability, targetNullability );
+            NullabilityResolver.Nullability parameterNullability = rhs.getSourceParameterNullability();
+            NullabilityResolver.Nullability resultNullability = rhs.getResultNullability();
+            Boolean jspecifyDecision = resolver.requiresNullCheck(
+                sourceNullability,
+                targetNullability,
+                parameterNullability,
+                resultNullability
+            );
             if ( jspecifyDecision != null ) {
                 ctx.getMessager().note( 2,
-                    jspecifyDecision
-                        ? Message.PROPERTYMAPPING_JSPECIFY_ADD_NULL_CHECK
-                        : Message.PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK,
+                    jspecifyDecision && parameterNullability == NullabilityResolver.Nullability.NON_NULL
+                        ? Message.PROPERTYMAPPING_JSPECIFY_ADD_NULL_CHECK_NON_NULL_PARAM
+                        : jspecifyDecision
+                            ? Message.PROPERTYMAPPING_JSPECIFY_ADD_NULL_CHECK
+                            : Message.PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK,
                     targetPropertyName,
                     sourceNullability,
                     targetNullability
@@ -634,6 +647,24 @@ public class PropertyMapping extends ModelElement {
             }
 
             return false;
+        }
+
+        private NullabilityResolver.Nullability getAssignmentResultNullability(
+            Assignment assignment,
+            NullabilityResolver.Nullability sourceNullability
+        ) {
+            NullabilityResolver.Nullability resultNullability = assignment.getResultNullability();
+            if ( resultNullability == null ) {
+                return sourceNullability;
+            }
+            if ( sourceNullability != NullabilityResolver.Nullability.NON_NULL
+                && assignment.getSourceParameterNullability() == NullabilityResolver.Nullability.NON_NULL
+                && resultNullability == NullabilityResolver.Nullability.NON_NULL ) {
+                // A guard before a non-null helper leaves the constructor argument nullable when the
+                // source is absent, even though the helper itself returns a non-null value.
+                return NullabilityResolver.Nullability.NULLABLE;
+            }
+            return resultNullability;
         }
 
         private NullabilityResolver.Nullability getSourceJSpecifyNullability() {
@@ -760,6 +791,9 @@ public class PropertyMapping extends ModelElement {
                 .nullValueCheckStrategy( hasDefaultValueOrDefaultExpression() ? ALWAYS : nvcs )
                 .nullValuePropertyMappingStrategy( nvpms )
                 .sourceJSpecifyNullability( getSourceJSpecifyNullability() )
+                .targetJSpecifyNullability( ctx.getNullabilityResolver().getSetterNullability(
+                    targetWriteAccessor.getElement(), this::targetDeclaringTypeIsNullMarked
+                ) )
                 .build();
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/ToOptionalTypeConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/ToOptionalTypeConversion.java
@@ -13,6 +13,7 @@ import org.mapstruct.ap.internal.model.common.Assignment;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.util.NullabilityResolver.Nullability;
 
 /**
  * An inline conversion from a source to an optional of the source.
@@ -67,6 +68,16 @@ public class ToOptionalTypeConversion extends ModelElement implements Assignment
     @Override
     public Type getSourceType() {
         return conversionAssignment.getSourceType();
+    }
+
+    @Override
+    public Nullability getSourceParameterNullability() {
+        return conversionAssignment.getSourceParameterNullability();
+    }
+
+    @Override
+    public Nullability getResultNullability() {
+        return conversionAssignment.getResultNullability();
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/TypeConversion.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/TypeConversion.java
@@ -13,6 +13,7 @@ import org.mapstruct.ap.internal.model.common.Assignment;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.util.NullabilityResolver.Nullability;
 
 /**
  * An inline conversion between source and target type of a mapping.
@@ -87,6 +88,16 @@ public class TypeConversion extends ModelElement implements Assignment {
     @Override
     public Type getSourceType() {
         return assignment.getSourceType();
+    }
+
+    @Override
+    public Nullability getSourceParameterNullability() {
+        return assignment.getSourceParameterNullability();
+    }
+
+    @Override
+    public Nullability getResultNullability() {
+        return assignment.getResultNullability();
     }
 
     @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AssignmentWrapper.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/assignment/AssignmentWrapper.java
@@ -12,6 +12,7 @@ import org.mapstruct.ap.internal.model.common.Assignment;
 import org.mapstruct.ap.internal.model.common.ModelElement;
 import org.mapstruct.ap.internal.model.common.PresenceCheck;
 import org.mapstruct.ap.internal.model.common.Type;
+import org.mapstruct.ap.internal.util.NullabilityResolver.Nullability;
 
 /**
  * Base class for decorators (wrappers). Decorator pattern is used to decorate assignments.
@@ -95,6 +96,16 @@ public abstract class AssignmentWrapper extends ModelElement implements Assignme
     @Override
     public AssignmentType getType() {
         return decoratedAssignment.getType();
+    }
+
+    @Override
+    public Nullability getSourceParameterNullability() {
+        return decoratedAssignment.getSourceParameterNullability();
+    }
+
+    @Override
+    public Nullability getResultNullability() {
+        return decoratedAssignment.getResultNullability();
     }
 
      @Override

--- a/processor/src/main/java/org/mapstruct/ap/internal/model/common/Assignment.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/model/common/Assignment.java
@@ -8,6 +8,8 @@ package org.mapstruct.ap.internal.model.common;
 import java.util.List;
 import java.util.Set;
 
+import org.mapstruct.ap.internal.util.NullabilityResolver.Nullability;
+
 /**
  * Assignment represents all kind of manners a source can be assigned to a target.
  *
@@ -153,6 +155,24 @@ public interface Assignment {
      * @return {@link  AssignmentType}
      */
     AssignmentType getType();
+
+    /**
+     * Returns the nullability expected by the innermost reused mapping method that consumes the source value.
+     *
+     * @return the method parameter nullability, or {@code null} when this assignment has no method contract
+     */
+    default Nullability getSourceParameterNullability() {
+        return null;
+    }
+
+    /**
+     * Returns the nullability guaranteed by the outermost reused mapping method in this assignment.
+     *
+     * @return the method result nullability, or {@code null} when this assignment has no method contract
+     */
+    default Nullability getResultNullability() {
+        return null;
+    }
 
     boolean isCallingUpdateMethod();
 }

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/MapperCreationProcessor.java
@@ -130,6 +130,7 @@ public class MapperCreationProcessor implements ModelElementProcessor<List<Sourc
                 elementUtils,
                 typeUtils,
                 typeFactory,
+                context.getNullabilityResolver(),
                 new ArrayList<>( sourceModel ),
                 mapperReferences,
                 options.isVerbose()

--- a/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/processor/creation/MappingResolverImpl.java
@@ -44,6 +44,7 @@ import org.mapstruct.ap.internal.model.common.ConversionContext;
 import org.mapstruct.ap.internal.model.common.DefaultConversionContext;
 import org.mapstruct.ap.internal.model.common.FieldReference;
 import org.mapstruct.ap.internal.model.common.FormattingParameters;
+import org.mapstruct.ap.internal.model.common.Parameter;
 import org.mapstruct.ap.internal.model.common.SourceRHS;
 import org.mapstruct.ap.internal.model.common.Type;
 import org.mapstruct.ap.internal.model.common.TypeFactory;
@@ -60,6 +61,7 @@ import org.mapstruct.ap.internal.util.FormattingMessager;
 import org.mapstruct.ap.internal.util.Message;
 import org.mapstruct.ap.internal.util.MessageConstants;
 import org.mapstruct.ap.internal.util.NativeTypes;
+import org.mapstruct.ap.internal.util.NullabilityResolver;
 import org.mapstruct.ap.internal.util.Strings;
 import org.mapstruct.ap.internal.util.TypeUtils;
 
@@ -81,6 +83,7 @@ public class MappingResolverImpl implements MappingResolver {
     private final FormattingMessager messager;
     private final TypeUtils typeUtils;
     private final TypeFactory typeFactory;
+    private final NullabilityResolver nullabilityResolver;
 
     private final List<Method> sourceModel;
     private final List<MapperReference> mapperReferences;
@@ -105,11 +108,13 @@ public class MappingResolverImpl implements MappingResolver {
     private final Set<Field> usedSupportedFields = new LinkedHashSet<>();
 
     public MappingResolverImpl(FormattingMessager messager, ElementUtils elementUtils, TypeUtils typeUtils,
-                               TypeFactory typeFactory, List<Method> sourceModel,
+                               TypeFactory typeFactory, NullabilityResolver nullabilityResolver,
+                               List<Method> sourceModel,
                                List<MapperReference> mapperReferences, boolean verboseLogging) {
         this.messager = messager;
         this.typeUtils = typeUtils;
         this.typeFactory = typeFactory;
+        this.nullabilityResolver = nullabilityResolver;
 
         this.sourceModel = sourceModel;
         this.mapperReferences = mapperReferences;
@@ -535,12 +540,33 @@ public class MappingResolverImpl implements MappingResolver {
         }
 
         private Assignment toMethodRef(SelectedMethod<Method> selectedMethod) {
-            MapperReference mapperReference = findMapperReference( selectedMethod.getMethod() );
+            Method method = selectedMethod.getMethod();
+            MapperReference mapperReference = findMapperReference( method );
+
+            NullabilityResolver.Nullability sourceParameterNullability = null;
+            NullabilityResolver.Nullability resultNullability = null;
+            if ( nullabilityResolver.isEnabled()
+                && method.getExecutable() != null
+                && method.getDefiningType() != null ) {
+                if ( !method.getSourceParameters().isEmpty() ) {
+                    Parameter sourceParameter = method.getSourceParameters().get( 0 );
+                    sourceParameterNullability = nullabilityResolver.getNullability(
+                        sourceParameter.getElement(),
+                        method.getDefiningType()::isNullMarked
+                    );
+                }
+                resultNullability = nullabilityResolver.getNullability(
+                    method.getExecutable(),
+                    method.getDefiningType()::isNullMarked
+                );
+            }
 
             return MethodReference.forMapperReference(
-                selectedMethod.getMethod(),
+                method,
                 mapperReference,
-                selectedMethod.getParameterBindings()
+                selectedMethod.getParameterBindings(),
+                sourceParameterNullability,
+                resultNullability
             );
         }
 

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/Message.java
@@ -100,6 +100,7 @@ public enum Message {
     PROPERTYMAPPING_NULLABLE_SOURCE_TO_NON_NULL_CONSTRUCTOR_PARAM( "Can't map potentially nullable source property \"%s\" to @NonNull constructor parameter \"%s\". Consider adding a defaultValue or defaultExpression." ),
     PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK_NON_NULL_SOURCE( "JSpecify skipping null check for property \"%s\": source is @NonNull.", Diagnostic.Kind.NOTE ),
     PROPERTYMAPPING_JSPECIFY_ADD_NULL_CHECK( "JSpecify adding null check for property \"%s\": source=%s, target=%s.", Diagnostic.Kind.NOTE ),
+    PROPERTYMAPPING_JSPECIFY_ADD_NULL_CHECK_NON_NULL_PARAM( "JSpecify adding null check for property \"%s\" because the reused method parameter is @NonNull: source=%s, target=%s.", Diagnostic.Kind.NOTE ),
     PROPERTYMAPPING_JSPECIFY_SKIP_NULL_CHECK( "JSpecify skipping null check for property \"%s\": source=%s, target=%s.", Diagnostic.Kind.NOTE ),
     PROPERTYMAPPING_JSPECIFY_SKIP_METHOD_GUARD_NON_NULL_PARAM( "JSpecify skipping method-level null guard for property \"%s\": parameter is @NonNull.", Diagnostic.Kind.NOTE ),
     MAPPING_METHOD_JSPECIFY_FORCE_RETURN_DEFAULT( "JSpecify forcing NullValueMappingStrategy.RETURN_DEFAULT for method \"%s\": return type is @NonNull.", Diagnostic.Kind.NOTE ),

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/NullabilityResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/NullabilityResolver.java
@@ -57,6 +57,13 @@ public class NullabilityResolver {
     }
 
     /**
+     * @return whether JSpecify inference is enabled for the current processor run
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
      * Determines the nullability of an accessor element based on JSpecify annotations.
      * <p>
      * For getter methods ({@link ExecutableElement}), this checks the return type's annotations
@@ -160,21 +167,35 @@ public class NullabilityResolver {
      * Determines whether a null check is required for a property mapping based on JSpecify annotations
      * on the source and target elements.
      * <p>
-     * Only returns a non-null decision for the clear-cut cases:
-     * source {@code @NonNull} (skip check) or target {@code @NonNull} (always check).
-     * All other cases return {@code null} to defer to the existing {@code NullValueCheckStrategy}.
+     * A reused mapping method can add a contract on either side of the assignment. The input
+     * contract is considered before the target contract because a non-null parameter must be
+     * protected at the call site, while a nullable parameter with a non-null result can safely
+     * receive the source value directly.
      *
      * @param sourceNullability the nullability of the source (getter return type / parameter)
      * @param targetNullability the nullability of the target (setter parameter / field)
+     * @param parameterNullability the nullability expected by the first reused method, or {@code null}
+     *                             when no reused method consumes the source
+     * @param resultNullability the nullability guaranteed by the outermost reused method, or {@code null}
+     *                          when no reused method produces the assignment result
      * @return {@code Boolean.TRUE} if a null check is needed, {@code Boolean.FALSE} if it should be skipped,
      * or {@code null} if JSpecify annotations are not present and the existing strategy should be used
      */
-    public Boolean requiresNullCheck(Nullability sourceNullability, Nullability targetNullability) {
+    public Boolean requiresNullCheck(Nullability sourceNullability, Nullability targetNullability,
+                                    Nullability parameterNullability, Nullability resultNullability) {
         if ( !enabled ) {
             return null;
         }
         if ( sourceNullability == Nullability.NON_NULL ) {
             // Source is guaranteed non-null, no null check needed
+            return Boolean.FALSE;
+        }
+        if ( parameterNullability == Nullability.NON_NULL ) {
+            // A nullable source must not be passed to a method with a non-null parameter
+            return Boolean.TRUE;
+        }
+        if ( parameterNullability == Nullability.NULLABLE && resultNullability == Nullability.NON_NULL ) {
+            // The method accepts null and guarantees a non-null result, so it must be invoked directly
             return Boolean.FALSE;
         }
         if ( targetNullability == Nullability.NON_NULL ) {
@@ -183,6 +204,17 @@ public class NullabilityResolver {
         }
         // All other cases: defer to existing NullValueCheckStrategy
         return null;
+    }
+
+    /**
+     * Determines whether a null check is required when no reused-method contract is available.
+     *
+     * @param sourceNullability the nullability of the source
+     * @param targetNullability the nullability of the target
+     * @return the JSpecify decision, or {@code null} when the existing strategy should be used
+     */
+    public Boolean requiresNullCheck(Nullability sourceNullability, Nullability targetNullability) {
+        return requiresNullCheck( sourceNullability, targetNullability, null, null );
     }
 
     /**

--- a/processor/src/main/java/org/mapstruct/ap/internal/util/NullabilityResolver.java
+++ b/processor/src/main/java/org/mapstruct/ap/internal/util/NullabilityResolver.java
@@ -169,8 +169,8 @@ public class NullabilityResolver {
      * <p>
      * A reused mapping method can add a contract on either side of the assignment. The input
      * contract is considered before the target contract because a non-null parameter must be
-     * protected at the call site, while a nullable parameter with a non-null result can safely
-     * receive the source value directly.
+     * protected at the call site, while a nullable parameter whose result is not explicitly
+     * nullable can safely receive the source value directly.
      *
      * @param sourceNullability the nullability of the source (getter return type / parameter)
      * @param targetNullability the nullability of the target (setter parameter / field)
@@ -194,8 +194,12 @@ public class NullabilityResolver {
             // A nullable source must not be passed to a method with a non-null parameter
             return Boolean.TRUE;
         }
-        if ( parameterNullability == Nullability.NULLABLE && resultNullability == Nullability.NON_NULL ) {
-            // The method accepts null and guarantees a non-null result, so it must be invoked directly
+        if ( parameterNullability == Nullability.NULLABLE
+            && resultNullability != null
+            && resultNullability != Nullability.NULLABLE ) {
+            // The method accepts null and does not declare a nullable result. UNKNOWN preserves the
+            // pre-JSpecify behavior for unannotated return types; only an explicit @Nullable result
+            // makes the assignment potentially nullable.
             return Boolean.FALSE;
         }
         if ( targetNullability == Nullability.NON_NULL ) {

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4106/jdk17/Issue4106Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4106/jdk17/Issue4106Mapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4106.jdk17;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+@NullMarked
+public interface Issue4106Mapper {
+
+    Issue4106Mapper INSTANCE = Mappers.getMapper( Issue4106Mapper.class );
+
+    TargetDto map(SourceEntity sourceEntity);
+
+    default OffsetDateTime toOffsetTime(ZonedDateTime zonedDateTime) {
+        return zonedDateTime.withZoneSameInstant( ZoneOffset.UTC ).toOffsetDateTime();
+    }
+
+    record SourceEntity(ZonedDateTime createdAt, @Nullable ZonedDateTime closedAt) {
+    }
+
+    record TargetDto(OffsetDateTime createdAt, @Nullable OffsetDateTime closedAt) {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/bugs/_4106/jdk17/Issue4106Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/bugs/_4106/jdk17/Issue4106Test.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4106.jdk17;
+
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.Compiler;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("4106")
+@WithJSpecify
+@WithClasses(Issue4106Mapper.class)
+class Issue4106Test {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest(Compiler.JDK)
+    void shouldGuardOnlyNullableReusedMethodInput() {
+        generatedSource.addComparisonToFixtureFor( Issue4106Mapper.class );
+
+        ZonedDateTime createdAt = ZonedDateTime.of( 2026, 8, 9, 12, 0, 0, 0, ZoneOffset.ofHours( 2 ) );
+        Issue4106Mapper.TargetDto target = Issue4106Mapper.INSTANCE.map(
+            new Issue4106Mapper.SourceEntity( createdAt, null )
+        );
+
+        assertThat( target.createdAt() ).isEqualTo(
+            createdAt.withZoneSameInstant( ZoneOffset.UTC ).toOffsetDateTime()
+        );
+        assertThat( target.closedAt() ).isNull();
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ErroneousJSpecifyNullableReturnConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ErroneousJSpecifyNullableReturnConstructorMapper.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface ErroneousJSpecifyNullableReturnConstructorMapper {
+
+    ErroneousJSpecifyNullableReturnConstructorMapper INSTANCE =
+        Mappers.getMapper( ErroneousJSpecifyNullableReturnConstructorMapper.class );
+
+    @Mapping(target = "value", source = "value")
+    ReusedConstructorTarget map(ReusedConstructorSource source);
+
+    default @Nullable ReusedTargetValue map(ReusedSourceValue source) {
+        return source == null ? null : new ReusedTargetValue( source.value() );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/Issue4086Mapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/Issue4086Mapper.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.Named;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface Issue4086Mapper {
+
+    Issue4086Mapper INSTANCE = Mappers.getMapper( Issue4086Mapper.class );
+
+    @Mapping(target = "payload", source = "value", qualifiedByName = "mapValue")
+    Target map(Source source);
+
+    @Named("mapValue")
+    default Target.Nested mapValue(@Nullable String value) {
+        return value == null ? new Target.Nested( "default" ) : new Target.Nested( value );
+    }
+
+    class Source {
+
+        private String value;
+
+        public @Nullable String getValue() {
+            return value;
+        }
+    }
+
+    class Target {
+
+        private final Nested payload;
+
+        public Target(@NonNull Nested payload) {
+            this.payload = payload;
+        }
+
+        public Nested getPayload() {
+            return payload;
+        }
+
+        static class Nested {
+
+            private final String value;
+
+            Nested(String value) {
+                this.value = value;
+            }
+
+            String getValue() {
+                return value;
+            }
+        }
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/Issue4086Test.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/Issue4086Test.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.Compiler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("4086")
+@WithJSpecify
+@WithClasses(Issue4086Mapper.class)
+class Issue4086Test {
+
+    @ProcessorTest(Compiler.JDK)
+    void shouldUseUnannotatedMappingMethodResultForNonNullConstructorParameter() {
+        Issue4086Mapper.Target target = Issue4086Mapper.INSTANCE.map( new Issue4086Mapper.Source() );
+
+        assertThat( target.getPayload().getValue() ).isEqualTo( "default" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledReusedMethodMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledReusedMethodMapper.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = JSpecifySimpleReusedMethodUses.class)
+@NullMarked
+public interface JSpecifyDisabledReusedMethodMapper {
+
+    JSpecifyDisabledReusedMethodMapper INSTANCE = Mappers.getMapper( JSpecifyDisabledReusedMethodMapper.class );
+
+    @Mapping(target = "value", source = "value", qualifiedByName = "map")
+    JSpecifySimpleReusedMethodTarget map(JSpecifySimpleReusedMethodSource source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledTest.java
@@ -5,6 +5,7 @@
  */
 package org.mapstruct.ap.test.nullcheck.jspecify;
 
+import org.junit.jupiter.api.extension.RegisterExtension;
 import org.mapstruct.ap.testutil.IssueKey;
 import org.mapstruct.ap.testutil.ProcessorTest;
 import org.mapstruct.ap.testutil.WithClasses;
@@ -12,6 +13,8 @@ import org.mapstruct.ap.testutil.WithJSpecify;
 import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
 import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
 import org.mapstruct.ap.testutil.compilation.annotation.ProcessorOption;
+import org.mapstruct.ap.testutil.runner.Compiler;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,6 +29,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 @WithJSpecify
 @ProcessorOption(name = "mapstruct.disableJSpecify", value = "true")
 class JSpecifyDisabledTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
 
     @ProcessorTest
     @WithClasses({ SourceBean.class, TargetBean.class, JSpecifyDisabledMapper.class })
@@ -79,5 +85,17 @@ class JSpecifyDisabledTest {
         // disabled, that forcing is suppressed and the default RETURN_NULL strategy applies, so a null source
         // maps to null.
         assertThat( JSpecifyDisabledNonNullReturnMapper.INSTANCE.mapAll( null ) ).isNull();
+    }
+
+    @ProcessorTest(Compiler.JDK)
+    @WithClasses({
+        JSpecifyDisabledReusedMethodMapper.class,
+        JSpecifySimpleReusedMethodSource.class,
+        JSpecifySimpleReusedMethodTarget.class,
+        JSpecifySimpleReusedMethodUses.class,
+        JSpecifySimpleReusedMethodValue.class
+    })
+    public void disabledFlagRestoresLegacyReusedMethodBehavior() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyDisabledReusedMethodMapper.class );
     }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableInputNonNullReturnConstructorMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableInputNonNullReturnConstructorMapper.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public interface JSpecifyNullableInputNonNullReturnConstructorMapper {
+
+    JSpecifyNullableInputNonNullReturnConstructorMapper INSTANCE =
+        Mappers.getMapper( JSpecifyNullableInputNonNullReturnConstructorMapper.class );
+
+    @Mapping(target = "value", source = "value")
+    ReusedConstructorTarget map(ReusedConstructorSource source);
+
+    default @NonNull ReusedTargetValue map(@Nullable ReusedSourceValue source) {
+        return new ReusedTargetValue( source == null ? "fallback" : source.value() );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReusedMethodConstructorTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReusedMethodConstructorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.compilation.annotation.CompilationResult;
+import org.mapstruct.ap.testutil.compilation.annotation.Diagnostic;
+import org.mapstruct.ap.testutil.compilation.annotation.ExpectedCompilationOutcome;
+import org.mapstruct.ap.testutil.runner.Compiler;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("4081")
+@WithJSpecify
+@WithClasses({
+    ReusedConstructorSource.class,
+    ReusedConstructorTarget.class,
+    ReusedSourceValue.class,
+    ReusedTargetValue.class
+})
+class JSpecifyReusedMethodConstructorTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest(Compiler.JDK)
+    @WithClasses(JSpecifyNullableInputNonNullReturnConstructorMapper.class)
+    void nullableInputNonNullReturnHelperSatisfiesConstructor() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyNullableInputNonNullReturnConstructorMapper.class );
+
+        ReusedConstructorSource source = new ReusedConstructorSource();
+        ReusedConstructorTarget target =
+            JSpecifyNullableInputNonNullReturnConstructorMapper.INSTANCE.map( source );
+
+        assertThat( target.getValue().value() ).isEqualTo( "fallback" );
+    }
+
+    @ProcessorTest(Compiler.JDK)
+    @WithClasses(ErroneousJSpecifyNullableReturnConstructorMapper.class)
+    @IssueKey("4081")
+    @ExpectedCompilationOutcome(value = CompilationResult.FAILED,
+        diagnostics = {
+            @Diagnostic(type = ErroneousJSpecifyNullableReturnConstructorMapper.class,
+                kind = javax.tools.Diagnostic.Kind.ERROR,
+                message = "Can't map potentially nullable source property \"value\" to @NonNull "
+                    + "constructor parameter \"value\". Consider adding a defaultValue or defaultExpression.")
+        })
+    void nullableHelperResultCannotSatisfyConstructor() {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReusedMethodMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReusedMethodMapper.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.List;
+import java.util.Map;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.factory.Mappers;
+
+@Mapper(uses = JSpecifyReusedMethodUses.class)
+@NullMarked
+public interface JSpecifyReusedMethodMapper {
+
+    JSpecifyReusedMethodMapper INSTANCE = Mappers.getMapper( JSpecifyReusedMethodMapper.class );
+
+    @Mapping(target = "guarded", source = "guarded", qualifiedByName = "nonNull")
+    @Mapping(target = "direct", source = "direct", qualifiedByName = "nullableInput")
+    @Mapping(target = "unmarked", source = "unmarked", qualifiedByName = "unmarked")
+    @Mapping(target = "values", source = "values", qualifiedByName = "list")
+    @Mapping(target = "entries", source = "entries", qualifiedByName = "map")
+    Target map(Source source);
+
+    @NullMarked
+    class Source {
+        private @Nullable GuardedValue guarded;
+        private @Nullable DirectValue direct;
+        private @Nullable UnmarkedValue unmarked;
+        private @Nullable ChainValue chain;
+        private @Nullable List<GuardedValue> values;
+        private @Nullable Map<String, GuardedValue> entries;
+
+        public @Nullable GuardedValue getGuarded() {
+            return guarded;
+        }
+
+        public void setGuarded(@Nullable GuardedValue guarded) {
+            this.guarded = guarded;
+        }
+
+        public @Nullable DirectValue getDirect() {
+            return direct;
+        }
+
+        public void setDirect(@Nullable DirectValue direct) {
+            this.direct = direct;
+        }
+
+        public @Nullable UnmarkedValue getUnmarked() {
+            return unmarked;
+        }
+
+        public void setUnmarked(@Nullable UnmarkedValue unmarked) {
+            this.unmarked = unmarked;
+        }
+
+        public @Nullable ChainValue getChain() {
+            return chain;
+        }
+
+        public void setChain(@Nullable ChainValue chain) {
+            this.chain = chain;
+        }
+
+        public @Nullable List<GuardedValue> getValues() {
+            return values;
+        }
+
+        public void setValues(@Nullable List<GuardedValue> values) {
+            this.values = values;
+        }
+
+        public @Nullable Map<String, GuardedValue> getEntries() {
+            return entries;
+        }
+
+        public void setEntries(@Nullable Map<String, GuardedValue> entries) {
+            this.entries = entries;
+        }
+    }
+
+    @NullMarked
+    class Target {
+        private GuardedTargetValue guarded;
+        private DirectTargetValue direct;
+        private UnmarkedTargetValue unmarked;
+        private ChainTargetValue chain;
+        private List<GuardedTargetValue> values;
+        private Map<String, GuardedTargetValue> entries;
+        private boolean guardedSet;
+        private boolean directSet;
+        private boolean unmarkedSet;
+        private boolean chainSet;
+        private boolean valuesSet;
+        private boolean entriesSet;
+
+        public GuardedTargetValue getGuarded() {
+            return guarded;
+        }
+
+        public void setGuarded(@Nullable GuardedTargetValue guarded) {
+            guardedSet = true;
+            this.guarded = guarded;
+        }
+
+        public DirectTargetValue getDirect() {
+            return direct;
+        }
+
+        public void setDirect(DirectTargetValue direct) {
+            directSet = true;
+            this.direct = direct;
+        }
+
+        public UnmarkedTargetValue getUnmarked() {
+            return unmarked;
+        }
+
+        public void setUnmarked(@Nullable UnmarkedTargetValue unmarked) {
+            unmarkedSet = true;
+            this.unmarked = unmarked;
+        }
+
+        public ChainTargetValue getChain() {
+            return chain;
+        }
+
+        public void setChain(@Nullable ChainTargetValue chain) {
+            chainSet = true;
+            this.chain = chain;
+        }
+
+        public List<GuardedTargetValue> getValues() {
+            return values;
+        }
+
+        public void setValues(List<GuardedTargetValue> values) {
+            valuesSet = true;
+            this.values = values;
+        }
+
+        public Map<String, GuardedTargetValue> getEntries() {
+            return entries;
+        }
+
+        public void setEntries(Map<String, GuardedTargetValue> entries) {
+            entriesSet = true;
+            this.entries = entries;
+        }
+
+        public boolean isGuardedSet() {
+            return guardedSet;
+        }
+
+        public boolean isDirectSet() {
+            return directSet;
+        }
+
+        public boolean isUnmarkedSet() {
+            return unmarkedSet;
+        }
+
+        public boolean isChainSet() {
+            return chainSet;
+        }
+
+        public boolean isValuesSet() {
+            return valuesSet;
+        }
+
+        public boolean isEntriesSet() {
+            return entriesSet;
+        }
+    }
+
+    record GuardedValue(String value) {
+    }
+
+    record DirectValue(String value) {
+    }
+
+    record UnmarkedValue(String value) {
+    }
+
+    record ChainValue(String value) {
+    }
+
+    record ChainIntermediate(String value) {
+    }
+
+    record GuardedTargetValue(String value) {
+    }
+
+    record DirectTargetValue(String value) {
+    }
+
+    record UnmarkedTargetValue(String value) {
+    }
+
+    record ChainTargetValue(String value) {
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReusedMethodTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReusedMethodTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.extension.RegisterExtension;
+import org.mapstruct.ap.testutil.IssueKey;
+import org.mapstruct.ap.testutil.ProcessorTest;
+import org.mapstruct.ap.testutil.WithClasses;
+import org.mapstruct.ap.testutil.WithJSpecify;
+import org.mapstruct.ap.testutil.runner.Compiler;
+import org.mapstruct.ap.testutil.runner.GeneratedSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IssueKey("4106")
+@WithJSpecify
+@WithClasses({ JSpecifyReusedMethodMapper.class, JSpecifyReusedMethodUses.class })
+class JSpecifyReusedMethodTest {
+
+    @RegisterExtension
+    final GeneratedSource generatedSource = new GeneratedSource();
+
+    @ProcessorTest(Compiler.JDK)
+    void honorsReusedMethodInputAndResultContracts() {
+        generatedSource.addComparisonToFixtureFor( JSpecifyReusedMethodMapper.class );
+
+        JSpecifyReusedMethodMapper.Source source = new JSpecifyReusedMethodMapper.Source();
+        JSpecifyReusedMethodMapper.Target target = JSpecifyReusedMethodMapper.INSTANCE.map( source );
+
+        assertThat( target.isGuardedSet() ).isFalse();
+        assertThat( target.isDirectSet() ).isTrue();
+        assertThat( target.getDirect().value() ).isEqualTo( "fallback" );
+        assertThat( target.isUnmarkedSet() ).isTrue();
+        assertThat( target.getUnmarked() ).isNull();
+        assertThat( target.isChainSet() ).isFalse();
+        assertThat( target.isValuesSet() ).isTrue();
+        assertThat( target.getValues() ).isEmpty();
+        assertThat( target.isEntriesSet() ).isTrue();
+        assertThat( target.getEntries() ).isEmpty();
+
+        source.setGuarded( new JSpecifyReusedMethodMapper.GuardedValue( "guarded" ) );
+        source.setDirect( new JSpecifyReusedMethodMapper.DirectValue( "direct" ) );
+        source.setChain( new JSpecifyReusedMethodMapper.ChainValue( "chain" ) );
+        source.setValues( Collections.singletonList( new JSpecifyReusedMethodMapper.GuardedValue( "value" ) ) );
+        target = JSpecifyReusedMethodMapper.INSTANCE.map( source );
+
+        assertThat( target.isGuardedSet() ).isTrue();
+        assertThat( target.isChainSet() ).isTrue();
+        assertThat( target.getValues() ).extracting( "value" ).containsExactly( "value" );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReusedMethodUses.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReusedMethodUses.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.NullUnmarked;
+import org.jspecify.annotations.Nullable;
+import org.mapstruct.Named;
+import org.mapstruct.ap.test.nullcheck.jspecify.JSpecifyReusedMethodMapper.ChainIntermediate;
+import org.mapstruct.ap.test.nullcheck.jspecify.JSpecifyReusedMethodMapper.ChainTargetValue;
+import org.mapstruct.ap.test.nullcheck.jspecify.JSpecifyReusedMethodMapper.ChainValue;
+import org.mapstruct.ap.test.nullcheck.jspecify.JSpecifyReusedMethodMapper.DirectTargetValue;
+import org.mapstruct.ap.test.nullcheck.jspecify.JSpecifyReusedMethodMapper.DirectValue;
+import org.mapstruct.ap.test.nullcheck.jspecify.JSpecifyReusedMethodMapper.GuardedTargetValue;
+import org.mapstruct.ap.test.nullcheck.jspecify.JSpecifyReusedMethodMapper.GuardedValue;
+
+@NullMarked
+public class JSpecifyReusedMethodUses {
+
+    @Named("nonNull")
+    public GuardedTargetValue mapNonNull(
+        GuardedValue source
+    ) {
+        return new GuardedTargetValue( source.value() );
+    }
+
+    @Named("nullableInput")
+    public @NonNull DirectTargetValue mapNullableInput(
+        @Nullable DirectValue source
+    ) {
+        return new DirectTargetValue( source == null ? "fallback" : source.value() );
+    }
+
+    @Named("unmarked")
+    @NullUnmarked
+    public JSpecifyReusedMethodMapper.UnmarkedTargetValue mapUnmarked(
+        JSpecifyReusedMethodMapper.UnmarkedValue source
+    ) {
+        return source == null ? null : new JSpecifyReusedMethodMapper.UnmarkedTargetValue( source.value() );
+    }
+
+    public ChainIntermediate mapChainStart(
+        ChainValue source
+    ) {
+        return new ChainIntermediate( source.value() );
+    }
+
+    public @NonNull ChainTargetValue mapChainEnd(
+        @Nullable ChainIntermediate source
+    ) {
+        return new ChainTargetValue( source == null ? "fallback" : source.value() );
+    }
+
+    @Named("list")
+    public @NonNull List<GuardedTargetValue> mapList(
+        @Nullable List<GuardedValue> source
+    ) {
+        return source == null
+            ? Collections.emptyList()
+            : source.stream()
+                .map( value -> new GuardedTargetValue( value.value() ) )
+                .toList();
+    }
+
+    @Named("map")
+    public @NonNull Map<String, GuardedTargetValue> mapMap(
+        @Nullable Map<String, GuardedValue> source
+    ) {
+        return source == null
+            ? Collections.emptyMap()
+            : source.entrySet().stream().collect(
+                java.util.stream.Collectors.toMap(
+                    Map.Entry::getKey,
+                    entry -> new GuardedTargetValue( entry.getValue().value() )
+                )
+            );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySimpleReusedMethodSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySimpleReusedMethodSource.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+public class JSpecifySimpleReusedMethodSource {
+
+    private @Nullable JSpecifySimpleReusedMethodValue value;
+
+    public @Nullable JSpecifySimpleReusedMethodValue getValue() {
+        return value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySimpleReusedMethodTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySimpleReusedMethodTarget.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
+@NullMarked
+public class JSpecifySimpleReusedMethodTarget {
+
+    private @Nullable JSpecifySimpleReusedMethodValue value;
+    private boolean valueSet;
+
+    public void setValue(@Nullable JSpecifySimpleReusedMethodValue value) {
+        valueSet = true;
+        this.value = value;
+    }
+
+    public @Nullable JSpecifySimpleReusedMethodValue getValue() {
+        return value;
+    }
+
+    public boolean isValueSet() {
+        return valueSet;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySimpleReusedMethodUses.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySimpleReusedMethodUses.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.mapstruct.Named;
+
+@NullMarked
+public class JSpecifySimpleReusedMethodUses {
+
+    @Named("map")
+    public JSpecifySimpleReusedMethodValue map(JSpecifySimpleReusedMethodValue source) {
+        return new JSpecifySimpleReusedMethodValue( source.value() );
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySimpleReusedMethodValue.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifySimpleReusedMethodValue.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+
+@NullMarked
+public class JSpecifySimpleReusedMethodValue {
+
+    private final String value;
+
+    public JSpecifySimpleReusedMethodValue(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyVerboseNoteTest.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyVerboseNoteTest.java
@@ -40,4 +40,18 @@ class JSpecifyVerboseNoteTest {
         + "parameter is @NonNull\\.$")
     public void emitsMethodLevelGuardSkipNote() {
     }
+
+    @ProcessorTest(Compiler.JDK)
+    @ProcessorOption(name = "mapstruct.verbose", value = "true")
+    @WithClasses({
+        JSpecifyVerboseReusedMethodMapper.class,
+        JSpecifySimpleReusedMethodSource.class,
+        JSpecifySimpleReusedMethodTarget.class,
+        JSpecifySimpleReusedMethodUses.class,
+        JSpecifySimpleReusedMethodValue.class
+    })
+    @ExpectedNote("^-- MapStruct: JSpecify adding null check for property \"value\" because the reused method "
+        + "parameter is @NonNull: source=\\w+, target=\\w+\\.$")
+    public void emitsReusedMethodParameterGuardNote() {
+    }
 }

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyVerboseReusedMethodMapper.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyVerboseReusedMethodMapper.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NullMarked;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(uses = JSpecifySimpleReusedMethodUses.class)
+@NullMarked
+public interface JSpecifyVerboseReusedMethodMapper {
+
+    @Mapping(target = "value", source = "value", qualifiedByName = "map")
+    JSpecifySimpleReusedMethodTarget map(JSpecifySimpleReusedMethodSource source);
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ReusedConstructorSource.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ReusedConstructorSource.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.Nullable;
+
+public class ReusedConstructorSource {
+
+    private @Nullable ReusedSourceValue value;
+
+    public @Nullable ReusedSourceValue getValue() {
+        return value;
+    }
+
+    public void setValue(@Nullable ReusedSourceValue value) {
+        this.value = value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ReusedConstructorTarget.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ReusedConstructorTarget.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import org.jspecify.annotations.NonNull;
+
+public class ReusedConstructorTarget {
+
+    private final ReusedTargetValue value;
+
+    public ReusedConstructorTarget(@NonNull ReusedTargetValue value) {
+        this.value = value;
+    }
+
+    public ReusedTargetValue getValue() {
+        return value;
+    }
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ReusedSourceValue.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ReusedSourceValue.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+public record ReusedSourceValue(String value) {
+}

--- a/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ReusedTargetValue.java
+++ b/processor/src/test/java/org/mapstruct/ap/test/nullcheck/jspecify/ReusedTargetValue.java
@@ -1,0 +1,9 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+public record ReusedTargetValue(String value) {
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_4106/jdk17/Issue4106MapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/bugs/_4106/jdk17/Issue4106MapperImpl.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.bugs._4106.jdk17;
+
+import java.time.OffsetDateTime;
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-08-09T22:10:29+0530",
+    comments = "version: , compiler: javac, environment: Java 25.0.2 (Oracle Corporation)"
+)
+public class Issue4106MapperImpl implements Issue4106Mapper {
+
+    @Override
+    public Issue4106Mapper.TargetDto map(Issue4106Mapper.SourceEntity sourceEntity) {
+
+        OffsetDateTime createdAt = null;
+        OffsetDateTime closedAt = null;
+
+        createdAt = toOffsetTime( sourceEntity.createdAt() );
+        if ( sourceEntity.closedAt() != null ) {
+            closedAt = toOffsetTime( sourceEntity.closedAt() );
+        }
+
+        Issue4106Mapper.TargetDto targetDto = new Issue4106Mapper.TargetDto( createdAt, closedAt );
+
+        return targetDto;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledReusedMethodMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyDisabledReusedMethodMapperImpl.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-08-10T10:00:00+0530",
+    comments = "version: , compiler: javac, environment: Java 25.0.2 (Oracle Corporation)"
+)
+public class JSpecifyDisabledReusedMethodMapperImpl implements JSpecifyDisabledReusedMethodMapper {
+
+    private final JSpecifySimpleReusedMethodUses jSpecifySimpleReusedMethodUses = new JSpecifySimpleReusedMethodUses();
+
+    @Override
+    public JSpecifySimpleReusedMethodTarget map(JSpecifySimpleReusedMethodSource source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        JSpecifySimpleReusedMethodTarget jSpecifySimpleReusedMethodTarget = new JSpecifySimpleReusedMethodTarget();
+
+        jSpecifySimpleReusedMethodTarget.setValue( jSpecifySimpleReusedMethodUses.map( source.getValue() ) );
+
+        return jSpecifySimpleReusedMethodTarget;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableInputNonNullReturnConstructorMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyNullableInputNonNullReturnConstructorMapperImpl.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-08-09T22:24:30+0530",
+    comments = "version: , compiler: javac, environment: Java 25.0.2 (Oracle Corporation)"
+)
+public class JSpecifyNullableInputNonNullReturnConstructorMapperImpl implements JSpecifyNullableInputNonNullReturnConstructorMapper {
+
+    @Override
+    public ReusedConstructorTarget map(ReusedConstructorSource source) {
+        if ( source == null ) {
+            return null;
+        }
+
+        ReusedTargetValue value = null;
+
+        value = map( source.getValue() );
+
+        ReusedConstructorTarget reusedConstructorTarget = new ReusedConstructorTarget( value );
+
+        return reusedConstructorTarget;
+    }
+}

--- a/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReusedMethodMapperImpl.java
+++ b/processor/src/test/resources/fixtures/org/mapstruct/ap/test/nullcheck/jspecify/JSpecifyReusedMethodMapperImpl.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright MapStruct Authors.
+ *
+ * Licensed under the Apache License version 2.0, available at http://www.apache.org/licenses/LICENSE-2.0
+ */
+package org.mapstruct.ap.test.nullcheck.jspecify;
+
+import javax.annotation.processing.Generated;
+
+@Generated(
+    value = "org.mapstruct.ap.MappingProcessor",
+    date = "2026-08-09T22:10:29+0530",
+    comments = "version: , compiler: javac, environment: Java 25.0.2 (Oracle Corporation)"
+)
+public class JSpecifyReusedMethodMapperImpl implements JSpecifyReusedMethodMapper {
+
+    private final JSpecifyReusedMethodUses jSpecifyReusedMethodUses = new JSpecifyReusedMethodUses();
+
+    @Override
+    public Target map(Source source) {
+
+        Target target = new Target();
+
+        if ( source.getGuarded() != null ) {
+            target.setGuarded( jSpecifyReusedMethodUses.mapNonNull( source.getGuarded() ) );
+        }
+        target.setDirect( jSpecifyReusedMethodUses.mapNullableInput( source.getDirect() ) );
+        target.setUnmarked( jSpecifyReusedMethodUses.mapUnmarked( source.getUnmarked() ) );
+        target.setValues( jSpecifyReusedMethodUses.mapList( source.getValues() ) );
+        target.setEntries( jSpecifyReusedMethodUses.mapMap( source.getEntries() ) );
+        if ( source.getChain() != null ) {
+            target.setChain( jSpecifyReusedMethodUses.mapChainEnd( jSpecifyReusedMethodUses.mapChainStart( source.getChain() ) ) );
+        }
+
+        return target;
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #4106 by carrying the JSpecify input and output contracts of reused mapping methods through generated assignments.

MapStruct previously based null guards primarily on source/target nullability and null-value-check strategy. It did not retain whether a selected helper method required a non-null argument or guaranteed a non-null result, which could generate unsafe calls or reject safe constructor mappings.

## Implementation

- Add internal assignment contracts for the innermost reused-method input and outermost reused-method result.
- Resolve explicit and scoped JSpecify nullability from selected mapping methods, including methods from `uses` types.
- Propagate contracts through method chains and conversion wrappers.
- Generate a source guard when a nullable value is passed to a non-null helper parameter.
- Invoke nullable-input helpers directly when their result is not explicitly `@Nullable`, preserving legacy behavior for unannotated return types.
- Validate constructor parameters against the effective assignment result.
- Preserve legacy behavior for built-ins, forged methods, assignments without method contracts, and `-Amapstruct.disableJSpecify=true`.
- Add a verbose diagnostic for guards introduced by reused-method input contracts.
- Document null propagation and clarify that JSpecify annotations do not participate in overload selection.

This also covers the related scenarios described in #4077, #4081, and #4086 without adding public API.

## Verification

- Exact #4086 reproducer: compiled and executed successfully; generated code invokes `mapValue(source.getValue())` directly.
- Explicit-`@Nullable` return negative case: still produces the expected non-null-constructor diagnostic.
- Full `JSpecify*Test` suite: 111 tests passed.
- Focused reused-method, disabled-option, and verbose-diagnostic tests: 13 passed.
- Constructor contract regression tests: 2 passed.
- Full processor Surefire results: 3,561 tests, 0 failures, 0 errors.
- Processor Checkstyle: passed with 0 violations.
- Targeted `MavenIntegrationTest#fullFeatureTest`: passed.

The full reactor `clean install -DskipDistribution=true` exceeded the local 15-minute command limit after the processor suite completed; the affected integration path and Checkstyle were rerun successfully afterward.